### PR TITLE
Fix syntax highlighting for no-partial-parse

### DIFF
--- a/website/docs/docs/running-a-dbt-project/using-the-command-line-interface/configure-your-profile.md
+++ b/website/docs/docs/running-a-dbt-project/using-the-command-line-interface/configure-your-profile.md
@@ -184,7 +184,7 @@ config:
   partial_parse: True
 ```
 
-This value can be overridden using the `--partial-parse` or --no-partial-parse` flags.
+This value can be overridden using the `--partial-parse` or `--no-partial-parse` flags.
 
 ### Using colors in terminal output
 By default, dbt will colorize the output it prints in your terminal. You can turn this off by adding the following to your `profiles.yml` file:


### PR DESCRIPTION
## Description & motivation

Tiny docs fix to close a '`' tag.