### PR TITLE
adding sentence to system reqs about supported K8s versions

### DIFF
--- a/website/docs/docs/dbt-cloud/on-premises/system-requirements.md
+++ b/website/docs/docs/dbt-cloud/on-premises/system-requirements.md
@@ -13,7 +13,9 @@ For every 20 developer users, it is recommended to add another 4 CPU cores, 16 G
 
 ### Install into an existing Kubernetes cluster
 
-As mentioned above, it is recommended that at least 4 CPU cores, 16GB of memory, and 100GB of storage is made available for the dbt Cloud application. These are the resource totals consumed across the entire Kubernetes cluster by the dbt Cloud application.
+The dbt Cloud application is currently compatible with all [Kubernetes versions](https://kubernetes.io/docs/home/supported-doc-versions/) up to **1.18**. A breaking change was introduced in Kubernetes 1.19 that will be mitigated in a future dbt Cloud release.
+
+As mentioned above, it is recommended that at least 4 CPU cores, 16GB of memory, and 100GB of storage is made available for the dbt Cloud application. These are the resource totals consumed across the entire Kubernetes cluster by the dbt Cloud application. 
 
 ### Install into a VM
 


### PR DESCRIPTION
## Description & motivation
This PR adds some documentation to the deployments section around the currently supported versions of Kubernetes for Customer Managed installs.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
