### PR TITLE
YAML selectors: add description, update manifest

### DIFF
--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-19-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-19-0.md
@@ -48,3 +48,4 @@ changes limited to minor versions and announced accordingly.
 - [rpc](rpc)
 - [snapshots](snapshots) ([invalidate_hard_deletes](invalidate_hard_deletes))
 - [state](understanding-state)
+- [YAML selectors](yaml-selectors)

--- a/website/docs/reference/artifacts/manifest.md
+++ b/website/docs/reference/artifacts/manifest.md
@@ -24,6 +24,7 @@ This file contains a full representation of your dbt project in a single file. R
 - `docs`: Dictionary of `docs` blocks.
 - `parent_map`: Dictionary that contains the first-order parents of each resource.
 - `child_map`: Dictionary that contains the first-order children of each resource.
+- `selectors`: Dictionary representation of YAML `selectors`.
 - `disabled`: Array of resources with `enabled: false`.
 
 ### Resource details

--- a/website/docs/reference/node-selection/yaml-selectors.md
+++ b/website/docs/reference/node-selection/yaml-selectors.md
@@ -2,7 +2,10 @@
 title: "YAML Selectors"
 ---
 
-<Changelog>New in v0.18.0</Changelog>
+<Changelog>
+- **v0.18.0**: Introduced YAML selectors
+- **v0.19.0**: Added optional `description` property
+</Changelog>
 
 :::info [β] Beta Feature
 This is net-new functionality in v0.18.0, with iterative improvements to come.
@@ -16,7 +19,7 @@ By recording selectors in a top-level `selectors.yml` file:
 * **Version control:** selector definitions are stored in the same git repository as the dbt project
 * **Reusability:** selectors can be referenced in multiple job definitions, and their definitions are extensible (via YAML anchors)
 
-Selectors live in a top-level file named `selectors.yml`. Each has a `name` and a `definition`:
+Selectors live in a top-level file named `selectors.yml`. Each has a `name`, a `definition`, and an optional `description`:
 
 <File name='selectors.yml'>
 
@@ -25,6 +28,7 @@ selectors:
   - name: nodes_to_joy
     definition: ...
   - name: nodes_to_a_grecian_urn
+    description: Attic shape with a fair attitude
     definition: ...
 ```
 </File>
@@ -130,6 +134,7 @@ $ dbt run --models @source:snowplow,tag:nightly models/export --exclude package:
 ```yml
 selectors:
   - name: nightly_diet_snowplow
+    description: "Non-incremental Snowplow models that power nightly exports"
     definition:
       union:
         - intersection:
@@ -151,6 +156,7 @@ selectors:
 ```yml
 selectors:
   - name: nightly_diet_snowplow
+    description: "Non-incremental Snowplow models that power nightly exports"
     definition:
       union:
         - intersection:


### PR DESCRIPTION
## Description & motivation
- YAML selectors can have `description` properties
- YAML selectors now appear in `manifest.json`
- See https://github.com/fishtown-analytics/dbt/pull/2866

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [x] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!