### PR TITLE
Update state:modified caveat re: testing

### DIFF
--- a/website/docs/reference/node-selection/state-comparison-caveats.md
+++ b/website/docs/reference/node-selection/state-comparison-caveats.md
@@ -38,13 +38,13 @@ $ dbt test -m state:modified --exclude test_name:relationships
 "Run all modified models, then execute all modified tests _except_ relationships tests."
 
 ```bash
-$ dbt run -m state:modified 1+state:modified,1+test_type:data
+$ dbt run -m state:modified @state:modified,1+test_type:data
 $ dbt test -m state:modified
 ```
 
-"Run all modified models _and_ all first-order parents of modified data tests, then execute all modified tests." This is a "safe not sorry" approach: you may find an extra model along for the ride, if it is the first-order parent of an modified model and the first-order parent of a data test, but not the first-order parent of a modified data test. ([For more on this phenomenon.](https://youtu.be/bWOfT45DShU?t=73))
+"Run all modified models _and_ all models which might be needed to run modified data tests _or_ unmodified data tests that select from modified models. Then, execute all modified tests." This is a "safe not sorry" approach: you may find an extra model along for the ride, if it is the parent of a child a modified model _and_ the first-order parent of an unrelated data test, but not the first-order parent of a modified data test.
 
-When your selection syntax gets too verbose, consider defining a [YAML selector](node-selection/yaml-selectors).
+If you find your selection syntax becoming overly verbose, consider defining a [YAML selector](node-selection/yaml-selectors).
 
 ### False positives
 


### PR DESCRIPTION
## Description & motivation
Based on [this Slack thread](https://getdbt.slack.com/archives/C2JRRQDTL/p1604399796387100)

Previously, I was recommending selection criteria like:
```
dbt run -m state:modified 1+state:modified,1+test_type:data
dbt test -m state:modified
```

This works if the data test itself is modified, and we need to ensure that its parent models will exist when it comes time to execute that test.

If you have a multi-pronged test (e.g. `relationships` or a data test with 2+ parents), however, and only one of the parents is modified, then this selection criteria isn't going to cut it—the missing prong is not included in `1+state:modified`.

By contrast, it is included within the criteria of `@state:modified`, because it's the parent of a shared child: the data test. (The fact that `@` now works for tests was something of a revelation earlier today, and enabled me to close https://github.com/fishtown-analytics/dbt/issues/1827.)

There's greater risk of extra baggage with this approach, since `@state:modified,1+test_type:data` is a more expansive set of criteria, but I think it's a small price to pay.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [x] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!