### PR TITLE
adding changelog for dbt Cloud v1.1.15

### DIFF
--- a/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
@@ -6,27 +6,27 @@ description: "Changelog for the dbt Cloud application"
 ---
 ## dbt Cloud v1.1.15 (December 10, 2020)
 
-TODO - add release summary and curate below notes
+Lots of great stuff to confer about this go-round: things really coalesced this week! Lots of excitement around adding Spark to the connection family, as well as knocking out some longstanding bugs. 
 
 #### Enhancements
 
-- Add spark as an option for database setup
+- Add Spark as an option for database setup
 
 #### Fixed
 
-- Fix creating multiple accounts with the same email
+- Fix this one hairy bug where one email could have multiple user accounts
 - Fix setup-connection react-page routing
-- Make group selection logic independent of license types and group names
-- handle json errors in v1/v2 body parsing
-- Handle AuthForbidden and AuthCancelled graciously and not throw 500s.
+- Break out group selection logic from license types and group names
+- Handle json errors in v1/v2 body parsing
+- Handle AuthForbidden and AuthCancelled graciously - ie, not throw 500s
 - Fix regression with IDE loading spinner
 
 #### Internal
 
 - Adding drf-spectacular
 - Hubspot signup integration
-- add additional ssh logging
-- Add datadog traces to IDE filesystem interactions
+- Add additional SSH logging
+- Add Datadog traces to IDE filesystem interactions
 
 ## dbt Cloud v1.1.14 (November 25, 2020)
 

--- a/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
@@ -4,6 +4,30 @@ id: "cloud-changelog"
 sidebar_label: Changelog
 description: "Changelog for the dbt Cloud application"
 ---
+## dbt Cloud v1.1.15 (December 10, 2020)
+
+TODO - add release summary and curate below notes
+
+#### Enhancements
+
+- Add spark as an option for database setup
+
+#### Fixed
+
+- Fix creating multiple accounts with the same email
+- Fix setup-connection react-page routing
+- Make group selection logic independent of license types and group names
+- handle json errors in v1/v2 body parsing
+- Handle AuthForbidden and AuthCancelled graciously and not throw 500s.
+- Fix regression with IDE loading spinner
+
+#### Internal
+
+- Adding drf-spectacular
+- Hubspot signup integration
+- add additional ssh logging
+- Add datadog traces to IDE filesystem interactions
+
 ## dbt Cloud v1.1.14 (November 25, 2020)
 
 This release adds a few new pieces of connective tissue, notably OAuth for BigQuery and SparkAdapter work. There are also some quality of life improvements and investments for the future, focused on our beloved IDE users, and some improved piping for observability into log management and API usage. 


### PR DESCRIPTION
## Description & motivation
This PR contains the changelog generator items for dbt Cloud v1.1.15.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
