### PR TITLE
Remove trailing quote from oauth command

### DIFF
--- a/website/docs/docs/supported-databases/profile-bigquery.md
+++ b/website/docs/docs/supported-databases/profile-bigquery.md
@@ -114,7 +114,7 @@ To connect to BigQuery using the `oauth` method, follow these steps:
 2. Activate the application-default account with
 
 ```shell
-gcloud auth application-default login --scopes=https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/drive.readonly"
+gcloud auth application-default login --scopes=https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/drive.readonly
 ```
 
 A browser window should open, and you should be promoted to log into your Google account. Once you've done that, dbt will use your oauth'd credentials to connect to BigQuery!


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

Copying the `gcloud` oauth command didn't work as the command had a trailing quote `"`. 

Removing it allows the command to work as displayed.

## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged
-->

¯\\_(ツ)_/¯