### PR TITLE
Clarify what to enter for the Snowflake account ID

### DIFF
--- a/website/docs/learn/2a-create-a-project-dbt-cloud.md
+++ b/website/docs/learn/2a-create-a-project-dbt-cloud.md
@@ -41,6 +41,10 @@ You should have received an invitation to dbt Cloud. Please accept the invitatio
 
 <Lightbox src="/img/dbt-cloud-github-integration.png" title="dbt Cloud GitHub Integration" />
 
+:::caution
+For the `[account id]` for Snowflake, this should be the account ID, not the entire URL.  For example, use `abc12345` instead of `abc12345/.snowflakecomputing.com`
+:::
+
 4. Go to the `Develop` interface by either:
     * Selecting `Start Developing`, or
     * Selecting the hamburger menu, and then `Develop`.

--- a/website/docs/learn/2a-create-a-project-dbt-cloud.md
+++ b/website/docs/learn/2a-create-a-project-dbt-cloud.md
@@ -42,7 +42,7 @@ You should have received an invitation to dbt Cloud. Please accept the invitatio
 <Lightbox src="/img/dbt-cloud-github-integration.png" title="dbt Cloud GitHub Integration" />
 
 :::caution
-For the `[account id]` for Snowflake, this should be the account ID, not the entire URL.  For example, use `abc12345` instead of `abc12345/.snowflakecomputing.com`
+For the `[account id]` for Snowflake, this should be the account ID, not the entire URL.  For example, use `abc12345` instead of `abc12345.snowflakecomputing.com`
 :::
 
 4. Go to the `Develop` interface by either:


### PR DESCRIPTION
## Description & motivation
A few Learn users are having trouble testing their Snowflake connection in dbt Cloud.  This edit is meant to clarify that the account ID from snowflake should be entered rather than the entire Snowflake URL.

I used the caution tag instead of info tag, but I think this could be either.

## To-do before merge
[ ] Decide on whether this should be info or caution.
[ ] Finalize the language used for clarifying this difference.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [X] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist
