### PR TITLE
Update license.md to add clarity

### DIFF
--- a/website/docs/docs/about/license.md
+++ b/website/docs/docs/about/license.md
@@ -3,4 +3,6 @@ title: "License"
 id: "license"
 ---
 
-[dbt is licensed under the Apache 2.0 License](https://github.com/fishtown-analytics/dbt).
+[dbt Core is licensed under the Apache 2.0 License](https://github.com/fishtown-analytics/dbt).
+
+dbt Cloud is proprietary.


### PR DESCRIPTION
We may not have touched this in a long time; the existing version is not reflective of the current way that "dbt" is used--"dbt" applies both to Core and Cloud, and as such we need to be more specific about our licenses.