### PR TITLE
Update link to additional profile configurations

### DIFF
--- a/website/docs/dbt-cli/configure-your-profile.md
+++ b/website/docs/dbt-cli/configure-your-profile.md
@@ -48,7 +48,7 @@ jaffle_shop:
 ## What goes in my `profiles.yml` file?
 In your `profiles.yml` file, you can store as many profiles as you need. Typically, you would have one profile for each warehouse you use – for most organizations, this means you would only have one profile.
 
-You can also configure some advanced dbt options in your `profiles.yml` file, see [Additional profile configurations](configure-your-profile#additional-profile-configurations).
+You can also configure some advanced dbt options in your `profiles.yml` file, see [Additional profile configurations](configure-your-profile/#additional-profile-configuration).
 
 ## What goes in a profile?
 A profile consists of _targets_, and a specified _default target_.

--- a/website/docs/dbt-cli/configure-your-profile.md
+++ b/website/docs/dbt-cli/configure-your-profile.md
@@ -48,7 +48,7 @@ jaffle_shop:
 ## What goes in my `profiles.yml` file?
 In your `profiles.yml` file, you can store as many profiles as you need. Typically, you would have one profile for each warehouse you use – for most organizations, this means you would only have one profile.
 
-You can also configure some advanced dbt options in your `profiles.yml` file, see [Additional profile configurations](configure-your-profile/#additional-profile-configuration).
+You can also configure some advanced dbt options in your `profiles.yml` file, see [the reference docs for `profiles.yml` files](reference/profiles.yml.md).
 
 ## What goes in a profile?
 A profile consists of _targets_, and a specified _default target_.


### PR DESCRIPTION
This was missing a slash to navigate towards the bottom of the page and the current heading is singular.  The link had configurations as plural.

## Description & motivation
In creating some learn material, I noticed that his link was broken.

## To-do before merge
- [ ] Ensure that the link navigates towards the correct page in the heading.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [X] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist
👍 
