### PR TITLE
adding changelog notes for dbt Cloud 1.1.17 release

### DIFF
--- a/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
@@ -4,6 +4,20 @@ id: "cloud-changelog"
 sidebar_label: Changelog
 description: "Changelog for the dbt Cloud application"
 ---
+## dbt Cloud v1.1.17 (January 7, 2021)
+
+TODO - Release summary and curate notes
+
+#### Internal
+
+- Fix Stripe event syncer
+- backfill all avalara metadata
+- bump psycopg2
+- fix circle jobs
+- fix duplicated circle jobs
+- Migrate to Python 3.8
+- Check the scribe image version before each scheduler loop
+
 ## dbt Cloud v1.1.16 (December 23, 2020)
 
 This release adds preview support for Databricks Spark in dbt Cloud

--- a/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
@@ -6,17 +6,19 @@ description: "Changelog for the dbt Cloud application"
 ---
 ## dbt Cloud v1.1.17 (January 7, 2021)
 
-TODO - Release summary and curate notes
+Tidying up this and that as we settle into 2021. No new user-facing functionality. Hope everyone had a safe and cozy New Year!
 
 #### Internal
 
 - Fix Stripe event syncer
-- backfill all avalara metadata
-- bump psycopg2
-- fix circle jobs
-- fix duplicated circle jobs
+- Take down the wreath
+- Sweep up the confetti
+- Backfill all Avalara metadata
+- Bump psycopg2
+- Fix Circle jobs
+- Fix duplicated Circle jobs
 - Migrate to Python 3.8
-- Check the scribe image version before each scheduler loop
+- Check the Scribe image version before each scheduler loop
 
 ## dbt Cloud v1.1.16 (December 23, 2020)
 


### PR DESCRIPTION
## Description & motivation
This PR contains the changelog notes for the dbt Cloud 1.1.17 release.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!




