### PR TITLE
Revise supported databases

### DIFF
--- a/website/docs/docs/supported-databases.md
+++ b/website/docs/docs/supported-databases.md
@@ -3,22 +3,20 @@ title: "Supported databases"
 id: "supported-databases"
 ---
 
-dbt supports the following databases:
+These database adapters are supported by the core dbt maintainers. (✅ indicates "full support.")
 
-These database plugins are supported by the core dbt maintainers.
+| Database | Documentation | Core features | dbt Cloud | Distribution |
+| -------- | ------------- | ------- | ------ | ---- |
+| Postgres | [Profile Setup](postgres-profile) | ✅ | ✅  | core |
+| Redshift | [Profile Setup](redshift-profile), [Configuration](redshift-configs) | ✅ | ✅  | core |
+| BigQuery | [Profile Setup](bigquery-profile), [Configuration](bigquery-configs) | ✅  | ✅  | core |
+| Snowflake | [Profile Setup](snowflake-profile), [Configuration](snowflake-configs) | ✅ | ✅  | core |
+| Spark | [Profile Setup](spark-profile), [Configuration](spark-configs) | nearly full support | preview | plugin |
+| Presto | [Profile Setup](presto-profile) | partial support |  | plugin |
 
-| Database | Documentation | Support |
-| -------- | ------------- | ------- |
-| Postgres | [Profile Setup](postgres-profile) | ✅Full Support |
-| Redshift | [Profile Setup](redshift-profile), [Configuration](redshift-configs) | ✅Full Support |
-| BigQuery | [Profile Setup](bigquery-profile), [Configuration](bigquery-configs) | ✅Full Support |
-| Snowflake | [Profile Setup](snowflake-profile), [Configuration](snowflake-configs) | ✅ Full Support |
-| Presto | [Profile Setup](presto-profile) | Partial Support |
-| Spark | [Profile Setup](spark-profile), [Configuration](spark-configs) | Partial Support |
+###  Community Plugins
 
-##  Community Supported dbt Plugins
-
-These database plugins are community-supported 🌱
+These database plugins are contributed and maintained by members of the community 🌱
 
 | Database | Documentation | Notes |
 | -------- | ------------- | ----- |
@@ -27,9 +25,15 @@ These database plugins are community-supported 🌱
 | Microsoft Azure Synapse DW ([dbt-synapse](https://github.com/swanderz/dbt-synapse)) | [Profile Setup](../reference/warehouse-profiles/azuresynapse-profile.md) | Azure Synapse 10+ 
 | Microsoft Azure Synapse DW ([dbt-azuresynapse](https://github.com/embold-health/dbt-azuresynapse)) | [Profile Setup](azuresynapse-profile) | Azure Synapse 10+ 
 | Exasol Analytics ([dbt-exasol](https://github.com/tglunde/dbt-exasol)) | [Profile Setup](exasol-profile) | Exasol 6.x and later |
-| Oracle Database ([dbt-oracle](https://github.com/techindicium/dbt-oracle)) | [Profile Setup](oracle-profile) |Oracle 11+ |
-| Dremio ([dbt-dremio](https://github.com/fabrice-etanchaud/dbt-dremio)) | [Profile Setup](dremio-profile) |Dremio 4.7+ |
+| Oracle Database ([dbt-oracle](https://github.com/techindicium/dbt-oracle)) | [Profile Setup](oracle-profile) | Oracle 11+ |
+| Dremio ([dbt-dremio](https://github.com/fabrice-etanchaud/dbt-dremio)) | [Profile Setup](dremio-profile) | Dremio 4.7+ |
+
+Community-supported plugins are works in progress, and all users are encouraged to contribute by testing and writing code. If you're interested in contributing:
+- Join the dedicated channel in [dbt Slack](https://community.getdbt.com/) (e.g. #db-sqlserver, #db-athena)
+- Check out the open issues in the plugin's source repository
+
+Note that, while no community plugins are currently supported in dbt Cloud, we expect this to change in 2021.
 
 ## Creating a new adapter
 
-dbt can be extended with "adapter plugins." These plugins can be built into separate Python modules, and dbt will discover them if they are installed on your system. If you're interested in developing a new adapter plugin for dbt, please [open an issue](https://github.com/fishtown-analytics/dbt/issues/new) and be sure to check out the docs on [building a new adapter](building-a-new-adapter).
+dbt can be extended to a new database or data platform by means of an "adapter plugin." These plugins can be built into separate Python modules, and dbt will discover them if they are installed on your system. If you're interested in developing a new database plugin for dbt, please check out the docs on [building a new adapter](building-a-new-adapter).

--- a/website/docs/reference/warehouse-profiles/azuresynapse-profile.md
+++ b/website/docs/reference/warehouse-profiles/azuresynapse-profile.md
@@ -3,24 +3,21 @@ title: "Microsoft Azure Synapse DW Profile"
 ---
 
 
-:::info Community contributed plugin
+:::info Community plugin
 
-These are Community Contributed plugins for dbt. If you're interested in contributing, check out the source code for each repository:
-- [`dbt-synapse`](https://github.com/swanderz/dbt-synapse)
-- [`dbt-azuresynapse`](https://github.com/embold-health/dbt-azuresynapse)
+Some core functionality may be limited. If you're interested in contributing, check out the source code for each repository listed below.
 
 :::
 
 ## Overview of dbt-synapse
-**Status:** Community Contributed
+**Maintained by:** Community      
+**Author:** Nandan Hegde and Anders Swanson    
+**Source:** https://github.com/swanderz/dbt-synapse    
+**Core version:** v0.18.0 and newer    
 
-**Author:** Nandan Hegde and Anders Swanson
+![dbt-synapse stars](https://img.shields.io/github/stars/swanderz/dbt-synapse?style=for-the-badge)
 
-**Source Code:** https://github.com/swanderz/dbt-synapse
-
-**dbt support**: version 0.18.0 and newer
-
-The pacakge can be installed from PyPI with:
+The package can be installed from PyPI with:
 
 ```python
 pip install dbt-synapse
@@ -153,14 +150,12 @@ client_secret: clientsecret
 
 
 ## Overview of dbt-azuresynapse
-**Status:** Community Contributed
+**Maintained by:** Community      
+**Author:** Ernesto Barajas and Matt Berns    
+**Source:** https://github.com/embold-health/dbt-azuresynapse    
+**Core version:** v0.17.0 and newer
 
-**Author:** Ernesto Barajas and Matt Berns
-
-**Source Code:** https://github.com/embold-health/dbt-azuresynapse
-
-**dbt-azuresynapse**
-Only supports dbt 0.17 and newer!
+![dbt-azuresynapse stars](https://img.shields.io/github/stars/embold-health/dbt-azuresynapse?style=for-the-badge)
 
 Easiest install is to use pip:
 

--- a/website/docs/reference/warehouse-profiles/azuresynapse-profile.md
+++ b/website/docs/reference/warehouse-profiles/azuresynapse-profile.md
@@ -12,10 +12,10 @@ Some core functionality may be limited. If you're interested in contributing, ch
 ## Overview of dbt-synapse
 **Maintained by:** Community      
 **Author:** Nandan Hegde and Anders Swanson    
-**Source:** https://github.com/swanderz/dbt-synapse    
+**Source:** https://github.com/dbt-msft/dbt-synapse    
 **Core version:** v0.18.0 and newer    
 
-![dbt-synapse stars](https://img.shields.io/github/stars/swanderz/dbt-synapse?style=for-the-badge)
+![dbt-synapse stars](https://img.shields.io/github/stars/dbt-msft/dbt-synapse?style=for-the-badge)
 
 The package can be installed from PyPI with:
 

--- a/website/docs/reference/warehouse-profiles/dremio-profile.md
+++ b/website/docs/reference/warehouse-profiles/dremio-profile.md
@@ -2,21 +2,19 @@
 title: "Dremio Profile"
 ---
 
+:::info Community plugin
 
-:::info Community contributed plugin
-
-This is a Community Contributed plugin for dbt. If you're interested in contributing, check out the source code for the repository [dbt-dremio](https://github.com/fabrice-etanchaud/dbt-dremio)
+Some core functionality may be limited. If you're interested in contributing, check out the source code for each repository listed below.
 
 :::
 
 ## Overview of dbt-dremio
-**Status:** Community Contributed
+**Maintained by:** Community      
+**Author:** Fabrice Etanchaud (Maif-vie)    
+**Source:** https://github.com/fabrice-etanchaud/dbt-dremio    
+**Core version:** v0.18.0 and newer
 
-**Author:** Fabrice Etanchaud (Maif-vie)
-
-**Source Code:** https://github.com/fabrice-etanchaud/dbt-dremio
-
-**dbt-dremio** supports dbt 0.18.0 or newer.
+![dbt-dremio stars](https://img.shields.io/github/stars/fabrice-etanchaud/dbt-dremio?style=for-the-badge)
 
 The easiest way to install it is to use pip:
 

--- a/website/docs/reference/warehouse-profiles/exasol-profile.md
+++ b/website/docs/reference/warehouse-profiles/exasol-profile.md
@@ -2,20 +2,19 @@
 title: "Exasol Profile"
 ---
 
+:::info Community plugin
 
-:::info Community contributed plugin
+Some core functionality may be limited. If you're interested in contributing, check out the source code for each repository listed below.
 
-This is a Community Contributed plugin for dbt. If you're interested in contributing, check out the source code at [dbt-exasol](https://github.com/tglunde/dbt-exasol).
-For more information on Exasol Analytics database visit [exasol home](https://www.exasol.com).
 :::
 
 ## Overview of dbt-exasol
-**Status:** Community Contributed
-**Author:** Torsten Glunde, Ilija Kutle
-**Source Code:** https://github.com/tglunde/dbt-exasol
+**Maintained by:** Community      
+**Author:** Torsten Glunde, Ilija Kutle    
+**Source:** https://github.com/tglunde/dbt-exasol    
+**Core version:** v0.14.0 and newer    
 
-**dbt-exasol**
-Only supports dbt 0.14 and newer!
+![dbt-exasol stars](https://img.shields.io/github/stars/tglunde/dbt-exasol?style=for-the-badge)
 
 Easiest install is to use pip:
 

--- a/website/docs/reference/warehouse-profiles/mssql-profile.md
+++ b/website/docs/reference/warehouse-profiles/mssql-profile.md
@@ -2,22 +2,19 @@
 title: "Microsoft SQL Server Profile"
 ---
 
+:::info Community plugin
 
-:::info Community contributed plugin
-
-This is a Community Contributed plugin for dbt. If you're interested in contributing, check out the source code for each repository [dbt-sqlserver](https://github.com/mikaelene/dbt-sqlserver), [dbt-mssql](https://github.com/jacobm001/dbt-mssql).
+Some core functionality may be limited. If you're interested in contributing, check out the source code for each repository listed below.
 
 :::
 
 ## Overview of dbt-sqlserver
-**Status:** Community Contributed
-**Author:** Mikael Ene
-**Source Code:** https://github.com/mikaelene/dbt-sqlserver
+**Maintained by:** Community      
+**Author:** Mikael Ene    
+**Source:** https://github.com/mikaelene/dbt-sqlserver    
+**Core version:** v0.14.0 and newer    
 
-**dbt-sqlserver**
-Only supports dbt 0.14 and newer!
-- For dbt 0.14.x use dbt-sqlserver 0.14.x
-- For dbt 0.15.x use dbt-sqlserver 0.15.x
+![dbt-sqlserver stars](https://img.shields.io/github/stars/mikaelene/dbt-sqlserver?style=for-the-badge)
 
 Easiest install is to use pip:
 
@@ -70,9 +67,12 @@ dbt-sqlserver:
 
 ## Overview of dbt-mssql
 
-**Status:** Community Contributed
-**Author:** Jacob M. Mastel
-**Source Code:** https://github.com/jacobm001/dbt-mssql
+**Maintained by:** Community      
+**Author:** Jacob M. Mastel    
+**Source:** https://github.com/jacobm001/dbt-mssql    
+**Core version:** v0.14.0     
+
+![dbt-mssql stars](https://img.shields.io/github/stars/jacobm001/dbt-mssql?style=for-the-badge)
 
 **dbt-mssql** is a custom adapter for dbt that adds support for Microsoft SQL Server versions 2008 R2 and later. `pyodbc` is used as the connection driver as that is what is [suggested by Microsoft](https://docs.microsoft.com/en-us/sql/connect/python/python-driver-for-sql-server). The adapter supports both windows auth, and specified user accounts.
 

--- a/website/docs/reference/warehouse-profiles/oracle-profile.md
+++ b/website/docs/reference/warehouse-profiles/oracle-profile.md
@@ -2,18 +2,19 @@
 title: "Oracle Profile"
 ---
 
+:::info Community plugin
 
-:::info Community contributed plugin
-
-This is a Community Contributed plugin for dbt. If you're interested in contributing, check out the source code [dbt-oracle](https://github.com/techindicium/dbt-oracle)
+Some core functionality may be limited. If you're interested in contributing, check out the source code for each repository listed below.
 
 :::
 
 ## Overview of dbt-oracle
-**Status:** Community Contributed
-**Author:** Vitor Avancini
-**Source Code:** https://github.com/techindicium/dbt-oracle
+**Maintained by:** Community      
+**Author:** Vitor Avancini    
+**Source:** https://github.com/techindicium/dbt-oracle    
+**Core version:** v0.16.0 and newer     
 
+![dbt-oracle stars](https://img.shields.io/github/stars/techindicium/dbt-oracle?style=for-the-badge)
 
 Easiest install is to use pip:
 

--- a/website/docs/reference/warehouse-profiles/presto-profile.md
+++ b/website/docs/reference/warehouse-profiles/presto-profile.md
@@ -2,6 +2,20 @@
 title: "Presto Profile"
 ---
 
+:::info Community plugin
+
+Some core functionality may be limited. If you're interested in contributing, check out the source code for each repository listed below.
+
+:::
+
+## Overview of dbt-presto
+**Maintained by:** core dbt maintainers    
+**Author:** Fishtown Analytics    
+**Source:** https://github.com/fishtown-analytics/dbt-presto    
+**Core version:** v0.13.0 and newer     
+
+![dbt-presto stars](https://img.shields.io/github/stars/fishtown-analytics/dbt-presto?style=for-the-badge)
+
 ## Set up a Presto Target
 
 Presto targets should be set up using the following configuration in your `profiles.yml` file.

--- a/website/docs/reference/warehouse-profiles/spark-profile.md
+++ b/website/docs/reference/warehouse-profiles/spark-profile.md
@@ -2,6 +2,21 @@
 title: "Spark Profile"
 ---
 
+:::info Community plugin
+
+Some core functionality may be limited. If you're interested in contributing, check out the source code for each repository listed below.
+
+:::
+
+## Overview of dbt-spark
+**Maintained by:** core dbt maintainers    
+**Author:** Fishtown Analytics    
+**Source:** https://github.com/fishtown-analytics/dbt-spark    
+**Core version:** v0.13.0 and newer     
+**dbt Cloud:** Preview
+
+![dbt-spark stars](https://img.shields.io/github/stars/fishtown-analytics/dbt-spark?style=for-the-badge)
+
 ## Connection Methods
 There are three supported connection methods for Spark targets: `thrift`, `http`, and `odbc`.
 


### PR DESCRIPTION
## Description & motivation

[This thread](https://getdbt.slack.com/archives/C01FFKU1QCT/p1607359278224200) inspired me to revise some of our docs on supported databases + specific plugin pages. (The lack of newlines has also been long-term annoying.)

Main changes:
- added columns about dbt Cloud + distribution to Fishtown-supported adapters
- added GitHub stars badge for each community plugin as a rough proxy for usage/popularity/reliability

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!