### PR TITLE
BigQuery authorized views

### DIFF
--- a/website/docs/reference/resource-configs/bigquery-configs.md
+++ b/website/docs/reference/resource-configs/bigquery-configs.md
@@ -543,3 +543,44 @@ select ...
 ```
 
 </File>
+
+## Authorized Views
+<Changelog>New in v0.18.0</Changelog>
+
+If the `grant_access_to` config is specified for a model materialized as a
+view, dbt will grant the view model access to select from the list of datasets
+provided. See [BQ docs on authorized views](https://cloud.google.com/bigquery/docs/share-access-views)
+for more details.
+
+<File name='dbt_project.yml'>
+
+```yml
+models:
+  [<resource-path>](resource-path):
+    +grant_access_to:
+      - project: project_1
+        dataset: dataset_1
+      - project: project_2
+        dataset: dataset_2
+```
+
+</File>
+
+<File name='models/<modelname>.sql'>
+
+```sql
+
+{{ config(
+    grant_access_to=[
+      {project: 'project_1', dataset: 'dataset_1'},
+      {project: 'project_2', dataset: 'dataset_2'}
+    ]
+) }}
+```
+
+</File>
+
+Views with this configuration will be able to select from objects in 
+`project_1.dataset_1` and `project_2.dataset_2`, even when they are located
+elsewhere and queried by users who do not otherwise have
+access to `project_1.dataset_1` and `project_2.dataset_2`.


### PR DESCRIPTION
## Description & motivation
- Add docs for BigQuery authorized views (aka `grant_access_to` config), which were added in v0.18.0 (https://github.com/fishtown-analytics/dbt/pull/2517)

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!