### PR TITLE
add tile to landing page for learn

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -64,6 +64,25 @@ function Home() {
                     </div>
                   </div>
                 </div>
+                <div className="col col--4">
+                  <div className="card large dark darkest">
+                    <div className="card__header">
+                      <h3>dbt Learn</h3>
+                    </div>
+                    <div className="card__body">
+                      <p>
+                        Learn dbt on your own time with our on demand course or sign up for an upcoming, live public course.
+                      </p>
+                    </div>
+                    <div className="card__footer">
+                        <Link
+                          className="button button--primary"
+                          to="https://learn.getdbt.com">
+                          Learn Now
+                        </Link>
+                    </div>
+                  </div>
+                </div>
             </div>
         </div>
         <div className="container container--fluid home" style={{"background": "#FFF", "padding": "10px 0"}}>


### PR DESCRIPTION
## Description & motivation
We are currently not referencing dbt Learn on the docs.getdbt.com site.  Let's change that so people can learn dbt in the way that best suits them.  This change positions dbt Learn next to `What is dbt Learn` and the `Getting Started Tutorial`.

This is a quick HTML change.  In the future, we should investigate a solution for the navbar and then consider pursuing adding clever references to learn chapter/lessons in intentional spots in docs 

## To-do before merge
- [ ] Check the Netlify Build
- [ ] Review the copy that is listed on the tile
- [ ] Ensure that the link **does actually** link to learn.getdbt.com in the Netlify build

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [X] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist

