### PR TITLE
changelog generator release notes for dbt Cloud v1.1.14

### DIFF
--- a/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
@@ -4,6 +4,33 @@ id: "cloud-changelog"
 sidebar_label: Changelog
 description: "Changelog for the dbt Cloud application"
 ---
+## dbt Cloud v1.1.14 (November 25, 2020)
+
+TODO - Add description and curate release notes
+
+#### Enhancements
+
+- Update IP allowlist
+- User can oauth for BQ in profile credentials
+- Adding SparkAdapter backend models, mappers and services
+- Added BQ oauth integration
+- Adding db index for owner_thread_id
+
+#### Fixed
+
+- fix post /run error rate
+- Fix bug where bad argument was passed to dbt runs
+- Log out unhandled error in environment variable context manager
+- Remove account settings permissions for user integrations
+
+#### Internal
+
+- fix some cases of missing params
+- Add a Datadog metric to count the number of log bytes written to the database
+- Add feature flag for IDE work/code retention
+- logging api usage
+- Add scribe to run pods
+
 ## dbt Cloud v1.1.13 (November 12, 2020)
 
 This release adds support for triggering runs with overriden attributes via the

--- a/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
@@ -6,29 +6,29 @@ description: "Changelog for the dbt Cloud application"
 ---
 ## dbt Cloud v1.1.14 (November 25, 2020)
 
-TODO - Add description and curate release notes
+This release adds a few new pieces of connective tissue, notably OAuth for BigQuery and SparkAdapter work. There are also some quality of life improvements and investments for the future, focused on our beloved IDE users, and some improved piping for observability into log management and API usage. 
 
 #### Enhancements
 
 - Update IP allowlist
-- User can oauth for BQ in profile credentials
+- User can OAuth for BigQuery in profile credentials
 - Adding SparkAdapter backend models, mappers and services
-- Added BQ oauth integration
+- Added BigQuery OAuth integration
 - Adding db index for owner_thread_id
 
 #### Fixed
 
-- fix post /run error rate
+- Fix post /run error rate
 - Fix bug where bad argument was passed to dbt runs
 - Log out unhandled error in environment variable context manager
 - Remove account settings permissions for user integrations
 
 #### Internal
 
-- fix some cases of missing params
+- Fix some cases of missing params
 - Add a Datadog metric to count the number of log bytes written to the database
 - Add feature flag for IDE work/code retention
-- logging api usage
+- Logging API usage
 - Add scribe to run pods
 
 ## dbt Cloud v1.1.13 (November 12, 2020)


### PR DESCRIPTION
## Description & motivation
This PR contains the changelog release notes for dbt Cloud v1.1.14.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
