### PR TITLE
Update Doc section link

### DIFF
--- a/website/docs/reference/model-configs.md
+++ b/website/docs/reference/model-configs.md
@@ -6,6 +6,6 @@ title: Model configurations
 
 These docs are a placeholder for a yet-to-be-written reference section.
 
-Please refer to the [docs section](docs/docs/building-a-dbt-project/building-models/configuring-models.md) for current documentation.
+Please refer to the [docs section](https://docs.getdbt.com/docs/building-a-dbt-project/building-models/configuring-models/) for current documentation.
 
 </Alert>


### PR DESCRIPTION
The docs section hyperlink was linking to a 'Page Not Found': https://docs.getdbt.com/reference/model-configs/docs/docs/building-a-dbt-project/building-models/configuring-models.md

## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged
-->
