### PR TITLE
adds example cloud-hosted github URLs

### DIFF
--- a/website/docs/docs/dbt-cloud/on-premises/prerequisites.md
+++ b/website/docs/docs/dbt-cloud/on-premises/prerequisites.md
@@ -140,8 +140,8 @@ During dbt Cloud setup, the installer will need to provide credentials for this 
 
 They will need the following:
 
-- the base URL of your Github enterprise installation, e.g. github.mycompany.com
-- the scheme-included API URL of your Github enterprise installation. Usually https://github.mycompany.com/api/v3
+- the base URL of your Github enterprise installation, e.g. github.mycompany.com or github.com (if you're a cloud-hosted)
+- the scheme-included API URL of your Github enterprise installation. Usually https://github.mycompany.com/api/v3 or https://api.github.com (if you're cloud-hosted)
 - the App ID, Client ID, and Client Secret from the "About" page of the newly created Github app
 - the Configuration URL for your Github app: right click "Install app" on the "About" page, click "Copy Link Location" to get the Configuration URL
 - the Install URL: right click "Public page" on the "About" page, click "Copy Link Location," and paste in the value here.


### PR DESCRIPTION
Adding in the cloud-hosted github URLs as they're different than what we have listed. Enterprise POC client was confused by our examples! 
