### PR TITLE
[Docs] Add command to FAQ page for testing seeds

### DIFF
--- a/website/docs/faqs/testing-seeds.md
+++ b/website/docs/faqs/testing-seeds.md
@@ -28,3 +28,9 @@ seeds:
 ```
 
 </File>
+
+To run tests on one seed:
+
+```
+$ dbt test --models country_codes
+```


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->
Add a clear command to a FAQ page in order to bring https://docs.getdbt.com/faqs/testing-seeds/ closer to https://docs.getdbt.com/faqs/testing-sources/

Relates to https://discourse.getdbt.com/t/how-to-test-your-dbt-seeds-after-v0-16/1495

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes
- [x] No (if you're not sure, it's probably "No")

If yes, please change the base branch of this PR to `next`
