### PR TITLE
Prerelease docs site

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,3 +11,10 @@ Include any notes about things that need to happen before this PR is merged, e.g
 - [ ] Change the base branch
 - [ ] Ensure PR #56 is merged
 -->
+
+## Pre-release docs
+Is this change related to an unreleased version of dbt?
+- [ ] Yes
+- [ ] No (if you're not sure, it's probably "No")
+
+If yes, please change the base branch of this PR to `next`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,21 @@
+# Releasing docs
+
+There are two long-lived branches of this repo:
+  - `current` is the version of dbt released at [docs.getdbt.com](docs.getdbt.com)
+  - `next` reflects the next version of dbt to be releases. It is accessible at [docs-next.getdbt.com](docs-next.getdbt.com), and a warning banner is displayed on the site.
+
+- Any fixes or revisions to existing docs should be merged into `current`
+- Any pre-release docs should be merged into `next`
+- The `next` branch should be rebased from `current` somewhat regularly
+
+When new versions of dbt are released:
+1. Rebase `next` on top of `current`. The workflow might look something like this:
+```
+(current) $ git fetch
+(current) $ git pull
+(current) $ git checkout next
+(next) $ git pull
+(next) $ git rebase current -i
+```
+2. Make a PR from `next` onto `current`
+3. Merge the PR once the deploy preview builds successfully

--- a/_headers
+++ b/_headers
@@ -1,0 +1,2 @@
+/*
+  X-robots-tag: noindex

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,12 +1,7 @@
 # for deployments of prerelease docs
 [context.next]
-  command = "make build"
+  command = "make build-prerelease"
   
-  [context.next.environment]
+[context.next.environment]
   PRERELEASE = "true"
   ALGOLIA_INDEX_NAME = "dbt-next"
-  
-  [[headers]]
-  for = "/*"
-    [headers.values]
-    X-robots-tag = "noindex"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,8 +3,8 @@
   command = "make build"
   
   [context.next.environment]
+  PRERELEASE = "true"
   ALGOLIA_INDEX_NAME = "dbt-next"
-  DISCLAIMER = "Prerelease "
   
   [[headers]]
   for = "/*"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,12 @@
+# for deployments of prerelease docs
+[context.next]
+  command = "make build"
+  
+  [context.next.environment]
+  ALGOLIA_INDEX_NAME = "dbt-next"
+  DISCLAIMER = "Prerelease "
+  
+  [[headers]]
+  for = "/*"
+    [headers.values]
+    X-robots-tag = "noindex"

--- a/website/Makefile
+++ b/website/Makefile
@@ -18,3 +18,7 @@ build:
 	cat ../_redirects | grep 'docs/' | awk '{ print "/v0.12" $$1 "\t" $$2 "\t" $$3 }' >> build/_redirects
 	cat ../_redirects | grep 'docs/' | awk '{ print "/v0.11" $$1 "\t" $$2 "\t" $$3 }' >> build/_redirects
 	cat ../_redirects | grep 'docs/' | awk '{ print "/v0.10" $$1 "\t" $$2 "\t" $$3 }' >> build/_redirects
+
+build-prerelease:
+	make build
+	cat ../_headers > build/_headers

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -9,11 +9,19 @@ if (!process.env.CONTEXT || process.env.CONTEXT == 'production') {
     SITE_URL = process.env.DEPLOY_URL;
 }
 
-var DISCLAIMER;
-if (!process.env.DISCLAIMER) {
-    DISCLAIMER = '';
+var PRERELEASE = (process.env.PRERELEASE || false);
+
+var WARNING_BANNER;
+if (!PRERELEASE) {
+    WARNING_BANNER = {};
 } else {
-    DISCLAIMER = process.env.DISCLAIMER;
+    WARNING_BANNER = {
+        id: 'prerelease', // Any value that will identify this message.
+        content:
+          'CAUTION: Prerelease! This documentation reflects the next minor version of dbt. <a href="https://docs.getdbt.com">View current docs</a>.',
+        backgroundColor: '#ffa376', // Defaults to `#fff`.
+        textColor: '#033744', // Defaults to `#000`.
+    }
 }
 
 var ALGOLIA_INDEX_NAME;
@@ -26,7 +34,7 @@ if (!process.env.ALGOLIA_INDEX_NAME) {
 console.log("DEBUG: CONTEXT =", process.env.CONTEXT);
 console.log("DEBUG: DEPLOY_URL =", process.env.DEPLOY_URL);
 console.log("DEBUG: SITE_URL = ", SITE_URL);
-console.log("DEBUG: DISCLAIMER = ", DISCLAIMER);
+console.log("DEBUG: PRERELEASE = ", PRERELEASE);
 console.log("DEBUG: ALGOLIA_INDEX_NAME = ", ALGOLIA_INDEX_NAME);
 
 
@@ -34,13 +42,15 @@ module.exports = {
   baseUrl: '/',
   favicon: '/img/favicon.ico',
   tagline: 'Your entire analytics engineering workflow',
-  title: 'dbt - ' + DISCLAIMER + 'Documentation',
+  title: 'dbt - Documentation',
   url: SITE_URL,
 
   themeConfig: {
     disableDarkMode: true,
     sidebarCollapsible: true,
     image: '/img/avatar.png',
+    
+    announcementBar: WARNING_BANNER,
 
     algolia: {
       apiKey: '0e9665cbb272719dddc6e7113b4131a5',
@@ -78,7 +88,7 @@ module.exports = {
       links: [
         {
           to: '/docs/introduction',
-          label: DISCLAIMER + 'Docs',
+          label: 'Docs',
           position: 'left',
           activeBaseRegex: 'docs\/(?!(dbt-cloud))',
         },

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -9,16 +9,32 @@ if (!process.env.CONTEXT || process.env.CONTEXT == 'production') {
     SITE_URL = process.env.DEPLOY_URL;
 }
 
+var DISCLAIMER;
+if (!process.env.DISCLAIMER) {
+    DISCLAIMER = '';
+} else {
+    DISCLAIMER = process.env.DISCLAIMER;
+}
+
+var ALGOLIA_INDEX_NAME;
+if (!process.env.ALGOLIA_INDEX_NAME) {
+    ALGOLIA_INDEX_NAME = 'dbt';
+} else {
+    ALGOLIA_INDEX_NAME = process.env.ALGOLIA_INDEX_NAME;
+}
+
 console.log("DEBUG: CONTEXT =", process.env.CONTEXT);
 console.log("DEBUG: DEPLOY_URL =", process.env.DEPLOY_URL);
 console.log("DEBUG: SITE_URL = ", SITE_URL);
+console.log("DEBUG: DISCLAIMER = ", DISCLAIMER);
+console.log("DEBUG: ALGOLIA_INDEX_NAME = ", ALGOLIA_INDEX_NAME);
 
 
 module.exports = {
   baseUrl: '/',
   favicon: '/img/favicon.ico',
   tagline: 'Your entire analytics engineering workflow',
-  title: 'dbt - Documentation',
+  title: 'dbt - ' + DISCLAIMER + 'Documentation',
   url: SITE_URL,
 
   themeConfig: {
@@ -29,7 +45,7 @@ module.exports = {
     algolia: {
       apiKey: '0e9665cbb272719dddc6e7113b4131a5',
       //debug: true,
-      indexName: 'dbt',
+      indexName: ALGOLIA_INDEX_NAME,
       algoliaOptions: {
       },
     },
@@ -62,7 +78,7 @@ module.exports = {
       links: [
         {
           to: '/docs/introduction',
-          label: 'Docs',
+          label: DISCLAIMER + 'Docs',
           position: 'left',
           activeBaseRegex: 'docs\/(?!(dbt-cloud))',
         },


### PR DESCRIPTION
I added Netlify config (`netlify.toml`) for branch-based deployment of the long-lived `next` branch, which will serve prerelease docs.

Here's the site: https://next--docs-getdbt-com.netlify.app/
For prettiness' sake, we'll want to CNAME this to `docs-next.getdbt.com`, but that's not _actually_ a blocker.

I defined two new environment variables:
* `ALGOLIA_INDEX_NAME`: `dbt` normally, `dbt-next` for prerelease docs
* `DISCLAIMER`: I just added the word "Prerelease " in some prominent places. We could/should add a bright warning banner to the top of the homepage / every page as well.

Also:
* Added `X-robots-tag = "noindex"` as a header for the `next` deployment
* Netlify already/automatically adds this header for all preview (PR-based) deployments
* In Netlify, I turned off all branch-based deployments that _aren't_ `master` or `next`. So the only deployments we'll have are `master` (production), `next` (prerelease), and previews of PRs that target either of those two branches.

My thinking is that we can merge this commit into `master` with absolutely zero effect, so that the two branches can stay even. Then, I'll merge #302 into the `next` branch.