### PR TITLE
adding section to onprem FAQs with commands to restart dbt and kotsad…

### DIFF
--- a/website/docs/docs/dbt-cloud/on-premises/faqs.md
+++ b/website/docs/docs/dbt-cloud/on-premises/faqs.md
@@ -64,3 +64,24 @@ spec:
 ```
 
 For more examples of using the nginx ingress controller, see [the Examples section](https://kubernetes.github.io/ingress-nginx/examples/tls-termination/) of their documentation.
+
+## Troubleshooting
+
+### Restarting the dbt or kotsadm Applications
+
+Certain tasks may require restarting the dbt or the kotsadm applications. In order to accomplish this, the below commands can be run.
+
+**Restarting dbt**
+
+```bash
+kubectl rollout restart deployment/api-gateway
+kubectl rollout restart deployment/app
+kubectl rollout restart deployment/scheduler
+```
+
+**Restarting kotsadm**
+
+```bash
+kubectl rollout restart deployment/kotsadm
+kubectl rollout restart deployment/kotsadm-api
+```

--- a/website/docs/docs/dbt-cloud/on-premises/faqs.md
+++ b/website/docs/docs/dbt-cloud/on-premises/faqs.md
@@ -67,11 +67,9 @@ For more examples of using the nginx ingress controller, see [the Examples secti
 
 ## Troubleshooting
 
-### Restarting the dbt or kotsadm Applications
+### Restarting the dbt Cloud Application
 
-Certain tasks may require restarting the dbt or the kotsadm applications. In order to accomplish this, the below commands can be run.
-
-**Restarting dbt**
+Certain tasks may require restarting the dbt Cloud application such as updating a configuration value. In order to accomplish this, the below commands can be run. Note that when these commands are run, the dbt Cloud application (including the IDE and job scheduler) will be unavailable for a few minutes until the restart is complete.
 
 ```bash
 kubectl rollout restart deployment/api-gateway
@@ -79,7 +77,9 @@ kubectl rollout restart deployment/app
 kubectl rollout restart deployment/scheduler
 ```
 
-**Restarting kotsadm**
+### Restarting the Configuration Console (kotsadm)
+
+Certain tasks may require restarting the Configuration Console (kotsadm) such as changing the TLS certificate. In order to accomplish this, the below commands can be run. Note that when these commands are run, the Configuration Console will be unavailable for a few minutes until the restart is complete.
 
 ```bash
 kubectl rollout restart deployment/kotsadm


### PR DESCRIPTION
adding section to onprem FAQs with commands to restart dbt and kotsadm applications

## Description & motivation
<!---
One frequently asked question in onprem deployments is how to restart the dbt and/or kotsadm applications. This change adds a section to the onprem FAQs to include the commands for how to do this.
-->

