### PR TITLE
Escape underscore character to not have unintentional italics

### DIFF
--- a/website/docs/docs/building-a-dbt-project/building-models/using-custom-schemas.md
+++ b/website/docs/docs/building-a-dbt-project/building-models/using-custom-schemas.md
@@ -17,7 +17,7 @@ You can use **custom schemas** in dbt to build models in a schema other than you
 | &lt;target_schema&gt; | None | &lt;target_schema&gt; |
 | analytics | None | analytics |
 | dbt_alice | None | dbt_alice |
-| &lt;target_schema&gt; | &lt;custom_schema&gt; | &lt;target_schema&gt;_&lt;custom_schema&gt; |
+| &lt;target_schema&gt; | &lt;custom_schema&gt; | &lt;target_schema&gt;\_&lt;custom_schema&gt; |
 | analytics | marketing | analytics_marketing |
 | dbt_alice | marketing | dbt_alice_marketing |
 


### PR DESCRIPTION
## Description & motivation

On the [page describing custom schemas](https://docs.getdbt.com/docs/building-a-dbt-project/building-models/using-custom-schemas/), an unescaped underscore character in a cell of the table is causing unintentional italics. And, it makes the Resulting schema incorrect.

This change escapes the underscore, fixing the issue. 

**Currently**
![Screen Shot 2020-05-02 at 4 59 27 PM](https://user-images.githubusercontent.com/904344/80892073-5c50be80-8c96-11ea-9577-67d6a2763a5b.png)

**With this PR**
![Screen Shot 2020-05-02 at 4 59 39 PM](https://user-images.githubusercontent.com/904344/80892077-607cdc00-8c96-11ea-901e-6db56884261d.png)




