### PR TITLE
Update/add an example of database switching onto the target reference page. 

### DIFF
--- a/website/docs/reference/dbt-jinja-functions/target.md
+++ b/website/docs/reference/dbt-jinja-functions/target.md
@@ -63,3 +63,22 @@ from source('web_events', 'page_views')
 where created_at >= dateadd('day', -3, current_date)
 {% endif %}
 ```
+
+### Use `target.name` to change your source database
+If you have specific Snowflake databases configured for your dev/qa/prod environments,
+you can set up your sources to compile to different databases depending on your 
+environment. 
+
+```yml
+version: 2
+ 
+sources:
+  - name: source_name 
+    database: |
+      {%- if  target.name == "dev" -%} raw_dev
+      {%- elif target.name == "qa"  -%} raw_qa
+      {%- elif target.name == "prd"  -%} raw_prod
+      {%- else -%} invalid_database
+      {%- endif -%}
+    schema: source_schema
+```

--- a/website/docs/reference/dbt-jinja-functions/target.md
+++ b/website/docs/reference/dbt-jinja-functions/target.md
@@ -77,7 +77,7 @@ sources:
     database: |
       {%- if  target.name == "dev" -%} raw_dev
       {%- elif target.name == "qa"  -%} raw_qa
-      {%- elif target.name == "prd"  -%} raw_prod
+      {%- elif target.name == "prod"  -%} raw_prod
       {%- else -%} invalid_database
       {%- endif -%}
     schema: source_schema


### PR DESCRIPTION
## Description & motivation
It's useful to note that you can change your database depending on the target. A lot of enterprise folks need to do this because of how their environments are configured (In order to maintain the multiple silo-ed environments). 
This code snippet that I'm including is one that I've had to share with multiple clients. 

