### PR TITLE
Fix payment_method_query to clarify the example for execute

### DIFF
--- a/website/docs/reference/dbt-jinja-functions/execute.md
+++ b/website/docs/reference/dbt-jinja-functions/execute.md
@@ -22,7 +22,7 @@ from {{ ref('raw_payments') }}
 order by 1
 {% endset %}
 
-{% set results = run_query(relation_query) %}
+{% set results = run_query(payment_method_query) %}
 
 {# Return the first column #}
 {% set payment_methods = results.columns[0].values() %}


### PR DESCRIPTION
## Description & motivation
Just figured there was en error in the example for the `execute` jinja function. run_query must actually be called on `payment_method_query`. See the rendered page here: https://docs.getdbt.com/reference/dbt-jinja-functions/execute/

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
