### PR TITLE
Add tags to Data Test documentation

### DIFF
--- a/website/docs/reference/data-test-configs.md
+++ b/website/docs/reference/data-test-configs.md
@@ -6,6 +6,7 @@ Note that this doc is not shown in the sidebar as it's sort of weird behavior.
 -->
 * enabled
 * severity
+* tags
 
 Can only be configured from a config block, not in a `dbt_project.yml`:
 
@@ -14,7 +15,8 @@ Can only be configured from a config block, not in a `dbt_project.yml`:
 {{
     config(
         enabled=true | false,
-        severity='warn' | 'error'
+        severity='warn' | 'error',
+        tags = 'example_tag' | ['example_tag_1', 'example_tag_2']
     )
 }}
 ```


### PR DESCRIPTION
## Description & motivation

Today I was searching whether it was possible to add tags to Data Tests so that the tests can be executed selectively. [According to the docs](https://docs.getdbt.com/reference/data-test-configs) it is not, however thanks to Tim Finkel's guidance I learned it is!

[Looking at the code](https://github.com/fishtown-analytics/dbt/blob/74eec3bdbee1e5be68c800ac400c0e6eac879e64/core/dbt/contracts/graph/model_config.py#L451-L453) there is are potentially more options from `NodeConfig`, however this PR is only for adding documentation about `tags`.

## To-do before merge

N/A

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist
N/A