### PR TITLE
Snowflake: automatic clustering + SSO updates

### DIFF
--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-18-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-18-0.md
@@ -75,6 +75,7 @@ can override schema test definitions
 
 **Snowflake**
 - `query_tag` in [profile](snowflake-profile), [model config](snowflake-configs#query-tags)
+- automatic SSO [session caching](snowflake-configs#sso-authentication) support
 
 **BigQuery**
 - [`impersonate_service_account`](https://docs.getdbt.com/reference/warehouse-profiles/bigquery-profile#service-account-impersonation)

--- a/website/docs/reference/resource-configs/snowflake-configs.md
+++ b/website/docs/reference/resource-configs/snowflake-configs.md
@@ -161,7 +161,9 @@ create or replace table my_database.my_schema.my_table as (
 
 ### Automatic clustering
 
-Automatic clustering is a preview feature in Snowflake (at the time of this writing) and as such, some accounts may have it turned on while others may not. You can use the `automatic_clustering` config to control whether or not automatic clustering is enabled for dbt models. When `automatic_clustering` is set to `true`, dbt will run an `alter table <table name> resume recluster` query after building the target table. This configuration is only required for Snowflake accounts which do not have automatic clustering enabled. For more information, consult the [Snowflake documentation on Manual Reclustering](https://docs.snowflake.net/manuals/user-guide/tables-clustering-manual.html#switching-from-manual-reclustering-to-automatic-clustering).
+Automatic clustering is [enabled by default in Snowflake today](https://docs.snowflake.com/en/user-guide/tables-clustering-manual.html), no action is needed to make use of it. Though there is an `automatic_clustering` config, it has no effect except for accounts with (deprecated) manual clustering enabled.
+
+If [manual clustering is still enabled for your account](https://docs.snowflake.com/en/user-guide/tables-clustering-manual.html), you can use the `automatic_clustering` config to control whether or not automatic clustering is enabled for dbt models. When `automatic_clustering` is set to `true`, dbt will run an `alter table <table name> resume recluster` query after building the target table. 
 
 The `automatic_clustering` config can be specified in the `dbt_project.yml` file, or in a model `config()` block.
 

--- a/website/docs/reference/resource-configs/snowflake-configs.md
+++ b/website/docs/reference/resource-configs/snowflake-configs.md
@@ -82,8 +82,8 @@ select ...
 
 ```
 
-**Note:** query tags are set at the _session_ level. At the start of each model 
-materialization, if the model has a custom `query_tag` 
+**Note:** query tags are set at the _session_ level. At the start of each model
+materialization, if the model has a custom `query_tag`
 configured, dbt will run `alter session set query_tag` to set the new value.
 At the end of the materialization, dbt will run another `alter` statement to reset
 the tag to its default value. As such, build failures midway through a materialization may result in subsequent
@@ -161,9 +161,9 @@ create or replace table my_database.my_schema.my_table as (
 
 ### Automatic clustering
 
-Automatic clustering is [enabled by default in Snowflake today](https://docs.snowflake.com/en/user-guide/tables-clustering-manual.html), no action is needed to make use of it. Though there is an `automatic_clustering` config, it has no effect except for accounts with (deprecated) manual clustering enabled.
+Automatic clustering is [enabled by default in Snowflake today](https://docs.snowflake.com/en/user-guide/tables-auto-reclustering.html), no action is needed to make use of it. Though there is an `automatic_clustering` config, it has no effect except for accounts with (deprecated) manual clustering enabled.
 
-If [manual clustering is still enabled for your account](https://docs.snowflake.com/en/user-guide/tables-clustering-manual.html), you can use the `automatic_clustering` config to control whether or not automatic clustering is enabled for dbt models. When `automatic_clustering` is set to `true`, dbt will run an `alter table <table name> resume recluster` query after building the target table. 
+If [manual clustering is still enabled for your account](https://docs.snowflake.com/en/user-guide/tables-clustering-manual.html), you can use the `automatic_clustering` config to control whether or not automatic clustering is enabled for dbt models. When `automatic_clustering` is set to `true`, dbt will run an `alter table <table name> resume recluster` query after building the target table.
 
 The `automatic_clustering` config can be specified in the `dbt_project.yml` file, or in a model `config()` block.
 

--- a/website/docs/reference/warehouse-profiles/snowflake-profile.md
+++ b/website/docs/reference/warehouse-profiles/snowflake-profile.md
@@ -68,7 +68,9 @@ my-snowflake-db:
 
 To use SSO authentication for Snowflake, omit a `password` and instead supply an `authenticator` config to your target. `authenticator` can be one of 'externalbrowser' or a valid Okta URL.
 
-**Note**: By default, every connection that dbt opens will require you to re-authenticate in a browser. The Snowflake connector package supports cacheing your session token, but it [currently only supports Windows and Mac OS](https://docs.snowflake.com/en/user-guide/odbc-parameters.html#using-browser-based-sso-with-connection-caching-macos-and-windows-only). See [the Snowflake docs](https://docs.snowflake.com/en/user-guide/odbc-parameters.html#using-browser-based-sso-with-connection-caching-macos-and-windows-only) for how to enable this feature in your account.
+<Changelog>New in v0.18.0</Changelog>
+
+**Note**: By default, every connection that dbt opens will require you to re-authenticate in a browser. The Snowflake connector package supports caching your session token, but it [currently only supports Windows and Mac OS](https://docs.snowflake.com/en/user-guide/admin-security-fed-auth-use.html#optional-using-connection-caching-to-minimize-the-number-of-prompts-for-authentication). See [the Snowflake docs](https://docs.snowflake.com/en/sql-reference/parameters.html#label-allow-id-token) for how to enable this feature in your account.
 
 <File name='~/.dbt/profiles.yml'>
 

--- a/website/docs/reference/warehouse-profiles/snowflake-profile.md
+++ b/website/docs/reference/warehouse-profiles/snowflake-profile.md
@@ -68,7 +68,7 @@ my-snowflake-db:
 
 To use SSO authentication for Snowflake, omit a `password` and instead supply an `authenticator` config to your target. `authenticator` can be one of 'externalbrowser' or a valid Okta URL.
 
-**Note**: By default, every connection that dbt opens will require you to re-authenticate in a browser. Contact your Snowflake support rep and inquire about turning on the "id token cache" for your account as described [here](https://github.com/snowflakedb/snowflake-connector-python/issues/140#issuecomment-447028785).
+**Note**: By default, every connection that dbt opens will require you to re-authenticate in a browser. The Snowflake connector package supports cacheing your session token, but it [currently only supports Windows and Mac OS](https://docs.snowflake.com/en/user-guide/odbc-parameters.html#using-browser-based-sso-with-connection-caching-macos-and-windows-only). See [the Snowflake docs](https://docs.snowflake.com/en/user-guide/odbc-parameters.html#using-browser-based-sso-with-connection-caching-macos-and-windows-only) for how to enable this feature in your account.
 
 <File name='~/.dbt/profiles.yml'>
 


### PR DESCRIPTION
## Description & motivation
As requested by @drewbanin https://github.com/fishtown-analytics/dbt/issues/1172#issuecomment-654240998.

The SSO docs reflect my and other experience. I have no included the part about overriding the snowflake-connector-python to >=2.2.8, I am hoping a dbt author can just update 1.18 to use this version instead?

Full disclosure, I've not used automatic clustering, but i skimmed the docs for other stuff that looked like it could be out of date, and that stuck out. Since May 2020 its on by default for everyone, and I notice the current implementation toggles between "the account default" and "on", so effectively there's no way to disable it anymore. The docs reflect that now.


## To-do before merge
- [x] Confirm someones going to update 1.18 to snowflake-connector-python >=2.2.8
