### PR TITLE
Fix broken links

### DIFF
--- a/website/docs/tutorial/faqs/run-downtime.md
+++ b/website/docs/tutorial/faqs/run-downtime.md
@@ -3,4 +3,4 @@ title: If I rerun dbt, will there be any downtime as models are rebuilt?
 ---
 Nope! The SQL that dbt generates behind the scenes ensures that any relations are replaced atomically (i.e. your business users won't experience any downtime).
 
-The implementation of this varies on each warehouse, check out the [logs](faqs/checking-logs) to see the SQL dbt is executing.
+The implementation of this varies on each warehouse, check out the [logs](https://tutorial.getdbt.com/tutorial/faqs/checking-logs) to see the SQL dbt is executing.

--- a/website/docs/tutorial/faqs/sql-errors.md
+++ b/website/docs/tutorial/faqs/sql-errors.md
@@ -26,4 +26,4 @@ Database Error in model customers (models/customers.sql)
 Done. PASS=0 WARN=0 ERROR=1 SKIP=0 TOTAL=1
 ```
 
-Any models downstream of this model will also be skipped. Use the error message and the [compiled SQL](faqs/checking-logs) to debug any errors.
+Any models downstream of this model will also be skipped. Use the error message and the [compiled SQL](https://tutorial.getdbt.com/tutorial/faqs/checking-logs) to debug any errors.


### PR DESCRIPTION
When an FAQ links to another FAQ, it does some weird stuff:

Consider this link within an FAQ:
`[logs](faqs/checking-logs)`

Clicking a relative link in an expanded FAQ:
1. Go [here](https://tutorial.getdbt.com/tutorial/build-your-first-models)
2. `cmd +f ` for "If I rerun dbt, will there be any downtime as models are rebuilt?"
3. Expand the FAQ, and click the `logs` hyperlink
4. ✅ success, it correctly takes you to `/tutorial/faqs/checking-logs/`

Clicking a relative link in a standalone FAQ:
1. Go [here](https://tutorial.getdbt.com/tutorial/faqs/run-downtime/)
2. Click the `logs` link
3. 🙅 It takes you to `/tutorial/faqs/run-downtime/faqs/checking-logs/`

My solution here is to hardcode the link, is there a better way of doing this?
