### PR TITLE
Accessibility for Caution Boxes

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -2,7 +2,7 @@
 :root {
     --ifm-color-success: #7ec631 !important;
     --ifm-color-info: #0bb !important;
-    --ifm-color-warning: #fc0 !important;
+    --ifm-color-warning: #d64c1d !important;
     --ifm-color-danger: #ff694b !important;
 }
 


### PR DESCRIPTION
## Description & motivation
The `::caution` boxes are low contrast and tough to read - [best accessibility practice](https://stephaniewalter.design/blog/tips-create-accessible-color-palette/) would be to make the text greyish / darker or the background color oranger/darker. This PR opts for the orange route but I'm open to suggestions. 

I'm not super familiar with docusaurus CSS rules - this seems OK locally but I wanted to make sure I wasn't going to break colors elsewhere!

## A GIF

![docs_accessibility](https://user-images.githubusercontent.com/35374357/97341536-907af580-185b-11eb-81d8-e8f66f371ad2.gif)

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [x] No: please ensure the base branch is `current`