### PR TITLE
Add in lost redirect.

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -96,6 +96,7 @@
 /docs/hooks	/docs/building-a-dbt-project/hooks-operations	302
 /docs/init	/reference/commands/init	302
 /docs/install-from-source	/dbt-cli/installation	302
+/docs/installation	/dbt-cli/installation	302
 /docs/invocation_id	/docs/writing-code-in-dbt/jinja-context/invocation_id	302
 /docs/jinja-context	/docs/writing-code-in-dbt/jinja-context	302
 /docs/license	/docs/about/license	302


### PR DESCRIPTION
## Description & motivation
During the `_redirects` manipulation in PR 410, I lost a redirect. This adds in back in.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

