### PR TITLE
fix very minor typo error

### DIFF
--- a/website/docs/faqs/exclude-table-from-freshness.md
+++ b/website/docs/faqs/exclude-table-from-freshness.md
@@ -4,7 +4,7 @@ title: How do I exclude a table from a freshness snapshot?
 
 Some tables in a data source may be updated infrequently. If you've set a `freshness` property at the source level, this table is likely to fail checks.
 
-To work around this, you can use set the table's freshness to null (`freshness: null`) to "unset" the freshness for a particular table:
+To work around this, you can set the table's freshness to null (`freshness: null`) to "unset" the freshness for a particular table:
 
 <File name='models/<filename>.yml'>
 


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->
Very simple typographical error with `you can use set`. Just dropped the word `use`.
