### PR TITLE
Fix edit URL

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -9,6 +9,13 @@ if (!process.env.CONTEXT || process.env.CONTEXT == 'production') {
     SITE_URL = process.env.DEPLOY_URL;
 }
 
+var GIT_BRANCH;
+if (!process.env.CONTEXT || process.env.CONTEXT == 'production') {
+    GIT_BRANCH = 'current';
+} else {
+    GIT_BRANCH = process.env.BRANCH;
+}
+
 var PRERELEASE = (process.env.PRERELEASE || false);
 
 var WARNING_BANNER;
@@ -150,7 +157,7 @@ module.exports = {
           routeBasePath: '/',
           sidebarPath: require.resolve('./sidebars.js'),
 
-          editUrl: 'https://github.com/fishtown-analytics/docs.getdbt.com/edit/master/website/',
+          editUrl: 'https://github.com/fishtown-analytics/docs.getdbt.com/edit/' + GIT_BRANCH + '/website/',
           showLastUpdateTime: false,
           //showLastUpdateAuthor: false,
         }

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -13,7 +13,7 @@ var GIT_BRANCH;
 if (!process.env.CONTEXT || process.env.CONTEXT == 'production') {
     GIT_BRANCH = 'current';
 } else {
-    GIT_BRANCH = process.env.BRANCH;
+    GIT_BRANCH = process.env.HEAD;
 }
 
 var PRERELEASE = (process.env.PRERELEASE || false);


### PR DESCRIPTION
Previously, the edit URL hard-coded the `master` branch. We now have two long-lived branches, `current` and `next`. I used the Netlify env var `process.env.BRANCH` to dynamically populate based on the branch, and fall back to `current` as the default.

This is something we need to fix in current docs. I'll pull this (along with other `current` changes) into `next` after merging.