### PR TITLE
Change example data test path

### DIFF
--- a/website/docs/docs/building-a-dbt-project/tests.md
+++ b/website/docs/docs/building-a-dbt-project/tests.md
@@ -208,7 +208,7 @@ A data test is a `select` statement that returns `0` records when the test is su
 
 Data tests are defined in `.sql` files, typically in your `tests` directory. Each `.sql` file contains one data test / one `select` statement:
 
-<File name='tests/assert_total_payment_amount_is_positive.sql'>
+<File name='test/assert_total_payment_amount_is_positive.sql'>
 
 ```sql
 -- Refunds have a negative amount, so the total amount should always be >= 0.


### PR DESCRIPTION
## Description & motivation
Change the example data test to point to the default file path for tests, which is `test`, instead of `tests`, which is the path I always put it in by accident.

I know dbt is wrong for making this one folder singular and all the rest plural, but the default directory names go way back. Maybe we should add that to the 1.0 milestone.