### PR TITLE
include dbt-synapse as a community-supported adapter

### DIFF
--- a/website/docs/docs/supported-databases.md
+++ b/website/docs/docs/supported-databases.md
@@ -24,6 +24,7 @@ These database plugins are community-supported 🌱
 | -------- | ------------- | ----- |
 | Microsoft SQL Server ([dbt-mssql](https://github.com/jacobm001/dbt-mssql)) | [Profile Setup](mssql-profile) | SQL Server 2008 R2 and later |
 | Microsoft SQL Server ([dbt-sqlserver](https://github.com/mikaelene/dbt-sqlserver)) | [Profile Setup](mssql-profile) | SQL Server 2016 and later 
+| Microsoft Azure Synapse DW ([dbt-synapse](https://github.com/swanderz/dbt-synapse)) | [Profile Setup](../reference/warehouse-profiles/azuresynapse-profile.md) | Azure Synapse 10+ 
 | Microsoft Azure Synapse DW ([dbt-azuresynapse](https://github.com/embold-health/dbt-azuresynapse)) | [Profile Setup](azuresynapse-profile) | Azure Synapse 10+ 
 | Exasol Analytics ([dbt-exasol](https://github.com/tglunde/dbt-exasol)) | [Profile Setup](exasol-profile) | Exasol 6.x and later |
 | Oracle Database ([dbt-oracle](https://github.com/techindicium/dbt-oracle)) | [Profile Setup](oracle-profile) |Oracle 11+ |

--- a/website/docs/reference/warehouse-profiles/azuresynapse-profile.md
+++ b/website/docs/reference/warehouse-profiles/azuresynapse-profile.md
@@ -50,10 +50,10 @@ password: password
 
 #### Active Directory Authentication
 
-The following [`pyodbc`-supported ActiveDirectory methods](https://docs.microsoft.com/en-us/sql/connect/odbc/using-azure-active-directory?view=sql-server-ver15#new-andor-modified-dsn-and-connection-string-keywords) are available to authenticate to Azure SQL:
+The following [`pyodbc`-supported ActiveDirectory methods](https://docs.microsoft.com/en-us/sql/connect/odbc/using-azure-active-directory?view=sql-server-ver15#new-andor-modified-dsn-and-connection-string-keywords) are available to authenticate to Azure SQL products:
 - ActiveDirectory Password
-- ActiveDirectory Interactive
-- ActiveDirectory Integrated
+- ActiveDirectory Interactive (*Windows only*)
+- ActiveDirectory Integrated (*Windows only*)
 - Service Principal (a.k.a. AAD Application)
 - ~~ActiveDirectory MSI~~ (not implemented)
 
@@ -90,9 +90,7 @@ password: iheartopensource
 
 <TabItem value="interactive">
 
-**Windows Only**
-
-brings up the Azure AD prompt so you can MFA if need be.
+*Windows Only* brings up the Azure AD prompt so you can MFA if need be.
 
 <File name='profiles.yml'>
 
@@ -112,9 +110,7 @@ user: bill.gates@microsoft.com
 
 <TabItem value="integrated">
 
-**Windows Only**
-
-uses your machine's credentials (might be disabled by your AAD admins)
+*Windows Only* uses your machine's credentials (might be disabled by your AAD admins)
 
 <File name='profiles.yml'>
 

--- a/website/docs/reference/warehouse-profiles/azuresynapse-profile.md
+++ b/website/docs/reference/warehouse-profiles/azuresynapse-profile.md
@@ -76,7 +76,7 @@ port: 1433
 schema: schemaname
 authentication: ActiveDirectoryPassword
 user: bill.gates@microsoft.com
-password: i<3opensource?
+password: iheartopensource
 ```
 </File>
 </TabItem>

--- a/website/docs/reference/warehouse-profiles/azuresynapse-profile.md
+++ b/website/docs/reference/warehouse-profiles/azuresynapse-profile.md
@@ -27,7 +27,7 @@ pip install dbt-synapse
 ```
 For further (and more likely up-to-date) info, see the [README](https://github.com/swanderz/dbt-synapse/blob/master/README.md)
 
-### Connecting to SQL Server with **`dbt-azuresynapse`**
+### Connecting to Azure Synapse with **`dbt-synapse`**
 
 
 #### standard SQL Server authentication
@@ -159,7 +159,7 @@ On Ubuntu make sure you have the ODBC header files as well as the appropriate OD
     sudo apt-get install msodbcsql17
     sudo apt-get install mssql-tools
 
-### Connecting to SQL Server with **dbt-azuresynapse**
+### Connecting to Azure Synapse with **dbt-azuresynapse**
 
 #### User / password authentication
 

--- a/website/docs/reference/warehouse-profiles/azuresynapse-profile.md
+++ b/website/docs/reference/warehouse-profiles/azuresynapse-profile.md
@@ -32,7 +32,9 @@ For further (and more likely up-to-date) info, see the [README](https://github.c
 
 #### standard SQL Server authentication
 SQL Server credentials are supported for on-prem as well as cloud, and it is the default authentication method for `dbt-sqlsever`
+
 <File name='profiles.yml'>
+
 ```yml
 type: sqlserver
 driver: 'ODBC Driver 17 for SQL Server' (The ODBC Driver installed on your system)
@@ -42,6 +44,7 @@ schema: schemaname
 user: username
 password: password
 ```
+
 </File>
 
 #### Active Directory Authentication
@@ -68,6 +71,7 @@ The following [`pyodbc`-supported ActiveDirectory methods](https://docs.microsof
 Definitely not ideal, but available
 
 <File name='profiles.yml'>
+
 ```yml
 type: sqlserver
 driver: 'ODBC Driver 17 for SQL Server' (The ODBC Driver installed on your system)
@@ -78,7 +82,9 @@ authentication: ActiveDirectoryPassword
 user: bill.gates@microsoft.com
 password: iheartopensource
 ```
+
 </File>
+
 </TabItem>
 
 <TabItem value="interactive">
@@ -88,6 +94,7 @@ password: iheartopensource
 brings up the Azure AD prompt so you can MFA if need be.
 
 <File name='profiles.yml'>
+
 ```yml
 type: sqlserver
 driver: 'ODBC Driver 17 for SQL Server' (The ODBC Driver installed on your system)
@@ -97,7 +104,9 @@ schema: schemaname
 authentication: ActiveDirectoryInteractive
 user: bill.gates@microsoft.com
 ```
+
 </File>
+
 </TabItem>
 
 <TabItem value="integrated">
@@ -107,6 +116,7 @@ user: bill.gates@microsoft.com
 uses your machine's credentials (might be disabled by your AAD admins)
 
 <File name='profiles.yml'>
+
 ```yml
 type: sqlserver
 driver: 'ODBC Driver 17 for SQL Server' (The ODBC Driver installed on your system)
@@ -115,7 +125,9 @@ port: 1433
 schema: schemaname
 authentication: ActiveDirectoryIntegrated
 ```
+
 </File>
+
 </TabItem>
 
 <TabItem value="serviceprincipal">
@@ -123,6 +135,7 @@ authentication: ActiveDirectoryIntegrated
 `client_*` and `app_*` can be used interchangeably
 
 <File name='profiles.yml'>
+
 ```yml
 type: sqlserver
 driver: 'ODBC Driver 17 for SQL Server' (The ODBC Driver installed on your system)
@@ -133,7 +146,9 @@ tenant_id: tenant_id
 client_id: clientid
 client_secret: ActiveDirectoryIntegrated
 ```
+
 </File>
+
 </TabItem>
 
 </Tabs>
@@ -166,6 +181,7 @@ On Ubuntu make sure you have the ODBC header files as well as the appropriate OD
 Configure your dbt profile for using SQL Server authentication or Integrated Security:
 
 ##### SQL Server authentication
+
 ```yml
 dbt-azuresynapse:
   target: dev

--- a/website/docs/reference/warehouse-profiles/azuresynapse-profile.md
+++ b/website/docs/reference/warehouse-profiles/azuresynapse-profile.md
@@ -62,7 +62,7 @@ The following [`pyodbc`-supported ActiveDirectory methods](https://docs.microsof
     { label: 'Password', value: 'password'},
     { label: 'Interactive', value:'interactive'},
     { label: 'Integrated', value: 'integrated'},
-    { label: 'ServicePrincipal', value: 'serviceprincipal'}
+    { label: 'Service Principal', value: 'serviceprincipal'}
     ]
 }>
 

--- a/website/docs/reference/warehouse-profiles/azuresynapse-profile.md
+++ b/website/docs/reference/warehouse-profiles/azuresynapse-profile.md
@@ -20,7 +20,12 @@ These are Community Contributed plugins for dbt. If you're interested in contrib
 
 **dbt support**: version 0.18.0 and newer
 
-For more info, see the [README](https://github.com/swanderz/dbt-synapse/blob/master/README.md)
+The pacakge can be installed from PyPI with:
+
+```python
+pip install dbt-synapse
+```
+For further (and more likely up-to-date) info, see the [README](https://github.com/swanderz/dbt-synapse/blob/master/README.md)
 
 ### Connecting to SQL Server with **`dbt-azuresynapse`**
 

--- a/website/docs/reference/warehouse-profiles/azuresynapse-profile.md
+++ b/website/docs/reference/warehouse-profiles/azuresynapse-profile.md
@@ -29,6 +29,7 @@ For further (and more likely up-to-date) info, see the [README](https://github.c
 
 ### Connecting to Azure Synapse with **`dbt-synapse`**
 
+First download and install the [MSFT ODBC Driver 17 for SQL Server](https://docs.microsoft.com/en-us/sql/connect/odbc/download-odbc-driver-for-sql-server?view=sql-server-ver15)
 
 #### standard SQL Server authentication
 SQL Server credentials are supported for on-prem as well as cloud, and it is the default authentication method for `dbt-sqlsever`

--- a/website/docs/reference/warehouse-profiles/azuresynapse-profile.md
+++ b/website/docs/reference/warehouse-profiles/azuresynapse-profile.md
@@ -29,21 +29,23 @@ For further (and more likely up-to-date) info, see the [README](https://github.c
 
 ### Connecting to SQL Server with **`dbt-azuresynapse`**
 
-the following is needed for every target definition for both SQL Server and Azure SQL.  The sections below details how to connect to SQL Server and Azure SQL specifically.
-```
+
+#### standard SQL Server authentication
+SQL Server credentials are supported for on-prem as well as cloud, and it is the default authentication method for `dbt-sqlsever`
+<File name='profiles.yml'>
+```yml
 type: sqlserver
 driver: 'ODBC Driver 17 for SQL Server' (The ODBC Driver installed on your system)
 server: server-host-name or ip
 port: 1433
 schema: schemaname
-```
-### standard SQL Server authentication
-SQL Server credentials are supported for on-prem as well as cloud, and it is the default authentication method for `dbt-sqlsever`
-```
 user: username
 password: password
 ```
-### Azure SQL-specific auth
+</File>
+
+#### Active Directory Authentication
+
 The following [`pyodbc`-supported ActiveDirectory methods](https://docs.microsoft.com/en-us/sql/connect/odbc/using-azure-active-directory?view=sql-server-ver15#new-andor-modified-dsn-and-connection-string-keywords) are available to authenticate to Azure SQL:
 - ActiveDirectory Password
 - ActiveDirectory Interactive
@@ -51,31 +53,90 @@ The following [`pyodbc`-supported ActiveDirectory methods](https://docs.microsof
 - Service Principal (a.k.a. AAD Application)
 - ~~ActiveDirectory MSI~~ (not implemented)
 
-#### ActiveDirectory Password 
+<Tabs
+  defaultValue="integrated"
+  values={[
+    { label: 'Password', value: 'password'},
+    { label: 'Interactive', value:'interactive'},
+    { label: 'Integrated', value: 'integrated'},
+    { label: 'ServicePrincipal', value: 'serviceprincipal'}
+    ]
+}>
+
+<TabItem value="password">
+
 Definitely not ideal, but available
-```
+
+<File name='profiles.yml'>
+```yml
+type: sqlserver
+driver: 'ODBC Driver 17 for SQL Server' (The ODBC Driver installed on your system)
+server: server-host-name or ip
+port: 1433
+schema: schemaname
 authentication: ActiveDirectoryPassword
 user: bill.gates@microsoft.com
 password: i<3opensource?
 ```
-#### ActiveDirectory Interactive (*Windows only*)
+</File>
+</TabItem>
+
+<TabItem value="interactive">
+
+**Windows Only**
+
 brings up the Azure AD prompt so you can MFA if need be.
-```
+
+<File name='profiles.yml'>
+```yml
+type: sqlserver
+driver: 'ODBC Driver 17 for SQL Server' (The ODBC Driver installed on your system)
+server: server-host-name or ip
+port: 1433
+schema: schemaname
 authentication: ActiveDirectoryInteractive
 user: bill.gates@microsoft.com
 ```
-#### ActiveDirectory Integrated (*Windows only*)
+</File>
+</TabItem>
+
+<TabItem value="integrated">
+
+**Windows Only**
+
 uses your machine's credentials (might be disabled by your AAD admins)
-```
+
+<File name='profiles.yml'>
+```yml
+type: sqlserver
+driver: 'ODBC Driver 17 for SQL Server' (The ODBC Driver installed on your system)
+server: server-host-name or ip
+port: 1433
+schema: schemaname
 authentication: ActiveDirectoryIntegrated
 ```
-##### Service Principal
+</File>
+</TabItem>
+
+<TabItem value="serviceprincipal">
+
 `client_*` and `app_*` can be used interchangeably
-```
-tenant_id: ActiveDirectoryIntegrated
+
+<File name='profiles.yml'>
+```yml
+type: sqlserver
+driver: 'ODBC Driver 17 for SQL Server' (The ODBC Driver installed on your system)
+server: server-host-name or ip
+port: 1433
+schema: schemaname
+tenant_id: tenant_id
 client_id: clientid
 client_secret: ActiveDirectoryIntegrated
 ```
+</File>
+</TabItem>
+
+</Tabs>
 
 
 ## Overview of dbt-azuresynapse
@@ -105,7 +166,7 @@ On Ubuntu make sure you have the ODBC header files as well as the appropriate OD
 Configure your dbt profile for using SQL Server authentication or Integrated Security:
 
 ##### SQL Server authentication
-```yaml
+```yml
 dbt-azuresynapse:
   target: dev
   outputs:

--- a/website/docs/reference/warehouse-profiles/azuresynapse-profile.md
+++ b/website/docs/reference/warehouse-profiles/azuresynapse-profile.md
@@ -5,9 +5,73 @@ title: "Microsoft Azure Synapse DW Profile"
 
 :::info Community contributed plugin
 
-This is a Community Contributed plugin for dbt. If you're interested in contributing, check out the source code for the repository [dbt-azuresynapse](https://github.com/embold-health/dbt-azuresynapse)
+These are Community Contributed plugins for dbt. If you're interested in contributing, check out the source code for each repository:
+- [`dbt-synapse`](https://github.com/swanderz/dbt-synapse)
+- [`dbt-azuresynapse`](https://github.com/embold-health/dbt-azuresynapse)
 
 :::
+
+## Overview of dbt-synapse
+**Status:** Community Contributed
+
+**Author:** Nandan Hegde and Anders Swanson
+
+**Source Code:** https://github.com/swanderz/dbt-synapse
+
+**dbt support**: version 0.18.0 and newer
+
+For more info, see the [README](https://github.com/swanderz/dbt-synapse/blob/master/README.md)
+
+### Connecting to SQL Server with **`dbt-azuresynapse`**
+
+the following is needed for every target definition for both SQL Server and Azure SQL.  The sections below details how to connect to SQL Server and Azure SQL specifically.
+```
+type: sqlserver
+driver: 'ODBC Driver 17 for SQL Server' (The ODBC Driver installed on your system)
+server: server-host-name or ip
+port: 1433
+schema: schemaname
+```
+### standard SQL Server authentication
+SQL Server credentials are supported for on-prem as well as cloud, and it is the default authentication method for `dbt-sqlsever`
+```
+user: username
+password: password
+```
+### Azure SQL-specific auth
+The following [`pyodbc`-supported ActiveDirectory methods](https://docs.microsoft.com/en-us/sql/connect/odbc/using-azure-active-directory?view=sql-server-ver15#new-andor-modified-dsn-and-connection-string-keywords) are available to authenticate to Azure SQL:
+- ActiveDirectory Password
+- ActiveDirectory Interactive
+- ActiveDirectory Integrated
+- Service Principal (a.k.a. AAD Application)
+- ~~ActiveDirectory MSI~~ (not implemented)
+
+#### ActiveDirectory Password 
+Definitely not ideal, but available
+```
+authentication: ActiveDirectoryPassword
+user: bill.gates@microsoft.com
+password: i<3opensource?
+```
+#### ActiveDirectory Interactive (*Windows only*)
+brings up the Azure AD prompt so you can MFA if need be.
+```
+authentication: ActiveDirectoryInteractive
+user: bill.gates@microsoft.com
+```
+#### ActiveDirectory Integrated (*Windows only*)
+uses your machine's credentials (might be disabled by your AAD admins)
+```
+authentication: ActiveDirectoryIntegrated
+```
+##### Service Principal
+`client_*` and `app_*` can be used interchangeably
+```
+tenant_id: ActiveDirectoryIntegrated
+client_id: clientid
+client_secret: ActiveDirectoryIntegrated
+```
+
 
 ## Overview of dbt-azuresynapse
 **Status:** Community Contributed


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a pull request on dbt core, etc?
-->
added `dbt-synapse` to the list of supported adapters, so that Synapse users browsing the docs site know that `dbt-synapse` is an option. I followed @mikaelene's approach from #161 in not adding an additional profile configuration file.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
