### PR TITLE
adding changelog generator notes for 1.1.11

### DIFF
--- a/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
@@ -4,6 +4,32 @@ id: "cloud-changelog"
 sidebar_label: Changelog
 description: "Changelog for the dbt Cloud application"
 ---
+## dbt Cloud v1.1.11 (TODO - enter release date)
+
+TODO - Enter summary and curate below release notes.
+
+#### Enhancements
+
+- Add InterfaceError exception handling for commands
+- Rename My Account --> Profile
+- Add project and connection to admin backend
+
+#### Fixed
+
+- resolve presence of null-characters in logs throwing errors
+- Email verifications backend
+- Undo run.serialize
+- Fix error while serialized run
+- Fix logic error in connection setup
+- Fix a bug with Gitlab auth flow for unauthenticated users
+- Fix bug where Native Okta SSO uses the wrong port
+
+#### Internal
+
+- Codex Exposure Tile Snippet Generation
+- Remove embedded database storage class preflight check for on-premises
+- Autogenerate Django secret key and remove from from config for on-premises
+
 ## dbt Cloud v1.1.10 (October 8, 2020)
 
 This release adds support for repositories imported via GitLab (Enterprise)

--- a/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
@@ -4,9 +4,9 @@ id: "cloud-changelog"
 sidebar_label: Changelog
 description: "Changelog for the dbt Cloud application"
 ---
-## dbt Cloud v1.1.11 (TODO - enter release date)
+## dbt Cloud v1.1.11 (to be released)
 
-TODO - Enter summary and curate below release notes.
+Release v1.1.11 includes some quality-of-life enhancements, copy tweaks, and error resolutions. It also marks the last time we'll have the same digit four times in a row in a release until v2.2.22.
 
 #### Enhancements
 
@@ -16,12 +16,12 @@ TODO - Enter summary and curate below release notes.
 
 #### Fixed
 
-- resolve presence of null-characters in logs throwing errors
+- Resolve errors from presence of null-characters in logs
 - Email verifications backend
 - Undo run.serialize
 - Fix error while serialized run
 - Fix logic error in connection setup
-- Fix a bug with Gitlab auth flow for unauthenticated users
+- Fix a bug with GitLab auth flow for unauthenticated users
 - Fix bug where Native Okta SSO uses the wrong port
 
 #### Internal

--- a/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
@@ -4,7 +4,7 @@ id: "cloud-changelog"
 sidebar_label: Changelog
 description: "Changelog for the dbt Cloud application"
 ---
-## dbt Cloud v1.1.11 (to be released)
+## dbt Cloud v1.1.11 (October 15, 2020)
 
 Release v1.1.11 includes some quality-of-life enhancements, copy tweaks, and error resolutions. It also marks the last time we'll have the same digit four times in a row in a release until v2.2.22.
 


### PR DESCRIPTION
## Description & motivation
This PR contains the release notes for dbt Cloud v1.1.11.


## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
