### PR TITLE
Add dbt Cloud v1.1.6

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-/website/docs/docs/dbt-cloud   @drewbanin
-/website/src/pages/dbt-cloud   @drewbanin
+/website/docs/docs/dbt-cloud/   @drewbanin
+/website/src/pages/dbt-cloud/   @drewbanin
 *                              @clrcrl

--- a/website/docs/docs/dbt-cloud/cloud-ide/viewing-docs-in-the-ide.md
+++ b/website/docs/docs/dbt-cloud/cloud-ide/viewing-docs-in-the-ide.md
@@ -1,0 +1,23 @@
+---
+title: Viewing Docs in the IDE
+id: viewing-docs-in-the-ide
+---
+
+The dbt Cloud IDE makes it possible to view [documentation](/building-a-dbt-project/documentation)
+for your dbt project while your code is still in development. With this
+workflow, you can inspect and verify what your project's generated documentation
+will look like before your changes are released to production.
+
+## Generating documentation
+
+To generate documentation in the IDE, run the `dbt docs generate` command in the
+Command Bar in the IDE. This command will generate the Docs
+for your dbt project as it exists in development in your IDE session.
+
+<LoomVideo id="4c2373238b3d474e9239c457411ac458" />
+
+After generating your documentation, you can click the "view docs" button to see
+the latest version of your documentation rendered in a new browser window.
+
+<LoomVideo id="c28ca8dcacae419187b7caa7aa71c7cd" />
+

--- a/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
@@ -5,7 +5,7 @@ sidebar_label: Changelog
 description: "Changelog for the dbt Cloud application"
 ---
 
-## dbt Cloud v1.1.6.0 (August 20, 2020)
+## dbt Cloud v1.1.6 (August 20, 2020)
 
 This release includes security enhancements and improvements across the entire
 dbt Cloud application.

--- a/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
@@ -5,7 +5,7 @@ sidebar_label: Changelog
 description: "Changelog for the dbt Cloud application"
 ---
 
-## dbt Cloud v1.1.6.0 (August 14, 2020)
+## dbt Cloud v1.1.6.0 (August 20, 2020)
 
 This release includes security enhancements and improvements across the entire
 dbt Cloud application.

--- a/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
@@ -5,6 +5,24 @@ sidebar_label: Changelog
 description: "Changelog for the dbt Cloud application"
 ---
 
+## dbt Cloud v1.1.6.0 (August 14, 2020)
+
+This release includes security enhancements and improvements across the entire
+dbt Cloud application.
+
+#### Enhancements
+- Support for viewing development docs inside of the IDE ([docs](viewing-docs-in-the-ide))
+- Change CI temporary schema names to be prefixed with `dbt_cloud` instead of `sinter`
+- Change coloring and iconography to improve accessibility and UX across the application
+- [Enterprise] Support the specification of multiple authorized domains in SSO configuration
+- [On-premises] Upgrade boto3 to support KIAM authentication
+
+#### Fixed
+- [Enterprise] Fix for missing IdP group membership mappings when users belong to >100 Azure AD groups
+- Disallow the creation of symlinks in the IDE
+- [Internal] Improve reliability of background cleanup processes
+- [Internal]Improve performance and reliability of artifact management and PR webhook processing
+
 ## dbt Cloud v1.1.5 (August 4, 2020)
 
 This release adds a major new feature to the IDE: merge conflict resolution!

--- a/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
@@ -21,7 +21,7 @@ dbt Cloud application.
 - [Enterprise] Fix for missing IdP group membership mappings when users belong to >100 Azure AD groups
 - Disallow the creation of symlinks in the IDE
 - [Internal] Improve reliability of background cleanup processes
-- [Internal]Improve performance and reliability of artifact management and PR webhook processing
+- [Internal] Improve performance and reliability of artifact management and PR webhook processing
 
 ## dbt Cloud v1.1.5 (August 4, 2020)
 

--- a/website/docs/docs/dbt-cloud/dbt-cloud-enterprise/setting-up-enterprise-sso-with-azure-active-directory.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-enterprise/setting-up-enterprise-sso-with-azure-active-directory.md
@@ -142,7 +142,7 @@ Settings.
 | **Client&nbspID** | Paste the **Application (client) ID** recorded in the steps above |
 | **Client&nbsp;Secret** | Paste the **Client Secret** recorded in the steps above |
 | **Tenant&nbsp;ID** | Paste the **Directory (tenant ID)** recorded in the steps above |
-| **Domain** | Enter the domain name for your Azure directory (eg. `fishtownanalytics.com`). Only users with accounts in this directory with this primary domain will be able to log into the dbt Cloud application. |
+| **Domain** | Enter the domain name for your Azure directory (eg. `fishtownanalytics.com`). Only users with accounts in this directory with this primary domain will be able to log into the dbt Cloud application. Optionally, you may specify a CSV of domains which are _all_ authorized to access your dbt Cloud account (eg. `fishtownanalytics.com, fishtowndata.com`) |
 | **Slug** | Enter your desired login slug. Users will be able to log into dbt Cloud by navigating to `https://cloud.getdbt.com/enterprise-login/<login-slug>`. Login slugs must be unique across all dbt Cloud accounts, so pick a slug that uniquely identifies your company. |
 
 

--- a/website/docs/docs/dbt-cloud/dbt-cloud-enterprise/setting-up-sso-with-google-gsuite.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-enterprise/setting-up-sso-with-google-gsuite.md
@@ -103,7 +103,8 @@ Settings.
     - **Client Secret**: Paste the Client Secret generated in the steps above
     - **Domain in GSuite**: Enter the domain name for your GSuite account (eg. `fishtownanalytics.com`).
       Only users with an email address from this domain will be able to log into your dbt Cloud
-      account using GSuite auth.
+      account using GSuite auth. Optionally, you may specify a CSV of domains
+      which are _all_ authorized to access your dbt Cloud account (eg. `fishtownanalytics.com, fishtowndata.com`)
     - **Slug**: Enter your desired login slug. Users will be able to log into dbt
       Cloud by navigating to `https://cloud.getdbt.com/enterprise-login/<login-slug>`. Login slugs must
       be unique across all dbt Cloud accounts, so pick a slug that uniquely

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -124,6 +124,7 @@ module.exports = {
       items: [
         "docs/dbt-cloud/cloud-ide/the-dbt-ide",
         "docs/dbt-cloud/cloud-ide/handling-merge-conflicts",
+        "docs/dbt-cloud/cloud-ide/viewing-docs-in-the-ide",
       ],
     },
     {


### PR DESCRIPTION
## Description & motivation
Adds dbt Cloud v1.1.6.0 (dated Aug 20) documentation, plus updated docs for newly released changes in the app.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes
- [x] No (if you're not sure, it's probably "No")
