### PR TITLE
Update/Removing Auth0 dependency from the dbt Cloud On-Prem documentation

### DIFF
--- a/website/docs/docs/dbt-cloud/on-premises/architecture.md
+++ b/website/docs/docs/dbt-cloud/on-premises/architecture.md
@@ -67,12 +67,6 @@ In order to perform basic maintenance and license checking, the following outbou
 
 ### Optional External Dependencies
 
-#### Auth0
-
-_Required for SSO integrations_
-
-Auth0 (https://auth0.com/) is a third-party service used by dbt Cloud to provide SSO integrations via SAML or Azure ADFS. Installations relying on SSO integrations must allow `auth.getdbt.com` to be accessed via HTTPS.
-
 #### Integrations
 
 _Can be individually enabled or disabled_


### PR DESCRIPTION
This removes the mention of Auth0 as an optional dependency for dbt Cloud. There is no need to merge this in until after the Okta integration is complete. 