### PR TITLE
Add link to the dbt Cloud signup page

### DIFF
--- a/website/docs/docs/dbt-cloud/cloud-overview.md
+++ b/website/docs/docs/dbt-cloud/cloud-overview.md
@@ -3,7 +3,7 @@ title: "Overview"
 id: "cloud-overview"
 ---
 
-![dbt Cloud](https://www.getdbt.com/signup/) is a hosted service that helps data analysts and engineers productionize dbt deployments. It comes equipped with turnkey support for scheduling jobs, CI/CD, serving documentation, monitoring & alerting, and an Integrated Developer Environment (IDE). dbt Cloud’s generous Developer (free) plan and deep integration with dbt Core make it well suited for data teams small and large alike.  
+[dbt Cloud](https://www.getdbt.com/signup/) is a hosted service that helps data analysts and engineers productionize dbt deployments. It comes equipped with turnkey support for scheduling jobs, CI/CD, serving documentation, monitoring & alerting, and an Integrated Developer Environment (IDE). dbt Cloud’s generous Developer (free) plan and deep integration with dbt Core make it well suited for data teams small and large alike.  
 
 
 ### Develop dbt projects

--- a/website/docs/docs/dbt-cloud/cloud-overview.md
+++ b/website/docs/docs/dbt-cloud/cloud-overview.md
@@ -3,7 +3,7 @@ title: "Overview"
 id: "cloud-overview"
 ---
 
-dbt Cloud is a hosted service that helps data analysts and engineers productionize dbt deployments. It comes equipped with turnkey support for scheduling jobs, CI/CD, serving documentation, monitoring & alerting, and an Integrated Developer Environment (IDE). dbt Cloud’s generous Developer (free) plan and deep integration with dbt Core make it well suited for data teams small and large alike.  
+![dbt Cloud](https://www.getdbt.com/signup/) is a hosted service that helps data analysts and engineers productionize dbt deployments. It comes equipped with turnkey support for scheduling jobs, CI/CD, serving documentation, monitoring & alerting, and an Integrated Developer Environment (IDE). dbt Cloud’s generous Developer (free) plan and deep integration with dbt Core make it well suited for data teams small and large alike.  
 
 
 ### Develop dbt projects


### PR DESCRIPTION
There isn't a link on this page that takes someone directly to the signup page. 

Adding one here to make it just a little easier for people to get started.

