### PR TITLE
Fix on-run-end context docs

### DIFF
--- a/website/docs/docs/writing-code-in-dbt/jinja-context/on-run-end-context.md
+++ b/website/docs/docs/writing-code-in-dbt/jinja-context/on-run-end-context.md
@@ -35,7 +35,7 @@ In practice, it might not be a bad idea to put this code into a macro:
 
 {% macro grant_usage_to_schemas(schemas, user) %}
   {% for schema in schemas %}
-    grant usage on {{ schema }} to {{ user }};
+    grant usage on schema {{ schema }} to {{ user }};
   {% endfor %}
 {% endmacro %}
 
@@ -51,7 +51,7 @@ In practice, it might not be a bad idea to put this code into a macro:
 ```yaml
 
 on-run-end:
- - "{{ grant_usage_to_schemas(schemas, user) }}"
+ - "{{ grant_usage_to_schemas(schemas, 'user') }}"
 
 
 ```


### PR DESCRIPTION
## Description & motivation

I wanted to use the grant_usage_to_schemas macro in my local project. After copying and pasting the code from the docs, I noticed there were a couple things missing that I needed to change in order for the macro to work. These changes include adding `schema` in front of the schema variable in the macro. I then put single quotes around the user in the grant block in the dbt_project.yml

I built the docs locally and I see my changes on the on run end context page.


