### PR TITLE
minor partial parsing correction

### DIFF
--- a/website/docs/reference/profiles.yml.md
+++ b/website/docs/reference/profiles.yml.md
@@ -57,7 +57,9 @@ Partial parsing can improve the performance characteristics of dbt runs by limit
 
 If partial parsing is enabled and files are unchanged between invocations of dbt, then dbt does not need to re-parse these files — it can instead use the parsed representation from the _last_ invocation of dbt. If a file *has* changed between invocations of dbt, then dbt will re-parse the file and update the parsed node cache accordingly.
 
-Use caution when enabling partial parsing in dbt. If environment variables or variables specified on the CLI with `--vars` control the parsed representation of your project, then the logic executed by dbt may differ from the logic specified in your project. Partial parsing should only be used when all of the logic in your dbt project is encoded in the files inside of that project.
+Use caution when enabling partial parsing in dbt. If environment variables control the parsed representation of your project, then the logic executed by dbt may differ from the logic specified in your project. Partial parsing should only be used when all of the logic in your dbt project is encoded in the files inside of that project.
+
+If partial parsing is enabled and `--vars` change between runs, dbt will always re-parse.
 
 By default, `partial_parse` is set to `false`
 


### PR DESCRIPTION
## Description & motivation

Since we invalidate the results on any vars change, part of this warning isn't really true anymore, unless there's some third way to set vars that I'm forgetting about.

We could also expand on the new bit I added. The current list of things that invalidate the partial parse result:
 - `dbt_project.yml` changing at all
 - `profiles.yml` changing at all
 - the `--profile` argument changing
 - the `--target` argument changing
 - the cli `--vars` arguments changing at all (even being the same dicts in different order would probably trigger this)

But I thought maybe we should just keep it simple.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please update the base branch to `next`
- [X] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
