### PR TITLE
Clarify --strict flag usage

### DIFF
--- a/website/docs/reference/global-cli-flags.md
+++ b/website/docs/reference/global-cli-flags.md
@@ -87,7 +87,9 @@ $ dbt --no-write-json run
 
 ## Strict
 
-The `-S` or `--strict` flag runs schema validations on dbt objects at runtime. This flag may incur a performance penalty, but it is useful for catching logic errors in development of the dbt project.
+The `-S` or `--strict` flag runs schema validations on dbt python objects at runtime. This flag may incur a performance penalty, but it is useful for catching logic errors in development of the dbt project.
+
+**N.B.** In versions >=0.15.0, dbt uses [hologram](https://github.com/fishtown-analytics/hologram) and [mypy](http://mypy-lang.org/) for object type declaration, validation, and testing. The `--strict` flag has no functional use except as an alias for `--warn-error`. We may choose to someday repurpose it.
 
 <File name='Usage'>
 

--- a/website/docs/reference/global-cli-flags.md
+++ b/website/docs/reference/global-cli-flags.md
@@ -87,9 +87,7 @@ $ dbt --no-write-json run
 
 ## Strict
 
-The `-S` or `--strict` flag runs schema validations on dbt python objects at runtime. This flag may incur a performance penalty, but it is useful for catching logic errors in development of the dbt project.
-
-**N.B.** In versions >=0.15.0, dbt uses [hologram](https://github.com/fishtown-analytics/hologram) and [mypy](http://mypy-lang.org/) for object type declaration, validation, and testing. The `--strict` flag has no functional use except as an alias for `--warn-error`. We may choose to someday repurpose it.
+The `-S` or `--strict` flag is _only_ for use during dbt development. It performs extra validation of dbt objects and internal consistency checks during compilation. Use of this flag incurs a significant performance penalty. We use it only when running integration tests against proposed changes to dbt.
 
 <File name='Usage'>
 


### PR DESCRIPTION
## Description & motivation

I've seen this question crop up a few times in dbt Slack. Based on the current language in the docs, it sounds like `--strict` does strict field validation (https://github.com/fishtown-analytics/dbt/issues/1570), rather than what it really does, which is nothing special since v0.15.0.

Let me know if I'm missing a technical piece of this.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes
- [x] No (if you're not sure, it's probably "No")