### PR TITLE
Update git master to git main in tutorial

### DIFF
--- a/website/docs/tutorial/2b-create-a-project-dbt-cli.md
+++ b/website/docs/tutorial/2b-create-a-project-dbt-cli.md
@@ -137,7 +137,7 @@ We need to commit our changes so that our repository has up-to-date code.
 $ git init
 $ git commit -m "Create a dbt project"
 $ git remote add origin https://github.com/USERNAME/dbt-tutorial.git
-$ git push -u origin master
+$ git push -u origin main
 ```
 
 :::info


### PR DESCRIPTION
Just noticed that the git push should push to the main branch of a new repo now as references to a master branch are no longer used by Github.

## Description & motivation

I was going through the tutorial and noticed there is a reference to 
```shell
$ git push -u origin master
```
which could be confusing to people who are new to git since git now uses main instead of master. I propose we change it to the following.
```shell
$ git push -u origin main
```


## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged
-->

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist
If you added new pages (delete if not applicable):
- [ ] The page has been added to `website/sidebars.js`
- [ ] The new page has a unique filename

If you removed existing pages (delete if not applicable):
- [ ] The page has been removed from `website/sidebars.js`
- [ ] An entry has been added to `_redirects`
