### PR TITLE
Add migration guides for old dbt versions

### DIFF
--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-12-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-12-0.md
@@ -1,0 +1,9 @@
+---
+title: "Upgrading to 0.12.0"
+id: "upgrading-to-0-12-0"
+---
+
+## End of support
+
+Support for the `repositories:` block in `dbt_project.yml` (deprecated in 0.10.0) was removed.
+In order to install packages in your dbt project, you must use a [`packages.yml`](package-management#how-do-i-add-a-package-to-my-project) file.

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-13-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-13-0.md
@@ -1,0 +1,27 @@
+---
+title: "Upgrading to 0.13.0"
+id: "upgrading-to-0-13-0"
+---
+
+## Breaking changes
+
+### on-run-start and on-run-end
+
+The special Jinja variable `{{this}}` is no longer implemented for `on-run-start` and `on-run-end` hooks. 
+Use `{{ target }}` or an [`on-run-end` context variable](on-run-end-context) instead.
+
+### Adapter methods
+
+A number of materialization-specific adapter methods have changed in breaking ways. If you use these adapter methods in your macros or materializations, you may need to update your code accordingly.
+  - query_for_existing - **removed**, use [get_relation](adapter/#get_relation) instead.
+  - [get_missing_columns](adapter/#get_missing_columns) - changed to take `Relation`s instead of schemas and identifiers
+  - [expand_target_column_types](adapter#expand_target_column_types) - changed to take a `Relation` instead of schema, identifier
+  - [get_relation](adapter/#get_relation) - added a `database` argument
+  - [create_schema](adapter#create_schema) - added a `database` argument
+  - [drop_schema](adapter#drop_schema) - added a `database` argument
+
+## End of support
+
+Version 1 schema.yml specs (deprecated in 0.11.0) are no longer supported. 
+Please use the version 2 spec instead. 
+See the [0.11.0 migration guide](upgrading-from-0-10-to-0-11#section-schema-yml-v2-syntax) for details.

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-15-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-15-0.md
@@ -1,0 +1,40 @@
+---
+title: "Upgrading to 0.15.0"
+id: "upgrading-to-0-15-0"
+---
+
+The dbt v0.15.0 release contains a handful of breaking code changes for users upgrading from v0.14.0.
+
+## Breaking changes
+
+### Stricter YML compilation
+ 
+Previous versions of dbt would raise warnings and ignore improperly formatted `.yml` files.
+Compilation errors in .yml files are now treated as errors instead of warnings.
+
+### Relation class
+
+The `table_name` field has been removed from Relations. Macros that
+expect this field will now return errors. See the latest 
+[class reference](docs/class-reference#Relation) for details.
+
+### Custom materializations
+
+All materializations must now [manage dbt's Relation cache](creating-new-materializations#section-6-update-the-relation-cache).
+
+### dbt Server
+
+The existing `compile` and `execute` rpc tasks have been renamed to `compile_sql` and `execute_sql`.
+For more details, see the latest [rpc docs](rpc).
+
+## Python requirements
+
+dbt v0.15.0 removes support for for Python 2.x, [as it will no longer be supported on January 1, 2020](https://www.python.org/dev/peps/pep-0373/).
+
+If you are installing dbt in a Python environment alongside other Python modules,
+please be mindful of the following changes to dbt's Python dependencies:
+
+- Dropped support for networkx 1.x
+- Upgraded werkzeug to 0.15.6
+- Pinned psycopg2 dependency to 2.8.x to prevent segfaults
+- Set a strict upper bound for jsonschema dependency


### PR DESCRIPTION
## Description & motivation

> We’re going to push to remove old/deprecated versions of dbt from Cloud. We want to remove everything < 0.13 and help users upgrade if they’re that far behind.
>
> The only thing for us to do is update the migration guides in the dbt docs to include an upgrading guide for these very old versions of dbt.

## To-do before merge

This is my first time editing the docs since they moved to Docusaurus, so I want to be sure that:
- [ ] All relative links are working