### PR TITLE
Redirect tutorial.getdbt.com to docs.getdbt.com

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -141,3 +141,4 @@
 /docs/viewpoint	/docs/about/viewpoint	302
 /docs/windows	/docs/running-a-dbt-project/using-the-command-line-interface/windows	302
 /reference/	/dbt-cloud/api	302
+https://tutorial.getdbt.com/* https://docs.getdbt.com/:splat 301!


### PR DESCRIPTION
## Description & motivation
Redirect tutorial.getdbt.com to docs.getdbt.com