### PR TITLE
Update adapter test suite link

### DIFF
--- a/website/docs/docs/contributing/building-a-new-adapter.md
+++ b/website/docs/docs/contributing/building-a-new-adapter.md
@@ -314,4 +314,4 @@ While much of dbt's adapter-specific functionality can be modified in adapter ma
 
 ### Testing your new adapter
 
-You can clone and use a pre-configured [dbt integration test suite](https://github.com/fishtown-analytics/dbt-integration-tests) to test that your new adapter works. This closely mirrors the test suite that we use on dbt itself, and tests much of dbt's basic functionality.
+You can use a pre-configured [dbt adapter test suite](https://github.com/fishtown-analytics/dbt-adapter-tests) to test that your new adapter works. These tests include much of dbt's basic functionality, with the option to override or disable functionality that may not be supported on your adapter.


### PR DESCRIPTION
## Description & motivation

Replace deprecated [dbt-integration-tests](https://github.com/fishtown-analytics/dbt-integration-tests) with new [dbt-adapter-tests](https://github.com/fishtown-analytics/dbt-adapter-tests)

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!