### PR TITLE
Scope links with leading slashes

### DIFF
--- a/website/docs/dbt-cli/installation-guides/macos.md
+++ b/website/docs/dbt-cli/installation-guides/macos.md
@@ -64,7 +64,7 @@ brew link dbt-development
 ```
 
 ## pip
-You can also use pip to install dbt – check out the [main installation documentation](installation) for more information.
+You can also use pip to install dbt – check out the [main installation documentation](dbt-cli/installation) for more information.
 
 If you encounter SSL cryptography errors during install, make sure your copy of pip is up-to-date (via [cryptography.io](https://cryptography.io/en/latest/faq/#compiling-cryptography-on-os-x-produces-a-fatal-error-openssl-aes-h-file-not-found-error))
 

--- a/website/docs/docs/building-a-dbt-project/documentation.md
+++ b/website/docs/docs/building-a-dbt-project/documentation.md
@@ -9,7 +9,7 @@ id: "documentation"
 * [`doc` Jinja function](dbt-jinja-functions/doc)
 
 ## Assumed knowledge
-* [Tests](tests)
+* [Tests](building-a-dbt-project/tests)
 
 ## Overview
 
@@ -31,7 +31,7 @@ If you're new to dbt, we recommend that you check out our [Getting Started Tutor
 :::
 
 ## Adding descriptions to your project
-To add descriptions to your project, use the `description:` key in the same files where you declare [tests](tests), like so:
+To add descriptions to your project, use the `description:` key in the same files where you declare [tests](building-a-dbt-project/tests), like so:
 
 <File name='models/<filename>.yml'>
 

--- a/website/docs/docs/building-a-dbt-project/hooks-operations.md
+++ b/website/docs/docs/building-a-dbt-project/hooks-operations.md
@@ -11,7 +11,7 @@ id: "hooks-operations"
 ## Assumed knowledge
 * [Project configurations](reference/dbt_project.yml.md)
 * [Model configurations](model-configs)
-* [Macros](macros)
+* [Macros](jinja-macros#macros)
 
 ## Getting started
 
@@ -71,12 +71,12 @@ select ...
 
 :::tip Calling a macro in a hook
 
-You can also use a [macro](macros) to bundle up hook logic. Check out some of the examples in the reference sections for [on-run-start and on-run-end hooks](on-run-start-on-run-end) and [pre- and post-hooks](pre-hook-post-hook),
+You can also use a [macro](jinja-macros#macros) to bundle up hook logic. Check out some of the examples in the reference sections for [on-run-start and on-run-end hooks](on-run-start-on-run-end) and [pre- and post-hooks](pre-hook-post-hook),
 
 :::
 
 ### Operations
-Operations are [macros](macros) that you can run using the [`run-operation` command](run-operation) command. As such, operations aren't actually a separate resource in your dbt project — they are just a convenient way to invoke a macro without needing to run a model.
+Operations are [macros](jinja-macros#macros) that you can run using the [`run-operation` command](run-operation) command. As such, operations aren't actually a separate resource in your dbt project — they are just a convenient way to invoke a macro without needing to run a model.
 
 :::info Explicitly execute the SQL in an operation
 Unlike hooks, you need to explicitly execute a query within a macro, by using either a [statement block](statement-blocks) or a helper macro like the [run_query macro](run_query) macro. Otherwise, dbt will return the query as a string without executing it.

--- a/website/docs/docs/building-a-dbt-project/jinja-macros.md
+++ b/website/docs/docs/building-a-dbt-project/jinja-macros.md
@@ -22,7 +22,7 @@ Using Jinja turns your dbt project into a programming environment for SQL, givin
 
 In fact, if you've used the [`{{ ref() }}` function](ref), you're already using Jinja!
 
-Jinja can be used in any SQL in a dbt project, including [models](building-models), [analyses](analyses), [tests](custom-schema-tests), and even [hooks](hooks).
+Jinja can be used in any SQL in a dbt project, including [models](building-models), [analyses](analyses), [tests](custom-schema-tests), and even [hooks](hooks-operations).
 
 
 :::info Ready to get started with Jinja and macros?
@@ -70,7 +70,7 @@ group by 1
 </File>
 
 You can recognize Jinja based on the delimiters the language uses, which we refer to as "curlies":
-- **Expressions `{{ ... }}`**: Expressions are used when you want to output a string. You can use expressions to reference [variables](var) and call [macros](macros).
+- **Expressions `{{ ... }}`**: Expressions are used when you want to output a string. You can use expressions to reference [variables](var) and call [macros](jinja-macros#macros).
 - **Statements `{% ... %}`**: Statements are used for control flow, for example, to set up `for` loops and `if` statements, or to define macros.
 -  **Comments `{# ... #}`**: Jinja comments are used to prevent the text within the comment from compiling.
 
@@ -79,7 +79,7 @@ When used in a dbt model, your Jinja needs to compile to a valid query. To check
 * **Using the dbt CLI:** Run `dbt compile` from the command line. Then open the compiled SQL file in the `target/compiled/{project name}/` directory. Use a split screen in your code editor to keep both files open at once.
 
 ### Macros
-[Macros](macros) in Jinja are pieces of code that can be reused multiple times – they are analogous to "functions" in other programming languages, and are extremely useful if you find yourself repeating code across multiple models. Macros are defined in `.sql` files, typically in your `macros` directory ([docs](macro-paths)).
+[Macros](jinja-macros#macros) in Jinja are pieces of code that can be reused multiple times – they are analogous to "functions" in other programming languages, and are extremely useful if you find yourself repeating code across multiple models. Macros are defined in `.sql` files, typically in your `macros` directory ([docs](macro-paths)).
 
 Macro files can contain one or more macros — here's an example:
 

--- a/website/docs/docs/building-a-dbt-project/projects.md
+++ b/website/docs/docs/building-a-dbt-project/projects.md
@@ -12,7 +12,7 @@ A dbt project is a directory of `.sql` and `.yml` files, which dbt uses to trans
 * A project file: A `dbt_project.yml` file tells dbt that a particular directory is a dbt project, and also contains configurations for your project.
 * [Models](building-models): A model is a single `.sql` file. Each model contains a single select statement that either transforms raw data into a dataset that is ready for analytics, or, more often, is an intermediate step in such a transformation.
 
-A project may also contain a number of other resources, such as [snapshots](snapshots), [seeds](seeds), [tests](building-a-dbt-project/tests), [macros](macros), [documentation](documentation), and [sources](using-sources).
+A project may also contain a number of other resources, such as [snapshots](snapshots), [seeds](seeds), [tests](building-a-dbt-project/tests), [macros](jinja-macros#macros), [documentation](documentation), and [sources](using-sources).
 
 ## Creating a dbt project
 

--- a/website/docs/docs/guides/best-practices.md
+++ b/website/docs/docs/guides/best-practices.md
@@ -119,7 +119,7 @@ where created_at >= dateadd('day', -3, current_date)
 ```
 
 ### Use hooks to manage privileges on objects that dbt creates
-Use `grant` statements from [hooks](hooks) to ensure that permissions are applied to the objects created by dbt. By codifying these grant statements in hooks, you can version control and repeatably apply these permissions.
+Use `grant` statements from [hooks](hooks-operations) to ensure that permissions are applied to the objects created by dbt. By codifying these grant statements in hooks, you can version control and repeatably apply these permissions.
 
 
 :::info Recommended grant statements

--- a/website/docs/docs/introduction.md
+++ b/website/docs/docs/introduction.md
@@ -54,7 +54,7 @@ To get started with a project and connection, follow the onboarding flow. Use th
 ### Developing locally with the Command Line Interface (CLI)
 To use the CLI:
 
-1. Follow [these instructions](installation) to install the dbt CLI
+1. Follow [these instructions](dbt-cli/installation) to install the dbt CLI
 2. [Set up a profile](configure-your-profile) to connect to your data warehouse
 3. Build your dbt project in a code editor, like Atom or VSCode
 4. Execute commands using your terminal

--- a/website/docs/reference/dbt-jinja-functions.md
+++ b/website/docs/reference/dbt-jinja-functions.md
@@ -3,7 +3,7 @@ title: "dbt Jinja Functions"
 ---
 
 In addition to the standard Jinja library ([docs](https://jinja.palletsprojects.com/en/2.11.x/templates/)), we've added additional functions and variables to the Jinja context that are useful when working with a dbt project:
-* [adapter](dbt-jinja-functions/adapter)
+* [adapter](adapter)
 * [as_bool](as_bool)
 * [as_native](as_native)
 * [as_number](as_number)
@@ -31,9 +31,9 @@ In addition to the standard Jinja library ([docs](https://jinja.palletsprojects.
 * [return](return)
 * [run_query](run_query)
 * [run_started_at](run_started_at)
-* [schema](schema)
+* [schema](dbt-jinja-functions/schema)
 * [schemas](schemas)
-* [source](source)
+* [source](dbt-jinja-functions/source)
 * [statement-blocks](statement-blocks)
 * [target](target)
 * [this](this)

--- a/website/docs/reference/model-configs.md
+++ b/website/docs/reference/model-configs.md
@@ -73,7 +73,7 @@ models:
 models:
   [<resource-path>](resource-path):
     +[enabled](enabled): true | false
-    +[tags](tags): <string> | [<string>]
+    +[tags](resource-configs/tags): <string> | [<string>]
     +[pre-hook](pre-hook-post-hook): <sql-statement> | [<sql-statement>]
     +[post-hook](pre-hook-post-hook): <sql-statement> | [<sql-statement>]
     +[database](resource-configs/database): <string>
@@ -96,7 +96,7 @@ models:
 
 {{ config(
     [enabled](enabled)=true | false,
-    [tags](tags)="<string>" | ["<string>"],
+    [tags](resource-configs/tags)="<string>" | ["<string>"],
     [pre_hook](pre-hook-post-hook)="<sql-statement>" | ["<sql-statement>"],
     [post_hook](pre-hook-post-hook)="<sql-statement>" | ["<sql-statement>"],
     [database](resource-configs/database): <string>,

--- a/website/docs/reference/model-properties.md
+++ b/website/docs/reference/model-properties.md
@@ -17,7 +17,7 @@ models:
     [docs](resource-properties/docs):
       show: true | false
     [meta](meta): {<dictionary>}
-    [tests](tests):
+    [tests](resource-properties/tests):
       - <test>
       - ... # declare additional tests
     columns:
@@ -25,7 +25,7 @@ models:
         [description](description): <markdown_string>
         [meta](meta): {<dictionary>}
         [quote](quote): true | false
-        [tests](tests):
+        [tests](resource-properties/tests):
           - <test>
           - ... # declare additional tests
         [tags](resource-properties/tags): [<string>]

--- a/website/docs/reference/model-selection-syntax.md
+++ b/website/docs/reference/model-selection-syntax.md
@@ -78,7 +78,7 @@ dbt run --models finance.base.*  # run all of the models in models/finance/base
 ```
 
 ### The "tag:" operator
-The `tag:` prefix is used to select models that match a specified [tag](tags) .
+The `tag:` prefix is used to select models that match a specified [tag](resource-configs/tags) .
 
 ```
 dbt run --models tag:nightly    # run all models with the `nightly` tag

--- a/website/docs/reference/project-configs/macro-paths.md
+++ b/website/docs/reference/project-configs/macro-paths.md
@@ -12,7 +12,7 @@ macro-paths: [directorypath]
 </File>
 
 ## Definition
-Optionally specify a custom list of directories where [macros](macros) are located. Note that you cannot co-locate models and macros.
+Optionally specify a custom list of directories where [macros](jinja-macros#macros) are located. Note that you cannot co-locate models and macros.
 
 ## Default
 By default, dbt will search for macros in a directory named `macros`, i.e. `macro-paths: ["macros"]`

--- a/website/docs/reference/resource-configs/bigquery-configs.md
+++ b/website/docs/reference/resource-configs/bigquery-configs.md
@@ -356,7 +356,7 @@ strategy is selected.
 
 :::info New in dbt v0.16.0
 
-This functionality is new in dbt v0.16.0. For upgrading instructions, check out [the docs](installation)
+This functionality is new in dbt v0.16.0. For upgrading instructions, check out [the docs](upgrading-to-0-16-0)
 
 :::
 

--- a/website/docs/reference/resource-configs/resource-path.md
+++ b/website/docs/reference/resource-configs/resource-path.md
@@ -1,7 +1,7 @@
 The `<resource-path>` nomenclature is used in this documentation when documenting how to configure a model, seed, or snapshot, from your `dbt_project.yml` file. It represents the nested dictionary keys that provide the path to either a directory of models, or a single model.
 
 ## Example
-:::info 
+:::info
 
 This example is for models, but the same concepts apply for seeds and snapshots.
 
@@ -18,7 +18,7 @@ models:
 
 </File>
 
-To apply a configuration to all models in _your_ project only, use your [project name](name) as the `<resource-path>`:
+To apply a configuration to all models in _your_ project only, use your [project name](project-configs/name) as the `<resource-path>`:
 
 <File name='dbt_project.yml'>
 

--- a/website/docs/reference/resource-configs/snowflake-configs.md
+++ b/website/docs/reference/resource-configs/snowflake-configs.md
@@ -136,7 +136,7 @@ models:
 
 ## Configuring virtual warehouses
 
-The default warehouse that dbt uses can be configured in your [Profile](profile) for Snowflake connections. To override the warehouse that is used for specific models (or groups of models), use the `snowflake_warehouse` model configuration. This configuration can be used to specify a larger warehouse for certain models in order to control Snowflake costs and project build times.
+The default warehouse that dbt uses can be configured in your [Profile](/reference/profiles.yml) for Snowflake connections. To override the warehouse that is used for specific models (or groups of models), use the `snowflake_warehouse` model configuration. This configuration can be used to specify a larger warehouse for certain models in order to control Snowflake costs and project build times.
 
 The following config uses the `EXTRA_SMALL` warehouse for all models in the project, except for the models in the `clickstream` folder, which are configured to use the `EXTRA_LARGE` warehouse. In this example, all Snapshot models are configured to use the `EXTRA_LARGE` warehouse.
 

--- a/website/docs/reference/resource-configs/tags.md
+++ b/website/docs/reference/resource-configs/tags.md
@@ -23,15 +23,15 @@ To tag a column, test, or source, use the [tag _property_](resource-properties/t
 
 models:
   [<resource-path>](resource-path):
-    +[tags](tags): <string> | [<string>]
+    +tags: <string> | [<string>]
 
 snapshots:
   [<resource-path>](resource-path):
-    +[tags](tags): <string> | [<string>]
+    +tags: <string> | [<string>]
 
 seeds:
   [<resource-path>](resource-path):
-    +[tags](tags): <string> | [<string>]
+    +tags: <string> | [<string>]
 
 ```
 
@@ -44,7 +44,7 @@ seeds:
 ```jinja
 
 {{ config(
-    [tags](tags)="<string>" | ["<string>"]
+    tags="<string>" | ["<string>"]
 ) }}
 
 ```

--- a/website/docs/reference/resource-properties/tests.md
+++ b/website/docs/reference/resource-properties/tests.md
@@ -152,7 +152,7 @@ This feature is not implemented for analyses.
 </Tabs>
 
 ## Related documentation
-* [Testing guide](tests)
+* [Testing guide](building-a-dbt-project/tests)
 
 ## Description
 

--- a/website/docs/reference/seed-properties.md
+++ b/website/docs/reference/seed-properties.md
@@ -18,7 +18,7 @@ seeds:
     [description](description): <markdown_string>
     [docs](resource-properties/docs):
       show: true | false
-    [tests](tests):
+    [tests](resource-properties/tests):
       - <test>
       - ... # declare additional tests
     columns:
@@ -27,7 +27,7 @@ seeds:
         [meta](meta): {<dictionary>}
         [quote](quote): true | false
         [tags](resource-properties/tags): [<string>]
-        [tests](tests):
+        [tests](resource-properties/tests):
           - <test>
           - ... # declare additional tests
 

--- a/website/docs/reference/snapshot-configs.md
+++ b/website/docs/reference/snapshot-configs.md
@@ -84,7 +84,7 @@ snapshots:
 snapshots:
   [<resource-path>](resource-path):
     +[enabled](enabled): true | false
-    +[tags](tags): <string> | [<string>]
+    +[tags](resource-configs/tags): <string> | [<string>]
     +[pre-hook](pre-hook-post-hook): <sql-statement> | [<sql-statement>]
     +[post-hook](pre-hook-post-hook): <sql-statement> | [<sql-statement>]
     +[persist_docs](persist_docs): {<dict>}
@@ -101,7 +101,7 @@ snapshots:
 
 {{ config(
     [enabled](enabled)=true | false,
-    [tags](tags)="<string>" | ["<string>"],
+    [tags](resource-configs/tags)="<string>" | ["<string>"],
     [pre_hook](pre-hook-post-hook)="<sql-statement>" | ["<sql-statement>"],
     [post_hook](pre-hook-post-hook)="<sql-statement>" | ["<sql-statement>"]
     [persist_docs](persist_docs)={<dict>}

--- a/website/docs/reference/snapshot-properties.md
+++ b/website/docs/reference/snapshot-properties.md
@@ -19,7 +19,7 @@ snapshots:
     [meta](meta): {<dictionary>}
     [docs](resource-properties/docs):
       show: true | false
-    [tests](tests):
+    [tests](resource-properties/tests):
       - <test>
       - ...
     columns:
@@ -28,7 +28,7 @@ snapshots:
         [meta](meta): {<dictionary>}
         [quote](quote): true | false
         [tags](resource-properties/tags): [<string>]
-        [tests](tests):
+        [tests](resource-properties/tests):
           - <test>
           - ... # declare additional tests
       - ... # declare properties of additional columns

--- a/website/docs/reference/source-properties.md
+++ b/website/docs/reference/source-properties.md
@@ -48,7 +48,7 @@ sources:
         [meta](meta): {<dictionary>}
         [identifier](identifier): <table_name>
         [loaded_at_field](resource-properties/freshness#loaded_at_field): <column_name>
-        [tests](tests):
+        [tests](resource-properties/tests):
           - <test>
           - ... # declare additional tests
         [tags](resource-properties/tags): [<string>]
@@ -70,7 +70,7 @@ sources:
             [description](description): <markdown_string>
             [meta](meta): {<dictionary>}
             [quote](quote): true | false
-            [tests](tests):
+            [tests](resource-properties/tests):
               - <test>
               - ... # declare additional tests
             [tags](resource-properties/tags): [<string>]

--- a/website/docs/tutorial/using-jinja.md
+++ b/website/docs/tutorial/using-jinja.md
@@ -153,7 +153,7 @@ Getting whitespace control right is often a lot of trial and error! We recommend
 ## Use a macro to return payment methods
 Here, we've hardcoded the list of payment methods in our model. We may need to access this list from another model. A good solution here is to use a [variable](using-variables), but for the purpose of this tutorial, we're going to instead use a macro!
 
-[Macros](macros) in Jinja are pieces of code that can be called multiple times – they are analogous to a function in Python, and are extremely useful if you find yourself repeating code across multiple models.
+[Macros](jinja-macros#macros) in Jinja are pieces of code that can be called multiple times – they are analogous to a function in Python, and are extremely useful if you find yourself repeating code across multiple models.
 
 Our macro is simply going to return the list of payment methods:
 

--- a/website/src/components/link/index.js
+++ b/website/src/components/link/index.js
@@ -2,6 +2,8 @@ import React from 'react';
 
 import Link from '@docusaurus/Link';
 
+const ENV = process ? process.env : {};
+
 const docsFiles = require.context(
     '../../../docs/',
     true,
@@ -25,7 +27,6 @@ docsFiles.keys().forEach(function(key, i) {
       var message = `Duplicate slug found: ${slug}\n`;
       message += ` - ${meta.source}\n`;
       message += ` - ${slugs[slug].source}`;
-      //throw new Error(message);
       console.error(message);
   }
 
@@ -35,19 +36,32 @@ docsFiles.keys().forEach(function(key, i) {
 
 function findSource(source_href) {
     var stripped_source_href = source_href.replace(/.md$/, '')
+    if (!stripped_source_href.startsWith('/')) {
+        stripped_source_href = '/' + stripped_source_href;
+    }
     var found = null;
     for (var source in sources) {
         var stripped_source = source.replace(/.md$/, '')
-        if (stripped_source.endsWith(stripped_source_href)) {
+        var is_match = stripped_source.endsWith(stripped_source_href);
+        if (is_match && !found) {
             found = sources[source];
-            break;
+        } else if (is_match && found) {
+            // The link is ambiguous. Pick one, but error?
+            var msg = (
+                `Ambiguous link slug: "${source_href}"\n`
+                + `- Two matched:, "${found.id}", "${sources[source].id}"`
+            );
+
+            console.error(msg);
+            if (ENV.DOCS_ENV == 'build') {
+                throw new Error(`Ambiguous link detected: ${msg}`)
+            }
         }
     }
     return found;
 }
 
 function expandRelativeLink(href, ignoreInvalid) {
-    var env = process ? process.env : {};
     if (!href) {
         //throw new Error(`Broken link detected (href is undefined)`)
         // how does this happen?
@@ -78,7 +92,7 @@ function expandRelativeLink(href, ignoreInvalid) {
             link: `${slugs[link].permalink}#${hash}`
         }
     } else if (!isExternal && !href.startsWith('/')) {
-        if (env.DOCS_ENV == 'build' && !ignoreInvalid) {
+        if (ENV.DOCS_ENV == 'build' && !ignoreInvalid) {
             throw new Error(`Broken link detected ${href}`)
         } else {
             return {


### PR DESCRIPTION
## Description & motivation
- Scope links with leading slashes
- Fail to build for ambiguous links


**Example:** You have three pages with the slugs:
 - `docs/guides/how-do-i-make-it-run`
 - `docs/using-dbt/run`
 - `reference/commands/run`

Previously, the Link component would match the first slug with the suffix specified in the link. So the markdown:
```
[run](run)
```

Would have linked to `docs/guides/how-do-i-make-it-run`. That was incorrect. Now, the Link component will add a leading slash before looking up a slug. This will make dbt resolve to either of:
 - `docs/using-dbt/run`
 - `reference/commands/run`

Unfortunately, a link like `[run](run)` is ambiguous, and we can't know which link was intended. With this PR, Docusaurus will fail to build if an ambiguous link is detected. There is more to do to make this easy to use, but it will hopefully be a good enough starting point for now.


## To-do before merge
I expect this build to fail with an ambiguous link error, and we should fix those errors before merging this PR.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes
- [x] No (if you're not sure, it's probably "No")