### PR TITLE
Describes regional locations too for 'location'

### DIFF
--- a/website/docs/reference/warehouse-profiles/bigquery-profile.md
+++ b/website/docs/reference/warehouse-profiles/bigquery-profile.md
@@ -166,7 +166,7 @@ my-profile:
 ### Dataset locations
 
 The location of BigQuery datasets can be configured using the `location` configuration in a BigQuery profile.
-`location` can accept one of multi-regional locations or one of regional locations, as [the google cloud official documentation](https://cloud.google.com/bigquery/docs/locations) describes.
+`location` may be iether a multi-regional location (e.g. `EU`, `US`), or a regional location (e.g. `us-west2` ) as per the [the BigQuery documentation](https://cloud.google.com/bigquery/docs/locations) describes.
 Example:
 
 ```yaml

--- a/website/docs/reference/warehouse-profiles/bigquery-profile.md
+++ b/website/docs/reference/warehouse-profiles/bigquery-profile.md
@@ -165,7 +165,9 @@ my-profile:
 
 ### Dataset locations
 
-The location of BigQuery datasets can be configured using the `location` configuration in a BigQuery profile. Example:
+The location of BigQuery datasets can be configured using the `location` configuration in a BigQuery profile.
+`location` can accept one of multi-regional locations or one of regional locations, as [the google cloud official documentation](https://cloud.google.com/bigquery/docs/locations) describes.
+Example:
 
 ```yaml
 my-profile:
@@ -176,7 +178,7 @@ my-profile:
       method: oauth
       project: abc-123
       dataset: my_dataset
-      location: US # Optional, one of US or EU
+      location: US # Optional, one of US or EU / one of regional locations
 ```
 
 ### Maximum Bytes Billed

--- a/website/docs/reference/warehouse-profiles/bigquery-profile.md
+++ b/website/docs/reference/warehouse-profiles/bigquery-profile.md
@@ -178,7 +178,7 @@ my-profile:
       method: oauth
       project: abc-123
       dataset: my_dataset
-      location: US # Optional, one of US or EU / one of regional locations
+      location: US # Optional, one of US or EU, or a regional location
 ```
 
 ### Maximum Bytes Billed


### PR DESCRIPTION
## Description & motivation
`location` for BigQuery profiles can accept not only multi-regional locations, but also regional locations, because the location information is just passed to `google.cloud.bigquery.Client`.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist
If you added new pages (delete if not applicable):
- [ ] The page has been added to `website/sidebars.js`
- [ ] The new page has a unique filename

If you removed existing pages (delete if not applicable):
- [ ] The page has been removed from `website/sidebars.js`
- [ ] An entry has been added to `_redirects`
