### PR TITLE
Add docs for adapter.dispatch, adapter_macro

### DIFF
--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-18-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-18-0.md
@@ -22,11 +22,17 @@ For more details, see [new and changed documentation](#new-and-changed-documenta
 - nth-parent/child
 - version-controlled YML selectors
 
+### Adapter macros
+- `adapter.dispatch` replaces `adapter_macro`, with much greater flexibility
+- Schema tests are now defined via `dispatch`, such that non-core plugins
+can override schema test definitions
+
 ### Docs
 - Include static assets (such as images) in auto-generated docs site
 
 ### Database-specific
 - Specify IAM profile when connecting to Redshift
+- Impersonate a BigQuery service account when connecting via oauth
 - Adding policy tags to BigQuery columns [not yet documented]
 - Snowflake query tags at connection and model level [not yet documented]
 
@@ -51,3 +57,4 @@ Please be aware of the following changes in v0.18.0. While breaking, we do not e
 - [Redshift profile](redshift-profile#specifying-an-iam-profile)
 - [`asset-paths` config](asset-paths) (also updated [dbt_project.yml](dbt_project.yml.md) and the [description](description) docs to match)
 - [`impersonate_service_account` in the BigQuery profile configuration](https://docs.getdbt.com/reference/warehouse-profiles/bigquery-profile#service-account-impersonation)
+- [adapter.dispatch](adapter#dispatch)

--- a/website/docs/reference/dbt-jinja-functions/adapter.md
+++ b/website/docs/reference/dbt-jinja-functions/adapter.md
@@ -9,6 +9,7 @@ id: "adapter"
 
 The following functions are available:
 
+- [adapter.dispatch](#dispatch)
 - [adapter.get_missing_columns](#get_missing_columns)
 - [adapter.expand_target_column_types](#expand_target_column_types)
 - [adapter.get_relation](#get_relation)
@@ -23,6 +24,102 @@ The following functions are available:
 The following adapter functions are deprecated, and will be removed in a future release.
 - [adapter.get_columns_in_table](#get_columns_in_table) **(deprecated)**
 - [adapter.already_exists](#already_exists) **(deprecated)**
+- [adapter_macro](#adapter_macro) **(deprecated)**
+
+## dispatch
+<Changelog>New in v0.18.0</Changelog>
+
+__Args__:
+
+  * `macro_name`: name of macro to dynamically implement
+  * `packages`: optional list (`[]`) of packages to search for implementations (defaults to root project)
+  
+Finds an adapter-appropriate version of a named macro. If `packages` is specified,
+searches the packages in order until it finds a working implementation.
+
+Adapter-specific macros are prefixed with the lowercase adapter name and two
+underscores. For a macro named `my_macro`:
+* Postgres: `postgres__my_macro`
+* Redshift: `redshift__my_macro`
+* Snowflake: `snowflake__my_macro`
+* BigQuery: `bigquery__my_macro`
+* OtherAdapter: `otheradapter__my_macro`
+* _default:_ `default__my_macro`
+
+**Usage**:
+
+<Tabs
+  defaultValue="simple"
+  values={[
+    { label: 'Simple', value: 'simple', },
+    { label: 'Intermediate', value: 'advanced', },
+  ]
+}>
+<TabItem value="simple">
+
+I want to define a macro, `concat`, that compiles to the SQL function `concat()` as its
+default behavior. On Redshift and Snowflake, however, I want to use the `||` operator instead.
+
+<File name='macros/concat.sql'>
+
+```sql
+{% macro concat(fields) -%}
+  {{ adapter.dispatch('concat')(fields) }}
+{%- endmacro %}
+
+
+{% macro default__concat(fields) -%}
+    concat({{ fields|join(', ') }})
+{%- endmacro %}
+
+
+{% macro redshift__concat(fields) %}
+    {{ fields|join(' || ') }}
+{% endmacro %}
+
+
+{% macro snowflake__concat(fields) %}
+    {{ fields|join(' || ') }}
+{% endmacro %}
+```
+
+</File>
+
+</TabItem>
+
+<TabItem value="advanced">
+
+I want to define a macro, `concat`, with a specific implementation on Redshift
+that handles null values. In all other cases—including the default implementation—
+I want to fall back on [`dbt_utils.concat`](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/cross_db_utils/concat.sql).
+
+<File name='macros/concat.sql'>
+
+```sql
+{% macro concat(fields) -%}
+  {{ adapter.dispatch('concat', packages = ['my_project', 'dbt_utils'])(fields) }}
+{%- endmacro %}
+
+
+{% macro redshift__concat(fields) %}
+    {% for field in fields %}
+        nullif({{ field }},'') {{ ' || ' if not loop.last }}
+    {% endfor %}
+{% endmacro %}
+```
+
+</File>
+
+dbt prioritizes package specificity over adapter specificity. If I call the `concat` 
+macro while running on Postgres, dbt will look for the following macros in order:
+
+1. `my_project.postgres__concat` (not found)
+2. `my_project.default__concat` (not found)
+3. `dbt_utils.postgres__concat` (not found)
+4. `dbt_utils.default__concat` (found!)
+
+</TabItem>
+</Tabs>
 
 ## get_missing_columns
 __Args__:
@@ -261,6 +358,54 @@ select * from {{ref('raw_table')}}
 {% if adapter.already_exists(this.schema, this.name) %}
   where id > (select max(id) from {{this}})
 {% endif %}
+```
+
+</File>
+
+## adapter_macro
+
+:::danger Deprecated
+
+This method is deprecated and will be removed in a future release. Please use [adapter.dispatch](#dispatch) instead.
+
+:::
+
+Prior to v0.18.0, dbt supported a limited version of `dispatch` functionality via
+a macro named `adapter_macro`.
+
+__Args__:
+
+  * `name`: name of macro to implement
+  * `*args`
+  * `**kwargs`
+  
+Finds an adapter-appropriate version of a named macro and implements it with the
+positional and/or keyword arguments provided. This is most relevant for macros
+in open-source packages with cross-database support.
+
+**Usage:**
+
+<File name='macros/concat.sql'>
+
+```sql
+{% macro concat(fields) -%}
+  {{ adapter_macro('concat', fields) }}
+{%- endmacro %}
+
+
+{% macro default__concat(fields) -%}
+    concat({{ fields|join(', ') }})
+{%- endmacro %}
+
+
+{% macro redshift__concat(fields) %}
+    {{ fields|join(' || ') }}
+{% endmacro %}
+
+
+{% macro snowflake__concat(fields) %}
+    {{ fields|join(' || ') }}
+{% endmacro %}
 ```
 
 </File>


### PR DESCRIPTION
## Description & motivation

* Add documentation for `adapter.dispatch` (new in v0.18.0) and `adapter_macro` (marked for deprecation in v0.18.0, previously undocumented)
* I added `dispatch` to the existing `adapter` reference article. While it's much more complex than all other `adapter` methods, I think the reference section feels right; this information is relevant to developers, maintainers, contributors, or curious users of packages and plugins.

@clrcrl would you mind giving this a sense check all the same?

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [x] Yes
- [ ] No (if you're not sure, it's probably "No")
