### PR TITLE
Update to fix macro resolution

### DIFF
--- a/website/docs/docs/building-a-dbt-project/hooks-operations.md
+++ b/website/docs/docs/building-a-dbt-project/hooks-operations.md
@@ -84,7 +84,7 @@ Unlike hooks, you need to explicitly execute a query within a macro, by using ei
 
 This macro performs a similar action as the above hooks:
 
-<File name='macros/grant_select.yml'>
+<File name='macros/grant_select.sql'>
 
 ```sql
 {% macro grant_select(role) %}


### PR DESCRIPTION
Unless a macro file has a `.sql` extension, DBT (Cloud) will not be able to run a given operation but will error out with the following message: 
```Encountered an error while running operation: Runtime Error
  dbt could not find a macro with the name "xxx" in any package
```

Other examples such as https://github.com/fishtown-analytics/redshift/tree/0.2.3/#redshift_maintenance_operation-source list .sql extension for their macro files.

## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a pull request on dbt core, etc?
-->

## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged
-->

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist
If you added new pages (delete if not applicable):
- [ ] The page has been added to `website/sidebars.js`
- [ ] The new page has a unique filename

If you removed existing pages (delete if not applicable):
- [ ] The page has been removed from `website/sidebars.js`
- [ ] An entry has been added to `_redirects`
