### PR TITLE
Add Dremio to the list of community supported backends.

### DIFF
--- a/website/docs/docs/supported-databases.md
+++ b/website/docs/docs/supported-databases.md
@@ -27,6 +27,7 @@ These database plugins are community-supported 🌱
 | Microsoft Azure Synapse DW ([dbt-azuresynapse](https://github.com/embold-health/dbt-azuresynapse)) | [Profile Setup](azuresynapse-profile) | Azure Synapse 10+ 
 | Exasol Analytics ([dbt-exasol](https://github.com/tglunde/dbt-exasol)) | [Profile Setup](exasol-profile) | Exasol 6.x and later |
 | Oracle Database ([dbt-oracle](https://github.com/techindicium/dbt-oracle)) | [Profile Setup](oracle-profile) |Oracle 11+ |
+| Dremio ([dbt-dremio](https://github.com/fabrice-etanchaud/dbt-dremio)) | [Profile Setup](dremio-profile) |Dremio 4.7+ |
 
 ## Creating a new adapter
 

--- a/website/docs/reference/warehouse-profiles/dremio-profile.md
+++ b/website/docs/reference/warehouse-profiles/dremio-profile.md
@@ -18,15 +18,11 @@ This is a Community Contributed plugin for dbt. If you're interested in contribu
 
 **dbt-dremio** supports dbt 0.18.0 or newer.
 
-When available, the easiest install will be to use pip:
+The easiest way to install it is to use pip:
 
     pip install dbt-dremio
 
-There is no package yet, you can clone the repository, cd in it, and then type 
-
-    pip3 install -e .
-
-Follow the repository's link for python and os dependencies.
+Follow the repository's link for os dependencies.
 
 ## Connecting to Dremio with **dbt-dremio**
 

--- a/website/docs/reference/warehouse-profiles/dremio-profile.md
+++ b/website/docs/reference/warehouse-profiles/dremio-profile.md
@@ -1,0 +1,53 @@
+---
+title: "Dremio Profile"
+---
+
+
+:::info Community contributed plugin
+
+This is a Community Contributed plugin for dbt. If you're interested in contributing, check out the source code for the repository [dbt-dremio](https://github.com/fabrice-etanchaud/dbt-dremio)
+
+:::
+
+## Overview of dbt-dremio
+**Status:** Community Contributed
+
+**Author:** Fabrice Etanchaud (Maif-vie)
+
+**Source Code:** https://github.com/fabrice-etanchaud/dbt-dremio
+
+**dbt-dremio** supports dbt 0.18.0 or newer.
+
+When available, the easiest install will be to use pip:
+
+    pip install dbt-dremio
+
+There is no package yet, you can clone the repository, cd in it, and then type 
+
+    pip3 install -e .
+
+Follow the repository's link for python and os dependencies.
+
+## Connecting to Dremio with **dbt-dremio**
+
+### Connecting with ZooKeeper
+
+I have no means to test [connection with ZooKeeper](https://docs.dremio.com/drivers/dremio-connector.html#connecting-to-zookeeper). 
+If you do need this, contact me and I will provide you with a branch you can test.
+
+### Direct connection to a coordinator
+
+```yaml
+my_profile:
+  outputs:
+    my_target:
+      type: dremio
+      threads: 2
+# please replace driver below with the one you gave to your dremio odbc driver installation      
+      driver: Dremio ODBC Driver 64-bit
+      host: [coordinator host]
+      port: 31010
+      schema: [schema]
+      user: [user]
+      password: [password]
+  target: my_target

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -450,6 +450,7 @@ module.exports = {
         "reference/warehouse-profiles/exasol-profile",
         "reference/warehouse-profiles/oracle-profile",
         "reference/warehouse-profiles/azuresynapse-profile",
+        "reference/warehouse-profiles/dremio-profile",        
       ],
     },
     "reference/dbt-artifacts",


### PR DESCRIPTION
## Description & motivation

As [Claire suggested](https://getdbt.slack.com/archives/C0100SUQ0CW/p1600714656004300?thread_ts=1600373396.161700&cid=C0100SUQ0CW), add a new community adapter

## To-do before merge

I need to take time to :
- build a package for pip
- use the integration test

## Pre-release docs
- No: the base branch is `current`

## Checklist

- the dremio-profile page has been added to `website/sidebars.js`

