### PR TITLE
fix for internal linking logic

### DIFF
--- a/website/docs/docs/dbt-cloud/on-premises/setup.md
+++ b/website/docs/docs/dbt-cloud/on-premises/setup.md
@@ -23,7 +23,7 @@ Enter the desired hostname, and upload your TLS certificate to establish secure 
 
 ### Upload License
 
-The first time you log into the configuration console, you will need to upload your license file. This contains information about your subscription, as well as configuration for your specific installation. If you don't already have a license file, [contact your account manager or support](support@getdbt.com).
+The first time you log into the configuration console, you will need to upload your license file. This contains information about your subscription, as well as configuration for your specific installation. If you don't already have a license file, [contact your account manager or support](mailto:support@getdbt.com).
 
 After you upload the license, you will be redirected to the Config page. You can access this page at any time to reconfigure your dbt Cloud installation.
 

--- a/website/docs/docs/guides/getting-help.md
+++ b/website/docs/docs/guides/getting-help.md
@@ -42,7 +42,7 @@ Sometimes you might hit a boundary of dbt because you're trying to use it in a w
 We use a number of different mediums to share information
 - If your question is roughly "I've hit this error and am stuck", please ask it on [Stack Overflow](https://stackoverflow.com/questions/ask?tags=dbt).
 - If you think you've found a bug, please report it on the relevant GitHub repo (e.g. [dbt repo](https://github.com/fishtown-analytics/dbt), [dbt-utils repo](https://github.com/fishtown-analytics/dbt-utils))
-- If you are looking for an opinionated answer (e.g. "What's the best approach to X?", "Why is Y done this way?"), then, feel free to join our [Slack community](http://community.getdbt.com/) and ask it in the correct channel:
+- If you are looking for an opinionated answer (e.g. "What's the best approach to X?", "Why is Y done this way?"), then, feel free to join our [Slack community](https://community.getdbt.com/) and ask it in the correct channel:
     * **#beginners:** A great channel if you're getting started with dbt and want to understand how it works.
     * **#modeling:** This channel is most useful when wanting to ask questions about data model design, SQL patterns, and testing.
     * **#suggestions:** Got an idea for dbt? This is the place!

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-14-1.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-14-1.md
@@ -142,4 +142,4 @@ If you have only recently started snapshotting tables using the `check` strategy
 
 ### Getting help
 
-We're happy to help with this migration if you have any questions or issues. Please let us know [on Slack](community.getdbt.com) if you'd like a hand!
+We're happy to help with this migration if you have any questions or issues. Please let us know [on Slack](https://community.getdbt.com) if you'd like a hand!

--- a/website/docs/faqs/model-custom-schemas.md
+++ b/website/docs/faqs/model-custom-schemas.md
@@ -3,7 +3,7 @@ title: Can I build my models in a schema other than my target schema?
 ---
 ## Or: Can I split my models across multiple schemas?
 
-Yes! Use the [schema](reference/configs/schema.md) configuration in your `dbt_project.yml` file, or using a `config` block:
+Yes! Use the [schema](reference/resource-configs/schema.md) configuration in your `dbt_project.yml` file, or using a `config` block:
 
 <File name='dbt_project.yml'>
 

--- a/website/docs/faqs/seed-custom-schemas.md
+++ b/website/docs/faqs/seed-custom-schemas.md
@@ -3,7 +3,7 @@ title: Can I build my seeds in a schema other than my target schema?
 ---
 ## Or: Can I split my seeds across multiple schemas?
 
-Yes! Use the [schema](reference/configs/schema.md) configuration in your `dbt_project.yml` file.
+Yes! Use the [schema](reference/resource-configs/schema.md) configuration in your `dbt_project.yml` file.
 
 <File name='dbt_project.yml'>
 

--- a/website/docs/faqs/seed-hooks.md
+++ b/website/docs/faqs/seed-hooks.md
@@ -3,9 +3,7 @@ title: Do hooks run with seeds?
 ---
 
 Yes! The following hooks are available:
-- [pre-hooks](reference/resource-configs/pre-hook.md)
-- [post-hooks](reference/resource-configs/post-hook.md)
-- [on-run-start](reference/project-configs/on-run-start.md)
-- [on-run-end](reference/project-configs/on-run-end.md)
+- [pre-hooks & post-hooks](reference/resource-configs/pre-hook-post-hook.md)
+- [on-run-start & on-run-end hooks](reference/project-configs/on-run-start-on-run-end.md)
 
 Configure these in your `dbt_project.yml` file.

--- a/website/docs/reference/project-configs/data-paths.md
+++ b/website/docs/reference/project-configs/data-paths.md
@@ -11,7 +11,7 @@ data-paths: [directorypath]
 </File>
 
 ## Definition
-Optionally specify a custom list of directories where [seed](docs/building-a-dbt-project.md) files are located.
+Optionally specify a custom list of directories where [seed](docs/building-a-dbt-project/seeds.md) files are located.
 
 ## Default
 

--- a/website/docs/reference/project-configs/profile.md
+++ b/website/docs/reference/project-configs/profile.md
@@ -15,7 +15,7 @@ The profile your dbt project should use to connect to your data warehouse.
 * If you are developing locally: This configuration is required, unless a command-line option (i.e. `--profile`) is supplied.
 
 ## Related guides
-* [Connecting to your warehouse](docs/running-a-dbt-project/using-the-command-line-interface/configure-your-profile.md)
+* [Connecting to your warehouse](docs/dbt-cli/configure-your-profile.md)
 
 ## Recommendation
 Often an organization has only one data warehouse, so it is sensible to use your organization's name as a profile name, in `snake_case`. For example:

--- a/website/src/components/link/index.js
+++ b/website/src/components/link/index.js
@@ -78,7 +78,7 @@ function expandRelativeLink(href, ignoreInvalid) {
         hash = ''
     }
 
-    var isExternal = !!link.match(/https?:/);
+    var isExternal = !!link.match(/https?:/) || !!link.match(/:/);
 
     var sourceLink = findSource(link);
     if (sourceLink) {
@@ -93,7 +93,8 @@ function expandRelativeLink(href, ignoreInvalid) {
         }
     } else if (!isExternal && !href.startsWith('/')) {
         if (ENV.DOCS_ENV == 'build' && !ignoreInvalid) {
-            throw new Error(`Broken link detected ${href}`)
+            console.log(` - Broken link detected ${href}`);
+            throw new Error("Broken link")
         } else {
             return {
                 bad: true,

--- a/website/src/theme/MDXComponents/index.js
+++ b/website/src/theme/MDXComponents/index.js
@@ -34,13 +34,7 @@ export default {
     }
     return children;
   },
-  a: props => {
-    if (/\.[^./]+$/.test(props.href)) {
-      // eslint-disable-next-line jsx-a11y/anchor-has-content
-      return <a {...props} />;
-    }
-    return <Link {...props} />;
-  },
+  a: (props) => <Link {...props} />,
   pre: props => <pre className={styles.mdxCodeBlock} {...props} />,
   h1: Heading('h1'),
   h2: Heading('h2'),


### PR DESCRIPTION
## Description & motivation
Fixes #379

This logic has been [updated upstream in docusaurus](https://github.com/facebook/docusaurus/blob/8bed33b81fcd245c287f5e4a688300abaf6431b5/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx#L27). In looking at the original regex, it appears that any internal link that included a `.` followed by a character other than `.` or `/` would not be "checked". I can't think of a good reason for it to work this way.... so I just removed that regex. In testing, the the failing url from #369 actually now works and is correctly re-written to the correct docusaurus URL.

```
[Using Custom Schemas](docs/docs/building-a-dbt-project/building-models/using-custom-schemas.md)

--> rewritten to 

/docs/building-a-dbt-project/building-models/using-custom-schemas/
```