### PR TITLE
Suggest dbt run before docs generate

### DIFF
--- a/website/docs/docs/building-a-dbt-project/documentation.md
+++ b/website/docs/docs/building-a-dbt-project/documentation.md
@@ -63,7 +63,7 @@ models:
 ## Generating project documentation
 You can generate a documentation site for your project (with or without descriptions) using the CLI.
 
-First, run `dbt docs generate` — this command tells dbt to compile relevant information about your dbt project and warehouse into `manifest.json` and `catalog.json` files respectively.
+First, run `dbt docs generate` — this command tells dbt to compile relevant information about your dbt project and warehouse into `manifest.json` and `catalog.json` files respectively. To see documentation for all columns and not just columns described in your project, ensure that you have created the models with `dbt run` beforehand.
 
 Then, run `dbt docs serve` to use these `.json` files to populate a local website.
 


### PR DESCRIPTION
## Description & motivation
I'm not sure this is the best way to describe this, but we should note somehow that if you don't use `dbt run`, `dbt docs generate` will only know about columns described in your configuration files.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes
- [X] No (if you're not sure, it's probably "No")

If yes, please change the base branch of this PR to `next`
