### PR TITLE
Add note about adapter_response in run_results.json, sources.json

### DIFF
--- a/website/docs/reference/artifacts/run-results-json.md
+++ b/website/docs/reference/artifacts/run-results-json.md
@@ -31,5 +31,5 @@ Each entry in `results` is a dictionary with the following keys:
 - `thread_id`: Which thread executed this node? E.g. `Thread-1`
 - `execution_time`: Total time spent executing this node
 - `timing`: Array that breaks down execution time into steps (often `compile` + `execute`)
-- `adapter_response`: Dictionary of information returned from the database, which varies by adapter. E.g. success `code`, number of `rows_affected`, total `bytes_processed`, etc.
+- `adapter_response`: Dictionary of information returned from the database, which varies by adapter. E.g. success `code`, number of `rows_affected`, total `bytes_processed`, etc. Not populated by tests, as of v0.19.0; we plan to fix in a future release ([dbt#2580](https://github.com/fishtown-analytics/dbt/issues/2580)).
 - `message`: How dbt will report this result on the CLI, based on information returned from the database

--- a/website/docs/reference/artifacts/sources-json.md
+++ b/website/docs/reference/artifacts/sources-json.md
@@ -22,3 +22,4 @@ Each entry in `results` is a dictionary with the following keys:
 - `max_loaded_at_time_ago_in_s`: Interval between `max_loaded_at` and `snapshotted_at`, calculated in python to handle timezone complexity.
 - `criteria`: The freshness threshold(s) for this source, defined in the project.
 - `status`: The freshness status of this source, based on `max_loaded_at_time_ago_in_s` + `criteria`, reported on the CLI. One of `pass`, `warn`, or `error` if the query succeeds, `runtime error` if the query fails.
+- `adapter_response`: Dictionary of information returned from the database, which varies by adapter. Not populated by source freshness checks, as of v0.19.0; we plan to fix in a future release ([dbt#2580](https://github.com/fishtown-analytics/dbt/issues/2580)).


### PR DESCRIPTION
## Description & motivation
(reflects ongoing work in https://github.com/fishtown-analytics/dbt/pull/2961 and future work proposed by https://github.com/fishtown-analytics/dbt/issues/2964)

`adapter_response` is going to be the best place for users to grab out database-specific info like:
- How many rows were created / inserted / updated / merged by this model run?
- [BigQuery] How many bytes were processed?

Today, it is populated for all "true" materializations (model runs, seeds, snapshots), but it's left empty by `dbt test` and `dbt source snapshot-freshness`. We'd like to change that in a future release; the immediate benefit is for BigQuery users who want to know the bytes processed / $$ of tests and freshness checks.

Also, while today it only reflects the "last" query executed within a materialization, we'd love someday to record a response for each step in multi-step materializations (e.g. incremental models with `create temp` + `delete` + `insert`).

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [x] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
