### PR TITLE
Modify Prism nightowl theme to improve YAML syntax highlighting

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -22,7 +22,23 @@ module.exports = {
     },
 
     prism: {
-      theme: require('prism-react-renderer/themes/nightOwl'),
+      theme: (() => {
+          var theme = require('prism-react-renderer/themes/nightOwl');
+          // Add additional rule to nightowl theme in order to change
+          // the color of YAML keys (to be different than values).
+          // There weren't many Prism themes that differentiated
+          // YAML keys and values. See link:
+          // https://github.com/FormidableLabs/prism-react-renderer/tree/master/src/themes
+          theme.styles.push({
+              types: ["atrule"],
+              style: {
+                  // color chosen from the nightowl theme palette
+                  // https://github.com/FormidableLabs/prism-react-renderer/blob/master/src/themes/nightOwl.js#L83
+                  color: "rgb(255, 203, 139)"
+              }
+          });
+          return theme
+      })(),
       additionalLanguages: ['bash', 'shell'],
     },
     navbar: {


### PR DESCRIPTION
## Description & motivation
As requested in #44 , YAML highlighting currently does not differentiate between keys and values.

The docs site relies on Docusaurs, which [uses Prism for syntax highlighting](https://v2.docusaurus.io/docs/markdown-features/#syntax-highlighting).

I tried a few of the different [Prism themes](https://github.com/FormidableLabs/prism-react-renderer/tree/master/src/themes), but most of them also had the same colors for YAML keys and values. Also, I thought changing the theme may be too large of a change for this issue.

So, the PR still imports the same nightOwl theme that was used before, but makes a small change to account for YAML keys. I chose a color that looked decent from the [nightOwl theme](https://github.com/FormidableLabs/prism-react-renderer/blob/master/src/themes/nightOwl.js#L62) palette

**Before this PR** on [seed config page](https://docs.getdbt.com/reference/seed-configs)
![Screen Shot 2020-05-02 at 7 15 39 PM](https://user-images.githubusercontent.com/904344/80894920-a85b2d80-8cad-11ea-889b-8b8d463527e4.png)

**With this PR** [ed: changed color in response to @drewbanin 's comment]
![Screen Shot 2020-05-04 at 11 46 00 AM](https://user-images.githubusercontent.com/904344/80985385-267a1a00-8dfd-11ea-881d-1139f37f3d8b.png)


Would be helpful to have the following input before merging
- [ ] Is the color chosen for YAML keys **appropriate**?
- [ ] Is the Javascript written **idiomatic**? (I'm rusty in modern Javascript)
- [ ] Is this approach **sustainable**? i.e. modifying the an existing Prism theme inline this way 
    * I'm inclined to say that having up to two total inline modifications is fine, but beyond that, it's probably a better idea to have a separate theme file within the repo

--

Edited to change color to rgb(255, 203, 139) per @drewbanin 's comment