### PR TITLE
changelog for dbt Cloud v1.1.12

### DIFF
--- a/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
@@ -4,33 +4,24 @@ id: "cloud-changelog"
 sidebar_label: Changelog
 description: "Changelog for the dbt Cloud application"
 ---
-## dbt Cloud v1.1.12 (TODO - Enter date)
+## dbt Cloud v1.1.12 (Unreleased)
 
-TODO - Enter description and curate release notes
+This release adds dbt v.18.1 and 0.19.0b1 to dbt Cloud. Additionally, a
+number of bugs have been fixed.
 
 #### Enhancements
 
-- Update copy on billing page
+- Update copy on billing page for picking a plan at the end of a trial
+- Improved authorization for metadata API
 - Add dbt 0.19.0b1
 - Add dbt 0.18.1
-- Added codex auth jwt endpoint
 
 #### Fixed
 
-- Add metric unable to pick up runs
-- Escape characters fix for codex html snippet
-- resolve groups from other logged-in accounts appearing
-- Fix requested Gitlab scopes, issue when encrypting deploy tokens
-- resolve presence of null-characters in logs throwing errors
+- Fixed an issue where groups from other logged-in accounts appeared in the RBAC UI
+- Fixed requested Gitlab scopes and an issue when encrypting deploy tokens for GitLab auth
+- Fixed an issue where null characters in logs threw errors in scheduled runs
 
-#### Internal
-
-- measure artifact upload time
-- change metric type for artifact upload duration
-- measure artifact upload time
-- change permission logs to info and prefix
-- Bump django from 2.2.10 to 2.2.16
-- Add FA snippets to IDE
 
 ## dbt Cloud v1.1.11 (October 15, 2020)
 

--- a/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
@@ -18,7 +18,7 @@ This release adds dbt v.18.1 and 0.19.0b1 to dbt Cloud. Additionally, a number o
 #### Fixed
 
 - Fixed an issue where groups from other logged-in accounts appeared in the RBAC UI
-- Fixed requested Gitlab scopes and an issue when encrypting deploy tokens for GitLab auth
+- Fixed requested GitLab scopes and an issue when encrypting deploy tokens for GitLab auth
 - Fixed an issue where null characters in logs threw errors in scheduled runs
 
 

--- a/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
@@ -4,10 +4,9 @@ id: "cloud-changelog"
 sidebar_label: Changelog
 description: "Changelog for the dbt Cloud application"
 ---
-## dbt Cloud v1.1.12 (Unreleased)
+## dbt Cloud v1.1.12 (October 30, 2020)
 
-This release adds dbt v.18.1 and 0.19.0b1 to dbt Cloud. Additionally, a
-number of bugs have been fixed.
+This release adds dbt v.18.1 and 0.19.0b1 to dbt Cloud. Additionally, a number of bugs have been fixed.
 
 #### Enhancements
 

--- a/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
@@ -4,6 +4,34 @@ id: "cloud-changelog"
 sidebar_label: Changelog
 description: "Changelog for the dbt Cloud application"
 ---
+## dbt Cloud v1.1.12 (TODO - Enter date)
+
+TODO - Enter description and curate release notes
+
+#### Enhancements
+
+- Update copy on billing page
+- Add dbt 0.19.0b1
+- Add dbt 0.18.1
+- Added codex auth jwt endpoint
+
+#### Fixed
+
+- Add metric unable to pick up runs
+- Escape characters fix for codex html snippet
+- resolve groups from other logged-in accounts appearing
+- Fix requested Gitlab scopes, issue when encrypting deploy tokens
+- resolve presence of null-characters in logs throwing errors
+
+#### Internal
+
+- measure artifact upload time
+- change metric type for artifact upload duration
+- measure artifact upload time
+- change permission logs to info and prefix
+- Bump django from 2.2.10 to 2.2.16
+- Add FA snippets to IDE
+
 ## dbt Cloud v1.1.11 (October 15, 2020)
 
 Release v1.1.11 includes some quality-of-life enhancements, copy tweaks, and error resolutions. It also marks the last time we'll have the same digit four times in a row in a release until v2.2.22.


### PR DESCRIPTION
## Description & motivation
This PR is for the changelog for dbt Cloud v1.1.12


## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

