### PR TITLE
exasol documentation fix

### DIFF
--- a/website/docs/reference/warehouse-profiles/exasol-profile.md
+++ b/website/docs/reference/warehouse-profiles/exasol-profile.md
@@ -25,7 +25,7 @@ Easiest install is to use pip:
 
 #### User / password authentication
 
-Configure your dbt profile for using SQL Server authentication or Integrated Security:
+Configure your dbt profile for using Exasol:
 
 ##### Exasol connection information
 <File name='profiles.yml'>
@@ -37,7 +37,7 @@ dbt-exasol:
     dev:
       type: exasol
       threads: 1
-      dsn: IP:PORT
+      dsn: HOST:PORT
       user: USERNAME
       pass: PASSWORD
       dbname: db


### PR DESCRIPTION
## Description & motivation
Small fix in Exasol plugin documentation, there was wrong database name.


## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please update the base branch to `next`
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
