### PR TITLE
Feature/add the RBAC loom to docs

### DIFF
--- a/website/docs/docs/dbt-cloud/access-control/enterprise-permissions.md
+++ b/website/docs/docs/dbt-cloud/access-control/enterprise-permissions.md
@@ -143,3 +143,12 @@ Stakeholders can perform the following actions in projects they are assigned to:
 <Lightbox src="/img/docs/dbt-cloud/dbt-cloud-enterprise/enterprise-permission-sets-diagram.png" title="Enterprise Permission Sets & Requirements."/>
 static/
 
+## How to Set Up RBAC Groups in dbt Cloud
+ 
+- **If you are on a Fishtown Hosted dbt Cloud instance:**
+Contact support via the Intercom button or support@getdbt.com to turn on this feature. 
+- **If you are on a customer deployed dbt Cloud instance:**
+Contact your account manager for instructions on how to turn on this feature.
+
+<LoomVideo id="8e2e00c57bde4fbfa4b519bf35d7632d" />
+


### PR DESCRIPTION
This adds the Loom video on how to set up RBAC groups onto the Enterprise Permission page. 