### PR TITLE
Remove note about partitioning requirement

### DIFF
--- a/website/docs/reference/resource-configs/bigquery-configs.md
+++ b/website/docs/reference/resource-configs/bigquery-configs.md
@@ -190,7 +190,7 @@ as (
 
 ### Clustering Clause
 
-BigQuery tables can be [clustered](https://cloud.google.com/bigquery/docs/clustered-tables) to colocate related data. At present, BigQuery is only able to cluster partitioned tables, so be sure to use the `cluster_by` config in conjunction with the `partition_by` config.
+BigQuery tables can be [clustered](https://cloud.google.com/bigquery/docs/clustered-tables) to colocate related data.
 
 Clustering on a single column:
 
@@ -200,7 +200,6 @@ Clustering on a single column:
 {{
   config(
     materialized = "table",
-    partition_by = "date(created_at)",
     cluster_by = "order_id",
   )
 }}
@@ -218,7 +217,6 @@ Clustering on a multiple columns:
 {{
   config(
     materialized = "table",
-    partition_by = "date(created_at)",
     cluster_by = ["customer_id", "order_id"],
   )
 }}


### PR DESCRIPTION
## Description & motivation
https://cloud.google.com/bigquery/docs/release-notes#June_09_2020 partitioning is no longer required to use clustering.

## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged
-->
