### PR TITLE
Observe config v2 for all documented node configs

### DIFF
--- a/website/docs/docs/building-a-dbt-project/building-models.md
+++ b/website/docs/docs/building-a-dbt-project/building-models.md
@@ -115,11 +115,11 @@ name: jaffle_shop
 
 models:
   jaffle_shop: # this matches the `name:`` config
-    materialized: view # this applies to all models in the current project
+    +materialized: view # this applies to all models in the current project
       marts:
-        materialized: table # this applies to all models in the `marts/` directory
+        +materialized: table # this applies to all models in the `marts/` directory
         marketing:
-          schema: marketing # this applies to all models in the `marts/marketing/`` directory
+          +schema: marketing # this applies to all models in the `marts/marketing/`` directory
 
 ```
 

--- a/website/docs/docs/building-a-dbt-project/building-models.md
+++ b/website/docs/docs/building-a-dbt-project/building-models.md
@@ -112,6 +112,8 @@ Here's an example of model configuration:
 
 ```yaml
 name: jaffle_shop
+config-version: 2
+...
 
 models:
   jaffle_shop: # this matches the `name:`` config

--- a/website/docs/docs/building-a-dbt-project/building-models/configuring-incremental-models.md
+++ b/website/docs/docs/building-a-dbt-project/building-models/configuring-incremental-models.md
@@ -169,7 +169,7 @@ for all models in your `dbt_project.yml` file:
 # Your dbt_project.yml file
 
 models:
-  incremental_strategy: "insert_overwrite"
+  +incremental_strategy: "insert_overwrite"
 ```
 
 </File>

--- a/website/docs/docs/building-a-dbt-project/building-models/configuring-incremental-models.md
+++ b/website/docs/docs/building-a-dbt-project/building-models/configuring-incremental-models.md
@@ -31,7 +31,7 @@ To use incremental models, you also need to tell dbt:
 ### Filtering rows on an incremental run
 To tell dbt which rows it should transform on an incremental run this, wrap valid SQL that filters for these rows in the `is_incremental()` macro.
 
-Often, you'll want to filter for "new" rows, as in, rows that have been created since the last time dbt ran this model. The best way to find the timestamp of the most recent run of this model is by checking the most recent timestamp in your target table. dbt makes it easy to query your target table by using the "[{{ this }}](this)" variable. 
+Often, you'll want to filter for "new" rows, as in, rows that have been created since the last time dbt ran this model. The best way to find the timestamp of the most recent run of this model is by checking the most recent timestamp in your target table. dbt makes it easy to query your target table by using the "[{{ this }}](this)" variable.
 
 For example, a model that includes a computationally slow transformation on a column can be built incrementally, as follows:
 
@@ -47,7 +47,7 @@ For example, a model that includes a computationally slow transformation on a co
 select
     *,
     my_slow_function(my_column)
-    
+
 from raw_app_data.events
 
 {% if is_incremental() %}
@@ -81,14 +81,14 @@ As an example, consider a model that calculates the number of daily active users
 {{
     config(
         materialized='incremental',
-        unique_key='date_day' 
+        unique_key='date_day'
     )
 }}
 
 select
     date_trunc('day', event_at) as date_day,
     count(distinct user_id) as daily_active_users
-    
+
 from raw_app_data.events
 
 
@@ -166,8 +166,6 @@ for all models in your `dbt_project.yml` file:
 <File name='dbt_project.yml'>
 
 ```yaml
-# Your dbt_project.yml file
-
 models:
   +incremental_strategy: "insert_overwrite"
 ```

--- a/website/docs/docs/building-a-dbt-project/building-models/materializations.md
+++ b/website/docs/docs/building-a-dbt-project/building-models/materializations.md
@@ -35,10 +35,10 @@ models:
   my_project:
     events:
       # materialize all models in models/events as tables
-      materialized: table
+      +materialized: table
     csvs:
       # this is redundant, and does not need to be set
-      materialized: view
+      +materialized: view
 ```
 
 </File>

--- a/website/docs/docs/building-a-dbt-project/building-models/materializations.md
+++ b/website/docs/docs/building-a-dbt-project/building-models/materializations.md
@@ -29,7 +29,7 @@ By default, dbt models are materialized as "views". Models can be configured wit
 
 name: my_project
 version: 1.0.0
-
+config-version: 2
 
 models:
   my_project:

--- a/website/docs/docs/building-a-dbt-project/building-models/using-custom-database.md
+++ b/website/docs/docs/building-a-dbt-project/building-models/using-custom-database.md
@@ -29,7 +29,7 @@ name: jaffle_shop
 
 models:
   my_project:
-    database: jaffle_shop
+    +database: jaffle_shop
 
     # For BigQuery users:
     # project: jaffle_shop

--- a/website/docs/docs/building-a-dbt-project/building-models/using-custom-schemas.md
+++ b/website/docs/docs/building-a-dbt-project/building-models/using-custom-schemas.md
@@ -45,7 +45,7 @@ select ...
 models:
   my_project:
     marketing:
-      schema: marketing
+      +schema: marketing
 ```
 
 </File>

--- a/website/docs/docs/building-a-dbt-project/package-management.md
+++ b/website/docs/docs/building-a-dbt-project/package-management.md
@@ -33,10 +33,10 @@ dbt _packages_ are in fact standalone dbt projects, with models and macros that 
 packages:
   - package: fishtown-analytics/snowplow
     version: 0.7.0
-    
+
   - git: "https://github.com/fishtown-analytics/dbt-utils.git"
     revision: 0.1.21
-    
+
   - local: /opt/dbt/redshift
 ```
 
@@ -125,8 +125,10 @@ When you remove a package from your `packages.yml` file, it isn't automatically 
 
 ### Configuring packages
 You can configure the models and seeds in a package from the `dbt_project.yml` file, like so:
-```
-# dbt_project.yml
+
+<File name='dbt_project.yml'>
+
+```yml
 
 vars:
   snowplow:
@@ -140,12 +142,15 @@ vars:
 
 models:
   snowplow:
-    schema: snowplow
+    +schema: snowplow
 
 seeds:
   snowplow:
-    schema: snowplow_seeds
+    +schema: snowplow_seeds
 ```
+
+</File>
+
 For example, when using a dataset specific package, you may need to configure variables for the names of the tables that contain your raw data.
 
 Configurations made in your `dbt_project.yml` file will override any configurations in a package (either in the `dbt_project.yml` file of the package, or in config blocks).

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-17-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-17-0.md
@@ -45,9 +45,9 @@ Previous releases of dbt allowed variables (`vars:`) to be scoped to a folder le
 
 In version 2 of the `dbt_project.yml` config, vars must now be defined in a top-level `vars:` dictionary, eg:
 
-```yml
-# dbt_project.yml
+<File name='dbt_project.yml'>
 
+```yml
 name: my_project
 version: 1.0.0
 
@@ -56,10 +56,13 @@ config-version: 2
 vars:
   my_var: 1
   another_var: true
-  
+
 models:
   ...
 ```
+
+</File>
+
 
 This syntax makes variable scoping unambiguous, as all of the nodes in a given package will receive the same value for a given variable. Note that this syntax _does_ still support package-level variable scoping. See the docs on the `dbt_project.yml` file syntax for more information.
 
@@ -67,17 +70,19 @@ This syntax makes variable scoping unambiguous, as all of the nodes in a given p
 
 Version 1 of the `dbt_project.yml` file spec allowed for ambiguous model configurations when dictionary configs were defined in a `models:` block. Consider:
 
-```yml
-# dbt_project.yml
+<File name='dbt_project.yml'>
 
+```yml
 models:
   my_project:
     reporting:
       partition_by:
         field: date_day
-        data_type: timestamp	
-      
+        data_type: timestamp
+
 ```
+
+</File>
 
 This example is intended to configure a `partition_by` setting for all of the BigQuery models in the `models/reporting/` folder. From the syntax in this file alone though, there are two possible interpretations:
 
@@ -86,8 +91,9 @@ This example is intended to configure a `partition_by` setting for all of the Bi
 
 To resolve this ambiguity, configurations can now be supplied using the `+` syntax for config keys. For the example above, this would look like:
 
+<File name='dbt_project.yml'>
+
 ```yml
-# dbt_project.yml
 
 models:
   my_project:
@@ -96,8 +102,12 @@ models:
         field: date_day
         data_type: timestamp
 ```
+</File>
+
 
 This syntax unambiguously defines `partition_by` as a configuration with a dictionary value of `{field: date_day, data_type: timestamp}`. This `+` decorator can be used for _any_ configuration, and can be helpful if you have a folder name that collides with a known dbt project config key. Example:
+
+<File name='dbt_project.yml'>
 
 ```yml
 # Your model lives in models/materialized/my_model.sql
@@ -108,6 +118,8 @@ models:
       +materialized: table
 
 ```
+</File>
+
 
 This configuration will work in dbt v0.17.0 when `config-version: 2` is used, but was not possible to represent in previous versions of dbt.
 
@@ -173,9 +185,9 @@ environment that dbt is running in. In this example, models in the `admin`
 package will be disabled in dev. This was not possible in previous versions of
 dbt.
 
-```yml
-# dbt_project.yml
+<File name='dbt_project.yml'>
 
+```yml
 name: my_project
 version: 1.0.0
 
@@ -183,11 +195,14 @@ config-version: 2
 
 models:
   my_project:
-    enabled: true
+    +enabled: true
 
   admin:
-    enabled: "{{ target.name == 'prod' }}"
+    +enabled: "{{ target.name == 'prod' }}"
 ```
+
+</File>
+
 
 ### Accessing sources in the `graph` object
 

--- a/website/docs/docs/writing-code-in-dbt/getting-started-with-jinja.md
+++ b/website/docs/docs/writing-code-in-dbt/getting-started-with-jinja.md
@@ -130,10 +130,10 @@ models:
   jaffle_shop:
     # 🙅 The yaml parser will interpret the { as the start of a dictionary
     # and get confused by the next {, resulting in a compliation error
-    schema: {{ env_var('DBT_SCHEMA') }}
+    +schema: {{ env_var('DBT_SCHEMA') }}
     
     # ✅ This works
-    schema: "{{ env_var('DBT_SCHEMA') }}"
+    +schema: "{{ env_var('DBT_SCHEMA') }}"
 ```
 
 </File>
@@ -151,7 +151,7 @@ models:
     description: {{ docs('users') }}
     
     # ✅ This is the correct way to reference a docs block
-		description: "{{ docs('users') }}"
+    description: "{{ docs('users') }}"
 
 ```
 

--- a/website/docs/docs/writing-code-in-dbt/jinja-context/dbt-project-yml-context.md
+++ b/website/docs/docs/writing-code-in-dbt/jinja-context/dbt-project-yml-context.md
@@ -25,7 +25,7 @@ and `snapshots:` keys in the `dbt_project.yml` file.
 
 ### Example configuration
 
-<File name="dbt_project.yml">
+<File name='dbt_project.yml'>
 
 ```yml
 name: my_project
@@ -37,7 +37,7 @@ version: 1.0.0
 models:
   my_project:
     facts:
-      materialized: "{{ 'view' if target.name == 'dev' else 'table' }}"
+      +materialized: "{{ 'view' if target.name == 'dev' else 'table' }}"
 ```
 
 </File>

--- a/website/docs/docs/writing-code-in-dbt/jinja-context/env_var.md
+++ b/website/docs/docs/writing-code-in-dbt/jinja-context/env_var.md
@@ -40,7 +40,7 @@ Be sure to quote the entire jinja string (as shown above), or else the yaml pars
 ...
 models:
   jaffle_shop:
-      materialized: "{{ env_var('DBT_MATERIALIZATION', 'view') }}"
+    +materialized: "{{ env_var('DBT_MATERIALIZATION', 'view') }}"
 ```
 
 </File>

--- a/website/docs/docs/writing-code-in-dbt/jinja-context/this.md
+++ b/website/docs/docs/writing-code-in-dbt/jinja-context/this.md
@@ -21,12 +21,12 @@ Before 0.11.0, there was a difference between `this.table` and `this.name`. In 0
 
 Here's an example of how to use `this` in `dbt_project.yml` to grant select rights on a table to a different db user.
 
-<File name='example.yml'>
+<File name='dbt_project.yml'>
 
 ```yaml
 models:
   project-name:
-    post-hook:
+    +post-hook:
       - "grant select on {{ this }} to db_reader"
 ```
 

--- a/website/docs/faqs/seed-datatypes.md
+++ b/website/docs/faqs/seed-datatypes.md
@@ -11,7 +11,7 @@ You can also explicitly set a datatype using the `column_types` [configuration](
 seeds:
   jaffle_shop: # you must include the project name
     warehouse_locations:
-      column_types:
+      +column_types:
         zipcode: varchar(5)
 ```
 

--- a/website/docs/learn/1-setting-up.md
+++ b/website/docs/learn/1-setting-up.md
@@ -14,7 +14,7 @@ If you are already **experienced with dbt**, you still need to complete this tut
 
 <LoomVideo id="cb99861ab1034f7fab5fa48529e61f85" />
 
-:::info 
+:::info
 Please note that this tutorial is adapted from the main <a href="https://tutorial.getdbt.com/tutorial/setting-up/">Getting Started</a> tutorial — there may be some references to BigQuery in various videos, however the same concepts should apply on Snowflake.
 :::
 
@@ -113,7 +113,7 @@ There’s two main ways of working with dbt:
 To use the CLI, it's important that you know some basics of your terminal. In particular, you should understand `cd`, `ls` and `pwd` to navigate through the directory structure of your computer easily. As such, if you are new to programming, we recommend using **dbt Cloud** for this tutorial.
 
 :::info
-    <p>During dbt Learn, we try our best to demonstrate using both workflows. However, we tend to default to using dbt Cloud for some of the shorter demonstrations.</p>
+During dbt Learn, we try our best to demonstrate using both workflows. However, we tend to default to using dbt Cloud for some of the shorter demonstrations.
 :::
 
 If you wish to use the CLI, please follow the [installation instructions](https://docs.getdbt.com/docs/installation) for your operating system.

--- a/website/docs/learn/2a-create-a-project-dbt-cloud.md
+++ b/website/docs/learn/2a-create-a-project-dbt-cloud.md
@@ -7,21 +7,21 @@ description: Now that we're set up, let's create a starter project with example 
 
 Now that we've successfully run our sample query in Snowflake, and chosen the way we want to develop, we can create a dbt project! In this step, we'll create a starter project with example models, before we build our own models.
 
-:::info 
+:::info
 
 These are the instructions for developing a project in dbt Cloud. If you're
 using the dbt CLI, follow the instructions [here](/learn/create-a-project-dbt-cli).
 
 :::
 
-:::caution 
+:::caution
 <strong>Learn students:</strong> please make sure you name your project "dbt Learn - [initialsurname]"
 :::
 
 <LoomVideo id="7386840381764d13b1d25f575719e218" />
 
 ## Create the starter project
-:::info 
+:::info
 You should have received an invitation to dbt Cloud. Please accept the invitation and create an account.
 :::
 
@@ -53,7 +53,7 @@ You should have received an invitation to dbt Cloud. Please accept the invitatio
 
 ```yaml
 name: jaffle_shop # this normally says my_new_package
-
+config-version: 2 # you must be using dbt v0.17.0 for this to work
 ...
 
 models:

--- a/website/docs/learn/2b-create-a-project-dbt-cli.md
+++ b/website/docs/learn/2b-create-a-project-dbt-cli.md
@@ -7,7 +7,7 @@ description: Now that we're set up, let's create a starter project with example 
 
 Now that we've successfully run our sample query in Snowflake, and chosen the way we want to develop, we can create a dbt project! In this step, we'll create a starter project with example models, before we build our own models.
 
-:::info 
+:::info
 
 These are the instructions for developing a project using the dbt CLI. If you're developing in dbt Cloud, follow the instructions [here](/tutorial/create-a-project-dbt-cloud).
 
@@ -24,7 +24,7 @@ $ dbt --version
 
 ```
 
-:::info 
+:::info
 
 dbt should have been installed as part of the  <a href="/tutorial/setting-up">Setting Up</a> part of the tutorial. If it was not installed, please follow the <a href="https://docs.getdbt.com/docs/installation"> installation instructions </a>
 
@@ -51,6 +51,7 @@ You can use `pwd` to confirm that you are in the right spot.
 
 ```yaml
 name: jaffle_shop # this normally says my_new_package
+config-version: 2 # you must be using dbt v0.17.0 for this to work
 
 ...
 
@@ -131,7 +132,7 @@ $ git remote add origin https://github.com/USERNAME/dbt-learn-[initialsurname].g
 $ git push -u origin master
 ```
 
-:::info 
+:::info
 
 If this is your first time using git, it's worth taking some time to understand the basics.
 

--- a/website/docs/learn/3-build-your-first-models.md
+++ b/website/docs/learn/3-build-your-first-models.md
@@ -59,6 +59,13 @@ If you switch back to the Snowflake console you'll be able to `select` from this
 ## Change the way your model is materialized
 One of the most powerful features of dbt is that you can change the way a model is materialized in your warehouse, simply by changing a configuration value. Let's see this in action.
 
+:::info Using the `+` sign in your `dbt_project.yml`
+These videos were recorded with a slightly older version of dbt (dbt v0.15.0), which did not use the `+` sign in the `dbt_project.yml` file (this was introduced in dbt v0.17.0).
+
+We'll try to update the videos soon, but for now, take extra note of the `+` signs in the code samples below, under the `models:` key.
+
+:::
+
 <CloudCore>
     <LoomVideo id="fbaa9948dccf4f74a17ffc7de1ddf4f2" />
     <LoomVideo id="22ebdc914426461ea5c617a415cb4c21" />
@@ -81,7 +88,7 @@ models:
 
 2. Execute `dbt run`. Your model, `customers` should now be built as a table!
 
-:::info 
+:::info
 To do this, dbt had to first run a `drop view` statement, then a `create table as` statement.
 :::
 

--- a/website/docs/learn/3-build-your-first-models.md
+++ b/website/docs/learn/3-build-your-first-models.md
@@ -71,9 +71,9 @@ One of the most powerful features of dbt is that you can change the way a model 
 ```yml
 models:
   jaffle_shop:
-    materialized: table
+    +materialized: table
     example:
-      materialized: view
+      +materialized: view
 
 ```
 
@@ -134,9 +134,9 @@ We don't need the sample files that dbt created for us anymore! Let's delete the
 # before
 models:
   jaffle_shop:
-    materialized: table
+    +materialized: table
     example:
-      materialized: view
+      +materialized: view
 ```
 </File>
 
@@ -146,7 +146,7 @@ models:
 # after
 models:
   jaffle_shop:
-    materialized: table
+    +materialized: table
 ```
 
 </File>

--- a/website/docs/reference/dbt_project.yml.md
+++ b/website/docs/reference/dbt_project.yml.md
@@ -11,6 +11,7 @@ dbt uses YAML in a few different places. If you're new to YAML, it would be wort
 ```yml
 [name](project-configs/name): string
 
+[config-version](project-configs/config-version): 2
 [version](project-configs/version): version
 
 [profile](project-configs/profile): profilename

--- a/website/docs/reference/model-configs.md
+++ b/website/docs/reference/model-configs.md
@@ -131,8 +131,10 @@ Model configurations are applied hierarchically — configurations applied to a 
 
 To configure models in your `dbt_project.yml` file, use the `models:` configuration option. Be sure to use namespace your configurations to your project (shown below):
 
-```yaml
-# dbt_project.yml
+<File name='dbt_project.yml'>
+
+```yml
+
 
 name: fishtown_analytics
 
@@ -151,7 +153,11 @@ models:
         +materialized: ephemeral
 
       ...
+
+
 ```
+
+</File>
 
 ### Apply configurations to one model only
 

--- a/website/docs/reference/model-configs.md
+++ b/website/docs/reference/model-configs.md
@@ -24,8 +24,8 @@ title: Model configurations
 ```yaml
 models:
   [<resource-path>](resource-path):
-    [materialized](materialized): <materialization_name>
-    [sql_header](sql_header): <string>
+    +[materialized](materialized): <materialization_name>
+    +[sql_header](sql_header): <string>
 
 ```
 
@@ -72,13 +72,13 @@ models:
 ```yaml
 models:
   [<resource-path>](resource-path):
-    [enabled](enabled): true | false
-    [tags](tags): <string> | [<string>]
-    [pre-hook](pre-hook): <sql-statement> | [<sql-statement>]
-    [post-hook](post-hook): <sql-statement> | [<sql-statement>]
-    [database](resource-configs/database): <string>
-    [schema](resource-configs/schema): <string>
-    [alias](resource-configs/alias): <string>
+    +[enabled](enabled): true | false
+    +[tags](tags): <string> | [<string>]
+    +[pre-hook](pre-hook): <sql-statement> | [<sql-statement>]
+    +[post-hook](post-hook): <sql-statement> | [<sql-statement>]
+    +[database](resource-configs/database): <string>
+    +[schema](resource-configs/schema): <string>
+    +[alias](resource-configs/alias): <string>
 
 ```
 
@@ -142,13 +142,13 @@ models:
 
     # This configures models found in models/events/
     events:
-      enabled: true
-      materialized: view
+      +enabled: true
+      +materialized: view
 
       # This configures models found in models/events/base
       # These models will be ephemeral, as the config above is overridden
       base:
-        materialized: ephemeral
+        +materialized: ephemeral
 
       ...
 ```

--- a/website/docs/reference/project-configs/config-version.md
+++ b/website/docs/reference/project-configs/config-version.md
@@ -1,0 +1,23 @@
+---
+datatype: integer
+---
+
+<File name='dbt_project.yml'>
+
+```yml
+config-version: 2
+```
+
+</File>
+
+## Definition
+Specify your `dbt_project.yml` as using the v2 structure.
+
+<Changelog>
+
+* `v0.17.0`: This configuration was introduced — see the [migration guide for 0.17.0](upgrading-to-0.17.0) for more details.
+
+</Changelog>
+
+## Default
+Without this configuration, dbt will assume your `dbt_project.yml` uses the version 1 syntax, which will be deprecated in a future release.

--- a/website/docs/reference/resource-configs/alias.md
+++ b/website/docs/reference/resource-configs/alias.md
@@ -34,7 +34,7 @@ The seed at `data/country_codes.csv` will be built as a table named `country_map
 seeds:
   jaffle_shop:
     country_codes:
-      alias: country_mappings
+      +alias: country_mappings
 
 ```
 

--- a/website/docs/reference/resource-configs/bigquery-configs.md
+++ b/website/docs/reference/resource-configs/bigquery-configs.md
@@ -244,7 +244,7 @@ version: 1.0.0
 models:
   my_project:
     encrypted:
-      kms_key_name: 'projects/PROJECT_ID/locations/global/keyRings/test/cryptoKeys/quickstart'
+      +kms_key_name: 'projects/PROJECT_ID/locations/global/keyRings/test/cryptoKeys/quickstart'
 ```
 
 </File>
@@ -283,10 +283,10 @@ select * from {{ ref('another_model') }}
 models:
   my_project:
     snowplow:
-      labels:
+      +labels:
         domain: clickstream
     finance:
-      labels:
+      +labels:
         domain: finance
 ```
 

--- a/website/docs/reference/resource-configs/check_cols.md
+++ b/website/docs/reference/resource-configs/check_cols.md
@@ -20,8 +20,8 @@ datatype: "[column_name] | all"
 ```yml
 snapshots:
   [<resource-path>](resource-path):
-    strategy: check
-    unique_key: [column_name] | all
+    +strategy: check
+    +unique_key: [column_name] | all
 
 ```
 

--- a/website/docs/reference/resource-configs/column_types.md
+++ b/website/docs/reference/resource-configs/column_types.md
@@ -17,7 +17,7 @@ Specify column types in your `dbt_project.yml` file:
 seeds:
   jaffle_shop:
     country_codes:
-      column_types:
+      +column_types:
         country_code: varchar(2)
         country_name: varchar(32)
 
@@ -36,7 +36,7 @@ seeds:
   jaffle_shop:
     marketing:
       utm_mappings:
-        column_types:
+        +column_types:
           ...
 
 ```
@@ -53,7 +53,7 @@ seeds:
 seeds:
   jaffle_shop: # you must include the project name
     warehouse_locations:
-      column_types:
+      +column_types:
         zipcode: varchar(5)
 ```
 

--- a/website/docs/reference/resource-configs/database.md
+++ b/website/docs/reference/resource-configs/database.md
@@ -33,7 +33,7 @@ To learn more about changing the way that dbt generates a relation's `database`,
 
 ```yml
 seeds:
-  database: RAW
+  +database: RAW
 
 ```
 

--- a/website/docs/reference/resource-configs/enabled.md
+++ b/website/docs/reference/resource-configs/enabled.md
@@ -34,7 +34,7 @@ select ...
 ```yml
 models:
   [<resource-path>](resource-path):
-    enabled: true | false
+    +enabled: true | false
 
 ```
 
@@ -50,7 +50,7 @@ models:
 ```yml
 seeds:
   [<resource-path>](resource-path):
-    enabled: true | false
+    +enabled: true | false
 
 ```
 
@@ -82,7 +82,7 @@ select ...
 ```yml
 snapshots:
   [<resource-path>](resource-path):
-    enabled: true | false
+    +enabled: true | false
 
 ```
 
@@ -116,7 +116,7 @@ models:
   segment:
     base:
       segment_web_page_views:
-        enabled: false
+        +enabled: false
 ```
 
 </File>

--- a/website/docs/reference/resource-configs/persist_docs.md
+++ b/website/docs/reference/resource-configs/persist_docs.md
@@ -22,7 +22,7 @@ select ...
 ```yml
 models:
   [<resource-path>](resource-path):
-    persist_docs:
+    +persist_docs:
       relation: true
       columns: true
 
@@ -77,19 +77,6 @@ models:
 Enable `persist_docs` for columns and relations in your project:
 
 <File name='dbt_project.yml'>
-
-```yml
-models:
-  persist_docs:
-    relation: true
-    columns: true
-```
-
-</File>
-
-<File name='dbt_project.yml'>
-
-Note that when using `config-version: 2` you will need to identify the `persist_docs` key as a config using the `+` config syntax:
 
 ```yml
 models:

--- a/website/docs/reference/resource-configs/post-hook.md
+++ b/website/docs/reference/resource-configs/post-hook.md
@@ -23,7 +23,7 @@ Post-hooks can also call macros that return SQL statements.
 ```yml
 
 seeds:
-  post-hook: "grant select on {{ this }} to group reporter"
+  +post-hook: "grant select on {{ this }} to group reporter"
 
 ```
 
@@ -36,7 +36,7 @@ seeds:
 ```yml
 
 seeds:
-  post-hook:
+  +post-hook:
     - "grant select on {{ this }} to group reporter"
     - "grant select on {{ this }} to group transformer"
 
@@ -51,7 +51,7 @@ seeds:
 ```yml
 
 seeds:
-  post-hook: "{{ grant_select(this) }}"
+  +post-hook: "{{ grant_select(this) }}"
 
 ```
 

--- a/website/docs/reference/resource-configs/pre-hook.md
+++ b/website/docs/reference/resource-configs/pre-hook.md
@@ -23,7 +23,7 @@ Pre-hooks work very similarly to post-hooks, check out the [post-hook](post-hook
 
 ```yml
 models:
-  pre-hook: "alter session set week_of_year_policy=1, week_start=1;"
+  +pre-hook: "alter session set week_of_year_policy=1, week_start=1;"
 ```
 
 </File>

--- a/website/docs/reference/resource-configs/quote_columns.md
+++ b/website/docs/reference/resource-configs/quote_columns.md
@@ -24,7 +24,7 @@ An optional seed configuration, used to determine whether column names in the se
 
 ```yml
 seeds:
-  quote_columns: true
+  +quote_columns: true
 ```
 
 </File>
@@ -38,7 +38,7 @@ For a project with:
 seeds:
   jaffle_shop:
     mappings:
-      quote_columns: true
+      +quote_columns: true
 ```
 
 ## Recommended configuration

--- a/website/docs/reference/resource-configs/redshift-configs.md
+++ b/website/docs/reference/resource-configs/redshift-configs.md
@@ -82,7 +82,7 @@ To make all views late-binding, configure your `dbt_project.yml` file like this:
 
 ```yaml
 models:
-  bind: false # Materialize all views as late-binding
+  +bind: false # Materialize all views as late-binding
   project_name:
     ....
 ```

--- a/website/docs/reference/resource-configs/resource-path.md
+++ b/website/docs/reference/resource-configs/resource-path.md
@@ -13,7 +13,7 @@ To apply a configuration to all models, do not use a `<resource-path>`:
 
 ```yml
 models:
-  enabled: false # this will disable all models (not a thing you probably want to do)
+  +enabled: false # this will disable all models (not a thing you probably want to do)
 ```
 
 </File>
@@ -27,7 +27,7 @@ name: jaffle_shop
 
 models:
   jaffle_shop:
-    enabled: false # this will apply to all models in your project, but not any installed packages
+    +enabled: false # this will apply to all models in your project, but not any installed packages
 ```
 
 </File>
@@ -42,7 +42,7 @@ name: jaffle_shop
 models:
   jaffle_shop:
     staging:
-      enabled: false # this will apply to all models in the `staging/` directory of your project
+      +enabled: false # this will apply to all models in the `staging/` directory of your project
 ```
 
 </File>
@@ -69,7 +69,7 @@ models:
     staging:
       stripe:
         payments:
-          enabled: false # this will apply to only one model
+          +enabled: false # this will apply to only one model
 ```
 
 </File>

--- a/website/docs/reference/resource-configs/schema.md
+++ b/website/docs/reference/resource-configs/schema.md
@@ -27,11 +27,11 @@ Configure groups of models from the `dbt_project.yml` file.
 
 <File name='dbt_project.yml'>
 
-```
+```yml
 models:
   jaffle_shop: # the name of a project
     marketing:
-      schema: marketing
+      +schema: marketing
 ```
 
 </File>
@@ -51,9 +51,9 @@ Configure individual models using a config block:
 ### Seeds
 <File name='dbt_project.yml'>
 
-```
+```yml
 seeds:
-  schema: mappings
+  +schema: mappings
 ```
 
 </File>

--- a/website/docs/reference/resource-configs/snowflake-configs.md
+++ b/website/docs/reference/resource-configs/snowflake-configs.md
@@ -29,7 +29,7 @@ name: my_project
 ...
 
 models:
-  transient: false
+  +transient: false
   my_project:
     ...
 ```
@@ -129,7 +129,7 @@ The `automatic_clustering` config can be specified in the `dbt_project.yml` file
 ```yaml
 
 models:
-  automatic_clustering: true
+  +automatic_clustering: true
 ```
 
 </File>
@@ -147,13 +147,13 @@ version: 1.0.0
 ...
 
 models:
-  snowflake_warehouse: "EXTRA_SMALL"
+  +snowflake_warehouse: "EXTRA_SMALL"
   my_project:
     clickstream:
-      snowflake_warehouse: "EXTRA_LARGE"
+      +snowflake_warehouse: "EXTRA_LARGE"
 
 snapshots:
-  snowflake_warehouse: "EXTRA_LARGE"
+  +snowflake_warehouse: "EXTRA_LARGE"
 ```
 
 ## Copying grants
@@ -165,7 +165,7 @@ When the `copy_grants` config is set to `true`, dbt will add the `copy grants` D
 ```yaml
 
 models:
-  copy_grants: true
+  +copy_grants: true
 ```
 
 </File>
@@ -186,8 +186,8 @@ version: 1.0.0
 models:
   my_project:
     sensitive:
-      materialized: view
-      secure: true
+      +materialized: view
+      +secure: true
 ```
 
 </File>

--- a/website/docs/reference/resource-configs/strategy.md
+++ b/website/docs/reference/resource-configs/strategy.md
@@ -35,8 +35,8 @@ select ...
 ```yml
 snapshots:
   [<resource-path>](resource-path):
-    strategy: timestamp
-    updated_at: column_name
+    +strategy: timestamp
+    +updated_at: column_name
 
 ```
 

--- a/website/docs/reference/resource-configs/strategy.md
+++ b/website/docs/reference/resource-configs/strategy.md
@@ -67,8 +67,8 @@ snapshots:
 ```yml
 snapshots:
   [<resource-path>](resource-path):
-    strategy: check
-    check_cols: [column_name] | all
+    +strategy: check
+    +check_cols: [column_name] | all
 
 ```
 

--- a/website/docs/reference/resource-configs/tags.md
+++ b/website/docs/reference/resource-configs/tags.md
@@ -23,15 +23,15 @@ To tag a column, test, or source, use the [tag _property_](resource-properties/t
 
 models:
   [<resource-path>](resource-path):
-    [tags](tags): <string> | [<string>]
+    +[tags](tags): <string> | [<string>]
 
 snapshots:
   [<resource-path>](resource-path):
-    [tags](tags): <string> | [<string>]
+    +[tags](tags): <string> | [<string>]
 
 seeds:
   [<resource-path>](resource-path):
-    [tags](tags): <string> | [<string>]
+    +[tags](tags): <string> | [<string>]
 
 ```
 
@@ -73,19 +73,19 @@ Apply tags in your `dbt_project.yml` as a single value or a string:
 ```yml
 models:
   jaffle_shop:
-    tags: "contains_pii"
+    +tags: "contains_pii"
 
     staging:
-      tags:
+      +tags:
         - "hourly"
 
     marts:
-      tags:
+      +tags:
         - "hourly"
         - "published"
 
     metrics:
-      tags:
+      +tags:
         - "daily"
         - "published"
 
@@ -126,7 +126,7 @@ $ dbt run --model tag:daily --exclude tag:hourly
 seeds:
   jaffle_shop:
     utm_mappings:
-      tags: marketing
+      +tags: marketing
 ```
 
 </File>
@@ -137,7 +137,7 @@ seeds:
 seeds:
   jaffle_shop:
     utm_mappings:
-      tags:
+      +tags:
         - marketing
         - hourly
 ```

--- a/website/docs/reference/resource-configs/target_database.md
+++ b/website/docs/reference/resource-configs/target_database.md
@@ -49,7 +49,7 @@ By default, dbt will use the [target](target) database associated with your prof
 
 ```yml
 snapshots:
-  target_database: snapshots
+  +target_database: snapshots
 
 ```
 
@@ -64,7 +64,7 @@ Note: consider whether this use-case is right for you, as downstream `refs` will
 
 ```yml
 snapshots:
-  target_database: "{% if target.name == 'dev' %}dev{% else %}{{ target.database }}{% endif %}"
+  +target_database: "{% if target.name == 'dev' %}dev{% else %}{{ target.database }}{% endif %}"
 
 ```
 

--- a/website/docs/reference/resource-configs/target_database.md
+++ b/website/docs/reference/resource-configs/target_database.md
@@ -8,7 +8,7 @@ datatype: string
 ```yml
 snapshots:
   [<resource-path>](resource-path):
-    target_database: string
+    +target_database: string
 
 ```
 

--- a/website/docs/reference/resource-configs/target_schema.md
+++ b/website/docs/reference/resource-configs/target_schema.md
@@ -43,7 +43,7 @@ This is a **required** parameter, no default is provided.
 
 ```yml
 snapshots:
-  target_schema: snapshots
+  +target_schema: snapshots
 
 ```
 
@@ -58,7 +58,7 @@ Note: consider whether this use-case is right for you, as downstream `refs` will
 
 ```yml
 snapshots:
-  target_schema: "{% if target.name == 'prod' %}snapshots{% else %}{{ target.schema }}{% endif %}"
+  +target_schema: "{% if target.name == 'prod' %}snapshots{% else %}{{ target.schema }}{% endif %}"
 
 ```
 

--- a/website/docs/reference/resource-configs/target_schema.md
+++ b/website/docs/reference/resource-configs/target_schema.md
@@ -8,7 +8,7 @@ datatype: string
 ```yml
 snapshots:
   [<resource-path>](resource-path):
-    target_schema: string
+    +target_schema: string
 
 ```
 

--- a/website/docs/reference/resource-configs/unique_key.md
+++ b/website/docs/reference/resource-configs/unique_key.md
@@ -19,7 +19,7 @@ datatype: column_name_or_expression
 ```yml
 snapshots:
   [<resource-path>](resource-path):
-    unique_key: column_name_or_expression
+    +unique_key: column_name_or_expression
 
 ```
 
@@ -60,7 +60,7 @@ You can also write this in yaml. This might be a good idea if multiple snapshots
 ```yml
 snapshots:
   [<resource-path>](resource-path):
-    unique_key: id
+    +unique_key: id
 
 ```
 

--- a/website/docs/reference/resource-configs/updated_at.md
+++ b/website/docs/reference/resource-configs/updated_at.md
@@ -19,8 +19,8 @@ datatype: column_name
 ```yml
 snapshots:
   [<resource-path>](resource-path):
-    strategy: timestamp
-    updated_at: column_name
+    +strategy: timestamp
+    +updated_at: column_name
 
 ```
 

--- a/website/docs/reference/seed-configs.md
+++ b/website/docs/reference/seed-configs.md
@@ -30,7 +30,7 @@ To apply a configuration to all seeds, including those in any installed [package
 ```yml
 
 seeds:
-  schema: seed_data
+  +schema: seed_data
 ```
 
 </File>
@@ -47,7 +47,7 @@ For a project named `jaffle_shop`:
 
 seeds:
   jaffle_shop:
-    schema: seed_data
+    +schema: seed_data
 ```
 
 </File>
@@ -66,7 +66,7 @@ seeds:
   jaffle_shop:
     marketing:
       utm_parameters:
-        schema: seed_data
+        +schema: seed_data
 ```
 
 </File>
@@ -86,16 +86,16 @@ name: jaffle_shop
 ...
 seeds:
   jaffle_shop:
-    enabled: true
-    schema: seed_data
+    +enabled: true
+    +schema: seed_data
     # This configures data/country_codes.csv
     country_codes:
       # Override column types
-      column_types:
+      +column_types:
         country_code: varchar(2)
         country_name: varchar(32)
     marketing:
-      schema: marketing # this will take precedence
+      +schema: marketing # this will take precedence
 ```
 
 </File>

--- a/website/docs/reference/snapshot-configs.md
+++ b/website/docs/reference/snapshot-configs.md
@@ -24,16 +24,21 @@ Parts of a snapshot:
 }>
 <TabItem value="yaml">
 
+<File name='dbt_project.yml'>
 
 ```yaml
-[target_schema](target_schema): <string>
-[target_database](target_database): <string>
-[unique_key](unique_key): <column_name_or_expression>
-[strategy](strategy): timestamp | check
-[updated_at](updated_at): <column_name>
-[check_cols](check_cols): [<column_name>] | all
+
+snapshots:
+  +[target_schema](target_schema): <string>
+  +[target_database](target_database): <string>
+  +[unique_key](unique_key): <column_name_or_expression>
+  +[strategy](strategy): timestamp | check
+  +[updated_at](updated_at): <column_name>
+  +[check_cols](check_cols): [<column_name>] | all
 
 ```
+
+</File>
 
 </TabItem>
 

--- a/website/docs/reference/snapshot-configs.md
+++ b/website/docs/reference/snapshot-configs.md
@@ -131,7 +131,7 @@ To apply a configuration to all snapshots, including those in any installed [pac
 ```yml
 
 snapshots:
-  target_schema: snapshots
+  +target_schema: snapshots
 ```
 
 </File>
@@ -148,7 +148,7 @@ For a project named `jaffle_shop`:
 
 snapshots:
   jaffle_shop:
-    target_schema: snapshot_data
+    +target_schema: snapshot_data
 ```
 
 </File>
@@ -188,9 +188,9 @@ snapshots:
   jaffle_shop:
     postgres_app:
       orders_snapshot:
-        unique_key: id
-        strategy: timestamp
-        updated_at: updated_at
+        +unique_key: id
+        +strategy: timestamp
+        +updated_at: updated_at
 ```
 
 </File>

--- a/website/docs/reference/source-configs.md
+++ b/website/docs/reference/source-configs.md
@@ -38,7 +38,7 @@ state your configuration under the [project name](project-configs/name.md) in th
 
 sources:
   events:
-    enabled: false
+    +enabled: false
 ```
 
 </File>
@@ -57,7 +57,7 @@ with both a package name and a source name.
 sources:
   events:
     clickstream:
-      enabled: false
+      +enabled: false
 ```
 
 </File>
@@ -72,7 +72,7 @@ sources:
   events:
     clickstream:
       pageviews:
-        enabled: false
+        +enabled: false
 ```
 
 </File>
@@ -93,16 +93,16 @@ config-version: 2
 sources:
   # project names
   jaffle_shop:
-    enabled: true
+    +enabled: true
 
   events:
     # source names
     clickstream:
       # table names
       pageviews:
-        enabled: false
+        +enabled: false
       link_clicks:
-        enabled: true
+        +enabled: true
 ```
 
 </File>

--- a/website/docs/tutorial/3-build-your-first-models.md
+++ b/website/docs/tutorial/3-build-your-first-models.md
@@ -72,9 +72,9 @@ One of the most powerful features of dbt is that you can change the way a model 
 ```yaml
 models:
   jaffle_shop:
-    materialized: table
+    +materialized: table
     example:
-      materialized: view
+      +materialized: view
 ```
 
 </File>
@@ -133,9 +133,9 @@ We don't need the sample files that dbt created for us anymore! Let's delete the
 # before
 models:
   jaffle_shop:
-    materialized: table
+    +materialized: table
     example:
-      materialized: view
+      +materialized: view
 ```
 </File>
 
@@ -145,7 +145,7 @@ models:
 # after
 models:
   jaffle_shop:
-    materialized: table
+    +materialized: table
 ```
 
 </File>

--- a/website/docs/tutorial/3-build-your-first-models.md
+++ b/website/docs/tutorial/3-build-your-first-models.md
@@ -60,6 +60,13 @@ If you switch back to the BigQuery console you'll be able to `select` from this 
 ## Change the way your model is materialized
 One of the most powerful features of dbt is that you can change the way a model is materialized in your warehouse, simply by changing a configuration value. Let's see this in action.
 
+:::info Using the `+` sign in your `dbt_project.yml`
+These videos were recorded with a slightly older version of dbt (dbt v0.15.0), which did not use the `+` sign in the `dbt_project.yml` file (this was introduced in dbt v0.17.0).
+
+We'll try to update the videos soon, but for now, take extra note of the `+` signs in the code samples below, under the `models:` key.
+
+:::
+
 <CloudCore>
     <LoomVideo id="fbaa9948dccf4f74a17ffc7de1ddf4f2" />
     <LoomVideo id="22ebdc914426461ea5c617a415cb4c21" />
@@ -80,7 +87,7 @@ models:
 </File>
 
 2. Execute `dbt run`. Your model, `customers` should now be built as a table!
-:::info 
+:::info
 To do this, dbt had to first run a `drop view` statement (or API call on BigQuery), then a `create table as` statement.
 :::
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -256,6 +256,7 @@ module.exports = {
         items: [
           "reference/project-configs/analysis-paths",
           "reference/project-configs/clean-targets",
+          "reference/project-configs/config-version",
           "reference/project-configs/data-paths",
           "reference/project-configs/docs-paths",
           "reference/project-configs/log-path",


### PR DESCRIPTION
* resolves #206
* Update all docs around node configs in `dbt_project.yml` to observe `config-version: 2`, introduced in 0.17.0
* Understood if we want to wait on this. My assumption is that, going forward, all _brand new_ dbt users will be on >= v0.17.0