### PR TITLE
[DRAFT] Add docs on load_result macro

### DIFF
--- a/website/docs/reference/dbt-classes.md
+++ b/website/docs/reference/dbt-classes.md
@@ -167,3 +167,201 @@ The execution of a resource in dbt generates a Result object. This object contai
     'required': ['node'],
 }
 ```
+
+
+## SQL Results
+:::warning These docs are a work in progress
+:::
+
+Note for the discerning reader: this is not a true python Class — it's a dictionary.
+
+The [`load_result` macro](load_result) macro returns a SQL Results object. The schema of a SQL Results Object is as follows ([source code](https://github.com/fishtown-analytics/dbt/blob/dev/marian-anderson/core/dbt/context/providers.py#L667)):
+
+```python
+{
+    'status': 'SUCCESS 1',
+    'data': [(Decimal('1'),)],
+    'table': <agate.table.Table object at 0x11466ad90>
+}
+```
+
+Note that this contract may be subject to change in the future until dbt's API has reached a "stable" state.
+
+Keys:
+- `status`: The status code returned by the database. Note: this varies across databases and query types.
+- `data`: An array of tuples represent the results. The first item represents the first row. For example, for a table with results:
+
+| my_col_1 | my_col_2 |
+|----------|----------|
+| 1        | 2        |
+| 3        | 4        |
+
+```python
+> results['data']
+
+[
+    (Decimal('1'), Decimal('2')),
+    (Decimal('3'), Decimal('4'))
+]
+
+```
+
+- `table`: An [Agate Table](https://agate.readthedocs.io/en/1.6.1/api/table.html) containing results. This is a powerful API for interacting with query results, but you may need to use the Agate docs to navigate it.
+
+### Examples
+
+All examples use this setup SQL:
+
+```sql
+{%- call statement('test_query', fetch_result=True) -%}
+
+    select 1 as my_col_1, 2 as my_col_2
+    union all
+    select 3 as my_col_1, 4 as my_col_2
+
+{%- endcall -%}
+
+{%- set test_query = load_result(name='test_query') -%}
+```
+
+We've included examples of how to use the [`log` macro](log) to print results to the command line in order to "see" what the object is.
+
+#### Returning the first row
+
+You can use both the `data` and the `table` properties to return this.
+
+Using the `data` property, both of these are equivalent:
+
+```sql
+
+{% set first_row=test_query['data'][0] %}
+
+{{ log(first_row, info=True) }}
+
+{% set first_row=test_query.data[0] %}
+
+{{ log(first_row, info=True) }}
+```
+
+```txt
+(Decimal('1'), Decimal('2'))
+
+(Decimal('1'), Decimal('2'))
+```
+
+You can also use the `table` property to return an `Agate Row`. This also has the benefit of retaining column name mappings.
+
+```sql
+
+{% set first_row=test_query.table[0] %}
+
+{# This is an Agate Row #}
+{{ log(first_row, info=True) }}
+
+{# This is a tuple #}
+{{ log(first_row.values(), info=True) }}
+
+{# Return a row value by column name #}
+{# Note: on Snowflake you will have to use ['MY_COL_2'] #}
+{{ log(first_row['my_col_2'], info=True) }}
+
+```
+
+
+```txt
+<agate.Row: (Decimal('1'), Decimal('2'))>
+
+(Decimal('1'), Decimal('2')
+
+1
+```
+
+#### Returning the first column from a query
+
+Using the `data` property — this requires some tricky Jinja.
+```sql
+{% set first_column=test_query.data | map(attribute=0) | list %}
+
+{# This is a list #}
+{{ log(first_column, info=True) }}
+```
+
+```txt
+[Decimal('1'), Decimal('3')]
+```
+
+Using the `table` property:
+```sql
+{% set first_column=test_query.table.columns[0] %}
+
+{# This is an Agate Column #}
+{{ log(first_column, info=True) }}
+
+{# This is a tuple #}
+{{ log(first_column.values(), info=True) }}
+
+{# This is the first value of the column #}
+{{ log(first_column[0], info=True) }}
+
+```
+
+```txt
+<agate.Column: (Decimal('1'), Decimal('3'))>
+
+(Decimal('1'), Decimal('3'))
+
+1
+```
+
+#### Returning a named column from a query
+
+```sql
+{# On snowflake you will need to use 'MY_COL_2' #}
+{% set named_column=test_query.table.columns['my_col_2'] %}
+
+{# This is an Agate Column #}
+{{ log(named_column, info=True) }}
+
+{# This is a tuple #}
+{{ log(named_column.values, info=True) }}
+
+{# This is a the first value of the column #}
+{{ log(named_column[0], info=True) }}
+```
+
+```txt
+<agate.Column: (Decimal('2'), Decimal('4'))>
+
+(Decimal('2'), Decimal('4'))
+
+2
+```
+
+
+#### Returning the column names of a query result
+Included for illustrative purposes only.
+
+Consider using the built-in [`get_columns_in_query` macro](https://github.com/fishtown-analytics/dbt/blob/dev/marian-anderson/core/dbt/include/global_project/macros/adapters/common.sql#L1) instead.
+
+```
+{% set column_names=test_query.table.columns | map(attribute='name') | list }
+
+{# This is a list #}
+{{ log(column_names, info=True) }}
+```
+
+```txt
+['my_col_1', 'my_col_2']
+```
+
+#### Print a table to stdout
+```sql
+{{ test_query.table.print_table() }}
+```
+
+```txt
+| my_col_1 | my_col_2 |
+| -------- | -------- |
+|        1 |        2 |
+|        3 |        4 |
+```

--- a/website/docs/reference/dbt-classes.md
+++ b/website/docs/reference/dbt-classes.md
@@ -344,7 +344,7 @@ Included for illustrative purposes only.
 Consider using the built-in [`get_columns_in_query` macro](https://github.com/fishtown-analytics/dbt/blob/dev/marian-anderson/core/dbt/include/global_project/macros/adapters/common.sql#L1) instead.
 
 ```
-{% set column_names=test_query.table.columns | map(attribute='name') | list }
+{% set column_names=test_query.table.columns | map(attribute='name') | list %}
 
 {# This is a list #}
 {{ log(column_names, info=True) }}

--- a/website/docs/reference/dbt-classes.md
+++ b/website/docs/reference/dbt-classes.md
@@ -189,7 +189,7 @@ Note that this contract may be subject to change in the future until dbt's API h
 
 Keys:
 - `status`: The status code returned by the database. Note: this varies across databases and query types.
-- `data`: An array of tuples represent the results. The first item represents the first row. For example, for a table with results:
+- `data`: An array of tuples representing the results. The first item represents the first row. For example, for a table with results:
 
 | my_col_1 | my_col_2 |
 |----------|----------|

--- a/website/docs/reference/dbt-classes.md
+++ b/website/docs/reference/dbt-classes.md
@@ -210,7 +210,7 @@ Keys:
 
 ### Examples
 
-All examples use this setup SQL:
+The examples below use this setup SQL:
 
 ```sql
 {%- call statement('test_query', fetch_result=True) -%}

--- a/website/docs/reference/dbt-classes.md
+++ b/website/docs/reference/dbt-classes.md
@@ -175,7 +175,7 @@ The execution of a resource in dbt generates a Result object. This object contai
 
 Note for the discerning reader: this is not a true python Class — it's a dictionary.
 
-The [`load_result` macro](load_result) macro returns a SQL Results object. The schema of a SQL Results Object is as follows ([source code](https://github.com/fishtown-analytics/dbt/blob/dev/marian-anderson/core/dbt/context/providers.py#L667)):
+The [`load_result` macro](load_result) returns a SQL Results object. The schema of a SQL Results Object is as follows ([source code](https://github.com/fishtown-analytics/dbt/blob/dev/marian-anderson/core/dbt/context/providers.py#L667)):
 
 ```python
 {

--- a/website/docs/reference/dbt-jinja-functions.md
+++ b/website/docs/reference/dbt-jinja-functions.md
@@ -22,6 +22,7 @@ In addition to the standard Jinja library ([docs](https://jinja.palletsprojects.
 * [fromyaml](fromyaml)
 * [graph](graph)
 * [invocation_id](invocation_id)
+* [load_result](load_result)
 * [log](log)
 * [modules](modules)
 * [on-run-end-context](on-run-end-context)

--- a/website/docs/reference/dbt-jinja-functions/load_result.md
+++ b/website/docs/reference/dbt-jinja-functions/load_result.md
@@ -1,0 +1,18 @@
+```sql
+{%- call statement('states', fetch_result=True) -%}
+
+    select distinct state from {{ ref('users') }}
+
+{%- endcall -%}
+
+{%- set states = load_result('states') -%}
+
+```
+
+## Description
+The `load_result` function returns a [SQL Result](dbt-classes#sql-results).
+
+## Args
+- `name` (required): The name of a statement, as defined in a [statement block])(statement-block)
+
+Note: since there is only one argument for this macro, often the argument name is omitted.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -385,6 +385,7 @@ module.exports = {
             "reference/dbt-jinja-functions/fromyaml",
             "reference/dbt-jinja-functions/graph",
             "reference/dbt-jinja-functions/invocation_id",
+            "reference/dbt-jinja-functions/load_result",
             "reference/dbt-jinja-functions/log",
             "reference/dbt-jinja-functions/modules",
             "reference/dbt-jinja-functions/project_name",


### PR DESCRIPTION
## Description & motivation
We don't do a great job of documenting this, and it comes up enough in Slack / dbt Learn that I think we should have something better.

I think this needs a bit of refinement:
- I want to change the docs to be "how to operate on the `data` object" and "how to operate on the `table` object". That way, we can also use the same docs for the results of `run_query` (since that just returns the `table` object, not the other two parts).
- The examples feel clunky at the moment, trying to figure out a good way to render these. I kind of want "raw" / "compiled" side by side, yanno? Or like a python notebook interface.

ANYWAY, this will do for now

## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged
-->

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please update the base branch to `next`
- [ ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist
If you added new pages (delete if not applicable):
- [ ] The page has been added to `website/sidebars.js`
- [ ] The new page has a unique filename

If you removed existing pages (delete if not applicable):
- [ ] The page has been removed from `website/sidebars.js`
- [ ] An entry has been added to `_redirects`
