### PR TITLE
Change _elt_loaded_at to _etl_loaded_at

### DIFF
--- a/website/docs/docs/building-a-dbt-project/using-sources.md
+++ b/website/docs/docs/building-a-dbt-project/using-sources.md
@@ -140,7 +140,7 @@ sources:
     freshness: # default freshness
       warn_after: {count: 12, period: hour}
       error_after: {count: 24, period: hour}
-    loaded_at_field: _elt_loaded_at
+    loaded_at_field: _etl_loaded_at
 
     tables:
       - name: orders


### PR DESCRIPTION
This came up in dbt Learn.  Folks were copying the snippet and getting errors.  This is currently correct in the slides though.

## Description & motivation
The code snippet here showed `_elt_loaded_at` instead of `_etl_loaded_at`

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [X] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!