### PR TITLE
Update exceptions example

### DIFF
--- a/website/docs/docs/writing-code-in-dbt/jinja-context/exceptions.md
+++ b/website/docs/docs/writing-code-in-dbt/jinja-context/exceptions.md
@@ -31,7 +31,7 @@ __Example usage__:
 
 ```sql
 {% if number < 0 or number > 100 %}
-  {{ exceptions.warn("Invalid `number`. Got: " ~ number) }}
+  {% do exceptions.warn("Invalid `number`. Got: " ~ number) %}
 {% endif %}
 ```
 


### PR DESCRIPTION
Noticed this today when I went to use it for the first time. If you use `{{ exceptions.warn("hello") }}` it gets resolved to `None` which can mess with your SQL.

@drewbanin -- Would you consider this a dbt bug? I expected this to work similarly to `{{ log() }}`, but my guess is that `log` was hacked to not return `None`.