### PR TITLE
Redo seeds documentation

### DIFF
--- a/website/docs/docs/building-a-dbt-project/seeds.md
+++ b/website/docs/docs/building-a-dbt-project/seeds.md
@@ -3,22 +3,30 @@ title: "Seeds"
 id: "seeds"
 ---
 
-## Overview
-`dbt seed` loads data from csv files into your data warehouse. Because these csv files are located in your dbt repository, they are version controlled and code reviewable. Thus, `dbt seed` is appropriate for loading static data which changes infrequently.
+## Getting started
+Seeds are CSV files in your dbt project (typically in your `data` directory),
+that dbt can load into your data warehouse using the `dbt seed` command.
 
-The `dbt seed` command will load `csv` files located in the `data-paths` directory of your dbt project into your data warehouse. You can configure the `data-paths` directory by adding the following line to your `dbt_project.yml` file:
+Seeds can be referenced in downstream models the same way as referencing models
+— by using the `ref` [function](docs/writing-code-in-dbt/jinja-context/ref.md).
 
-<File name='dbt_project.yml'>
+Because these CSV files are located in your dbt repository, they are version
+controlled and code reviewable. Seeds are best suited to static data which
+changes infrequently.
 
-```yaml
-data-paths: ["data"] # default is './data'
-```
+Good use-cases for seeds:
+* A list of mappings of country codes to country names
+* A list of test emails to exclude from analysis
+* A list of employee account IDs
 
-</File>
+Poor use-cases of dbt seeds:
+* Loading raw data that has been exported to CSVs
 
-Assuming you have a `csv` file that looks like this:
+## Example
+To load a seed file in your dbt project:
+1. Add the file to your `data` directory, with a `.csv` file extension, e.g. `data/country_codes.csv`
 
-<File name='country_codes.csv'>
+<File name='data/country_codes.csv'>
 
 ```text
 country_code,country_name
@@ -30,12 +38,9 @@ GB,United Kingdom
 
 </File>
 
-Running `dbt seed` with the above csv located at `data/country_codes.csv` will create a table in your data warehouse with two columns: `country_code` and `country_name`.
-
-To see a sample of the data loaded by dbt, use the `--show` argument to `dbt seed`:
-
+2. Run the `dbt seed` [command](running-a-dbt-project/command-line-interface/seed.md) — a new table will be created in your warehouse in your target schema, named `country_codes`
 ```
-$ dbt seed --show
+$ dbt seed
 
 Found 2 models, 3 tests, 0 archives, 0 analyses, 53 macros, 0 operations, 1 seed file
 
@@ -46,130 +51,33 @@ Found 2 models, 3 tests, 0 archives, 0 analyses, 53 macros, 0 operations, 1 seed
 14:46:16 |
 14:46:16 | Finished running 1 seed in 0.14s.
 
-Random sample of table: analytics.country_codes
------------------------------------------------
-| country_code | country_name   |
-| ------------ | -------------- |
-| GB           | United Kingdom |
-| CA           | Canada         |
-| US           | United States  |
-
 Completed successfully
 
 Done. PASS=1 ERROR=0 SKIP=0 TOTAL=1
 ```
 
-In addition to the standard `--profile` and `--target` arguments, `dbt seed` also accepts the `--full-refresh` argument. If provided, dbt will drop and re-create the specified table instead of truncating and inserting new data. This is useful if the schema of the csv file changes in a way which is incompatible with the existing table.
+3. Refer to seeds in downstream models using the `ref` function.
 
-Seed files can be used with the `ref()` function in models. In practice, this looks like:
-
-<File name='models/my_model.sql'>
+<File name='models/orders.csv'>
 
 ```sql
-
 -- This refers to the table created from data/country_codes.csv
 select * from {{ ref('country_codes') }}
-
-```
-
-### Running specific seeds
-
-</File>
-
-## Configuring seeds
-### Basic configuration
-
-Seed files can be configured using the same semantics as models. With these configurations, you can selectively enable or disabled seed files, or configure them to materialize in a [custom schema](using-custom-schemas). To configure seed files, use the `seeds:` option in your `dbt_project.yml file`. To load seeds into the default schema (as defined in `profiles.yml`), leave the schema field blank.
-
-```yaml
-
-data-paths: ["data"]
-
-...
-
-models:
-  your_package_name:
-    materialized: view
-
-seeds:
-  your_package_name:
-    enabled: true
-    schema: seed_data
-    post-hook: "grant select on {{ this }} to bi_user"
-```
-
-### Specify column quoting
-Whether or not seed columns are quoted can be configured with the `quote_columns`  seed config. When `true`, dbt will quote the column names defined in the seed file when building a table for the seed. When `quote_columns` is set to `false`, dbt will _not_ quote the column names defined in the seed file.
-
-As of dbt v0.15.0, the default value for `quote_columns` is **False**, however this may change in a future release. If you're using seed files, it is recommended that you set the `quote_columns` config explicitly to avoid breaking changes in the future.
-
-The following example show quoting being explicitly enabled for seed columns.
-
-<File name='dbt_project.yml'>
-
-```yaml
-
-data-paths: ["data"]
-
-...
-
-# Enable quoting of seed columns in your project
-seeds:
-  quote_columns: True
 ```
 
 </File>
 
-The following example show quoting being explicitly disabled for seed columns.
+## Related documentation
+* [Seed configurations](reference/seed-configs.md)
+* The `dbt seed` [command](running-a-dbt-project/command-line-interface/seed.md)
 
-<File name='dbt_project.yml'>
-
-```yaml
-
-data-paths: ["data"]
-
-...
-
-# Explicitly disable quoting of seed columns in your project
-seeds:
-  quote_columns: False
-```
-
-</File>
-
-### Override column types
-
-The column types of a seed file can also be configured in the `dbt_project.yml` file. Note that if you change these types, you'll need to run `dbt seed` in `--full-refresh` mode to update the table schema. Example usage:
-
-<File name='dbt_project.yml'>
-
-```yaml
-
-data-paths: ["data"]
-
-...
-
-models:
-  your_package_name:
-    materialized: view
-
-seeds:
-  your_package_name:
-    enabled: true
-    schema: seed_data
-    # This configures data/country_codes.csv
-    country_codes:
-
-      # Override column types
-      column_types:
-        country_code: varchar(2)
-        country_name: varchar(32)
-```
-
-</File>
-
-## Considerations
-
-Any operation in dbt which creates resources in the database will execute on-run-start and on-run-end hooks. Operations which create resources in the the database can include dbt run, dbt seed, and dbt snapshot. If you plan to execute dbt seed before executing dbt run, ensure that any on-run-start and on-run-end hooks are idempotent and there are no issues with re-running them for each operation.
-
-Another alternative is pushing particular hooks down to the model level.
+## FAQs:
+<FAQ src="load-raw-data-with-seed" />
+<FAQ src="configurable-data-path" />
+<FAQ src="full-refresh-seed" />
+<FAQ src="testing-seeds" />
+<FAQ src="seed-datatypes" />
+<FAQ src="run-downstream-of-seed" />
+<FAQ src="leading-zeros-in-seed" />
+<FAQ src="build-one-seed" />
+<FAQ src="seed-hooks" />

--- a/website/docs/docs/building-a-dbt-project/seeds.md
+++ b/website/docs/docs/building-a-dbt-project/seeds.md
@@ -4,15 +4,11 @@ id: "seeds"
 ---
 
 ## Getting started
-Seeds are CSV files in your dbt project (typically in your `data` directory),
-that dbt can load into your data warehouse using the `dbt seed` command.
+Seeds are CSV files in your dbt project (typically in your `data` directory), that dbt can load into your data warehouse using the `dbt seed` command.
 
-Seeds can be referenced in downstream models the same way as referencing models
-— by using the `ref` [function](docs/writing-code-in-dbt/jinja-context/ref.md).
+Seeds can be referenced in downstream models the same way as referencing models — by using the `ref` [function](docs/writing-code-in-dbt/jinja-context/ref.md).
 
-Because these CSV files are located in your dbt repository, they are version
-controlled and code reviewable. Seeds are best suited to static data which
-changes infrequently.
+Because these CSV files are located in your dbt repository, they are version controlled and code reviewable. Seeds are best suited to static data which changes infrequently.
 
 Good use-cases for seeds:
 * A list of mappings of country codes to country names
@@ -38,7 +34,7 @@ GB,United Kingdom
 
 </File>
 
-2. Run the `dbt seed` [command](running-a-dbt-project/command-line-interface/seed.md) — a new table will be created in your warehouse in your target schema, named `country_codes`
+2. Run the `dbt seed` [command](docs/running-a-dbt-project/command-line-interface/seed.md) — a new table will be created in your warehouse in your target schema, named `country_codes`
 ```
 $ dbt seed
 
@@ -67,11 +63,14 @@ select * from {{ ref('country_codes') }}
 
 </File>
 
+## Configuring seeds
+Seeds are configured in your `dbt_project.yml`, check out the [seed configurations](reference/seed-configs.md) docs for a full list of available configurations.
+
 ## Related documentation
 * [Seed configurations](reference/seed-configs.md)
-* The `dbt seed` [command](running-a-dbt-project/command-line-interface/seed.md)
+* The `dbt seed` [command](docs/running-a-dbt-project/command-line-interface/seed.md)
 
-## FAQs:
+## FAQs
 <FAQ src="load-raw-data-with-seed" />
 <FAQ src="configurable-data-path" />
 <FAQ src="full-refresh-seed" />

--- a/website/docs/faqs/build-one-seed.md
+++ b/website/docs/faqs/build-one-seed.md
@@ -1,0 +1,13 @@
+---
+title: How do I build one seed at a time?
+---
+As of v0.16.0, you can use a `--select` option with the `dbt seed` command, like so:
+
+```
+$ dbt seed --select country_codes
+```
+There is also an `--exclude` option.
+
+Check out more in the [model selection syntax](docs/running-a-dbt-project/command-line-interface/model-selection-syntax.md) documentation.
+
+Prior to v0.16.0, there was no way to build one seed at a time.

--- a/website/docs/faqs/configurable-data-path.md
+++ b/website/docs/faqs/configurable-data-path.md
@@ -4,7 +4,7 @@ title: Can I store my seeds in a directory other than the `data` directory in my
 Be default, dbt expects your seed files to be located in the `data` subdirectory
 of your project.
 
-To change this, update the [data-paths](reference/data-paths.md) configuration in your `dbt_project.yml`
+To change this, update the [data-paths](reference/project-configs/data-paths.md) configuration in your `dbt_project.yml`
 file, like so:
 
 <File name='dbt_project.yml'>

--- a/website/docs/faqs/configurable-data-path.md
+++ b/website/docs/faqs/configurable-data-path.md
@@ -1,0 +1,16 @@
+---
+title: Can I store my seeds in a directory other than the `data` directory in my project?
+---
+Be default, dbt expects your seed files to be located in the `data` subdirectory
+of your project.
+
+To change this, update the [data-paths](reference/data-paths.md) configuration in your `dbt_project.yml`
+file, like so:
+
+<File name='dbt_project.yml'>
+
+```yml
+data-paths: ["seeds"]
+```
+
+</File>

--- a/website/docs/faqs/full-refresh-seed.md
+++ b/website/docs/faqs/full-refresh-seed.md
@@ -1,0 +1,78 @@
+---
+title: The columns of my seed changed, and now I get an error when running `seed`, what do I do?
+---
+If you changed the columns of your seed, you may get an `Database Error`:
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs
+  defaultValue="snowflake"
+  values={[
+    { label: 'Snowflake', value: 'snowflake', },
+    { label: 'Redshift', value: 'redshift', }
+  ]
+}>
+<TabItem value="snowflake">
+
+```
+$ dbt seed
+Running with dbt=0.16.0-rc2
+Found 0 models, 0 tests, 0 snapshots, 0 analyses, 130 macros, 0 operations, 1 seed file, 0 sources
+
+12:12:27 | Concurrency: 8 threads (target='dev_snowflake')
+12:12:27 |
+12:12:27 | 1 of 1 START seed file dbt_claire.country_codes...................... [RUN]
+12:12:30 | 1 of 1 ERROR loading seed file dbt_claire.country_codes.............. [ERROR in 2.78s]
+12:12:31 |
+12:12:31 | Finished running 1 seed in 10.05s.
+
+Completed with 1 error and 0 warnings:
+
+Database Error in seed country_codes (data/country_codes.csv)
+  000904 (42000): SQL compilation error: error line 1 at position 62
+  invalid identifier 'COUNTRY_NAME'
+
+Done. PASS=0 WARN=0 ERROR=1 SKIP=0 TOTAL=1
+
+```
+
+</TabItem>
+<TabItem value="redshift">
+
+```
+$ dbt seed
+Running with dbt=0.16.0-rc2
+Found 0 models, 0 tests, 0 snapshots, 0 analyses, 149 macros, 0 operations, 1 seed file, 0 sources
+
+12:14:46 | Concurrency: 1 threads (target='dev_redshift')
+12:14:46 |
+12:14:46 | 1 of 1 START seed file dbt_claire.country_codes...................... [RUN]
+12:14:46 | 1 of 1 ERROR loading seed file dbt_claire.country_codes.............. [ERROR in 0.23s]
+12:14:46 |
+12:14:46 | Finished running 1 seed in 1.75s.
+
+Completed with 1 error and 0 warnings:
+
+Database Error in seed country_codes (data/country_codes.csv)
+  column "country_name" of relation "country_codes" does not exist
+
+Done. PASS=0 WARN=0 ERROR=1 SKIP=0 TOTAL=1
+```
+
+</TabItem>
+
+</Tabs>
+
+In this case, you should rerun the command with a `--full-refresh` flag, like so:
+```
+dbt seed --full-refresh
+```
+
+**Why is this the case?**
+
+When you typically run dbt seed, dbt truncates the existing table and reinserts the data. This pattern avoids a `drop cascade` command, which may cause downstream objects (that your BI users might be querying!) to get dropped.
+
+However, when column names are changed, or new columns are added, these statements will fail as the table structure has changed.
+
+The `--full-refresh` flag will force dbt to `drop cascade` the existing table before rebuilding it.

--- a/website/docs/faqs/full-refresh-seed.md
+++ b/website/docs/faqs/full-refresh-seed.md
@@ -1,10 +1,7 @@
 ---
-title: The columns of my seed changed, and now I get an error when running `seed`, what do I do?
+title: The columns of my seed changed, and now I get an error when running the `seed` command, what should I do?
 ---
-If you changed the columns of your seed, you may get an `Database Error`:
-
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+If you changed the columns of your seed, you may get a `Database Error`:
 
 <Tabs
   defaultValue="snowflake"

--- a/website/docs/faqs/leading-zeros-in-seed.md
+++ b/website/docs/faqs/leading-zeros-in-seed.md
@@ -1,0 +1,8 @@
+---
+title: How do I preserve leading zeros in a seed?
+---
+
+If you need to preserve leading zeros (for example in a zipcode or mobile number):
+
+1. v0.16.0 onwards: Include leading zeros in your seed file, and use the `column_types` [configuration](reference/column_types.md) with a varchar datatype of the correct length.
+2. Prior to v0.16.0: Use a downstream model to pad the leading zeros using SQL, for example: `lpad(zipcode, 5, '0')`

--- a/website/docs/faqs/leading-zeros-in-seed.md
+++ b/website/docs/faqs/leading-zeros-in-seed.md
@@ -4,5 +4,5 @@ title: How do I preserve leading zeros in a seed?
 
 If you need to preserve leading zeros (for example in a zipcode or mobile number):
 
-1. v0.16.0 onwards: Include leading zeros in your seed file, and use the `column_types` [configuration](reference/column_types.md) with a varchar datatype of the correct length.
+1. v0.16.0 onwards: Include leading zeros in your seed file, and use the `column_types` [configuration](reference/resource-configs/column_types.md) with a varchar datatype of the correct length.
 2. Prior to v0.16.0: Use a downstream model to pad the leading zeros using SQL, for example: `lpad(zipcode, 5, '0')`

--- a/website/docs/faqs/load-raw-data-with-seed.md
+++ b/website/docs/faqs/load-raw-data-with-seed.md
@@ -1,0 +1,13 @@
+---
+title: Can I use seeds to load raw data?
+---
+
+Seeds should **not** be used to load raw data (for example, large CSV exports
+from a production database).
+
+Since seeds are version controlled, they are best suited to files that contain
+business-specific logic, for example a list of country codes or user IDs of
+employees.
+
+Loading CSVs using dbt's seed functionality is not performant for large files.
+Consider using a different tool to load these CSVs into your data warehouse.

--- a/website/docs/faqs/load-raw-data-with-seed.md
+++ b/website/docs/faqs/load-raw-data-with-seed.md
@@ -2,12 +2,8 @@
 title: Can I use seeds to load raw data?
 ---
 
-Seeds should **not** be used to load raw data (for example, large CSV exports
-from a production database).
+Seeds should **not** be used to load raw data (for example, large CSV exports from a production database).
 
-Since seeds are version controlled, they are best suited to files that contain
-business-specific logic, for example a list of country codes or user IDs of
-employees.
+Since seeds are version controlled, they are best suited to files that contain business-specific logic, for example a list of country codes or user IDs of employees.
 
-Loading CSVs using dbt's seed functionality is not performant for large files.
-Consider using a different tool to load these CSVs into your data warehouse.
+Loading CSVs using dbt's seed functionality is not performant for large files. Consider using a different tool to load these CSVs into your data warehouse.

--- a/website/docs/faqs/run-downstream-of-seed.md
+++ b/website/docs/faqs/run-downstream-of-seed.md
@@ -1,0 +1,11 @@
+---
+title: How do I run models downstream of a seed?
+---
+
+You can run models downstream of a seed using the [model selection syntax](docs/running-a-dbt-project/command-line-interface/model-selection-syntax.md), and treating the seed like a model.
+
+For example, the following would run all models downstream of a seed named `country_codes`:
+
+```
+$ dbt run --models country_codes+
+```

--- a/website/docs/faqs/seed-custom-schemas.md
+++ b/website/docs/faqs/seed-custom-schemas.md
@@ -3,8 +3,7 @@ title: Can I put my seeds in a schema other than my target schema?
 ---
 ## Or: Can I split my seeds across multiple schemas?
 
-Yes! The [schema](reference/configs/schema.md) configuration can be applied to seeds in
-your `dbt_project.yml` file.
+Yes! The [schema](reference/configs/schema.md) configuration can be applied to seeds in your `dbt_project.yml` file.
 
 <File name='dbt_project.yml'>
 

--- a/website/docs/faqs/seed-custom-schemas.md
+++ b/website/docs/faqs/seed-custom-schemas.md
@@ -1,0 +1,23 @@
+---
+title: Can I put my seeds in a schema other than my target schema?
+---
+## Or: Can I split my seeds across multiple schemas?
+
+Yes! The [schema](reference/configs/schema.md) configuration can be applied to seeds in
+your `dbt_project.yml` file.
+
+<File name='dbt_project.yml'>
+
+```yml
+
+name: jaffle_shop
+...
+
+seeds:
+  jaffle_shop:
+    schema: mappings # all seeds in this project will use the mapping schema by default
+    marketing:
+      schema: marketing # seeds in the `data/mapping/ subdirectory will use the marketing schema
+```
+
+</File>

--- a/website/docs/faqs/seed-datatypes.md
+++ b/website/docs/faqs/seed-datatypes.md
@@ -3,7 +3,7 @@ title: How do I set a datatype for a column in my seed?
 ---
 dbt will infer the datatype for each column based on the data in your CSV.
 
-You can also explicitly set a datatype using the `column_types` [configuration](reference/configs/column_types.md) like so:
+You can also explicitly set a datatype using the `column_types` [configuration](reference/resource-configs/column_types.md) like so:
 
 <File name='dbt_project.yml'>
 

--- a/website/docs/faqs/seed-datatypes.md
+++ b/website/docs/faqs/seed-datatypes.md
@@ -1,0 +1,18 @@
+---
+title: How do I set a datatype for a column in my seed?
+---
+dbt will infer the datatype for each column based on the data in your CSV.
+
+You can also explicitly set a datatype using the `column_types` [configuration](reference/configs/column_types.md) like so:
+
+<File name='dbt_project.yml'>
+
+```yml
+seeds:
+  jaffle_shop: # you must include the project name
+    warehouse_locations:
+      column_types:
+        zipcode: varchar(5)
+```
+
+</File>

--- a/website/docs/faqs/seed-hooks.md
+++ b/website/docs/faqs/seed-hooks.md
@@ -1,0 +1,11 @@
+---
+title: Do hooks run with seeds?
+---
+
+Yes! The following hooks are available:
+- [pre-hooks](reference/configs/pre-hooks.md)
+- [post-hooks](reference/configs/post-hooks.md)
+- [on-run-start](reference/on-run-end.md)
+- [on-run-end](reference/on-run-end.md)
+
+Configure these in your `dbt_project.yml` file.

--- a/website/docs/faqs/seed-hooks.md
+++ b/website/docs/faqs/seed-hooks.md
@@ -3,9 +3,9 @@ title: Do hooks run with seeds?
 ---
 
 Yes! The following hooks are available:
-- [pre-hooks](reference/configs/pre-hooks.md)
-- [post-hooks](reference/configs/post-hooks.md)
-- [on-run-start](reference/on-run-end.md)
-- [on-run-end](reference/on-run-end.md)
+- [pre-hooks](reference/resource-configs/pre-hook.md)
+- [post-hooks](reference/resource-configs/post-hook.md)
+- [on-run-start](reference/project-configs/on-run-start.md)
+- [on-run-end](reference/project-configs/on-run-end.md)
 
 Configure these in your `dbt_project.yml` file.

--- a/website/docs/faqs/testing-seeds.md
+++ b/website/docs/faqs/testing-seeds.md
@@ -1,0 +1,28 @@
+---
+title: How do I test and document seeds?
+---
+
+To test and document seeds, use a [schema file](docs/building-a-dbt-project/testing-and-documentation/schemayml-files.md) and nest the configurations under a `seeds:` key
+
+## Example:
+
+<File name='data/schema.yml'>
+
+```yml
+version: 2
+
+seeds:
+  - name: country_codes
+    description: A mapping of two letter country codes to country names
+    columns:
+      - name: country_code
+        tests:
+          - unique
+          - not_null
+      - name: country_name
+        tests:
+          - unique
+          - not_null
+```
+
+</File>

--- a/website/docs/reference/config-datatypes.yml
+++ b/website/docs/reference/config-datatypes.yml
@@ -1,0 +1,34 @@
+
+- name: string
+
+- name: [string]
+  description: An array of strings
+
+- name: version
+  description: A valid semantic version number, for example, 0.0.1
+
+- name: directorypath
+  description: A valid path to a directory, relative to the `dbt_project.yml` file. For example, `data` would point to a subdirectory named `data`
+
+- name: [directorypath]
+  description: An array of directory paths
+
+- name: boolean
+  render_as: "true | false" # where `render_as` is not specified, it should be rendered in a dbt_project.yml as the name
+
+- name: version-range
+  description: A valid version range, e.g. `0.1.0`, or `>=0.1.0` or `>=0.1.0<0.2.0`
+
+- name: sql-statement
+  description: A SQL statement that can be executed against a warehouse.
+
+- name: [sql-statements]
+  description: An array of sql-statements
+
+- name: column_name
+  description: The identifier of a column that can be selected from a relation.
+
+- name: column_name_or_expression # this is for like the loaded_at field, but I'll fill it in when we get there
+
+- name: datatype
+  description: A valid datatype according for a data warehouse, e.g. `varchar`

--- a/website/docs/reference/dbt_project.yml.md
+++ b/website/docs/reference/dbt_project.yml.md
@@ -54,8 +54,8 @@ seeds:
 snapshots:
   [<snapshot-configs>](snapshot-configs.md)
 
-[on-run-start](project-configs/on-run-start.md): sql-snippet
-[on-run-end](project-configs/on-run-start.md): sql-snippet
+[on-run-start](project-configs/on-run-start.md): sql-statement
+[on-run-end](project-configs/on-run-start.md): sql-statement
 
 ```
 

--- a/website/docs/reference/dbt_project.yml.md
+++ b/website/docs/reference/dbt_project.yml.md
@@ -1,0 +1,65 @@
+
+<Alert type='warning'>
+<h4>Heads up!</h4>
+This is a work in progress document. It has only been completed for seeds.
+
+</Alert>
+
+Every dbt project needs a `dbt_project.yml` file — this is how dbt knows a directory is a dbt project. It also contains important information that tells dbt how to operate on your project.
+
+The following is a list of all available configurations in the `dbt_project.yml` file.
+
+<Alert type='info'>
+    <h4>YAML syntax</h4>
+    dbt uses YAML in a few different places. If you're new to YAML, it would be worth doing a tutorial to learn how arrays, dictionaries and strings are represented in YAML.
+</Alert>
+
+<File name='dbt_project.yml'>
+
+```yml
+name: string
+
+version: string
+
+profile: profilename
+
+source-paths: [directorypath]
+[data-paths](project-configs/data-paths.md): [directorypath]
+test-paths: [directorypath]
+analysis-paths: [directorypath]
+macro-paths: [directorypath]
+snapshot-paths: [directorypath]
+
+target-path: directorypath
+log-path: directorypath
+modules-path: directorypath
+
+clean-targets: [directorypath]
+
+query-comment: string
+
+require-dbt-version: version-range
+
+quoting:
+  database: true | false
+  identifier: true | false
+  schema: true | false
+
+models:
+  [<model-configs>](model-configs.md)
+
+seeds:
+  [<seed-configs>](seed-configs.md)
+
+snapshots:
+  [<snapshot-configs>](snapshot-configs.md)
+
+[on-run-start](project-configs/on-run-start.md): sql-snippet
+[on-run-end](project-configs/on-run-start.md): sql-snippet
+
+```
+
+</File>
+
+Relevant links:
+* [data-paths](project-configs/data-paths.md)

--- a/website/docs/reference/dbt_project.yml.md
+++ b/website/docs/reference/dbt_project.yml.md
@@ -63,8 +63,8 @@ on-run-end: sql-statement | [sql-statement]
 
 Relevant links:
 * [data-paths](project-configs/data-paths.md)
-* [<model-configs>](model-configs.md)
-* [<seed-configs>](seed-configs.md)
-* [<snapshot-configs>](snapshot-configs.md)
+* [model-configs](model-configs.md)
+* [seed-configs](seed-configs.md)
+* [snapshot-configs](snapshot-configs.md)
 * [on-run-start](project-configs/on-run-start.md)
 * [on-run-end](project-configs/on-run-end.md)

--- a/website/docs/reference/dbt_project.yml.md
+++ b/website/docs/reference/dbt_project.yml.md
@@ -24,7 +24,7 @@ version: string
 profile: profilename
 
 source-paths: [directorypath]
-[data-paths](project-configs/data-paths.md): [directorypath]
+data-paths: [directorypath]
 test-paths: [directorypath]
 analysis-paths: [directorypath]
 macro-paths: [directorypath]
@@ -46,16 +46,16 @@ quoting:
   schema: true | false
 
 models:
-  [<model-configs>](model-configs.md)
+  <model-configs>
 
 seeds:
-  [<seed-configs>](seed-configs.md)
+  <seed-configs>
 
 snapshots:
-  [<snapshot-configs>](snapshot-configs.md)
+  <snapshot-configs>
 
-[on-run-start](project-configs/on-run-start.md): sql-statement
-[on-run-end](project-configs/on-run-start.md): sql-statement
+on-run-start: sql-statement | [sql-statement]
+on-run-end: sql-statement | [sql-statement]
 
 ```
 
@@ -63,3 +63,8 @@ snapshots:
 
 Relevant links:
 * [data-paths](project-configs/data-paths.md)
+* [<model-configs>](model-configs.md)
+* [<seed-configs>](seed-configs.md)
+* [<snapshot-configs>](snapshot-configs.md)
+* [on-run-start](project-configs/on-run-start.md)
+* [on-run-end](project-configs/on-run-end.md)

--- a/website/docs/reference/model-configs.md
+++ b/website/docs/reference/model-configs.md
@@ -1,0 +1,11 @@
+---
+title: Model configurations
+---
+
+<Alert type='danger'>
+
+These docs are a placeholder for a yet-to-be-written reference section.
+
+Please refer to the [docs section](docs/docs/building-a-dbt-project/building-models/configuring-models.md) for current documentation.
+
+</Alert>

--- a/website/docs/reference/project-configs/data-paths.md
+++ b/website/docs/reference/project-configs/data-paths.md
@@ -1,0 +1,39 @@
+---
+datatype: [directorypath]
+default_value: [data]
+---
+## Definition
+Optionally specify a custom list of directories where [seed](docs/building-a-dbt-project.md) files are located.
+
+* Default: `data-paths: ["data"]`
+
+## Examples
+### Use a subdirectory named `seeds` instead of `data`
+
+<File name='dbt_project.yml'>
+
+```yml
+data-paths: ["seeds"]
+```
+
+</File>
+
+### Co-locate your models and seeds in the `models` directory
+
+<File name='dbt_project.yml'>
+
+```yml
+data-paths: ["models"]
+model-paths: ["models"]
+```
+
+</File>
+
+### Split your seeds across two directories
+<File name='dbt_project.yml'>
+
+```yml
+data-paths: ["data", "seeds"]
+```
+
+</File>

--- a/website/docs/reference/project-configs/on-run-end.md
+++ b/website/docs/reference/project-configs/on-run-end.md
@@ -1,0 +1,73 @@
+---
+datatype: sql-statement | [sql-statement]
+---
+<Alert type='warning'>
+<h4>Heads up!</h4>
+This is a work in progress document.
+
+</Alert>
+
+## Definition
+A SQL statement (or list of SQL statements) to be run at the end of the following commands:
+- `dbt run`
+- `dbt seed`
+
+`on-run-end` hooks can also call macros that return SQL statements.
+
+
+## Examples
+### Grant privileges at the end of a run
+
+<File name='dbt_project.yml'>
+
+```yml
+
+on-run-end: "grant select on all tables in schema {{ target.schema }} group transformer"
+
+```
+
+</File>
+
+### Grant multiple privileges at the end of a run
+
+<File name='dbt_project.yml'>
+
+```yml
+
+on-run-end:
+  - "grant usage on schema {{ target.schema }} to group reporter"
+  - "grant select on all tables in schema {{ target.schema }} group reporter"
+
+```
+
+</File>
+
+### Grant privileges on all schemas that dbt uses at the end of a run
+
+<File name='dbt_project.yml'>
+
+```yml
+
+on-run-end:
+  - "{% for schema in schemas %}grant usage on schema {{ schema }} to group reporter; {% endfor %}"
+
+```
+
+</File>
+
+### Call a macro to grant privileges
+
+<File name='dbt_project.yml'>
+
+```yml
+
+on-run-end: "{{ grant_select(schemas) }}"
+
+```
+
+</File>
+
+<!--
+## Available context
+
+-->

--- a/website/docs/reference/project-configs/on-run-start.md
+++ b/website/docs/reference/project-configs/on-run-start.md
@@ -1,0 +1,19 @@
+---
+datatype: sql-statement | [sql-statement]
+---
+<Alert type='warning'>
+<h4>Heads up!</h4>
+
+This is a work in progress document.
+
+</Alert>
+
+## Definition
+A SQL statement (or list of SQL statements) to be run at the start of the following commands:
+- `dbt run`
+- `dbt seed`
+
+`on-run-start` hooks can also call macros that return SQL statements.
+
+## Examples
+`on-run-start` hooks work very similarly to `on-run-end` hooks, check out the [post-hook](post-hook.md) docs for more examples.

--- a/website/docs/reference/resource-configs/alias.md
+++ b/website/docs/reference/resource-configs/alias.md
@@ -1,0 +1,42 @@
+---
+resource_types: [models, seeds]
+datatype: string
+---
+
+<Alert type='warning'>
+<h4>Heads up!</h4>
+This is a work in progress document. While this configuration applies to multiple resource types, the documentation has only been written for seeds.
+
+</Alert>
+
+## Definition
+
+Optionally specify a custom alias for a [model](docs/docs/building-a-dbt-project/building-models.md) or [seed](docs/docs/building-a-dbt-project/seeds.md).
+
+When dbt creates a relation (table/view) in a database, it creates it as: `{{ database }}.{{ schema }}.{{ identifier }}`, e.g. `analytics.finance.payments`
+
+The standard behavior of dbt is:
+* If a custom alias is _not_ specified, the identifier of the relation is the resource name (i.e. the filename).
+* If a custom alias is specified, the identifier of the relation is the `{{ alias }}` value.
+
+To learn more about changing the way that dbt generates a relation's `identifier`, read [Using Aliases](docs/building-a-dbt-project/building-models/using-custom-aliases.md).
+
+
+## Usage
+
+### Seeds
+Configure a seed's alias in your `dbt_project.yml` file.
+
+The seed at `data/country_codes.csv` will be built as a table named `country_mappings`.
+
+<File name='dbt_project.yml'>
+
+```yml
+seeds:
+  jaffle_shop:
+    country_codes:
+      alias: country_mappings
+
+```
+
+</File>

--- a/website/docs/reference/resource-configs/column_types.md
+++ b/website/docs/reference/resource-configs/column_types.md
@@ -1,0 +1,63 @@
+---
+resource_types: [seeds]
+datatype: {column_name: datatype}
+---
+
+## Description
+Optionally specify the database type of columns in a [seed](docs/building-a-dbt-project/seeds.md), by providing a dictionary where the keys are the column names, and the values are a valid datatype (this varies across databases).
+
+Without specifying this, dbt will infer the datatype based on the column values in your seed file.
+
+## Usage
+Specify column types in your `dbt_project.yml` file:
+
+<File name='dbt_project.yml'>
+
+```yml
+seeds:
+  jaffle_shop:
+    country_codes:
+      column_types:
+        country_code: varchar(2)
+        country_name: varchar(32)
+
+```
+
+</File>
+
+If you have previously run `dbt seed`, you'll need to run `dbt seed --full-refresh` for the changes to take effect.
+
+Note that you will need to use the fully directory path of a seed when configuring `column_types`. For example, for a seed file at `data/marketing/utm_mappings.csv`, you will need to configure it like so:
+
+<File name='dbt_project.yml'>
+
+```yml
+seeds:
+  jaffle_shop:
+    marketing:
+      utm_mappings:
+        column_types:
+          ...
+
+```
+
+</File>
+
+## Examples
+
+### Use a varchar column type to preserve leading zeros in a zipcode
+(Note: preservation of leading zeros works for v0.16.0 onwards)
+<File name='dbt_project.yml'>
+
+```yml
+seeds:
+  jaffle_shop: # you must include the project name
+    warehouse_locations:
+      column_types:
+        zipcode: varchar(5)
+```
+
+</File>
+
+## Recommendations
+* Use this configuration only when required, i.e. when the type inference is not working as expected. Otherwise you can omit this configuration.

--- a/website/docs/reference/resource-configs/database.md
+++ b/website/docs/reference/resource-configs/database.md
@@ -1,0 +1,42 @@
+---
+resource_types: [models, seeds]
+datatype: string
+---
+
+<Alert type='warning'>
+<h4>Heads up!</h4>
+This is a work in progress document. While this configuration applies to multiple resource types, the documentation has only been written for seeds.
+
+</Alert>
+
+## Definition
+
+Optionally specify a custom database for a [model](docs/docs/building-a-dbt-project/building-models.md) or [seed](docs/docs/building-a-dbt-project/seeds.md).
+
+When dbt creates a relation (table/view) in a database, it creates it as: `{{ database }}.{{ schema }}.{{ identifier }}`, e.g. `analytics.finance.payments`
+
+The standard behavior of dbt is:
+* If a custom database is _not_ specified, the database of the relation is the target database (`{{ target.database }}`).
+* If a custom database is specified, the database of the relation is the `{{ database }}` value.
+
+To learn more about changing the way that dbt generates a relation's `database`, read [Using Custom Databases](docs/building-a-dbt-project/building-models/using-custom-database.md)
+
+## Usage
+### Load seeds into the RAW database
+<File name='dbt_project.yml'>
+
+```yml
+seeds:
+  database: RAW
+
+```
+
+</File>
+
+## Warehouse specific information
+* BigQuery: `project` and `database` are interchangeable
+* Redshift: Cross-database queries are not possible in Redshift. As such, dbt will return a Database Error if you use this configuration.
+
+
+## Changelog
+* v0.16.0: Introduced in v0.16.0

--- a/website/docs/reference/resource-configs/enabled.md
+++ b/website/docs/reference/resource-configs/enabled.md
@@ -1,0 +1,34 @@
+---
+resource_types: all
+datatype: boolean
+default_value: true
+---
+
+## Definition
+An optional configuration for disabling models, seeds, and snapshots.
+
+* Default: true
+
+When a resource is disabled, dbt will not consider it as part of your project. Note that this can cause compilation errors.
+
+If you instead want to exclude a model from a particular run, consider using the `--exclude` parameter as part of the [model selection syntax](docs/running-a-dbt-project/command-line-interface/model-selection-syntax.md)
+
+If you are disabling models because they are no longer being used, but you want to version control their SQL, consider making them an [analysis](docs/building-a-dbt-project/analyses.md) instead.
+
+## Examples
+### Disable a model in a package in order to use your own version of the model.
+This could be useful if you want to change the logic of a model in a package. For example, if you need to change the logic in the `segment_web_page_views` from the `segment` package ([original model](https://github.com/fishtown-analytics/segment/blob/master/models/base/segment_web_page_views.sql)):
+1. Add a model named `segment_web_page_views` the same name to your own project.
+2. To avoid a compilation error due to duplicate models, disable the segment package's version of the model like so:
+
+<File name='dbt_project.yml'>
+
+```yml
+models:
+  segment:
+    base:
+      segment_web_page_views:
+        enabled: false
+```
+
+</File>

--- a/website/docs/reference/resource-configs/post-hook.md
+++ b/website/docs/reference/resource-configs/post-hook.md
@@ -1,0 +1,59 @@
+---
+resource_types: [models, seeds]
+datatype: sql-statement | [sql-statement]
+---
+
+<Alert type='warning'>
+<h4>Heads up!</h4>
+
+This is a work in progress document. While this configuration applies to multiple resource types, the documentation has only been written for seeds.
+
+</Alert>
+
+
+## Definition
+A SQL statement (or list of SQL statements) to be run after a model is built / a seed is built.
+
+Post-hooks can also call macros that return SQL statements.
+
+## Examples
+### Grant select privileges on a seed
+
+<File name='dbt_project.yml'>
+
+```yml
+
+seeds:
+  post-hook: "grant select on {{ this }} to group reporter"
+
+```
+
+</File>
+
+### Grant multiple select privileges on a seed
+
+<File name='dbt_project.yml'>
+
+```yml
+
+seeds:
+  post-hook:
+    - "grant select on {{ this }} to group reporter"
+    - "grant select on {{ this }} to group transformer"
+
+```
+
+</File>
+
+### Call a macro to grant select privileges on a seed
+
+<File name='dbt_project.yml'>
+
+```yml
+
+seeds:
+  post-hook: "{{ grant_select(this) }}"
+
+```
+
+</File>

--- a/website/docs/reference/resource-configs/pre-hook.md
+++ b/website/docs/reference/resource-configs/pre-hook.md
@@ -1,0 +1,18 @@
+---
+resource_types: [models, seeds]
+datatype: sql-statement | [sql-statement]
+---
+
+<Alert type='warning'>
+<h4>Heads up!</h4>
+This is a work in progress document. While this configuration applies to multiple resource types, the documentation has only been written for seeds.
+
+</Alert>
+
+## Definition
+A SQL statement to be run after a model is created / a seed is updated.
+
+Pre-hooks can also call macros that return SQL statements.
+
+## Examples
+Pre-hooks work very similarly to post-hooks, check out the [post-hook](post-hook.md) docs for more examples.

--- a/website/docs/reference/resource-configs/quote_columns.md
+++ b/website/docs/reference/resource-configs/quote_columns.md
@@ -1,0 +1,45 @@
+---
+resource_types: [seeds]
+datatype: boolean
+default_value: false
+---
+
+## Definition
+An optional seed configuration, used to determine whether column names in the seed file should be quoted when the table is created.
+
+* When `True`, dbt will quote the column names defined in the seed file when building a table for the seed, preserving casing.
+* (Default) When `False`, dbt will not quote the column names defined in the seed file.
+
+## Usage
+### Globally quote all seed columns
+
+<File name='dbt_project.yml'>
+
+```yml
+seeds:
+  quote_columns: true
+```
+
+</File>
+
+### Only quote seeds in the `data/mappings` directory.
+For a project with:
+* `name: jaffle_shop` in the `dbt_project.yml` file
+* `data-paths: ["data"]` in the `dbt_project.yml` file
+
+```yml
+seeds:
+  jaffle_shop:
+    mappings:
+      quote_columns: true
+```
+
+
+## Changelog
+* v0.15.0: Introduced in v0.15.0, with a default of False
+* Future: The default value may change in a future release. If you're using seed files, it is recommended that you set this configuration explicitly to avoid breaking changes in the future.
+
+## Recommended configuration
+* Explicitly set this value if using seed files.
+* Apply the configuration globally rather than to individual projects/seeds.
+* Set `quote_columns: false` _unless_ your column names include a special character or casing needs to be preserved. In that case, consider renaming your seed columns (this will simplify code downstream)

--- a/website/docs/reference/resource-configs/schema.md
+++ b/website/docs/reference/resource-configs/schema.md
@@ -1,0 +1,63 @@
+---
+resource_types: [models, seeds]
+datatype: string
+---
+
+<Alert type='warning'>
+<h4>Heads up!</h4>
+This is a work in progress document. While this configuration applies to multiple resource types, the documentation has only been written for seeds.
+
+</Alert>
+
+## Definition
+Optionally specify a custom schema for a [model](docs/docs/building-a-dbt-project/building-models.md) or [seed](docs/docs/building-a-dbt-project/seeds.md).
+
+When dbt creates a relation (table/view) in a database, it creates it as: `{{ database }}.{{ schema }}.{{ identifier }}`, e.g. `analytics.finance.payments`
+
+The standard behavior of dbt is:
+* If a custom schema is _not_ specified, the schema of the relation is the target schema (`{{ target.schema }}`).
+* If a custom schema is specified, by default, the schema of the relation is `{{ target.schema }}_{{ schema }}`.
+
+To learn more about changing the way that dbt generates a relation's `schema`, read [Using Custom Schemas](docs/docs/building-a-dbt-project/building-models/using-custom-schemas.md)
+
+## Usage
+
+### Models
+
+Configure groups of models from the `dbt_project.yml` file.
+
+<File name='dbt_project.yml'>
+
+```
+models:
+  jaffle_shop: # the name of a project
+    marketing:
+      schema: marketing
+```
+
+</File>
+
+Configure individual models using a config block:
+
+<File name='models/my_model.sql'>
+
+```sql
+{{ config(
+    schema='marketing'
+) }}
+```
+
+</File>
+
+### Seeds
+<File name='dbt_project.yml'>
+
+```
+seeds:
+  schema: mappings
+```
+
+</File>
+
+## Warehouse specific information
+* BigQuery: `dataset` and `schema` are interchangeable

--- a/website/docs/reference/resource-configs/tags.md
+++ b/website/docs/reference/resource-configs/tags.md
@@ -1,0 +1,43 @@
+---
+resource_types: all
+datatype: string | [string]
+---
+<Alert type='warning'>
+<h4>Heads up!</h4>
+This is a work in progress document.
+
+</Alert>
+
+## Definition
+Apply a tag (or list of tags) to a resource (models, seeds).
+
+Tags can be used to select resources when running the following commands:
+- `dbt run`
+- `dbt seed`
+
+## Examples
+### Seeds
+
+<File name='dbt_project.yml'>
+
+```yml
+seeds:
+  jaffle_shop:
+    utm_mappings:
+      tags: marketing
+```
+
+</File>
+
+<File name='dbt_project.yml'>
+
+```yml
+seeds:
+  jaffle_shop:
+    utm_mappings:
+      tags:
+        - marketing
+        - hourly
+```
+
+</File>

--- a/website/docs/reference/seed-configs.md
+++ b/website/docs/reference/seed-configs.md
@@ -1,0 +1,98 @@
+---
+title: Seed configurations
+---
+
+## Available configurations
+
+* [quote_columns](resource-configs/quote_columns.md): true | false
+* [enabled](resource-configs/enabled.md): true | false
+* [schema](resource-configs/schema.md): string
+* [database](resource-configs/database.md): string
+* [alias](resource-configs/alias.md): string
+* [pre-hook](resource-configs/pre-hook.md): sql-statement
+* [post-hook](resource-configs/post-hook.md): sql-statement
+* [column_types](resource-configs/column_types.md): {column_name: datatype}
+* [tags](resource-configs/tags.md): string | [string]
+
+## Configuring seeds
+Seeds can only be configured from the `dbt_project.yml` file, under the `seeds:` key. To apply a configuration to a seed, or directory of seeds, define the resource path as nested dictionary keys.
+
+Seed configurations, like model configurations, are applied hierarchically — configurations applied to a `marketing` subdirectory will take precedence over configurations applied to the entire `jaffle_shop` project.
+
+### Examples
+#### Apply the `schema` configuration to all seeds
+To apply a configuration to all seeds, nest it directly under the `seeds` key:
+
+<File name='dbt_project.yml'>
+
+```yml
+
+seeds:
+  schema: seed_data
+```
+
+</File>
+
+
+#### Apply the `schema` configuration to all seeds in your project
+To apply a configuration to all seeds in a project, provide the project name as part of the resource path.
+<!-- To-do: hyperlink project name -->
+
+For a project named `jaffle_shop`:
+
+<File name='dbt_project.yml'>
+
+```yml
+
+seeds:
+  jaffle_shop:
+    schema: seed_data
+```
+
+</File>
+
+#### Apply the `schema` configuration to one seed only
+To apply a configuration to one seed only, provide the full resource path (including the project name, and subdirectories).
+
+For a project named `jaffle_shop`, with a seed file at `data/marketing/utm_parameters.csv`:
+
+<File name='dbt_project.yml'>
+
+```yml
+seeds:
+  jaffle_shop:
+    marketing:
+      utm_parameters:
+        schema: seed_data
+```
+
+</File>
+
+
+## Example seed configuration
+The following is a valid seed configuration for a project with:
+* `name: jaffle_shop`
+* A seed file at `data/country_codes.csv`, and
+* A seed file at `data/marketing/utm_parameters.csv`
+
+
+<File name='dbt_project.yml'>
+
+```yml
+name: jaffle_shop
+...
+seeds:
+  jaffle_shop:
+    enabled: true
+    schema: seed_data
+    # This configures data/country_codes.csv
+    country_codes:
+      # Override column types
+      column_types:
+        country_code: varchar(2)
+        country_name: varchar(32)
+    marketing:
+      schema: marketing # this will take precedence
+```
+
+</File>

--- a/website/docs/reference/seed-configs.md
+++ b/website/docs/reference/seed-configs.md
@@ -9,8 +9,8 @@ title: Seed configurations
 * [schema](resource-configs/schema.md): string
 * [database](resource-configs/database.md): string
 * [alias](resource-configs/alias.md): string
-* [pre-hook](resource-configs/pre-hook.md): sql-statement
-* [post-hook](resource-configs/post-hook.md): sql-statement
+* [pre-hook](resource-configs/pre-hook.md): sql-statement | [sql-statement]
+* [post-hook](resource-configs/post-hook.md): sql-statement | [sql-statement]
 * [column_types](resource-configs/column_types.md): {column_name: datatype}
 * [tags](resource-configs/tags.md): string | [string]
 

--- a/website/docs/reference/snapshot-configs.md
+++ b/website/docs/reference/snapshot-configs.md
@@ -1,0 +1,11 @@
+---
+title: Snapshot configurations
+---
+
+<Alert type='danger'>
+
+These docs are a placeholder for a yet-to-be-written reference section.
+
+Please refer to the [docs section](docs/docs/building-a-dbt-project/snapshots.md) for current documentation.
+
+</Alert>

--- a/website/docs/tutorial/add-a-seed.md
+++ b/website/docs/tutorial/add-a-seed.md
@@ -1,0 +1,34 @@
+---
+title: Add a seed file
+id: add-a-seed
+description: Learn how to add a seed file to your project
+---
+<Callout type='warning' title="Heads up!">
+You'll need to have completed the Getting Started part of this tutorial to
+complete this lesson
+</Callout>
+
+1. Add a seed file:
+
+<File name='data/country_codes.csv'>
+
+```text
+country_code,country_name
+US,United States
+CA,Canada
+GB,United Kingdom
+...
+```
+
+</File>
+
+2. Run `dbt seed`
+3. Ref the model in a downstream model
+
+<File name='models/something.sql'>
+
+```sql
+select * from {{ ref('country_codes') }}
+```
+
+</File>

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -36,6 +36,11 @@ module.exports = {
           position: 'left',
         },
         {
+          to: '/reference/dbt_project.yml',
+          label: 'Reference',
+          position: 'left',
+        },
+        {
           to: '/tutorial/setting-up',
           label: 'Tutorial',
           position: 'left',

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -258,9 +258,6 @@ module.exports = {
       "tutorial/build-your-first-models",
       "tutorial/test-and-document-your-project",
       "tutorial/deploy-your-project"
-    ],
-    "Building out your project": [
-      "tutorial/add-a-seed"
     ]
   },
   learn: {

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -236,7 +236,14 @@ module.exports = {
     ],
     About: ["docs/about/license", "docs/about/viewpoint"]
   },
-
+  reference: {
+    "Configurations": [
+      "reference/dbt_project.yml",
+      "reference/model-configs",
+      "reference/seed-configs",
+      "reference/snapshot-configs"
+    ]
+  },
   tutorial: {
     "Getting Started": [
       "tutorial/setting-up",
@@ -251,6 +258,9 @@ module.exports = {
       "tutorial/build-your-first-models",
       "tutorial/test-and-document-your-project",
       "tutorial/deploy-your-project"
+    ],
+    "Building out your project": [
+      "tutorial/add-a-seed"
     ]
   },
   learn: {


### PR DESCRIPTION
## Description & motivation
* Redo seeds docs to leverage FAQ structure + a new reference section
* Include placeholder docs for other reference sections to be written

## To-do before merge
- [x] Fact checking, esp. around hooks and quote_columns advice
- [x] Proof reading — I need to step away and come back to it to do this :) 
- [ ] Get the hyperlinked yaml working in the `dbt_project.yml` docs
- [ ] Component-ify the configs sections so they render on the page
- [ ] Ensure each config will show up as a sensible search result
- [x] Ensure we don't break existing redirects, esp. around the `reference` path

## Notes
- There's still a few tiny inconsistencies in the docs — some say "usage", others just have "examples". I'm not too fussed right now as I think we'll figure out what we want to do as we build more of these reference pages.