### PR TITLE
Update for v0.19: Result, response objects

### DIFF
--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-19-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-19-0.md
@@ -56,7 +56,7 @@ See [dbt#2961](https://github.com/fishtown-analytics/dbt/pull/2961) for full imp
 - [RPC](rpc): Added `state` and `defer` as arguments to RPC methods for which it is supported on the CLI.
 
 ### BigQuery
-- [Bigquery profile](bigquery-profile): dbt can connect via OAuth tokens (one-time or refresh), and it can use the default project when connecting via `gcloud` oauth.
+- [BigQuery profile](bigquery-profile): dbt can connect via OAuth tokens (one-time or refresh), and it can use the default project when connecting via `gcloud` oauth.
 - [Hourly, monthly and yearly partitions](bigquery-configs#partitioning-by-a-date-or-timestamp): With a new `granularity` attribute of the `partition_by` config, dbt can materialize models as tables partitioned by hour, month, or year.
 
 ### Spark

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-19-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-19-0.md
@@ -43,21 +43,21 @@ See [dbt#2961](https://github.com/fishtown-analytics/dbt/pull/2961) for full imp
 ## New and changed documentation
 
 ### Core
-- [dbt-artifacts](dbt-artifacts): The JSON artifacts produced by dbt—manifest, catalog, run results, and sources—are simpler to consume and more clearly documented.
-- [dbt classes](dbt-classes): The `Result` object has a new schema, related to the new schema in `run_results.json`.
-- [statement-blocks]: The `call statement` result `status` string is now a structured object named `response`.
-- [snapshots](snapshots) ([invalidate_hard_deletes](invalidate_hard_deletes)): If the config `invalidate_hard_deletes` is enabled, `dbt snapshot` will update records whose unique key no longer exist in the snapshot query. Should those uniquely identified records "revive," `dbt snapshot` will re-add them.
+- [dbt Artifacts](dbt-artifacts): The JSON artifacts produced by dbt—manifest, catalog, run results, and sources—are simpler to consume and more clearly documented.
+- [dbt Classes](dbt-classes#result-objects), [on-run-end Context](on-run-end-context#results): The `Result` object has a new schema,
+- [Statement blocks](statement-blocks): The `call statement` result `status` string is now a structured object named `response`.
+- [Snapshots](snapshots#invalidate_hard_deletes): If the config `invalidate_hard_deletes` is enabled, `dbt snapshot` will update records whose unique key no longer exist in the snapshot query. Should those uniquely identified records "revive," `dbt snapshot` will re-add them.
 - [YAML selectors](yaml-selectors) support a `description` property and record their expanded dictionary representations in the manifest.
-- [modules](modules): The regex python module, `re`, is available in dbt's Jinja context.
+- [Modules](modules): The regex python module, `re`, is available in dbt's Jinja context.
 
 #### State
 - [Understanding state](understanding-state): New docs outlining the conceptual background of state-informed runs, as well as the [known caveats](state-comparison-caveats) for state comparison. In v0.19.0, dbt is a little bit smarter at identifying `state:modified` "false positives" that previously resulted from env-based configurations in `dbt_project`.
 - [Defer](defer) has changed: Instead of deferring all unselected node references, dbt now defers an unselected node reference _if and only if_ it does not exist in the current environment. Tests can defer their upstream references as well. This better supports the "Slim CI" use case by addressing the current environment's resources across `seed`, `run`, and `test` steps.
-- [rpc](rpc): Added `state` and `defer` as arguments to RPC methods for which it is supported on the CLI.
+- [RPC](rpc): Added `state` and `defer` as arguments to RPC methods for which it is supported on the CLI.
 
 ### BigQuery
-- [bigquery-profile](bigquery-profile): dbt can connect via OAuth tokens (one-time or refresh), and it can use the default project when connecting via `gcloud` oauth.
+- [Bigquery profile](bigquery-profile): dbt can connect via OAuth tokens (one-time or refresh), and it can use the default project when connecting via `gcloud` oauth.
 - [Hourly, monthly and yearly partitions](bigquery-configs#partitioning-by-a-date-or-timestamp): With a new `granularity` attribute of the `partition_by` config, dbt can materialize models as tables partitioned by hour, month, or year.
 
 ### Spark
-- [spark-profile](spark-profile): The `thrift` and `http` connection methods require installation of a `PyHive` extra.
+- [Spark profile](spark-profile): The `thrift` and `http` connection methods require installation of a `PyHive` extra.

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-19-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-19-0.md
@@ -44,7 +44,7 @@ See [dbt#2961](https://github.com/fishtown-analytics/dbt/pull/2961) for full imp
 
 ### Core
 - [dbt Artifacts](dbt-artifacts): The JSON artifacts produced by dbt—manifest, catalog, run results, and sources—are simpler to consume and more clearly documented.
-- [dbt Classes](dbt-classes#result-objects), [on-run-end Context](on-run-end-context#results): The `Result` object has a new schema,
+- [dbt Classes](dbt-classes#result-objects), [on-run-end Context](on-run-end-context#results): The `Result` object has a new schema, in line with changes to `run_results.json`.
 - [Statement blocks](statement-blocks): The `call statement` result `status` string is now a structured object named `response`.
 - [Snapshots](snapshots#invalidate_hard_deletes): If the config `invalidate_hard_deletes` is enabled, `dbt snapshot` will update records whose unique key no longer exist in the snapshot query. Should those uniquely identified records "revive," `dbt snapshot` will re-add them.
 - [YAML selectors](yaml-selectors) support a `description` property and record their expanded dictionary representations in the manifest.

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-19-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-19-0.md
@@ -20,8 +20,9 @@ title: "Upgrading to 0.19.0"
 
 Please be aware of the following changes in v0.19.0:
 
-- dbt artifacts have a new schema. From here on, artifact schemas are officially versioned at **schemas.getdbt.com**. Future breaking changes will be limited to minor version releases.
-- Defer, a beta feature introduced in v0.18.0, has subtly changed to better support the "Slim CI" use case.
+1. dbt artifacts have a new schema. From here on, artifact schemas are officially versioned at **schemas.getdbt.com**. Future breaking changes will be limited to minor version releases. Some dbt classes, such as the `Result` object, have associated breaking changes.
+2. Defer, a beta feature introduced in v0.18.0, has subtly changed to better support the "Slim CI" use case.
+3. The `call statement` block returns a structured `AdapterResponse` instead of a string `status`. If you previously accessed `statement['status']` within a custom macro or materalization, you should now use `statement[response]`.
 
 See the docs below for more details. We don't expect these to require action in most projects.
 
@@ -29,7 +30,7 @@ See the docs below for more details. We don't expect these to require action in 
 
 (You know who you are!)
 
-The `results` context and `run_results.json` artifact include a new unstructured dictionary called `adapter_response`. This reflects structured information returned by the database after dbt runs the "main" query for a model, seed, snapshot, etc.
+Related to change #3 above: The `results` context and `run_results.json` artifact include a new unstructured dictionary called `adapter_response`. This reflects structured information returned by the database after dbt runs the "main" query for a model, seed, snapshot, etc.
 
 By default, this dict accepts keys such as `code` (`OK`, `SUCCESS`, `CREATE TABLE`, etc) and `rows_affected` (integer). You can add custom arguments to reflect information specific to your adapter. For instance, `dbt-bigquery` populates an additional argument, `bytes_processed`.
 
@@ -43,6 +44,7 @@ See [dbt#2961](https://github.com/fishtown-analytics/dbt/pull/2961) for full imp
 
 ### Core
 - [dbt-artifacts](dbt-artifacts): The JSON artifacts produced by dbt—manifest, catalog, run results, and sources—are simpler to consume and more clearly documented.
+- [dbt classes](dbt-classes): The `Result` object has a new schema, related to the new schema in `run_results.json`.
 - [snapshots](snapshots) ([invalidate_hard_deletes](invalidate_hard_deletes)): If the config `invalidate_hard_deletes` is enabled, `dbt snapshot` will update records whose unique key no longer exist in the snapshot query. Should those uniquely identified records "revive," `dbt snapshot` will re-add them.
 - [YAML selectors](yaml-selectors) support a `description` property and record their expanded dictionary representations in the manifest.
 - [modules](modules): The regex python module, `re`, is available in dbt's Jinja context.

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-19-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-19-0.md
@@ -20,8 +20,9 @@ title: "Upgrading to 0.19.0"
 
 Please be aware of the following changes in v0.19.0:
 
-- dbt artifacts have a new schema. From here on, artifact schemas are officially versioned at **schemas.getdbt.com**. Future breaking changes will be limited to minor version releases.
-- Defer, a beta feature introduced in v0.18.0, has subtly changed to better support the "Slim CI" use case.
+1. dbt artifacts have a new schema. From here on, artifact schemas are officially versioned at **schemas.getdbt.com**. Future breaking changes will be limited to minor version releases. Some dbt classes, such as the `Result` object, have associated breaking changes.
+2. Defer, a beta feature introduced in v0.18.0, has subtly changed to better support the "Slim CI" use case.
+3. The `call statement` block returns a structured `response` instead of a `status` string, though they print identically. If you previously accessed `statement['status']` within a custom macro or materalization, you should now use `statement['response']`.
 
 See the docs below for more details. We don't expect these to require action in most projects.
 
@@ -29,7 +30,7 @@ See the docs below for more details. We don't expect these to require action in 
 
 (You know who you are!)
 
-The `results` context and `run_results.json` artifact include a new unstructured dictionary called `adapter_response`. This reflects structured information returned by the database after dbt runs the "main" query for a model, seed, snapshot, etc.
+Related to change #3 above: The `results` context and `run_results.json` artifact include a new unstructured dictionary called `adapter_response`. This reflects structured information returned by the database after dbt runs the "main" query for a model, seed, snapshot, etc.
 
 By default, this dict accepts keys such as `code` (`OK`, `SUCCESS`, `CREATE TABLE`, etc) and `rows_affected` (integer). You can add custom arguments to reflect information specific to your adapter. For instance, `dbt-bigquery` populates an additional argument, `bytes_processed`.
 
@@ -43,6 +44,8 @@ See [dbt#2961](https://github.com/fishtown-analytics/dbt/pull/2961) for full imp
 
 ### Core
 - [dbt-artifacts](dbt-artifacts): The JSON artifacts produced by dbt—manifest, catalog, run results, and sources—are simpler to consume and more clearly documented.
+- [dbt classes](dbt-classes): The `Result` object has a new schema, related to the new schema in `run_results.json`.
+- [statement-blocks]: The `call statement` result `status` string is now a structured object named `response`.
 - [snapshots](snapshots) ([invalidate_hard_deletes](invalidate_hard_deletes)): If the config `invalidate_hard_deletes` is enabled, `dbt snapshot` will update records whose unique key no longer exist in the snapshot query. Should those uniquely identified records "revive," `dbt snapshot` will re-add them.
 - [YAML selectors](yaml-selectors) support a `description` property and record their expanded dictionary representations in the manifest.
 - [modules](modules): The regex python module, `re`, is available in dbt's Jinja context.

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-19-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-19-0.md
@@ -22,7 +22,7 @@ Please be aware of the following changes in v0.19.0:
 
 1. dbt artifacts have a new schema. From here on, artifact schemas are officially versioned at **schemas.getdbt.com**. Future breaking changes will be limited to minor version releases. Some dbt classes, such as the `Result` object, have associated breaking changes.
 2. Defer, a beta feature introduced in v0.18.0, has subtly changed to better support the "Slim CI" use case.
-3. The `call statement` block returns a structured `AdapterResponse` instead of a string `status`. If you previously accessed `statement['status']` within a custom macro or materalization, you should now use `statement[response]`.
+3. The `call statement` block returns a structured `AdapterResponse` instead of a string `status`. If you previously accessed `statement['status']` within a custom macro or materalization, you should now use `statement['response']`.
 
 See the docs below for more details. We don't expect these to require action in most projects.
 

--- a/website/docs/reference/artifacts/run-results-json.md
+++ b/website/docs/reference/artifacts/run-results-json.md
@@ -24,12 +24,12 @@ Note: `dbt source snapshot-freshness` produces a different artifact, [`sources.j
 - `elapsed_time`: Total invocation time in seconds.
 - `results`: Array of node execution details.
 
-Each entry in `results` is a dictionary with the following keys:
+Each entry in `results` is a [`Result` object](dbt-classes#result-objects), with one difference: Instead of including the entire `node` object, only the `unique_id` is included. (The full `node` object is recorded in [`manifest.json`](manifest-json).)
 
 - `unique_id`: Unique node identifier, which map results to `nodes` in the [manifest](manifest-json)
 - `status`: dbt's interpretation of runtime success, failure, or error
 - `thread_id`: Which thread executed this node? E.g. `Thread-1`
 - `execution_time`: Total time spent executing this node
 - `timing`: Array that breaks down execution time into steps (often `compile` + `execute`)
-- `adapter_response`: Dictionary of information returned from the database, which varies by adapter. E.g. success `code`, number of `rows_affected`, total `bytes_processed`, etc.
+- `adapter_response`: Dictionary of metadata returned from the database, which varies by adapter. E.g. success `code`, number of `rows_affected`, total `bytes_processed`, etc.
 - `message`: How dbt will report this result on the CLI, based on information returned from the database

--- a/website/docs/reference/dbt-classes.md
+++ b/website/docs/reference/dbt-classes.md
@@ -133,37 +133,19 @@ will be expanded to:
 ```
 
 ## Result objects
-The execution of a resource in dbt generates a Result object. This object contains information about the node that was executed, as well as its resulting status. The JSON Schema for a Result object can be found [here](https://github.com/fishtown-analytics/dbt/blob/6563b0329936dbd75b6a4cdf8a98e90fb717cd84/core/dbt/contracts/results.py#L9). Note that this contract may be subject to change in the future until dbt's API has reached a "stable" state.
 
+<Changelog>
 
-```python
-{
-    'type': 'object',
-    'additionalProperties': False,
-    'description': 'The result of a single node being run',
-    'properties': {
-        'error': {
-            'type': ['string', 'null'],
-            'description': 'The error string, or None if there was no error',
-        },
-        'skip': {
-            'type': 'boolean',
-            'description': 'True if this node was skipped',
-        },
-        'fail': {
-            'type': ['boolean', 'null'],
-            'description': 'On tests, true if the test failed',
-        },
-        'status': {
-            'type': ['string', 'null', 'number', 'boolean'],
-            'description': 'The status result of the node execution',
-        },
-        'execution_time': {
-            'type': 'number',
-            'description': 'The execution time, in seconds',
-        },
-        'node': <Node Contract>;,
-    },
-    'required': ['node'],
-}
-```
+* `v0.19.0`: The `Result` object significantly changed its schema. See https://schemas.getdbt.com/dbt/run-results/v1.json for the full specification.
+
+</Changelog>
+
+The execution of a resource in dbt generates a `Result` object. This object contains information about the node that was executed, as well as metadata returned by the adapter. These objects are recorded in more-concise form in two dbt artifacts: [`run_results.json`](run-results-json) and [`sources.json`](sources-json).
+
+- `node`: Full object representation of the dbt resource (model, seed, snapshot, test) executed, including its `unique_id`
+- `status`: dbt's interpretation of runtime success, failure, or error
+- `thread_id`: Which thread executed this node? E.g. `Thread-1`
+- `execution_time`: Total time spent executing this node
+- `timing`: Array that breaks down execution time into steps (often `compile` + `execute`)
+- `adapter_response`: Dictionary of metadata returned from the database, which varies by adapter. E.g. success `code`, number of `rows_affected`, total `bytes_processed`, etc.
+- `message`: How dbt will report this result on the CLI, based on information returned from the database

--- a/website/docs/reference/dbt-classes.md
+++ b/website/docs/reference/dbt-classes.md
@@ -140,7 +140,7 @@ will be expanded to:
 
 </Changelog>
 
-The execution of a resource in dbt generates a `Result` object. This object contains information about the node that was executed, as well as metadata returned by the adapter. These objects are recorded in more-concise form in two dbt artifacts: [`run_results.json`](run-results-json) and [`sources.json`](sources-json).
+The execution of a resource in dbt generates a `Result` object. This object contains information about the executed node, timing, status, and metadata returned by the adapter. At the end of an invocation, dbt records these objects in [`run_results.json`](run-results-json).
 
 - `node`: Full object representation of the dbt resource (model, seed, snapshot, test) executed, including its `unique_id`
 - `status`: dbt's interpretation of runtime success, failure, or error

--- a/website/docs/reference/dbt-jinja-functions/on-run-end-context.md
+++ b/website/docs/reference/dbt-jinja-functions/on-run-end-context.md
@@ -96,7 +96,7 @@ on-run-end:
 
 
 ## Results
-The `results` variable contains a list of [Result objects](dbt-classes#result-objects) with one element per resource that executed in the dbt job.
+The `results` variable contains a list of [Result objects](dbt-classes#result-objects) with one element per resource that executed in the dbt job. The Result object provides access within the Jinja on-run-end context to the information that will populate the [run results JSON artifact](run-results-json).
 
 Example usage:
 
@@ -150,34 +150,3 @@ node: model.my_project.abc; status: CREATE VIEW (error: None)
 11:27:52 |
 11:27:52 | Finished running 1 table models, 1 view models in 0.26s.
 ```
-
-## Advanced Usage
-
-Objects of the Results class have the following properties:
-```
-{
-    'error': {
-        'type': ['string', 'null'],
-        'description': 'The error string, or None if there was no error',
-    },
-    'skip': {
-        'type': 'boolean',
-        'description': 'True if this node was skipped',
-    },
-    'fail': {
-        'type': ['boolean', 'null'],
-        'description': 'On tests, true if the test failed',
-    },
-    'status': {
-        'type': ['string', 'null', 'number', 'boolean'],
-        'description': 'The status result of the node execution',
-    },
-    'execution_time': {
-        'type': 'number',
-        'description': 'The execution time, in seconds',
-    },
-    'node': COMPILE_RESULT_NODE_CONTRACT,
-}
-```
-
-Additionally, Result objects have a `serialize()` method which can be used to convert the object into a Python dictionary.

--- a/website/docs/reference/dbt-jinja-functions/on-run-end-context.md
+++ b/website/docs/reference/dbt-jinja-functions/on-run-end-context.md
@@ -96,6 +96,13 @@ on-run-end:
 
 
 ## Results
+
+<Changelog>
+
+* `v0.19.0`: The `Result` object significantly changed its schema. See https://schemas.getdbt.com/dbt/run-results/v1.json for the full specification.
+
+</Changelog>
+
 The `results` variable contains a list of [Result objects](dbt-classes#result-objects) with one element per resource that executed in the dbt job. The Result object provides access within the Jinja on-run-end context to the information that will populate the [run results JSON artifact](run-results-json).
 
 Example usage:
@@ -105,15 +112,17 @@ Example usage:
 ```sql
 {% macro log_results(results) %}
 
+  {% if execute %}
   {{ log("========== Begin Summary ==========", info=True) }}
   {% for res in results -%}
     {% set line -%}
-        node: {{ res.node.unique_id }}; status: {{ res.status }} (error: {{ res.error }})
+        node: {{ res.node.unique_id }}; status: {{ res.status }} (message: {{ res.message }})
     {%- endset %}
 
     {{ log(line, info=True) }}
   {% endfor %}
   {{ log("========== End Summary ==========", info=True) }}
+  {% endif %}
 
 {% endmacro %}
 ```
@@ -133,20 +142,23 @@ on-run-end: "{{ log_results(results) }}"
 
 Results:
 ```
-11:27:52 | Concurrency: 8 threads (target='dev')
-11:27:52 |
-11:27:52 | 1 of 2 START view model demo_schema.abc.............................. [RUN]
-11:27:52 | 2 of 2 START table model demo_schema.def............................. [RUN]
-11:27:52 | 2 of 2 ERROR creating table model demo_schema.def.................... [ERROR in 0.08s]
-11:27:52 | 1 of 2 OK created view model demo_schema.abc......................... [CREATE VIEW in 0.10s]
-
+12:48:17 | Concurrency: 1 threads (target='dev')
+12:48:17 |
+12:48:17 | 1 of 2 START view model dbt_jcohen.abc............................... [RUN]
+12:48:17 | 1 of 2 OK created view model dbt_jcohen.abc.......................... [CREATE VIEW in 0.11s]
+12:48:17 | 2 of 2 START table model dbt_jcohen.def.............................. [RUN]
+12:48:17 | 2 of 2 ERROR creating table model dbt_jcohen.def..................... [ERROR in 0.09s]
+12:48:17 |
+12:48:17 | Running 1 on-run-end hook
 ========== Begin Summary ==========
-node: model.my_project.def; status: ERROR (error: Database Error in model def (models/def.sql)
+node: model.testy.abc; status: success (message: CREATE VIEW)
+node: model.testy.def; status: error (message: Database Error in model def (models/def.sql)
   division by zero
-  compiled SQL at target/compiled/my_project/def.sql)
-node: model.my_project.abc; status: CREATE VIEW (error: None)
+  compiled SQL at target/run/testy/models/def.sql)
 ========== End Summary ==========
-
-11:27:52 |
-11:27:52 | Finished running 1 table models, 1 view models in 0.26s.
+12:48:17 | 1 of 1 START hook: testy.on-run-end.0................................ [RUN]
+12:48:17 | 1 of 1 OK hook: testy.on-run-end.0................................... [OK in 0.00s]
+12:48:17 |
+12:48:17 |
+12:48:17 | Finished running 1 view model, 1 table model, 1 hook in 1.94s.
 ```

--- a/website/docs/reference/dbt-jinja-functions/statement-blocks.md
+++ b/website/docs/reference/dbt-jinja-functions/statement-blocks.md
@@ -24,18 +24,29 @@ statement(name=None, fetch_result=False, auto_begin=True)
 ```
 
 __Args__:
-  - name (string): The name for the result set returned by this statement
- - fetch_result (bool): If True, load the results of the statement into the Jinja context
- - auto_begin (bool): If True, open a transaction if one does not exist. If false, do not open a transaction.
+ - `name` (string): The name for the result set returned by this statement
+ - `fetch_result` (bool): If True, load the results of the statement into the Jinja context
+ - `auto_begin` (bool): If True, open a transaction if one does not exist. If false, do not open a transaction.
 
-Once the statement block has executed, the result set is accessible via the `load_result` function. For the above statement, that would look like:
+Once the statement block has executed, the result set is accessible via the `load_result` function. The result object includes three keys:
+- `response`: Structured object containing metadata returned from the database, which varies by adapter. E.g. success `code`, number of `rows_affected`, total `bytes_processed`, etc. Comparable to `adapter_response` in the [Result object](dbt-classes#result-objects).
+- `data`: Pythonic representation of data returned by query (arrays, tuples, dictionaries).
+- `table`: [Agate](https://agate.readthedocs.io/en/1.1.0/api/table.html) table representation of data returned by query.
+
+<Changelog>
+
+* `v0.19.0`: The `response` structured object replaced a `status` string that contained similar information.
+
+</Changelog>
+
+For the above statement, that could look like:
 
 <File name='load_states.sql'>
 
 ```sql
 {%- set states = load_result('states') -%}
 {%- set states_data = states['data'] -%}
-{%- set states_status = states['status'] -%}
+{%- set states_status = states['response'] -%}
 ```
 
 </File>


### PR DESCRIPTION
## Description & motivation

Thanks to @clrcrl, I realized this evening (https://github.com/fishtown-analytics/dbt-utils/pull/319 + https://github.com/fishtown-analytics/dbt-utils/pull/320) that the `call statement` object has very subtly changed in dbt v0.19.0.

Instead of returning a `status`, the `call statement` block now returns an adapter-specific `response` which includes the same basic info in a structured format, while still rendering to the same thing `status` used to, via its `_message` attribute. I'd say this is a big improvement overall!

```python
{
    'response': BigQueryAdapterResponse(_message='OK', code=None, rows_affected=None, bytes_processed=None),
    'data': [(Decimal('1'),)],
    'table': <agate.table.Table object at 0x111ceafd0>
}
```

It's also a potentially breaking change for macros, materializations, packages (e.g. `dbt_utils.insert_by_period`, `dbt_external_tables.stage_external_sources`) that hook right into the `statement['status']` field. It should be as simple as switching this from `statement['status']` to `statement['response']`. Or, to be compatible both ways:
```
{% set my_msg = statement['response'] if 'response' in statement.keys() else statement['status'] %}
```

While I was there, I realized that I'd failed to update the "dbt Classes" `Result` object docs. I... had also kind of forgotten these docs existed. They were still linking to a JSON Schema that went away in v0.15.0. I think the whole "dbt Classes" docs could use some love.

## To-do before merge

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [x] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!