### PR TITLE
Fix/learn tutorial snippets

### DIFF
--- a/website/docs/learn/2b-create-a-project-dbt-cli.md
+++ b/website/docs/learn/2b-create-a-project-dbt-cli.md
@@ -21,7 +21,6 @@ The dbt CLI comes with a command to help you scaffold a dbt project. To create y
 1. Ensure dbt is installed by running `dbt --version`:
 ```shell-session
 $ dbt --version
-
 ```
 
 :::info
@@ -127,6 +126,7 @@ We need to commit our changes so that our repository has up-to-date code.
 1. Link the GitHub repository you created in the [Setting Up](/learn/setting-up) instructions to your dbt project by running the following commands. Make sure you use the correct git URL for your repository.
 ```shell-session
 $ git init
+$ git add -A
 $ git commit -m "Create a dbt project"
 $ git remote add origin https://github.com/USERNAME/dbt-learn-[initialsurname].git
 $ git push -u origin master

--- a/website/docs/learn/4-test-and-document-your-project.md
+++ b/website/docs/learn/4-test-and-document-your-project.md
@@ -161,18 +161,14 @@ First off, we need to commit the changes we made to our project so that our repo
 ### dbt Cloud
 <LoomVideo id="afd55d89abdc4a77b34deaee90da0813" />
 
-Click the `commit` button, with a message like "Add customers model"
+Click the `commit` button, with a message like "Add customers model, tests, docs"
 
 ### dbt CLI
 <LoomVideo id="b07d7efe3f054e3bb357b4bccd805e70" />
 
-1. Add all your changes to git: `git add -a`
-2. Commit your changes: `git commit -m "Add customers models"`
+1. Add all your changes to git: `git add -A`
+2. Commit your changes: `git commit -m "Add customers model, tests, docs"`
 3. Push your changes to your repository: `git push`
-
-:::caution
-We just pushed straight to master 😬! We <strong>always</strong> use a git flow when working on dbt projects, and recommend you do too!
-:::
 
 ## Next steps
 

--- a/website/docs/tutorial/2b-create-a-project-dbt-cli.md
+++ b/website/docs/tutorial/2b-create-a-project-dbt-cli.md
@@ -30,7 +30,6 @@ The dbt CLI comes with a command to help you scaffold a dbt project. To create y
 1. Ensure dbt is installed by running `dbt --version`:
 ```shell-session
 $ dbt --version
-
 ```
 
 :::info

--- a/website/docs/tutorial/5-deploy-your-project.md
+++ b/website/docs/tutorial/5-deploy-your-project.md
@@ -14,14 +14,14 @@ First off, we need to commit the changes we made to our project so that our repo
 ### dbt Cloud
 <LoomVideo id="afd55d89abdc4a77b34deaee90da0813" />
 
-1. Click the `commit` button, with a message like "Add customers model"
+1. Click the `commit` button, with a message like "Add customers model, tests, docs"
 2. Click the `merge to master` button
 
 ### dbt CLI
 <LoomVideo id="b07d7efe3f054e3bb357b4bccd805e70" />
 
-1. Add all your changes to git: `git add -a`
-2. Commit your changes: `git commit -m "Add customers models"`
+1. Add all your changes to git: `git add -A`
+2. Commit your changes: `git commit -m "Add customers model, tests, docs"`
 3. Push your changes to your repository: `git push`
 4. Navigate to your repository, and open a Pull Request to merge the code into your master branch.
 


### PR DESCRIPTION
## Description & motivation
@fwinokur found these tiny typos in our Learn Getting Started Tutorial.  These are super subtle.  This included:
- adjust whitespace
- add files before initial commit
- tweak `git add -a` to `git add -A`
- remove warning about commits to master because it is assumed that learners are working on the `add-customers-model` branch

## To-do before merge
[ ] Check rendering on netlify build.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [X] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
