### PR TITLE
Option 1 sidebars

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -269,6 +269,21 @@ module.exports = {
       "reference/model-configs",
       "reference/seed-configs",
       "reference/snapshot-configs",
+      {
+        type: "category",
+        label: "Resource configurations",
+        items: [
+          "reference/resource-configs/alias",
+          "reference/resource-configs/column_types",
+          "reference/resource-configs/database",
+          "reference/resource-configs/enabled",
+          "reference/resource-configs/post-hook",
+          "reference/resource-configs/pre-hook",
+          "reference/resource-configs/quote_columns",
+          "reference/resource-configs/schema",
+          "reference/resource-configs/tags",
+        ],
+      },
     ],
   },
   tutorial: {


### PR DESCRIPTION
I wanted to make a PR to bring the seed configs into line with how we did the project configs.

Two different PRs open here:
- Option 1 (this PR): Nest all model/seed/ configs under a heading `resource configs`:

- Option 2 ([PR](https://github.com/fishtown-analytics/docs.getdbt.com/pull/102), [preview](https://deploy-preview-102--docs-getdbt-com.netlify.app/reference/resource-configs/alias)): Nest each config under a separate sub-heading.

- Option 3 (not done): break up into "general configurations" (enabled, tags, etc) and "model configurations/seed configurations/snapshot configurations". But then things like `schema` apply to some but not all resources ¯\_(ツ)_/¯

Please watch this [Loom](https://www.loom.com/share/534c492ac696404793bec3343bd59867) where I talk about the two options

@drewbanin — can you give me your feedback?