### PR TITLE
Update jinja function docs

### DIFF
--- a/website/docs/reference/dbt-jinja-functions/model.md
+++ b/website/docs/reference/dbt-jinja-functions/model.md
@@ -1,0 +1,8 @@
+---
+title: "model"
+id: "model"
+---
+
+`model` is the dbt [graph object](graph) (or node) for the current model. It can be used to:
+- Access `config` settings, say, in a post-hook
+- Access the path to the model

--- a/website/docs/reference/dbt-jinja-functions/this.md
+++ b/website/docs/reference/dbt-jinja-functions/this.md
@@ -3,23 +3,17 @@ title: "this"
 id: "this"
 ---
 
+`this` is the database representation of the current model. It is useful when:
+- Defining a `where` statement within [incremental models](configuring-incremental-models)
+- Using [pre or post hooks](pre-hook-post-hook)
 
-:::info New in dbt 0.11.0
+`this` is a [Relation](dbt-classes/#relation), and as such, properties such as `{{ this.database }}` and `{{ this.schema }}` compile as expected.
 
-Before 0.11.0, there was a difference between `this.table` and `this.name`. In 0.11.0, this distinction was removed! Both syntaxes can be used, but `this.table` is recommended, and `this.name` may be deprecated in a future release.
+`this` can be thought of as equivalent to `ref('<the_current_model>')`, and is a neat way to avoid circular dependencies.
 
-:::
+## Examples
 
-`this` makes available schema information about the currently executing model. It's is useful in any context in which you need to write code that references the current model, for example when defining a `sql_where` clause for an incremental model and for writing pre- and post-model hooks that operate on the model in some way. Developers have options for how to use `this`:
-
-| dbt Model Syntax | Output |
-| ---------------- | ------ |
-| `{{this}}` | `"schema"."table"` |
-| `{{this.schema}}` | `schema` |
-| `{{this.table}}` | `table` |
-| `{{this.name}}` | `table` |
-
-Here's an example of how to use `this` in `dbt_project.yml` to grant select rights on a table to a different db user.
+### Grant permissions on a model in a post-hook
 
 <File name='dbt_project.yml'>
 
@@ -28,6 +22,27 @@ models:
   project-name:
     +post-hook:
       - "grant select on {{ this }} to db_reader"
+```
+
+</File>
+
+
+### Configuring incremental models
+
+<File name='models/stg_events.sql'>
+
+```sql
+{{ config(materialized='incremental') }}
+
+select
+    *,
+    my_slow_function(my_column)
+
+from raw_app_data.events
+
+{% if is_incremental() %}
+  where event_time > (select max(event_time) from {{ this }})
+{% endif %}
 ```
 
 </File>

--- a/website/docs/reference/dbt-jinja-functions/this.md
+++ b/website/docs/reference/dbt-jinja-functions/this.md
@@ -7,7 +7,7 @@ id: "this"
 - Defining a `where` statement within [incremental models](configuring-incremental-models)
 - Using [pre or post hooks](pre-hook-post-hook)
 
-`this` is a [Relation](dbt-classes/#relation), and as such, properties such as `{{ this.database }}` and `{{ this.schema }}` compile as expected.
+`this` is a [Relation](dbt-classes#relation), and as such, properties such as `{{ this.database }}` and `{{ this.schema }}` compile as expected.
 
 `this` can be thought of as equivalent to `ref('<the_current_model>')`, and is a neat way to avoid circular dependencies.
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -415,6 +415,7 @@ module.exports = {
             "reference/dbt-jinja-functions/graph",
             "reference/dbt-jinja-functions/invocation_id",
             "reference/dbt-jinja-functions/log",
+            "reference/dbt-jinja-functions/model",
             "reference/dbt-jinja-functions/modules",
             "reference/dbt-jinja-functions/project_name",
             "reference/dbt-jinja-functions/ref",


### PR DESCRIPTION
## Description & motivation
Ghost writing a Discourse article. Found that `this` was terribly documented, and `model` was undocumented

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist
If you added new pages (delete if not applicable):
- [x] The page has been added to `website/sidebars.js`
- [x] The new page has a unique filename

