### PR TITLE
Spark, Presto, incremental strategy updates

### DIFF
--- a/website/docs/docs/building-a-dbt-project/building-models/bigquery-configs.md
+++ b/website/docs/docs/building-a-dbt-project/building-models/bigquery-configs.md
@@ -353,13 +353,11 @@ select * from {{ ref('another_model') }}
 
 ## Merge behavior (incremental models)
 
-The `incremental_strategy` config controls how dbt builds incremental models. dbt uses a [merge statement](https://cloud.google.com/bigquery/docs/reference/standard-sql/dml-syntax) on BigQuery to refresh incremental tables.
+The [`incremental_strategy` config](configuring-incremental-models#what-is-an-incremental_strategy) controls how dbt builds incremental models. dbt uses a [merge statement](https://cloud.google.com/bigquery/docs/reference/standard-sql/dml-syntax) on BigQuery to refresh incremental tables.
 
 The `incremental_strategy` config can be set to one of two values:
  - `merge` (default)
  - `insert_overwrite`
- 
- See also: [configuring incremental strategy](docs/configuring-incremental-models#configuring-incremental-strategy).
 
 ### Performance and cost
 

--- a/website/docs/docs/building-a-dbt-project/building-models/bigquery-configs.md
+++ b/website/docs/docs/building-a-dbt-project/building-models/bigquery-configs.md
@@ -358,6 +358,8 @@ The `incremental_strategy` config controls how dbt builds incremental models. db
 The `incremental_strategy` config can be set to one of two values:
  - `merge` (default)
  - `insert_overwrite`
+ 
+ See also: [configuring incremental strategy](docs/configuring-incremental-models#configuring-incremental-strategy).
 
 ### Performance and cost
 
@@ -390,6 +392,12 @@ This can be slow and costly if the incremental model is transforming very large 
 strategy is selected.
 
 ### The `insert_overwrite` strategy
+
+<Callout type="info" title="New in dbt v0.16.0">
+
+This functionality is new in dbt v0.16.0. For upgrading instructions, check out [the docs](installation)
+
+</Callout>
 
 The `insert_overwrite` strategy generates a merge statement that replaces entire partitions
 in the destination table. **Note:** this configuration requires that the model is configured
@@ -523,37 +531,3 @@ with events as (
 
 ... rest of model ...
 ```
-
-### Configuring incremental strategy
-
-The `incremental_strategy` config can either be specified in specific models, or
-for all models in your `dbt_project.yml` file:
-
-<File name='dbt_project.yml'>
-
-```yaml
-# Your dbt_project.yml file
-
-models:
-  incremental_strategy: "insert_overwrite"
-```
-
-</File>
-
-or:
-
-<File name='models/my_model.sql'>
-
-```sql
-{{
-  config(
-    materialized='incremental',
-    incremental_strategy='insert_overwrite',
-    ...
-  )
-}}
-
-select ...
-```
-
-</File>

--- a/website/docs/docs/building-a-dbt-project/building-models/configuring-incremental-models.md
+++ b/website/docs/docs/building-a-dbt-project/building-models/configuring-incremental-models.md
@@ -154,8 +154,8 @@ On some adapters, an optional `incremental_strategy` config controls the code th
 to build incremental models. Different approaches may vary by effectiveness depending on the volume of data,
 the reliability of your `unique_key`, or the availability of certain features.
 
-* [Snowflake](snowflake-configs/#merge-behavior-incremental-models): `merge` (default), `delete+insert` (optional)
-* [BigQuery](bigquery-configs/#merge-behavior-incremental-models): `merge` (default), `insert_overwrite` (optional)
+* [Snowflake](snowflake-configs#merge-behavior-incremental-models): `merge` (default), `delete+insert` (optional)
+* [BigQuery](bigquery-configs#merge-behavior-incremental-models): `merge` (default), `insert_overwrite` (optional)
 * [Spark](spark-configs#incremental-models): `insert_overwrite` (default), `merge` (optional, Delta-only)
 
 ### Configuring incremental strategy

--- a/website/docs/docs/building-a-dbt-project/building-models/configuring-incremental-models.md
+++ b/website/docs/docs/building-a-dbt-project/building-models/configuring-incremental-models.md
@@ -150,13 +150,13 @@ Instead, whenever the logic of your incremental changes, execute a full-refresh 
 
 ## What is an incremental_strategy?
 
-On some adapters, the `incremental_strategy` config controls how dbt builds incremental models.
-The different approaches vary by effectiveness depending on the volume of data and the reliability
-of your `unique_key`.
+On some adapters, an optional `incremental_strategy` config controls the code that dbt uses
+to build incremental models. Different approaches may vary by effectiveness depending on the volume of data,
+the reliability of your `unique_key`, or the availability of certain features.
 
-* [Snowflake](docs/snowflake-configs/#merge-behavior-incremental-models): `merge` (default), `delete+insert` (optional)
-* [BigQuery]((docs/bigquery-configs/#merge-behavior-incremental-models)): `merge` (default), `insert_overwrite` (optional)
-* Spark: `insert_overwrite` (default), `merge` (optional, Delta-only)
+* [Snowflake](snowflake-configs/#merge-behavior-incremental-models): `merge` (default), `delete+insert` (optional)
+* [BigQuery](bigquery-configs/#merge-behavior-incremental-models): `merge` (default), `insert_overwrite` (optional)
+* [Spark](spark-configs#incremental-models): `insert_overwrite` (default), `merge` (optional, Delta-only)
 
 ### Configuring incremental strategy
 

--- a/website/docs/docs/building-a-dbt-project/building-models/configuring-incremental-models.md
+++ b/website/docs/docs/building-a-dbt-project/building-models/configuring-incremental-models.md
@@ -147,3 +147,47 @@ If you add a column from your incremental model, and execute a `dbt run`, this c
 Similarly, if you remove a column from your incremental model, and execute a `dbt run`, this column will _not_ be removed from your target table.
 
 Instead, whenever the logic of your incremental changes, execute a full-refresh run of both your incremental model and any downstream models.
+
+## What is an incremental_strategy?
+
+On some adapters, the `incremental_strategy` config controls how dbt builds incremental models.
+The different approaches vary by effectiveness depending on the volume of data and the reliability
+of your `unique_key`.
+
+* [Snowflake](docs/snowflake-configs/#merge-behavior-incremental-models): `merge` (default), `delete+insert` (optional)
+* [BigQuery]((docs/bigquery-configs/#merge-behavior-incremental-models)): `merge` (default), `insert_overwrite` (optional)
+* Spark: `insert_overwrite` (default), `merge` (optional, Delta-only)
+
+### Configuring incremental strategy
+
+The `incremental_strategy` config can either be specified in specific models, or
+for all models in your `dbt_project.yml` file:
+
+<File name='dbt_project.yml'>
+
+```yaml
+# Your dbt_project.yml file
+
+models:
+  incremental_strategy: "insert_overwrite"
+```
+
+</File>
+
+or:
+
+<File name='models/my_model.sql'>
+
+```sql
+{{
+  config(
+    materialized='incremental',
+    incremental_strategy='insert_overwrite',
+    ...
+  )
+}}
+
+select ...
+```
+
+</File>

--- a/website/docs/docs/building-a-dbt-project/building-models/snowflake-configs.md
+++ b/website/docs/docs/building-a-dbt-project/building-models/snowflake-configs.md
@@ -42,11 +42,9 @@ select * from ...
 
 ## Merge behavior (incremental models)
 
-The `incremental_strategy` config controls how dbt builds incremental models. By default, dbt will use a [merge statement](https://docs.snowflake.net/manuals/sql-reference/sql/merge.html) on Snowflake to refresh incremental tables.
+The [`incremental_strategy` config](configuring-incremental-models#what-is-an-incremental_strategy) controls how dbt builds incremental models. By default, dbt will use a [merge statement](https://docs.snowflake.net/manuals/sql-reference/sql/merge.html) on Snowflake to refresh incremental tables.
 
 Snowflake's `merge` statement fails with a "nondeterministic merge" error if the `unique_key` specified in your model config is not actually unique. If you encounter this error, you can instruct dbt to use a two-step incremental approach by setting the `incremental_strategy` config for your model to `delete+insert`. 
-
-See also: [configuring incremental strategy](docs/configuring-incremental-models#configuring-incremental-strategy).
 
 ## Configuring table clustering
 

--- a/website/docs/docs/building-a-dbt-project/building-models/snowflake-configs.md
+++ b/website/docs/docs/building-a-dbt-project/building-models/snowflake-configs.md
@@ -46,36 +46,7 @@ The `incremental_strategy` config controls how dbt builds incremental models. By
 
 Snowflake's `merge` statement fails with a "nondeterministic merge" error if the `unique_key` specified in your model config is not actually unique. If you encounter this error, you can instruct dbt to use a two-step incremental approach by setting the `incremental_strategy` config for your model to `delete+insert`. 
 
-This config can either be specified in specific models, or for all models in your `dbt_project.yml` file:
-
-<File name='dbt_project.yml'>
-
-```yaml
-# Your dbt_project.yml file
-
-models:
-  incremental_strategy: "delete+insert"
-```
-
-</File>
-
-or:
-
-<File name='models/my_model.sql'>
-
-```sql
-{{
-  config(
-    materialized='incremental',
-    unique_key='id',
-    incremental_strategy='delete+insert'
-  )
-}}
-
-select ...
-```
-
-</File>
+See also: [configuring incremental strategy](docs/configuring-incremental-models#configuring-incremental-strategy).
 
 ## Configuring table clustering
 

--- a/website/docs/docs/building-a-dbt-project/building-models/spark-configs.md
+++ b/website/docs/docs/building-a-dbt-project/building-models/spark-configs.md
@@ -1,0 +1,133 @@
+---
+title: "Spark specific configurations"
+id: "spark-configs"
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+## Properties of Spark tables
+
+When materializing a model as `table`, you may include several optional configs:
+
+| Option  | Description                                        | Required?               | Example                  |
+|---------|----------------------------------------------------|-------------------------|--------------------------|
+| file_format | The file format to use when creating tables (`parquet`, `delta`, `csv`, `json`, `text`, `jdbc`, `orc`, `hive` or `libsvm`). | Optional | `parquet`|
+| location_root  | The created table uses the specified directory to store its data. The table alias is appended to it. | Optional                | `/mnt/root`              |
+| partition_by  | Partition the created table by the specified columns. A directory is created for each partition. | Optional                | `partition_1`              |
+| clustered_by  | Each partition in the created table will be split into a fixed number of buckets by the specified columns. | Optional               | `cluster_1`              |
+| buckets  | The number of buckets to create while clustering | Required if `clustered_by` is specified                | `8`              |
+
+## Incremental Models
+
+The `incremental_strategy` config controls how dbt builds incremental models, and it can be set to one of two values:
+ - `insert_overwrite` (default)
+ - `merge` (Delta Lake only)
+ 
+ See also: [configuring incremental strategies](docs/configuring-incremental-models#configuring-incremental-strategies).
+
+### The `insert_overwrite` strategy
+
+Apache Spark does not natively support `delete`, `update`, or `merge` statements. As such, [incremental models](configuring-incremental-models) are implemented differently than usual in this plugin. To use incremental models, specify a `partition_by` clause in your model config. dbt will run an `insert overwrite` statement to dynamically overwrite the partitions included in your query. Be sure to re-select _all_ of the relevant data for a partition when using incremental models.
+
+<File name='spark_incremental.sql'>
+
+```sql
+{{ config(
+    materialized='incremental',
+    partition_by=['date_day'],
+    file_format='parquet'
+) }}
+
+/*
+  Every partition returned by this query will be overwritten
+  when this model runs
+*/
+
+select
+    date_day,
+    count(*) as users
+
+from {{ ref('events') }}
+where date_day::date >= '2019-01-01'
+group by 1
+```
+
+</File>
+
+### The `merge` strategy
+
+<Callout type="info" title="New in dbt-spark v0.15.3">
+
+This functionality is new in dbt-spark v0.15.3
+
+</Callout>
+
+There are three prerequisites for the `merge` incremental strategy:
+- Delta file format
+- Databricks Runtime 5.1 and above
+- Specify a `unique_key`
+
+dbt will run an atomic `merge` statement which looks nearly identical to the default merge behavior on Snowflake and BigQuery.
+
+<File name='delta_incremental.sql'>
+
+```sql
+{{ config(
+    materialized='incremental',
+    file_format='delta',
+    unique_key='user_id',
+    incremental_strategy='merge'
+) }}
+
+select
+    user_id,
+    max(date_day) as last_seen
+
+from {{ ref('events') }}
+where date_day::date >= '2019-01-01'
+group by 1
+```
+
+</File>
+
+## Persisting model descriptions
+
+<Callout type="info" title="New in dbt-spark v0.15.3">
+
+This functionality is new in dbt-spark v0.15.3
+
+</Callout>
+
+The `persist_docs` config can be used to persist the dbt `description` supplied for a model to the resulting Spark table or view. The `persist_docs` config is not yet supported for objects other than tables and views.
+
+The `persist_docs` config can be specified in the `dbt_project.yml` file, or in a specific model.
+
+<File name='dbt_project.yml'>
+
+```yaml
+
+models:
+  # enable docs persistence for all models
+  persist_docs:
+    relation: true
+```
+
+</File>
+
+or:
+
+<File name='models/my_model.sql'>
+
+```sql
+{{
+  config(persist_docs={"relation": true})
+}}
+
+select ...
+```
+
+</File>
+
+When the `persist_docs` option is configured appropriately, you'll be able to see your model descriptions
+in the `Comment` field of `describe [table] extended` or `show table extended in [database] like '*'`.

--- a/website/docs/docs/building-a-dbt-project/building-models/spark-configs.md
+++ b/website/docs/docs/building-a-dbt-project/building-models/spark-configs.md
@@ -6,7 +6,7 @@ id: "spark-configs"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-## Properties of Spark tables
+## Configuring Spark tables
 
 When materializing a model as `table`, you may include several optional configs:
 
@@ -26,7 +26,18 @@ The [`incremental_strategy` config](configuring-incremental-models#what-is-an-in
 
 ### The `insert_overwrite` strategy
 
-Apache Spark does not natively support `delete`, `update`, or `merge` statements. As such, [incremental models](configuring-incremental-models) are implemented differently than usual in this plugin. To use incremental models, specify a `partition_by` clause in your model config. dbt will run an `insert overwrite` statement to dynamically overwrite the partitions included in your query. Be sure to re-select _all_ of the relevant data for a partition when using incremental models.
+Apache Spark does not natively support `delete`, `update`, or `merge` statements. As such, Spark's default incremental behavior is different [from the standard](configuring-incremental-models).
+
+To use incremental models, specify a `partition_by` clause in your model config. dbt will run an [atomic `insert overwrite` statement](https://spark.apache.org/docs/3.0.0-preview/sql-ref-syntax-dml-insert-overwrite-table.html) that dynamically replaces all partitions included in your query. Be sure to re-select _all_ of the relevant data for a partition when using this incremental strategy.
+
+<Tabs
+  defaultValue="source"
+  values={[
+    { label: 'Source code', value: 'source', },
+    { label: 'Run code', value: 'run', },
+  ]
+}>
+<TabItem value="source">
 
 <File name='spark_incremental.sql'>
 
@@ -42,27 +53,82 @@ Apache Spark does not natively support `delete`, `update`, or `merge` statements
   when this model runs
 */
 
+with new_events as (
+    
+    select * from {{ ref('events') }}
+    
+    {% if is_incremental() %}
+    where date_day::date >= date_add(current_date, -1)
+    {% endif %}
+    
+)
+
 select
     date_day,
     count(*) as users
 
-from {{ ref('events') }}
-where date_day::date >= '2019-01-01'
+from events
 group by 1
 ```
 
 </File>
+</TabItem>
+<TabItem value="run">
+
+<File name='spark_incremental.sql'>
+
+```sql
+create temporary view spark_incremental__dbt_tmp as
+    
+    with new_events as (
+        
+        select * from analytics.events
+        
+
+        where date_day::date >= date_add(current_date, -1)
+
+        
+    )
+
+    select
+        date_day,
+        count(*) as users
+
+    from events
+    group by 1
+    
+;
+
+insert overwrite table analytics.spark_incremental
+    partition (date_day)
+    select `date_day`, `users` from spark_incremental__dbt_tmp
+```
+
+</File>
+</TabItem>
+</Tabs>
 
 ### The `merge` strategy
 
-<Callout type="info" title="New in dbt-spark v0.15.3"></Callout>
+<Callout type="info" title="New in dbt-spark v0.15.3">
+This functionality is new in dbt-spark v0.15.3. See [installation instructions](profile-spark/#installation-and-distribution)
+</Callout>
 
 There are three prerequisites for the `merge` incremental strategy:
-- Delta file format
-- Databricks Runtime 5.1 and above
-- Specify a `unique_key`
+- Creating the table in Delta file format
+- Using Databricks Runtime 5.1 and above
+- Specifying a `unique_key`
 
-dbt will run an atomic `merge` statement which looks nearly identical to the default merge behavior on Snowflake and BigQuery.
+dbt will run an [atomic `merge` statement](https://docs.databricks.com/spark/latest/spark-sql/language-manual/merge-into.html) which looks nearly identical to the default merge behavior on Snowflake and BigQuery.
+
+<Tabs
+  defaultValue="source"
+  values={[
+    { label: 'Source code', value: 'source', },
+    { label: 'Compiled code', value: 'compiled', },
+  ]
+}>
+<TabItem value="source">
 
 <File name='delta_incremental.sql'>
 
@@ -74,20 +140,69 @@ dbt will run an atomic `merge` statement which looks nearly identical to the def
     incremental_strategy='merge'
 ) }}
 
+with new_events as (
+    
+    select * from {{ ref('events') }}
+    
+    {% if is_incremental() %}
+    where date_day::date >= date_add(current_date, -1)
+    {% endif %}
+    
+)
+
 select
     user_id,
     max(date_day) as last_seen
 
-from {{ ref('events') }}
-where date_day::date >= '2019-01-01'
+from events
 group by 1
 ```
 
 </File>
+</TabItem>
+<TabItem value="run">
+
+<File name='delta_incremental.sql'>
+
+```sql
+create temporary view delta_incremental__dbt_tmp as
+    
+    with new_events as (
+        
+        select * from analytics.events
+        
+
+        where date_day::date >= date_add(current_date, -1)
+
+        
+    )
+
+    select
+        user_id,
+        max(date_day) as last_seen
+
+    from events
+    group by 1
+    
+;
+
+merge into analytics.delta_incremental as DBT_INTERNAL_DEST
+    using delta_incremental__dbt_tmp as DBT_INTERNAL_SOURCE
+    on DBT_INTERNAL_SOURCE.user_id = DBT_INTERNAL_DEST.user_id
+    when matched then update set *
+    when not matched then insert *
+```
+
+</File>
+
+</TabItem>
+</Tabs>
 
 ## Persisting model descriptions
 
-<Callout type="info" title="New in dbt-spark v0.15.3"></Callout>
+<Callout type="info" title="New in dbt-spark v0.15.3">
+This functionality is new in dbt-spark v0.15.3. See [installation instructions](profile-spark/#installation-and-distribution)
+</Callout>
 
 The `persist_docs` config can be used to persist the dbt `description` supplied for a model to the resulting Spark table or view. The `persist_docs` config is not yet supported for objects other than tables and views.
 

--- a/website/docs/docs/building-a-dbt-project/building-models/spark-configs.md
+++ b/website/docs/docs/building-a-dbt-project/building-models/spark-configs.md
@@ -20,11 +20,9 @@ When materializing a model as `table`, you may include several optional configs:
 
 ## Incremental Models
 
-The `incremental_strategy` config controls how dbt builds incremental models, and it can be set to one of two values:
+The [`incremental_strategy` config](configuring-incremental-models#what-is-an-incremental_strategy) controls how dbt builds incremental models, and it can be set to one of two values:
  - `insert_overwrite` (default)
  - `merge` (Delta Lake only)
- 
- See also: [configuring incremental strategies](docs/configuring-incremental-models#configuring-incremental-strategies).
 
 ### The `insert_overwrite` strategy
 
@@ -57,11 +55,7 @@ group by 1
 
 ### The `merge` strategy
 
-<Callout type="info" title="New in dbt-spark v0.15.3">
-
-This functionality is new in dbt-spark v0.15.3
-
-</Callout>
+<Callout type="info" title="New in dbt-spark v0.15.3"></Callout>
 
 There are three prerequisites for the `merge` incremental strategy:
 - Delta file format
@@ -93,11 +87,7 @@ group by 1
 
 ## Persisting model descriptions
 
-<Callout type="info" title="New in dbt-spark v0.15.3">
-
-This functionality is new in dbt-spark v0.15.3
-
-</Callout>
+<Callout type="info" title="New in dbt-spark v0.15.3"></Callout>
 
 The `persist_docs` config can be used to persist the dbt `description` supplied for a model to the resulting Spark table or view. The `persist_docs` config is not yet supported for objects other than tables and views.
 

--- a/website/docs/docs/building-a-dbt-project/building-models/spark-configs.md
+++ b/website/docs/docs/building-a-dbt-project/building-models/spark-configs.md
@@ -58,7 +58,7 @@ with new_events as (
     select * from {{ ref('events') }}
     
     {% if is_incremental() %}
-    where date_day::date >= date_add(current_date, -1)
+    where date_day >= date_add(current_date, -1)
     {% endif %}
     
 )
@@ -85,7 +85,7 @@ create temporary view spark_incremental__dbt_tmp as
         select * from analytics.events
         
 
-        where date_day::date >= date_add(current_date, -1)
+        where date_day >= date_add(current_date, -1)
 
         
     )
@@ -111,7 +111,9 @@ insert overwrite table analytics.spark_incremental
 ### The `merge` strategy
 
 <Callout type="info" title="New in dbt-spark v0.15.3">
+
 This functionality is new in dbt-spark v0.15.3. See [installation instructions](profile-spark/#installation-and-distribution)
+
 </Callout>
 
 There are three prerequisites for the `merge` incremental strategy:
@@ -145,7 +147,7 @@ with new_events as (
     select * from {{ ref('events') }}
     
     {% if is_incremental() %}
-    where date_day::date >= date_add(current_date, -1)
+    where date_day >= date_add(current_date, -1)
     {% endif %}
     
 )
@@ -172,7 +174,7 @@ create temporary view delta_incremental__dbt_tmp as
         select * from analytics.events
         
 
-        where date_day::date >= date_add(current_date, -1)
+        where date_day >= date_add(current_date, -1)
 
         
     )
@@ -201,7 +203,9 @@ merge into analytics.delta_incremental as DBT_INTERNAL_DEST
 ## Persisting model descriptions
 
 <Callout type="info" title="New in dbt-spark v0.15.3">
+
 This functionality is new in dbt-spark v0.15.3. See [installation instructions](profile-spark/#installation-and-distribution)
+
 </Callout>
 
 The `persist_docs` config can be used to persist the dbt `description` supplied for a model to the resulting Spark table or view. The `persist_docs` config is not yet supported for objects other than tables and views.

--- a/website/docs/docs/building-a-dbt-project/building-models/spark-configs.md
+++ b/website/docs/docs/building-a-dbt-project/building-models/spark-configs.md
@@ -112,7 +112,7 @@ insert overwrite table analytics.spark_incremental
 
 <Callout type="info" title="New in dbt-spark v0.15.3">
 
-This functionality is new in dbt-spark v0.15.3. See [installation instructions](profile-spark/#installation-and-distribution)
+This functionality is new in dbt-spark v0.15.3. See [installation instructions](profile-spark#installation-and-distribution)
 
 </Callout>
 
@@ -204,7 +204,7 @@ merge into analytics.delta_incremental as DBT_INTERNAL_DEST
 
 <Callout type="info" title="New in dbt-spark v0.15.3">
 
-This functionality is new in dbt-spark v0.15.3. See [installation instructions](profile-spark/#installation-and-distribution)
+This functionality is new in dbt-spark v0.15.3. See [installation instructions](profile-spark#installation-and-distribution)
 
 </Callout>
 

--- a/website/docs/docs/building-a-dbt-project/building-models/spark-configs.md
+++ b/website/docs/docs/building-a-dbt-project/building-models/spark-configs.md
@@ -14,8 +14,8 @@ When materializing a model as `table`, you may include several optional configs:
 |---------|----------------------------------------------------|-------------------------|--------------------------|
 | file_format | The file format to use when creating tables (`parquet`, `delta`, `csv`, `json`, `text`, `jdbc`, `orc`, `hive` or `libsvm`). | Optional | `parquet`|
 | location_root  | The created table uses the specified directory to store its data. The table alias is appended to it. | Optional                | `/mnt/root`              |
-| partition_by  | Partition the created table by the specified columns. A directory is created for each partition. | Optional                | `partition_1`              |
-| clustered_by  | Each partition in the created table will be split into a fixed number of buckets by the specified columns. | Optional               | `cluster_1`              |
+| partition_by  | Partition the created table by the specified columns. A directory is created for each partition. | Optional                | `date_day`              |
+| clustered_by  | Each partition in the created table will be split into a fixed number of buckets by the specified columns. | Optional               | `country_code`              |
 | buckets  | The number of buckets to create while clustering | Required if `clustered_by` is specified                | `8`              |
 
 ## Incremental Models
@@ -125,7 +125,7 @@ dbt will run an [atomic `merge` statement](https://docs.databricks.com/spark/lat
   defaultValue="source"
   values={[
     { label: 'Source code', value: 'source', },
-    { label: 'Compiled code', value: 'compiled', },
+    { label: 'Run code', value: 'run', },
   ]
 }>
 <TabItem value="source">

--- a/website/docs/docs/supported-databases.md
+++ b/website/docs/docs/supported-databases.md
@@ -16,7 +16,7 @@ These database plugins are supported by the core dbt maintainers.
 | BigQuery | [Profile Setup](profile-bigquery), [Configuration](bigquery-configs) | ✅Full Support |
 | Snowflake | [Profile Setup](profile-snowflake), [Configuration](snowflake-configs) | ✅ Full Support |
 | Presto | [Profile Setup](profile-presto) | Partial Support |
-| Spark | [Profile Setup](profile-spark) | Partial Support |
+| Spark | [Profile Setup](profile-spark), [Configuration](spark-configs) | Partial Support |
 
 ##  Community Supported dbt Plugins
 

--- a/website/docs/docs/supported-databases/profile-presto.md
+++ b/website/docs/docs/supported-databases/profile-presto.md
@@ -15,7 +15,9 @@ my-presto-db:
   outputs:
     dev:
       type: presto
-      method: none # One of {none | kerberos}
+      method: none  # optional, one of {none | ldap | kerberos}
+      user: [user]
+      password: [password]  # required if method is ldap or kerberos
       database: [database name]
       host: [hostname]
       port: [port number]

--- a/website/docs/docs/supported-databases/profile-presto.md
+++ b/website/docs/docs/supported-databases/profile-presto.md
@@ -48,7 +48,7 @@ Due to the nature of Presto, not all core dbt functionality is supported. The fo
 1. [Snapshots](snapshots) 
 2. [Incremental models](configuring-incremental-models)
 
-If you are interested in helping to add support for this functionality in dbt on Presto, please [open an issue](https://github.com/fishtown-analytics/dbt/issues/new)
+If you are interested in helping to add support for this functionality in dbt on Presto, please [open an issue](https://github.com/fishtown-analytics/dbt-presto/issues/new).
 
 ### Required configuration
 

--- a/website/docs/docs/supported-databases/profile-presto.md
+++ b/website/docs/docs/supported-databases/profile-presto.md
@@ -30,10 +30,10 @@ my-presto-db:
 
 ## Installation and Distribution
 
-dbt's Presto adapter is managed in its own repository, [dbt-presto](https://github.com/fishtown-analytics/dbt-presto). To use the Presto adapter, you must install the `dbt-presto` package in addition to installing `dbt` on your system.
+dbt's Presto adapter is managed in its own repository, [dbt-presto](https://github.com/fishtown-analytics/dbt-presto). To use the Presto adapter, you must install the `dbt-presto` plugin:
 
 ### Using pip
-The following command will install `dbt-presto` as well as `dbt-core`.
+The following command will install the latest version of `dbt-presto` as well as the requisite version of `dbt-core`:
 
 ```
 pip install dbt-presto
@@ -41,7 +41,7 @@ pip install dbt-presto
 
 ## Caveats
 
-### Supported Functionality
+### Unsupported Functionality
 
 Due to the nature of Presto, not all core dbt functionality is supported. The following features of dbt are not implemented on Presto:
 

--- a/website/docs/docs/supported-databases/profile-spark.md
+++ b/website/docs/docs/supported-databases/profile-spark.md
@@ -71,3 +71,9 @@ pip install dbt-spark
 
 ### Usage with EMR
 To connect to Spark running on an Amazon EMR cluster, you will need to run `sudo /usr/lib/spark/sbin/start-thriftserver.sh` on the master node of the cluster to start the Thrift server (see [the docs](https://aws.amazon.com/premiumsupport/knowledge-center/jdbc-connection-emr/) for more information). You will also need to connect to port 10001, which will connect to the Spark backend Thrift server; port 10000 will instead connect to a Hive backend, which will not work correctly with dbt.
+
+### Supported Functionality
+
+Not all core dbt functionality is supported. The following features of dbt are not yet implemented for the Spark plugin:
+
+1. [Snapshots](snapshots) 

--- a/website/docs/docs/supported-databases/profile-spark.md
+++ b/website/docs/docs/supported-databases/profile-spark.md
@@ -3,7 +3,7 @@ title: "Spark"
 id: "profile-spark"
 ---
 
-## Authentication Methods
+## Connection Methods
 There are two supported connection methods for Spark targets: `http` and `thrift`.
 
 ### thrift
@@ -18,16 +18,16 @@ your_profile_name:
     dev:
       type: spark
       method: thrift
-      schema: analytics
-      host: 127.0.0.1
-      port: 10001
-      user: hadoop
+      schema: [database/schema name]
+      host: [hostname]
+      port: [port]
+      user: [user]
 ```
 
 </File>
 
 ### http
-Use the `http` method if your Spark provider supports connections over HTTP (eg. DataBricks Spark).
+Use the `http` method if your Spark provider supports connections over HTTP (e.g. Databricks).
 
 <File name='~/.dbt/profiles.yml'>
 
@@ -38,58 +38,36 @@ your_profile_name:
     dev:
       type: spark
       method: http
-      schema: analytics
-      host: yourorg.sparkhost.com
-      port: 443
-      token: abc123
-      cluster: 01234-23423-coffeetime
+      schema: [database/schema name]
+      host: [yourorg.sparkhost.com]
+      organization: [org id]    # required if Azure Databricks, exclude if AWS Databricks
+      port: [port]
+      token: [abc123]
+      cluster: [cluster id]
+      connect_timeout: 60   # optional, default 10
+      connect_retries: 5    # optional, default 0
 ```
+
+Databricks interactive clusters can take several minutes to start up. You may 
+include the optional profile configs `connect_timeout` and `connect_retries`,
+and dbt will periodically retry the connection.
 
 </File>
 
 ## Installation and Distribution
 
-dbt's Spark adapter is managed in its own repository, [dbt-spark](https://github.com/fishtown-analytics/dbt-spark). To use the Spark adapter, you must install the `dbt-spark` package in addition to installing `dbt` on your system.
+dbt's Spark adapter is managed in its own repository, [dbt-spark](https://github.com/fishtown-analytics/dbt-spark). To use the Spark adapter, you must install the `dbt-spark` package in addition to installing `dbt` on your system. Check the information
+in that repo for the latest information on installing the dbt-spark plugin.
 
 ### Using pip
-The following command will install `dbt-spark` as well as `dbt-core`.
+The following command will install the latest version of `dbt-spark` as well as
+the requisite version of `dbt-core`.
 
 ```
 pip install dbt-spark
 ```
 
-See the [repo](https://github.com/fishtown-analytics/dbt-spark) for the latest information on installing the dbt-spark plugin.
-
 ## Caveats
 
 ### Usage with EMR
 To connect to Spark running on an Amazon EMR cluster, you will need to run `sudo /usr/lib/spark/sbin/start-thriftserver.sh` on the master node of the cluster to start the Thrift server (see [the docs](https://aws.amazon.com/premiumsupport/knowledge-center/jdbc-connection-emr/) for more information). You will also need to connect to port 10001, which will connect to the Spark backend Thrift server; port 10000 will instead connect to a Hive backend, which will not work correctly with dbt.
-
-### Incremental Models
-
-Spark does not natively support `delete`, `update`, or `merge` statements. As such, [incremental models](configuring-incremental-models) are implemented differently than usual in this plugin. To use incremental models, specify a `partition_by` clause in your model config. dbt will use an `insert overwrite` query to overwrite the partitions included in your query. Be sure to re-select _all_ of the relevant data for a partition when using incremental models.
-
-<File name='spark_incremental.sql'>
-
-```sql
-{{ config(
-    materialized='incremental',
-    partition_by=['date_day'],
-    file_format='parquet'
-) }}
-
-/*
-  Every partition returned by this query will be overwritten
-  when this model runs
-*/
-
-select
-    date_day,
-    count(*) as users
-
-from {{ ref('events') }}
-where date_day::date >= '2019-01-01'
-group by 1
-```
-
-</File>

--- a/website/docs/docs/supported-databases/profile-spark.md
+++ b/website/docs/docs/supported-databases/profile-spark.md
@@ -56,12 +56,10 @@ and dbt will periodically retry the connection.
 
 ## Installation and Distribution
 
-dbt's Spark adapter is managed in its own repository, [dbt-spark](https://github.com/fishtown-analytics/dbt-spark). To use the Spark adapter, you must install the `dbt-spark` package in addition to installing `dbt` on your system. Check the information
-in that repo for the latest information on installing the dbt-spark plugin.
+dbt's Spark adapter is managed in its own repository, [dbt-spark](https://github.com/fishtown-analytics/dbt-spark). To use the Spark adapter, you must install the `dbt-spark` plugin.
 
 ### Using pip
-The following command will install the latest version of `dbt-spark` as well as
-the requisite version of `dbt-core`.
+The following command will install the latest version of `dbt-spark` as well as the requisite version of `dbt-core`:
 
 ```
 pip install dbt-spark
@@ -72,7 +70,7 @@ pip install dbt-spark
 ### Usage with EMR
 To connect to Spark running on an Amazon EMR cluster, you will need to run `sudo /usr/lib/spark/sbin/start-thriftserver.sh` on the master node of the cluster to start the Thrift server (see [the docs](https://aws.amazon.com/premiumsupport/knowledge-center/jdbc-connection-emr/) for more information). You will also need to connect to port 10001, which will connect to the Spark backend Thrift server; port 10000 will instead connect to a Hive backend, which will not work correctly with dbt.
 
-### Supported Functionality
+### Unsupported Functionality
 
 Not all core dbt functionality is supported. The following features of dbt are not yet implemented for the Spark plugin:
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -44,7 +44,8 @@ module.exports = {
           "docs/building-a-dbt-project/building-models/using-sql-headers",
           "docs/building-a-dbt-project/building-models/snowflake-configs",
           "docs/building-a-dbt-project/building-models/redshift-configs",
-          "docs/building-a-dbt-project/building-models/bigquery-configs"
+          "docs/building-a-dbt-project/building-models/bigquery-configs",
+          "docs/building-a-dbt-project/building-models/spark-configs"
         ]
       },
       "docs/building-a-dbt-project/hooks",


### PR DESCRIPTION
## Description & motivation

- Update Presto profile (as of 0.15.3)
- Update Spark profile (as of 0.15.3)
- Add "Spark specific configurations" feature list
- Move "Configuring incremental strategy" from Snowflake/BigQuery pages (duplicated) into "Configuring incremental models," with links back to Snowflake, BigQuery, and Spark specific configs

## To-do before merge

- [x] Check relative links
