### PR TITLE
Update sample test logic

### DIFF
--- a/website/docs/docs/building-a-dbt-project/testing-and-documentation/testing.md
+++ b/website/docs/docs/building-a-dbt-project/testing-and-documentation/testing.md
@@ -241,7 +241,7 @@ agg as (
 
 select *
 from agg
-where pct_null < 0.05
+where pct_null >= 0.05
 ```
 
 </File>


### PR DESCRIPTION
I think the logic in the test is accidentally flipped.

## Description & motivation
Reviewing testing documentation I noticed the test logic didn't seem right.  The test should pass if no rows are returned, therefore, I think `where pct_null < 0.05` should be changed to `where pct_null >= 0.05`.


## To-do before merge
make sure I'm not crazy

