### PR TITLE
Update using-operations.md

### DIFF
--- a/website/docs/docs/building-a-dbt-project/using-operations.md
+++ b/website/docs/docs/building-a-dbt-project/using-operations.md
@@ -74,7 +74,7 @@ Create a macro in your project. This macro should call a [statement](statement-b
 Run the macro from the command line, providing arguments as a YAML string.
 
 ```shell
-$ dbt run-operation say_hi --args '{name: world}'
+$ dbt run-operation say_hi --args "{name: world}"
 ```
 
 ### Exit codes


### PR DESCRIPTION
The given example of run-operation would result in error, as the argument should be given in ""
existing: $ dbt run-operation say_hi --args '{name: world}'
revised: $ dbt run-operation say_hi --args "{name: world}"

## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged
-->
