### PR TITLE
Fix a typo in profiles-yml-context.md

### DIFF
--- a/website/docs/reference/dbt-jinja-functions/profiles-yml-context.md
+++ b/website/docs/reference/dbt-jinja-functions/profiles-yml-context.md
@@ -8,7 +8,7 @@ resources in the `profiles.yml` file.
 
 **Available context variables:**
 - [env_var](env_var)
-- [vars](var) (_Note: only variables defined with `--vars` are availabe_)
+- [vars](var) (_Note: only variables defined with `--vars` are available_)
 
 ### Example usage
 


### PR DESCRIPTION
availabe -> available

## Description & motivation
This is just changing a spelling mistake typo in the docs. The "edit" button was just too tempting to not click

## To-do before merge
None

## Pre-release docs
No