### PR TITLE
Fix Syntax hint in "Forcing Dependencies" example

### DIFF
--- a/website/docs/reference/dbt-jinja-functions/ref.md
+++ b/website/docs/reference/dbt-jinja-functions/ref.md
@@ -49,10 +49,10 @@ select * from {{ ref('package_name', 'model_name') }}
 
 In normal usage, dbt knows the proper order to run all models based on the usage of the `ref` function. There are cases though where dbt doesn't know when a model should be run. An example of this is when a model only references a macro. In that case, dbt thinks the model can run first because no explicit references are made at compilation time. To address this, you can use a SQL comment along with the `ref` function — dbt will understand the dependency, and the compiled query will still be valid:
 
-     ```sql
-      -- depends on: {{ ref('upstream_parent_model') }}
+```sql
+ -- depends on: {{ ref('upstream_parent_model') }}
 
-      {{ your_macro('variable') }}
-     ```
+ {{ your_macro('variable') }}
+```
 
 dbt will see the `ref` and build this model after the specified reference.


### PR DESCRIPTION
## Description & motivation
The example for the "Forcing Dependencies" Section seems to be malformatted. The current parsing of the documentation makes it hard to copy the example.

https://docs.getdbt.com/reference/dbt-jinja-functions/ref/#forcing-dependencies

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [X] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!