### PR TITLE
0.17.1: opt-in native env rendering

### DIFF
--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-17-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-17-0.md
@@ -133,19 +133,21 @@ Support for version 1 will be removed in a future release of dbt.
 
 ### NativeEnvironment rendering for yaml fields
 
-In dbt v0.17.0, dbt enables use of Jinja's Native Environment to render values in
+In dbt v0.17.0, dbt enabled use of Jinja's Native Environment to render values in
 YML files. This Native Environment coerces string values to their
 primitive Python types (booleans, integers, floats, and tuples). With this
 change, you can now provide boolean and integer values to configurations via
 string-oriented inputs, like environment variables or command line variables.
 
-<Changelog>
+:::danger Heads up
 
   In dbt v0.17.1, native rendering is not enabled by default. It is possible to
   natively render specific values using the [`as_bool`](as_bool), 
   [`as_number`](as_number), and [`as_native`](as_native) filters.
+  
+  The examples below have been updated to reflect 0.17.1 functionality.
 
-</Changelog>
+:::
 
 This example specifies a port number as an integer from an environment variable.
 This was not possible in previous versions of dbt.
@@ -162,28 +164,8 @@ debug:
       host: "{{ env_var('DBT_HOST') }}"
 
       # The port number will be coerced from a string to an integer
-      port: "{{ env_var('DBT_PORT') }}"
+      port: "{{ env_var('DBT_PORT') | as_number }}"
 
-      dbname: analytics
-      schema: analytics
-```
-
-If you want to bypass this type coercion, you can use the [as_text](as_text)
-jinja filter to force the value to be a string instead:
-
-```yml
-
-debug:
-  target: dev
-  outputs:
-    dev:
-      type: postgres
-
-      # The DBT_USER env var will be force-casted to a string
-      user: "{{ env_var('DBT_USER') | as_text }}"
-      pass: "{{ env_var('DBT_PASS') }}"
-      host: "{{ env_var('DBT_HOST') }}"
-      port: "{{ env_var('DBT_PORT') }}"
       dbname: analytics
       schema: analytics
 ```
@@ -206,7 +188,7 @@ models:
     +enabled: true
 
   admin:
-    +enabled: "{{ target.name == 'prod' }}"
+    +enabled: "{{ (target.name == 'prod') | as_bool }}"
 ```
 
 </File>

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-17-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-17-0.md
@@ -133,11 +133,19 @@ Support for version 1 will be removed in a future release of dbt.
 
 ### NativeEnvironment rendering for yaml fields
 
-In dbt v0.17.0, dbt will use a jinja Native Environment to render values in
-schema.yml files. This Native Environment will coerce string values to their
+In dbt v0.17.0, dbt enables use of Jinja's Native Environment to render values in
+YML files. This Native Environment coerces string values to their
 primitive Python types (booleans, integers, floats, and tuples). With this
 change, you can now provide boolean and integer values to configurations via
 string-oriented inputs, like environment variables or command line variables.
+
+<Changelog>
+
+  In dbt v0.17.1, native rendering is not enabled by default. It is possible to
+  natively render specific values using the [`as_bool`](as_bool), 
+  [`as_number`](as_number), and [`as_native`](as_native) filters.
+
+</Changelog>
 
 This example specifies a port number as an integer from an environment variable.
 This was not possible in previous versions of dbt.

--- a/website/docs/reference/dbt-jinja-functions.md
+++ b/website/docs/reference/dbt-jinja-functions.md
@@ -4,6 +4,9 @@ title: "dbt Jinja Functions"
 
 In addition to the standard Jinja library ([docs](https://jinja.palletsprojects.com/en/2.11.x/templates/)), we've added additional functions and variables to the Jinja context that are useful when working with a dbt project:
 * [adapter](dbt-jinja-functions/adapter)
+* [as_bool](as_bool)
+* [as_native](as_native)
+* [as_number](as_number)
 * [as_text](as_text)
 * [builtins](builtins)
 * [config](config)

--- a/website/docs/reference/dbt-jinja-functions/as_bool.md
+++ b/website/docs/reference/dbt-jinja-functions/as_bool.md
@@ -7,12 +7,6 @@ The `as_number` Jinja filter will coerce Jinja-compiled output into a boolean
 value (`True` or `False`), or return an error if it cannot be represented
 as a bool.
 
-:::caution Heads up!
-In dbt v0.17.1, native rendering is not enabled by default. It is possible to
-natively render specific values using the [`as_bool`](as_bool), 
-[`as_number`](as_number), and [`as_native`](as_native) filters.
-:::
-
 ### Usage:
 
 In the example below, the `as_bool` filter is used to coerce a Jinja 

--- a/website/docs/reference/dbt-jinja-functions/as_bool.md
+++ b/website/docs/reference/dbt-jinja-functions/as_bool.md
@@ -4,7 +4,7 @@ id: "as_bool"
 ---
 
 The `as_number` Jinja filter will coerce Jinja-compiled output into a boolean
-value (`true` or `false`), or return an error if it cannot be represented
+value (`True` or `False`), or return an error if it cannot be represented
 as a bool.
 
 :::caution Heads up!

--- a/website/docs/reference/dbt-jinja-functions/as_bool.md
+++ b/website/docs/reference/dbt-jinja-functions/as_bool.md
@@ -1,0 +1,37 @@
+---
+title: "as_bool"
+id: "as_bool"
+---
+
+The `as_number` Jinja filter will coerce Jinja-compiled output into a boolean
+value (`true` or `false`), or return an error if it cannot be represented
+as a bool.
+
+:::caution Heads up!
+In dbt v0.17.1, native rendering is not enabled by default. It is possible to
+natively render specific values using the [`as_bool`](as_bool), 
+[`as_number`](as_number), and [`as_native`](as_native) filters.
+:::
+
+### Usage:
+
+In the example below, the `as_bool` filter is used to coerce a Jinja 
+expression to enable or disable a set of models based on the `target`.
+
+<File name='dbt_project.yml'>
+
+```yml
+models:
+  my_project:
+    for_export:
+      enabled: "{{ (target.name == 'prod') | as_bool }}"
+```
+
+</File>
+
+<Changelog>
+
+* `v0.17.1`: Native rendering is disabled by default. The `as_bool` filter was 
+introduced.
+
+</Changelog>

--- a/website/docs/reference/dbt-jinja-functions/as_native.md
+++ b/website/docs/reference/dbt-jinja-functions/as_native.md
@@ -7,6 +7,9 @@ The `as_native` Jinja filter will coerce Jinja-compiled output into its
 Python native representation according to [`ast.literal_eval`](https://docs.python.org/3/library/ast.html#ast.literal_eval). 
 The result can be any Python native type (set, list, tuple, dict, etc).
 
+To render boolean and numeric values, it is recommended to use [`as_bool`](as_bool) 
+and [`as_number`](as_number) instead.
+
 :::danger Proceed with caution
 Unlike `as_bool` and `as_number`, `as_native` will return a rendered value
 regardless of the input type. Ensure that your inputs match expectations.

--- a/website/docs/reference/dbt-jinja-functions/as_native.md
+++ b/website/docs/reference/dbt-jinja-functions/as_native.md
@@ -12,33 +12,6 @@ Unlike `as_bool` and `as_number`, `as_native` will return a rendered value
 regardless of the input type. Ensure that your inputs match expectations.
 :::
 
-### Usage
-
-In the example below, the `as_native` filter is used to coerce a dbt project
-variable into a dictionary for freshness testing.
-
-<File name='src_stripe.yml'>
-
-```yml
-sources:
-  - name: stripe
-    loaded_at_field: synced_at
-    freshness: "{{ var('stripe_freshness') | as_native }}"
-```
-
-</File>
-
-<File name='dbt_project.yml'>
-
-```yml
-vars:
-  stripe_freshness:
-    warn_after: {count: 12, period: hour}
-    error_after: {count: 24, period: hour}
-```
-
-</File>
-
 <Changelog>
 
 * `v0.17.1`: Native rendering is disabled by default. The `as_native` filter was 

--- a/website/docs/reference/dbt-jinja-functions/as_native.md
+++ b/website/docs/reference/dbt-jinja-functions/as_native.md
@@ -22,6 +22,7 @@ variable into a dictionary for freshness testing.
 ```yml
 sources:
   - name: stripe
+    loaded_at_field: synced_at
     freshness: "{{ var('stripe_freshness') | as_native }}"
 ```
 

--- a/website/docs/reference/dbt-jinja-functions/as_native.md
+++ b/website/docs/reference/dbt-jinja-functions/as_native.md
@@ -1,0 +1,46 @@
+---
+title: "as_native"
+id: "as_native"
+---
+
+The `as_native` Jinja filter will coerce Jinja-compiled output into its 
+Python native representation according to [`ast.literal_eval`](https://docs.python.org/3/library/ast.html#ast.literal_eval). 
+The result can be any Python native type (set, list, tuple, dict, etc).
+
+:::danger Proceed with caution
+Unlike `as_bool` and `as_number`, `as_native` will return a rendered value
+regardless of the input type. Ensure that your inputs match expectations.
+:::
+
+### Usage
+
+In the example below, the `as_native` filter is used to coerce a dbt project
+variable into a dictionary for freshness testing.
+
+<File name='src_stripe.yml'>
+
+```yml
+sources:
+  - name: stripe
+    freshness: "{{ var('stripe_freshness') | as_native }}"
+```
+
+</File>
+
+<File name='dbt_project.yml'>
+
+```yml
+vars:
+  stripe_freshness:
+    warn_after: {count: 12, period: hour}
+    error_after: {count: 24, period: hour}
+```
+
+</File>
+
+<Changelog>
+
+* `v0.17.1`: Native rendering is disabled by default. The `as_native` filter was 
+introduced.
+
+</Changelog>

--- a/website/docs/reference/dbt-jinja-functions/as_number.md
+++ b/website/docs/reference/dbt-jinja-functions/as_number.md
@@ -17,8 +17,9 @@ variables into a numeric value to dynamically control the connection port.
 ```yml
 my_profile:
   outputs:
-    type: postgres
-    port: "{{ env_var('PGPORT') | as_number }}"
+    dev:
+      type: postgres
+      port: "{{ env_var('PGPORT') | as_number }}"
 ```
 
 </File>

--- a/website/docs/reference/dbt-jinja-functions/as_number.md
+++ b/website/docs/reference/dbt-jinja-functions/as_number.md
@@ -1,0 +1,31 @@
+---
+title: "as_number"
+id: "as_number"
+---
+
+The `as_number` Jinja filter will coerce Jinja-compiled output into a numeric
+value (integer or float), or return an error if it cannot be represented as
+a number.
+
+### Usage
+
+In the example below, the `as_number` filter is used to coerce an environment
+variables into a numeric value to dynamically control the connection port.
+
+<File name='profiles.yml.yml'>
+
+```yml
+my_profile:
+  outputs:
+    type: postgres
+    port: "{{ env_var('PGPORT') | as_number }}"
+```
+
+</File>
+
+<Changelog>
+
+* `v0.17.1`: Native rendering is disabled by default. The `as_number` filter was 
+introduced.
+
+</Changelog>

--- a/website/docs/reference/dbt-jinja-functions/as_text.md
+++ b/website/docs/reference/dbt-jinja-functions/as_text.md
@@ -20,7 +20,8 @@ It is still possible to natively render specific values using the [`as_bool`](as
 
 In the example below, the `as_text` filter is used to assert that `''` is an
 empty string. In a native rendering, `''` would be coerced to the Python 
-keyword `None`. This specification is necessary in `v0.17.0`.
+keyword `None`. This specification is necessary in `v0.17.0`, but it is not
+useful or necessary in later versions of dbt.
 
 <File name='schema.yml'>
 
@@ -38,7 +39,7 @@ models:
 </File>
 
 As of `v0.17.1`, native rendering does not occur by default, and the `as_text`
-specification is unnecessary.
+specification is superfluous.
 
 <File name='schema.yml'>
 

--- a/website/docs/reference/dbt-jinja-functions/as_text.md
+++ b/website/docs/reference/dbt-jinja-functions/as_text.md
@@ -18,44 +18,38 @@ It is still possible to natively render specific values using the [`as_bool`](as
 
 ### Usage
 
-In the example below, the `as_text` filter is used to assert that `1.0` is a string,
-not the integer 1. This specification is necessary in `v0.17.0`.
+In the example below, the `as_text` filter is used to assert that `''` is an
+empty string. In a native rendering, `''` would be coerced to the Python 
+keyword `None`. This specification is necessary in `v0.17.0`.
 
 <File name='schema.yml'>
 
 ```yml
-version: 2
-
 models:
-  - name: devices
+  - name: orders
     columns:
-      - name: installed_version
+      - name: order_status
         tests:
-          accepted_values:
-            values:
-              - "{{ 1.0 | as_text }}"
-              - 1.1
+          - accepted_values:
+              values: ['pending', 'shipped', "{{ '' | as_text }}"]
+
 ```
 
 </File>
 
-As of `v0.17.1`, this native rendering is not necessary, because `values` treats 
-all its inputs as strings by default.
+As of `v0.17.1`, native rendering does not occur by default, and the `as_text`
+specification is unnecessary.
 
 <File name='schema.yml'>
 
 ```yml
-version: 2
-
 models:
-  - name: devices
+  - name: orders
     columns:
-      - name: installed_version
+      - name: order_status
         tests:
-          accepted_values:
-            values:
-              - 1.0
-              - 1.1
+          - accepted_values:
+              values: ['pending', 'shipped', '']
 ```
 
 </File>

--- a/website/docs/reference/dbt-jinja-functions/as_text.md
+++ b/website/docs/reference/dbt-jinja-functions/as_text.md
@@ -3,26 +3,68 @@ title: "as_text"
 id: "as_text"
 ---
 
-The `as_text` Jinja filter will coerce jinja-compiled output back to text. It
+The `as_text` Jinja filter will coerce Jinja-compiled output back to text. It
 can be used in yaml rendering contexts where values _must_ be provided as
 strings, rather than as the datatype that they look like.
 
-### Usage:
+:::info Heads up
+In dbt v0.17.1, native rendering is not enabled by default. As such, 
+the `as_text` filter has no functional effect.
 
-In the example below, the `as_text` filter is used to convert the number "17",
-a dataset id, from a number into a string.
+It is still possible to natively render specific values using the [`as_bool`](as_bool), 
+[`as_number`](as_number), and [`as_native`](as_native) filters. 
+
+:::
+
+### Usage
+
+In the example below, the `as_text` filter is used to assert that `1.0` is a string,
+not the integer 1. This specification is necessary in `v0.17.0`.
 
 <File name='schema.yml'>
 
 ```yml
-bigquery-profile:
-  target: dev
-  outputs:
-    dev:
-      type: bigquery
-      method: oauth
-      project: 'dbt-project-1'
-      dataset: "{{ 12345 | as_text }}"
+version: 2
+
+models:
+  - name: devices
+    columns:
+      - name: installed_version
+        tests:
+          accepted_values:
+            values:
+              - "{{ 1.0 | as_text }}"
+              - 1.1
 ```
 
 </File>
+
+As of `v0.17.1`, this native rendering is not necessary, because `values` treats 
+all its inputs as strings by default.
+
+<File name='schema.yml'>
+
+```yml
+version: 2
+
+models:
+  - name: devices
+    columns:
+      - name: installed_version
+        tests:
+          accepted_values:
+            values:
+              - 1.0
+              - 1.1
+```
+
+</File>
+
+<Changelog>
+
+* `v0.17.0`: Native rendering is enabled by default. The `as_text` filter was 
+introduced.
+* `v0.17.1`: Native rendering is disabled by default. The `as_text` filter works
+as before, with no functional effect.
+
+</Changelog>

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -349,6 +349,9 @@ module.exports = {
           label: "List of dbt Jinja functions",
           items: [
             "reference/dbt-jinja-functions/adapter",
+            "reference/dbt-jinja-functions/as_bool",
+            "reference/dbt-jinja-functions/as_native",
+            "reference/dbt-jinja-functions/as_number",
             "reference/dbt-jinja-functions/as_text",
             "reference/dbt-jinja-functions/builtins",
             "reference/dbt-jinja-functions/config",


### PR DESCRIPTION
## Description & motivation

* Add reference docs for `is_bool`, `is_number`, `is_native`
* Update `is_text` and 0.17.0 migration guide with changelogs, callouts
* Reflects changes in https://github.com/fishtown-analytics/dbt/pull/2618

## To do before merge

Confirm that the pseudo-code I wrote as examples _actually_ works

**Update:** All the example code is working when I've checked out https://github.com/fishtown-analytics/dbt/pull/2618. One catch: the `freshness` example for `is_native` works _without_ the `is_native` filter. I'm guessing that the coercion-to-dict is already happening because of hologram. Can you think of a better example?