### PR TITLE
Fixed typo "Be default" -> "By default".

### DIFF
--- a/website/docs/faqs/configurable-data-path.md
+++ b/website/docs/faqs/configurable-data-path.md
@@ -1,7 +1,7 @@
 ---
 title: Can I store my seeds in a directory other than the `data` directory in my project?
 ---
-Be default, dbt expects your seed files to be located in the `data` subdirectory
+By default, dbt expects your seed files to be located in the `data` subdirectory
 of your project.
 
 To change this, update the [data-paths](reference/project-configs/data-paths.md) configuration in your `dbt_project.yml`

--- a/website/docs/faqs/configurable-data-test-path.md
+++ b/website/docs/faqs/configurable-data-test-path.md
@@ -1,7 +1,7 @@
 ---
 title: Can I store my data tests in a directory other than the `test` directory in my project?
 ---
-Be default, dbt expects your data test files to be located in the `tests` subdirectory of your project.
+By default, dbt expects your data test files to be located in the `tests` subdirectory of your project.
 
 To change this, update the [test-paths](reference/project-configs/test-paths.md) configuration in your `dbt_project.yml`
 file, like so:

--- a/website/docs/faqs/configurable-model-path.md
+++ b/website/docs/faqs/configurable-model-path.md
@@ -1,7 +1,7 @@
 ---
 title: Can I store my models in a directory other than the `models` directory in my project?
 ---
-Be default, dbt expects your seed files to be located in the `models` subdirectory of your project.
+By default, dbt expects your seed files to be located in the `models` subdirectory of your project.
 
 To change this, update the [source-paths](reference/project-configs/source-paths.md) configuration in your `dbt_project.yml`
 file, like so:

--- a/website/docs/faqs/configurable-snapshot-path.md
+++ b/website/docs/faqs/configurable-snapshot-path.md
@@ -1,7 +1,7 @@
 ---
 title: Can I store my snapshots in a directory other than the `snapshot` directory in my project?
 ---
-Be default, dbt expects your snapshot files to be located in the `snapshots` subdirectory of your project.
+By default, dbt expects your snapshot files to be located in the `snapshots` subdirectory of your project.
 
 To change this, update the [snapshot-paths](reference/project-configs/snapshot-paths.md) configuration in your `dbt_project.yml`
 file, like so:


### PR DESCRIPTION
## Description & motivation
Just typo.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [v] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!