### PR TITLE
Update learn tutorial re: viewing docs

### DIFF
--- a/website/docs/learn/4-test-and-document-your-project.md
+++ b/website/docs/learn/4-test-and-document-your-project.md
@@ -130,8 +130,8 @@ models:
 
 </File>
 
-2. [dbt CLI only] Execute `dbt docs generate` to generate the documentation for your project. dbt introspects your project and your warehouse to generate a json file with rich documentation about your project.
-3. [dbt CLI only] Execute `dbt docs serve` to launch the documentation in a local website.
+2. Execute `dbt docs generate` to generate the documentation for your project. dbt introspects your project and your warehouse to generate a json file with rich documentation about your project.
+3. [CLI] Execute `dbt docs serve` to launch the documentation in a local website. [Cloud] Click the link above the file tree in the develop interface to launch documentation in a new tab.
 
 
 :::tip

--- a/website/docs/tutorial/4-test-and-document-your-project.md
+++ b/website/docs/tutorial/4-test-and-document-your-project.md
@@ -132,8 +132,8 @@ models:
 
 </File>
 
-2. [dbt CLI only] Execute `dbt docs generate` to generate the documentation for your project. dbt introspects your project and your warehouse to generate a json file with rich documentation about your project.
-3. [dbt CLI only] Execute `dbt docs serve` to launch the documentation in a local website.
+2. Execute `dbt docs generate` to generate the documentation for your project. dbt introspects your project and your warehouse to generate a json file with rich documentation about your project.
+3. [CLI] Execute `dbt docs serve` to launch the documentation in a local website. [Cloud] Click the link above the file tree in the develop interface to launch documentation in a new tab.
 
 
 :::tip


### PR DESCRIPTION
## Description & motivation
We can now see documentation in development in the Cloud IDE!


## To-do before merge
- [ ] Review the text for clarifying how to generate and serve documentation in the Cloud IDE

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [X] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

