### PR TITLE
Use a script to update dbt_project.yml to version 2 syntax

### DIFF
--- a/replace_project_yaml.py
+++ b/replace_project_yaml.py
@@ -29,7 +29,8 @@ config_keys = [
     'incremental_strategy',
     'cluster_by',
     'automatic_clustering',
-    'secure'
+    'secure',
+    'persist_docs'
 ]
 
 def fixPath(path):

--- a/replace_project_yaml.py
+++ b/replace_project_yaml.py
@@ -1,0 +1,62 @@
+import os
+import re
+
+config_keys = [
+    'materialized',
+    'sql_header',
+    'enabled',
+    'tags',
+    'pre-hook',
+    'post-hook',
+    'database',
+    'schema',
+    'alias',
+    'quote_columns',
+    'column_types',
+    'target_schema',
+    'target_database',
+    'unique_key',
+    'strategy',
+    'updated_at',
+    'check_cols',
+    'labels',
+    'encrypted',
+    'sort',
+    'dist',
+    'bind',
+    'sort_type',
+    'transient',
+    'incremental_strategy',
+    'cluster_by',
+    'automatic_clustering',
+    'secure'
+]
+
+def fixPath(path):
+    with open(path) as fh:
+        contents = fh.read()
+
+    print(f"Found dbt_project.yml in {path}")
+
+    for config in config_keys:
+        # Do it once for the non-hyperlinked version, e.g. `schema`
+        regex = '''(?<=<File name='dbt_project.yml'>)(.*)(''' + config + ''')(.*)(?=<\/File>)'''
+        out = re.sub(regex, '+' + config, contents, flags=re.S)
+
+        # and then again for the hyperlinked version, e.g. `[schema](schema)`
+        regex = '''(?<=<File name='dbt_project.yml'>)(.*)(\[''' + config + ''')(.*)(?=<\/File>)'''
+        out = re.sub(regex, '+[' + config, contents, flags=re.S)
+
+    with open(path, 'w') as fh:
+        fh.write(out)
+
+fixPath('test.md')
+
+# rootDir = '.'
+# for dirName, subdirList, fileList in os.walk(rootDir):
+#     for fname in fileList:
+#         if not fname.endswith('.md'):
+#             continue
+#
+#         path = os.path.join(dirName, fname)
+#         fixPath(path)

--- a/test.md
+++ b/test.md
@@ -1,0 +1,13 @@
+something
+
+<File name='dbt_project.yml'>
+
+```yaml
+name: my_dbt_project
+version: 1.0.0
+models:
+  schema: foo
+```
+</File>
+
+else


### PR DESCRIPTION
This doesn't work, but is close to working. Feel like finishing it off @drewbanin?

Here's my current [regex test](https://regex101.com/r/AlZ8zs/1) — I can't figure out how to _just_ pluck out "schema".

Once this is done, we'll also likely need to go through and check if we should add `config-version: 2` to some of the full-length `dbt_project.yml` samples