### PR TITLE
Fix/broken relative links

### DIFF
--- a/website/docs/reference/dbt_project.yml.md
+++ b/website/docs/reference/dbt_project.yml.md
@@ -10,47 +10,46 @@ The following is a list of all available configurations in the `dbt_project.yml`
 <File name='dbt_project.yml'>
 
 ```yml
-[name](project-configs/name.md): string
+[name](project-configs/name): string
 
-[version](project-configs/version.md): version
+[version](project-configs/version): version
 
-[profile](project-configs/profile.md): profilename
+[profile](project-configs/profile): profilename
 
-[source-paths](project-configs/source-paths.md): [directorypath]
-[data-paths](project-configs/data-paths.md): [directorypath]
-[test-paths](project-configs/test-paths.md): [directorypath]
-[analysis-paths](project-configs/analysis-paths.md): [directorypath]
-[macro-paths](project-configs/macro-paths.md): [directorypath]
-[snapshot-paths](project-configs/snapshot-paths.md): [directorypath]
-[docs-paths](project-configs/docs-paths.md): [directorypath]
+[source-paths](project-configs/source-paths): [directorypath]
+[data-paths](project-configs/data-paths): [directorypath]
+[test-paths](project-configs/test-paths): [directorypath]
+[analysis-paths](project-configs/analysis-paths): [directorypath]
+[macro-paths](project-configs/macro-paths): [directorypath]
+[snapshot-paths](project-configs/snapshot-paths): [directorypath]
+[docs-paths](project-configs/docs-paths): [directorypath]
 
-[modules-path](project-configs/modules-paths.md): directorypath
-[target-path](project-configs/target-path.md): directorypath
-[log-path](project-configs/log-path.md): directorypath
-[modules-path](project-configs/modules-path.md): directorypath
+[target-path](project-configs/target-path): directorypath
+[log-path](project-configs/log-path): directorypath
+[modules-path](project-configs/modules-path): directorypath
 
-[clean-targets](project-configs/clean-targets.md): [directorypath]
+[clean-targets](project-configs/clean-targets): [directorypath]
 
-[query-comment](project-configs/query-comment.md): string
+[query-comment](project-configs/query-comment): string
 
-[require-dbt-version](project-configs/require-dbt-version.md): version-range
+[require-dbt-version](project-configs/require-dbt-version): version-range
 
-[quoting](project-configs/quoting.md):
+[quoting](project-configs/quoting):
   database: true | false
   schema: true | false
   identifier: true | false
 
 models:
-  [<model-configs>](model-configs.md)
+  [<model-configs>](model-configs)
 
 seeds:
-  [<seed-configs>](seed-configs.md)
+  [<seed-configs>](seed-configs)
 
 snapshots:
-  [<snapshot-configs>](snapshot-configs.md)
+  [<snapshot-configs>](snapshot-configs)
 
-[on-run-start](project-configs/on-run-start.md): sql-statement | [sql-statement]
-[on-run-end](project-configs/on-run-end.md): sql-statement | [sql-statement]
+[on-run-start](project-configs/on-run-start): sql-statement | [sql-statement]
+[on-run-end](project-configs/on-run-end): sql-statement | [sql-statement]
 
 ```
 

--- a/website/docs/reference/dbt_project.yml.md
+++ b/website/docs/reference/dbt_project.yml.md
@@ -32,7 +32,7 @@ The following is a list of all available configurations in the `dbt_project.yml`
 
 [query-comment](project-configs/query-comment): string
 
-[require-dbt-version](project-configs/require-dbt-version): version-range
+[require-dbt-version](project-configs/require-dbt-version): version-range | [version-range]
 
 [quoting](project-configs/quoting):
   database: true | false

--- a/website/docs/reference/dbt_project.yml.md
+++ b/website/docs/reference/dbt_project.yml.md
@@ -10,47 +10,47 @@ The following is a list of all available configurations in the `dbt_project.yml`
 <File name='dbt_project.yml'>
 
 ```yml
-[name](name): string
+[name](project-configs/name.md): string
 
-[version](version): version
+[version](project-configs/version.md): version
 
-[profile](profile): profilename
+[profile](project-configs/profile.md): profilename
 
-[source-paths](source-paths): [directorypath]
-[data-paths](data-paths): [directorypath]
-[test-paths](test-paths): [directorypath]
-[analysis-paths](analysis-paths): [directorypath]
-[macro-paths](macro-paths): [directorypath]
-[snapshot-paths](snapshot-paths): [directorypath]
-[docs-paths](docs-paths): [directorypath]
+[source-paths](project-configs/source-paths.md): [directorypath]
+[data-paths](project-configs/data-paths.md): [directorypath]
+[test-paths](project-configs/test-paths.md): [directorypath]
+[analysis-paths](project-configs/analysis-paths.md): [directorypath]
+[macro-paths](project-configs/macro-paths.md): [directorypath]
+[snapshot-paths](project-configs/snapshot-paths.md): [directorypath]
+[docs-paths](project-configs/docs-paths.md): [directorypath]
 
-[modules-path](modules-path): directorypath
-[target-path](target-path): directorypath
-[log-path](log-path): directorypath
-[modules-path](modules-path): directorypath
+[modules-path](project-configs/modules-paths.md): directorypath
+[target-path](project-configs/target-path.md): directorypath
+[log-path](project-configs/log-path.md): directorypath
+[modules-path](project-configs/modules-path.md): directorypath
 
-[clean-targets](clean-targets): [directorypath]
+[clean-targets](project-configs/clean-targets.md): [directorypath]
 
-[query-comment](query-comment): string
+[query-comment](project-configs/query-comment.md): string
 
-[require-dbt-version](require-dbt-version): version-range | [version-range]
+[require-dbt-version](project-configs/require-dbt-version.md): version-range
 
-[quoting](quoting):
+[quoting](project-configs/quoting.md):
   database: true | false
   schema: true | false
   identifier: true | false
 
 models:
-  [<model-configs>](model-configs)
+  [<model-configs>](model-configs.md)
 
 seeds:
-  [<seed-configs>](seed-configs)
+  [<seed-configs>](seed-configs.md)
 
 snapshots:
-  [<snapshot-configs>](snapshot-configs)
+  [<snapshot-configs>](snapshot-configs.md)
 
-[on-run-start](on-run-start): sql-statement | [sql-statement]
-[on-run-end](on-run-end): sql-statement | [sql-statement]
+[on-run-start](project-configs/on-run-start.md): sql-statement | [sql-statement]
+[on-run-end](project-configs/on-run-end.md): sql-statement | [sql-statement]
 
 ```
 

--- a/website/src/components/link/index.js
+++ b/website/src/components/link/index.js
@@ -34,9 +34,11 @@ docsFiles.keys().forEach(function(key, i) {
 });
 
 function findSource(source_href) {
+    var stripped_source_href = source_href.replace(/.md$/, '')
     var found = null;
     for (var source in sources) {
-        if (source.endsWith(source_href)) {
+        var stripped_source = source.replace(/.md$/, '')
+        if (stripped_source.endsWith(stripped_source_href)) {
             found = sources[source];
             break;
         }
@@ -62,6 +64,10 @@ function expandRelativeLink(href, ignoreInvalid) {
         hash = ''
     }
 
+    var tmp = document.createElement('a');
+    tmp.href = link;
+    var isExternal = tmp.hostname != window.location.hostname;
+
     var sourceLink = findSource(link);
     if (sourceLink) {
         return {
@@ -73,7 +79,7 @@ function expandRelativeLink(href, ignoreInvalid) {
             bad: false,
             link: `${slugs[link].permalink}#${hash}`
         }
-    } else if (link.indexOf("/") == -1) {
+    } else if (!isExternal) {
         if (env.DOCS_ENV == 'build' && !ignoreInvalid) {
             throw new Error(`Broken link detected ${href}`)
         } else {

--- a/website/src/components/link/index.js
+++ b/website/src/components/link/index.js
@@ -64,9 +64,7 @@ function expandRelativeLink(href, ignoreInvalid) {
         hash = ''
     }
 
-    var tmp = document.createElement('a');
-    tmp.href = link;
-    var isExternal = tmp.hostname != window.location.hostname;
+    var isExternal = !!link.match(/https?:/);
 
     var sourceLink = findSource(link);
     if (sourceLink) {

--- a/website/src/components/link/index.js
+++ b/website/src/components/link/index.js
@@ -9,6 +9,7 @@ const docsFiles = require.context(
 );
 
 var slugs = {};
+var sources = {};
 docsFiles.keys().forEach(function(key, i) {
   var doc = docsFiles(key);
   var meta = doc.metadata;
@@ -29,8 +30,19 @@ docsFiles.keys().forEach(function(key, i) {
   }
 
   slugs[slug] = meta;
+  sources[meta.source] = meta
 });
 
+function findSource(source_href) {
+    var found = null;
+    for (var source in sources) {
+        if (source.endsWith(source_href)) {
+            found = sources[source];
+            break;
+        }
+    }
+    return found;
+}
 
 function expandRelativeLink(href, ignoreInvalid) {
     var env = process ? process.env : {};
@@ -50,7 +62,13 @@ function expandRelativeLink(href, ignoreInvalid) {
         hash = ''
     }
 
-    if (slugs[link]) {
+    var sourceLink = findSource(link);
+    if (sourceLink) {
+        return {
+            bad: false,
+            link: `${sourceLink.permalink}#${hash}`
+        }
+    } else if (slugs[link]) {
         return {
             bad: false,
             link: `${slugs[link].permalink}#${hash}`

--- a/website/src/components/link/index.js
+++ b/website/src/components/link/index.js
@@ -77,7 +77,7 @@ function expandRelativeLink(href, ignoreInvalid) {
             bad: false,
             link: `${slugs[link].permalink}#${hash}`
         }
-    } else if (!isExternal) {
+    } else if (!isExternal && !href.startsWith('/')) {
         if (env.DOCS_ENV == 'build' && !ignoreInvalid) {
             throw new Error(`Broken link detected ${href}`)
         } else {


### PR DESCRIPTION
## Description & motivation

TODO : Change base branch to `feature/project-configs` after testing

Summary of changes:
 - support "relative" links in Markdown links (both inside and outside of code blocks)
 - change example code block links to use `.md` file extenstions

Let's consider this a WIP / proof-of-concept for the time being.

How linking works now:
 - Markdown links (or links created manually with the `<Link>` component will rewrite provided links to return "permalinks" that should work regardless of the path that the link is being clicked from
 - These aren't proper "relative" links, though I imagine we could support those in the future if we wanted to
 - Now, you can link to a document by either using:
  - The slug: `[my link](doc-slug)`
  - The trailing paths parts of the url: `[my link](some-path/doc-slug.md)`

When using the "trailing path-parts", the link will render to the first document which ends with with specified with the given path. This has two benefits:
1. We don't need to think super hard about relative paths if we move files around
2. The link will render nicely in GitHub's markdown viewer in most cases

This will _not_ work for relative links like `../some-path/other-path/../../the-path.md`. The link rewriting isn't going to know anything about the path that the link is being created from. I think that's ok?