### PR TITLE
Update v0.18.0 migration guide, PR template for `next`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,4 +17,9 @@ Is this change related to an unreleased version of dbt?
 - [ ] Yes
 - [ ] No (if you're not sure, it's probably "No")
 
-If yes, please change the base branch of this PR to `next`
+If yes, please:
+- Change the base branch of this PR to `next`
+- Add Changelog components
+    - if new: `<Changelog>New in v0.x.0</Changelog>`
+    - if changed: `<Changelog>Changed in v0.x.0: In prior versions, ...</Changelog>`
+- Add links to the "New and changed documentation" section of the latest [Migration Guide](website/docs/docs/guides/migration-guide)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,4 +22,4 @@ If yes, please:
 - Add Changelog components
     - if new: `<Changelog>New in v0.x.0</Changelog>`
     - if changed: `<Changelog>Changed in v0.x.0: In prior versions, ...</Changelog>`
-- Add links to the "New and changed documentation" section of the latest [Migration Guide](website/docs/docs/guides/migration-guide)
+- Add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-18-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-18-0.md
@@ -14,17 +14,21 @@ dbt v0.18.0 is currently in beta. Please post in dbt Slack #prereleases with que
 
 ## New features
 
+For more details, see [new and changed documentation](#new-and-changed-documentation) below.
+
 ### Node selection
 - methods: `config`, `test_type`, `test_name`, `package`
 - intersections
 - nth-parent/child
 - version-controlled YML selectors
 
-See the updated docs on [model selection syntax](model-selection-syntax) for details.
+### Docs
+- Include static assets (such as images) in auto-generated docs site
 
-### Not yet documented
-- Adding policy tags to BigQuery columns
-- Include static assets (such as images) in auto-generated docs
+### Database-specific
+- Specify IAM profile when connecting to Redshift
+- Adding policy tags to BigQuery columns [not yet documented]
+- Snowflake query tags at connection and model level [not yet documented]
 
 
 ## Resources


### PR DESCRIPTION
* Reorganize + update migration guide (again—I know)
* Add notes to PR template: if base branch is `next`, ask contributors to add Changelog components + docs links to migration guide