### PR TITLE
Update link to CLI installation from tutorial

### DIFF
--- a/website/docs/tutorial/2b-create-a-project-dbt-cli.md
+++ b/website/docs/tutorial/2b-create-a-project-dbt-cli.md
@@ -35,7 +35,7 @@ $ dbt --version
 
 :::info
 
-dbt should have been installed as part of the  <a href="/tutorial/setting-up">Setting Up</a> part of the tutorial. If it was not installed, please follow the <a href="https://docs.getdbt.com/docs/installation"> installation instructions </a>
+dbt should have been installed as part of the  <a href="/tutorial/setting-up">Setting Up</a> part of the tutorial. If it was not installed, please follow the <a href="https://docs.getdbt.com/dbt-cli/installation"> installation instructions </a>
 
 :::
 


### PR DESCRIPTION
## Description & motivation
Update link to dbt CLI installation instructions from the "dbt CLI: Create a project" page
## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!