### PR TITLE
Updated tutorial link to learn link

### DIFF
--- a/website/docs/learn/2a-create-a-project-dbt-cloud.md
+++ b/website/docs/learn/2a-create-a-project-dbt-cloud.md
@@ -10,7 +10,7 @@ Now that we've successfully run our sample query in Snowflake, and chosen the wa
 <Callout type="info">
 
 These are the instructions for developing a project in dbt Cloud. If you're
-using the dbt CLI, follow the instructions [here](/tutorial/create-a-project-dbt-cli).
+using the dbt CLI, follow the instructions [here](/learn/create-a-project-dbt-cli).
 
 </Callout>
 


### PR DESCRIPTION
Updated link so it points to the correct dbt Learn page instead of the tutorial page (which uses BigQuery and has the repo creation step that was already done).

Also, in this file it says to name your Github Repo `dbt Learn - [initialsurname]`. However, the [Setting Up](https://docs.getdbt.com/learn/setting-up) page says to name it `dbt-learn-[initialsurname]`