### PR TITLE
dynamically set site baseurl for netlify

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,12 +1,25 @@
 
 const path = require('path');
 
+/* Debugging */
+var SITE_URL;
+if (!process.env.CONTEXT || process.env.CONTEXT == 'production') {
+    SITE_URL = 'https://docs.getdbt.com';
+} else {
+    SITE_URL = process.env.DEPLOY_URL;
+}
+
+console.log("DEBUG: CONTEXT =", process.env.CONTEXT);
+console.log("DEBUG: DEPLOY_URL =", process.env.DEPLOY_URL);
+console.log("DEBUG: SITE_URL = ", SITE_URL);
+
+
 module.exports = {
   baseUrl: '/',
   favicon: '/img/favicon.ico',
   tagline: 'Your entire analytics engineering workflow',
   title: 'dbt - Documentation',
-  url: 'https://docs.getdbt.com',
+  url: SITE_URL,
 
   themeConfig: {
     disableDarkMode: true,


### PR DESCRIPTION
## Description & motivation
- Check netlify builtin env vars to determine the deployment environment
- in prod and for local dev, use https://www.getdbt.com
- in a build preview, use the netlify-generated URL

## To-do before merge
- Confirm that the branch preview works and the `og:image` meta tag uses the netlify deploy url

Netlify docs on env vars [here](https://docs.netlify.com/configure-builds/environment-variables/#build-metadata)