### PR TITLE
Add initial docs for exposures

### DIFF
--- a/website/docs/reference/exposure-properties.md
+++ b/website/docs/reference/exposure-properties.md
@@ -1,0 +1,57 @@
+---
+title: Exposure properties
+---
+
+<Changelog>
+
+* Exposures are new in `v0.18.1`
+
+</Changelog>
+
+## Related documentation
+- [Using exposures](using-exposures)
+- [Declaring resource properties](declaring-properties)
+
+Exposure properties can be declared in `.yml` files in:
+- your `data/` directory (as defined by the [`data-paths` config](data-paths))
+
+You can name these files `whatever_you_want.yml`, and nest them arbitrarily deeply in subfolders within `models/` directory.
+
+### Available Properties
+
+Required:
+- **name**
+- **type**: one of `dashboard`, `notebook`, `analysis`, `ml`, `application`
+- **owner**: email
+
+Expected:
+- **depends_on**: list of relations (`ref` + `source`)
+
+Optional properties:
+- **maturity**: one of `high`, `medium`, `low`
+- **owner**: name
+
+We plan to add more subtypes and optional properties in future releases.
+
+<File name='data/<filename>.yml'>
+
+```yml
+version: 2
+
+exposures:
+  - name: <string>
+    [description](description): <markdown_string>
+    type: {dashboard, notebook, analysis, ml, application}
+    maturity: {high, medium, low}
+    owner:
+      name: <string>
+      email: <string>
+    
+    depends_on:
+      - ref('model')
+      - ref('seed')
+      - source('name', 'table')
+
+  - name: ... # declare properties of additional exposures
+```
+</File>

--- a/website/docs/reference/exposure-properties.md
+++ b/website/docs/reference/exposure-properties.md
@@ -9,7 +9,6 @@ title: Exposure properties
 </Changelog>
 
 ## Related documentation
-- [Using exposures](using-exposures)
 - [Declaring resource properties](declaring-properties)
 
 Exposure properties can be declared in `.yml` files in:

--- a/website/docs/reference/exposure-properties.md
+++ b/website/docs/reference/exposure-properties.md
@@ -11,10 +11,9 @@ title: Exposure properties
 ## Related documentation
 - [Declaring resource properties](declaring-properties)
 
-Exposure properties can be declared in `.yml` files in:
-- your `data/` directory (as defined by the [`data-paths` config](data-paths))
+Exposures are defined in `.yml` files in your `models` directory (as defined by the [`source-paths` config](source-paths)), nested under an `exposures:` key.
 
-You can name these files `whatever_you_want.yml`, and nest them arbitrarily deeply in subfolders within `models/` directory.
+You can name these files `whatever_you_want.yml`, and nest them arbitrarily deeply in subfolders within the `models/` directory.
 
 ### Available Properties
 

--- a/website/docs/reference/node-selection/methods.md
+++ b/website/docs/reference/node-selection/methods.md
@@ -119,3 +119,14 @@ In projects with intricate env-aware logic, dbt will err on the side of running
 too many models (i.e. false positives). We're working on better options for more 
 complex projects, in the form of more-specific subselectors.
 Track [this issue](https://github.com/fishtown-analytics/dbt/issues/2704) for progress.
+
+### The "exposure" method
+<Changelog>New in v0.18.1</Changelog>
+
+The `exposure` method is used to select parent resources of a specified [exposure](exposure-properties). Use in conjunction with the `+` operator.
+
+```bash
+$ dbt run --models +exposure:weekly_kpis                # run all models that feed into the weekly_kpis exposure
+$ dbt test --models +exposure:*                         # test all resources upstream of all exposures
+$ dbt ls --select +exposure:* --resource-type source    # list all sources upstream of all exposures
+```

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -316,6 +316,7 @@ module.exports = {
         "reference/snapshot-properties",
         "reference/analysis-properties",
         "reference/macro-properties",
+        "reference/exposure-properties",
         {
           type: "category",
           label: "List of general properties",


### PR DESCRIPTION
## Description & motivation

- Add initial docs (reference only) for exposure properties and `exposure:` node selector
- Eventually, I'll want to add exposures under "Building a dbt project" (exposure equivalent of [this](https://docs.getdbt.com/docs/building-a-dbt-project/using-sources))
- Rather than fuddling with `current`/`next`, since `next` already includes some v0.19-specific things and since we're releasing v0.18.1 quite soon, I'm thinking of waiting until v0.18.1 is out in the world to merge this PR

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current` (v0.18.1 is currently a release candidate and my current plan is to release it next week)
- [ ] Unsure: we'll let you know!

## Checklist
If you added new pages (delete if not applicable):
- [x] The page has been added to `website/sidebars.js`
- [ ] The new page has a unique filename
