### PR TITLE
add redirect from /docs to /docs/introduction

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,3 +1,4 @@
+/docs	/docs/introduction	302
 /docs/adapter	/docs/writing-code-in-dbt/jinja-context/adapter	302
 /docs/analyses	/docs/building-a-dbt-project/analyses	302
 /docs/api-variable	/docs/writing-code-in-dbt/api-variable	302


### PR DESCRIPTION
## Description & motivation
Redirects `/docs`/ to `/docs/introduction`. `/docs` was the landing page for Readme.io docs
