### PR TITLE
Make Slack preview work by adding description

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -17,7 +17,9 @@ function Home() {
 
   return (
 	  
-    <Layout permalink="/">
+    <Layout
+      permalink="/"
+      description="Documentation for dbt (data build tool)">
         <div className="container container--fluid home" style={{"padding": "10px 0"}}>
         	<div className="row" style={{"maxWidth": "var(--ifm-container-width)", "margin": "calc(5vh) auto calc(2vh)"}}>
         		<div className="col col--8">


### PR DESCRIPTION
## Description & motivation
Addresses issue #40 

I read an [article on the Slack blog](https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254) about what's involved to get these previews to work, and I think what the docs website needs is a meta tag "og:description".

The change in this PR adds a description to the index page, which appears in the headers as meta tags "description" and "og:description".

Currently at [https://docs.getdbt.com](https://docs.getdbt.com):
![view-source_https___docs_getdbt_com](https://user-images.githubusercontent.com/904344/81511932-d1517300-92ea-11ea-9886-25b05ed55c95.png)

With PR at [https://elastic-visvesvaraya-1e6683.netlify.app/](https://elastic-visvesvaraya-1e6683.netlify.app/):
![view-source_https___elastic-visvesvaraya-1e6683_netlify_app](https://user-images.githubusercontent.com/904344/81511985-1f667680-92eb-11ea-8625-d0f0aba4b9bd.png)

**Unfortunately** the [dev site](https://elastic-visvesvaraya-1e6683.netlify.app/) I deployed on netlify won't display a Slack preview when I shared it with myself. I believe it's because the meta tag "og:url" is "https://docs.getdbt.com" (not the netlify URL), which probably makes Slack not want to generate the preview.

## To-do before merge
- [ ] The description that will be in the preview is currently "Documentation for dbt (data build tool)". This should probably be changed to something else - what should that description be?
