### PR TITLE
Clarify use of persist_docs using config-version 2

### DIFF
--- a/website/docs/reference/resource-configs/persist_docs.md
+++ b/website/docs/reference/resource-configs/persist_docs.md
@@ -89,7 +89,7 @@ models:
 
 <File name='dbt_project.yml'>
 
-Note that when using `config-version: 2` you will need to use the `+persist_docs`
+Note that when using `config-version: 2` you will need to identify the `persist_docs` key as a config using the `+` config syntax:
 
 ```yml
 models:

--- a/website/docs/reference/resource-configs/persist_docs.md
+++ b/website/docs/reference/resource-configs/persist_docs.md
@@ -87,6 +87,19 @@ models:
 
 </File>
 
+<File name='dbt_project.yml'>
+
+Note that when using `config-version: 2` you will need to use the `+persist_docs`
+
+```yml
+models:
+  +persist_docs:
+    relation: true
+    columns: true
+```
+
+</File>
+
 Run dbt and observe that the created relation and columns are annotated with
 your descriptions:
 


### PR DESCRIPTION
Updating from config-version 1 to 2 break the previous persist_docs configuration

## Description & motivation
Clarify use of `persist_docs` using `config-version: 2`

When updating to config-version 2 the current suggested configuration generate an "unused configuration paths" warning.

I just wanted to propose this clarification because I found myself confused when updating to the new config-version.