### PR TITLE
Update/bigquery configuration with information about project and dataset

### DIFF
--- a/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/connecting-your-database.md
+++ b/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/connecting-your-database.md
@@ -48,7 +48,7 @@ The following fields are required when creating a Snowflake connection:
 
 | Field | Description | Examples |
 | ----- | ----------- | -------- |
-| Account | The Snowflake account to connect to. See [notes](setting-up-enterprise-snowflake-oauth)| `db5261993`, `db5261993.east-us-2.azure` |
+| Account | The Snowflake account to connect to.| `db5261993`, `db5261993.east-us-2.azure` |
 | Role | An optional field indicating what role should be assumed after connecting to Snowflake | `transformer` |
 | Database | The logical database to connect to and run queries against. | `analytics` |
 | Warehouse | The virtual warehouse to use for running queries. | `transforming` |

--- a/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/connecting-your-database.md
+++ b/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/connecting-your-database.md
@@ -48,7 +48,7 @@ The following fields are required when creating a Snowflake connection:
 
 | Field | Description | Examples |
 | ----- | ----------- | -------- |
-| Account | The Snowflake account to connect to | `db5261993`, `db5261993.east-us-2.azure` |
+| Account | The Snowflake account to connect to. See [notes](setting-up-enterprise-snowflake-oauth)| `db5261993`, `db5261993.east-us-2.azure` |
 | Role | An optional field indicating what role should be assumed after connecting to Snowflake | `transformer` |
 | Database | The logical database to connect to and run queries against. | `analytics` |
 | Warehouse | The virtual warehouse to use for running queries. | `transforming` |

--- a/website/docs/reference/resource-configs/bigquery-configs.md
+++ b/website/docs/reference/resource-configs/bigquery-configs.md
@@ -13,6 +13,14 @@ To-do:
 - use the reference doc structure for this article/split into separate articles
 --->
 
+## Use `project` and `dataset` in configurations
+
+- `schema` is interchangeable with the BigQuery concept `dataset`
+- `database` is interchangeable with the BigQuery concept of `project`
+
+For our reference documentation, you can declare `project` in place of `database.` 
+This will allow you to read and write from multiple BigQuery projects. Same for `dataset`.
+
 ## Using table partitioning and clustering
 
 ### Partition clause


### PR DESCRIPTION
## Description & motivation
I get a lot of questions about if dbt supports writing into multiple BQ projects and datasets. Unless you know where to look, most people are not seeing the extra information on the bottom of the model configuration page where it calls out that database and projects are interchangeable. 


## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!


