### PR TITLE
fix codeowners precedence

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
+*                               @clrcrl
 /website/docs/docs/dbt-cloud/   @drewbanin
 /website/src/pages/dbt-cloud/   @drewbanin
-*                              @clrcrl


### PR DESCRIPTION
I had these inverted - lower entries on the list take precedence over higher entries on the list! Via https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners

If there are any other codeowners adjustments we should make, let's do them here :)