### PR TITLE
Deprecate outdate freshness syntax

### DIFF
--- a/website/docs/docs/building-a-dbt-project/using-sources.md
+++ b/website/docs/docs/building-a-dbt-project/using-sources.md
@@ -151,7 +151,7 @@ sources:
 
 
       - name: product_skus
-        freshness: {} # do not check freshness for this table
+        freshness: null # do not check freshness for this table
 ```
 
 </File>

--- a/website/docs/faqs/exclude-table-from-freshness.md
+++ b/website/docs/faqs/exclude-table-from-freshness.md
@@ -4,7 +4,7 @@ title: How do I exclude a table from a freshness snapshot?
 
 Some tables in a data source may be updated infrequently. If you've set a `freshness` property at the source level, this table is likely to fail checks.
 
-To work around this, you can use an empty dictionary (`freshness: {}`) or null (`freshness: null`) to "unset" the freshness for a particular table:
+To work around this, you can use set the table's freshness to null (`freshness: null`) to "unset" the freshness for a particular table:
 
 <File name='models/<filename>.yml'>
 
@@ -25,7 +25,7 @@ sources:
     tables:
       - name: orders
       - name: product_skus
-        freshness: {} # do not check freshness for this table
+        freshness: null # do not check freshness for this table
 ```
 
 </File>


### PR DESCRIPTION
## Description & motivation

Looks like the old syntax of `freshness: {}` does not work anymore and will still run the freshness test against the table that has an emptied out config. The `null` flag still works and does also look like the cleaner implementation. I opted to just drop the old syntax altogether.