### PR TITLE
Fix IDE page redirect

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -118,7 +118,7 @@
 /docs/test	/reference/commands/test	302
 /docs/testing	/docs/building-a-dbt-project/tests	302
 /docs/testing-and-documentation	/docs/building-a-dbt-project/tests	302
-/docs/the-dbt-ide	/docs/dbt-cloud/the-dbt-ide	302
+/docs/the-dbt-ide	/docs/dbt-cloud/cloud-ide/the-dbt-ide	302
 /docs/this	/docs/writing-code-in-dbt/jinja-context/this	302
 /docs/tojson	/docs/writing-code-in-dbt/jinja-context/tojson	302
 /docs/ubuntu-debian	/dbt-cli/installation-guides/ubuntu-debian	302


### PR DESCRIPTION
## Description & motivation
Redirect for link from [getdbt.com/pricing](https://www.getdbt.com/pricing/) broke based on file reorg in https://github.com/fishtown-analytics/docs.getdbt.com/pull/320. See [Slack thread](https://getdbt.slack.com/archives/C2JRTGLLS/p1597192716000300).

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes
- [x] No (if you're not sure, it's probably "No")