### PR TITLE
adding changelog generated release notes for dbt Cloud 1.1.16 release

### DIFF
--- a/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
@@ -6,24 +6,18 @@ description: "Changelog for the dbt Cloud application"
 ---
 ## dbt Cloud v1.1.16 (December 23, 2020)
 
-TODO - Enter release summary and curate below notes.
+This release adds preview support for Databricks Spark in dbt Cloud
+and adds two new permission sets for Enterprise acccounts.
 
 #### Enhancements
 
-- Added taxcode metadata for charging sales tax
-- [1956] added sales tax verbiage to confirmation page
-- Adding DatabricksSparkAdapter
-- Adds local storage services for persisting data between browser refreshes and sessions
-- Add scribe service for each run
-- use boto3 session cache everywhere
-- Adjusted stripe client to charge sales tax through avalara
+- Added preview support for Databricks Spark support
+- Added two new Enterprise permission sets: Account Viewer and Project Creator
 
-#### Internal
+#### Fixed
 
-- Improve application logging when running dbt core processes
-- 1486: new permission sets
-- Fix typo and add remote-debugger for every develop pod
-- ssh logging fix
+- Improve logging infrastructure for dbt run logs
+- Fix for SSH tunnel logging errors
 
 ## dbt Cloud v1.1.15 (December 10, 2020)
 

--- a/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
@@ -4,6 +4,27 @@ id: "cloud-changelog"
 sidebar_label: Changelog
 description: "Changelog for the dbt Cloud application"
 ---
+## dbt Cloud v1.1.16 (December 23, 2020)
+
+TODO - Enter release summary and curate below notes.
+
+#### Enhancements
+
+- Added taxcode metadata for charging sales tax
+- [1956] added sales tax verbiage to confirmation page
+- Adding DatabricksSparkAdapter
+- Adds local storage services for persisting data between browser refreshes and sessions
+- Add scribe service for each run
+- use boto3 session cache everywhere
+- Adjusted stripe client to charge sales tax through avalara
+
+#### Internal
+
+- Improve application logging when running dbt core processes
+- 1486: new permission sets
+- Fix typo and add remote-debugger for every develop pod
+- ssh logging fix
+
 ## dbt Cloud v1.1.15 (December 10, 2020)
 
 Lots of great stuff to confer about this go-round: things really coalesced this week! Lots of excitement around adding Spark to the connection family, as well as knocking out some longstanding bugs. 


### PR DESCRIPTION
## Description & motivation
This PR is for the dbt Cloud 1.1.16 changelog.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

