### PR TITLE
Update notes on test selection and invocation.

### DIFF
--- a/website/docs/faqs/test-sources.md
+++ b/website/docs/faqs/test-sources.md
@@ -2,10 +2,12 @@
 title: How do I run tests on sources only?
 ---
 
-Because the test selection syntax grew out of the model selection syntax (and pre-dates sources), the syntax here is a little unintuitive, but it is possible!
-
+Test selection syntax predates sources. It is based on model selection syntax:
 ```
-$ dbt test --models source:*
+$ dbt test --models source:<source_name>.<table_name>  # run tests on a single source table
+$ dbt test --models source:<source_name>               # run tests on a source
+$ dbt test --models source:\*                          # run all tests for all sources
 ```
+Take special note of the slash, or escape character. This is necessary for command prompts to parse * as a character and not what is sometimes called a [wildcard](https://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm).
 
-Check out the [model selection syntax documentation](node-selection/test-selection-examples) for more operators and examples.
+See our [test selection examples](node-selection/test-selection-examples) for more operators and examples.

--- a/website/docs/faqs/test-sources.md
+++ b/website/docs/faqs/test-sources.md
@@ -6,8 +6,8 @@ Test selection syntax predates sources. It is based on model selection syntax:
 ```
 $ dbt test --models source:<source_name>.<table_name>  # run tests on a single source table
 $ dbt test --models source:<source_name>               # run tests on a source
-$ dbt test --models source:\*                          # run all tests for all sources
+$ dbt test --models 'source:*'                         # run all tests for all sources
 ```
-Take special note of the slash, or escape character. This is necessary for command prompts to parse * as a character and not what is sometimes called a [wildcard](https://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm).
+On some systems, the slash, or escape character may be necessary. Some command prompts parse the * not as a character but as a [wildcard](https://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm). Sometimes single quoting disables the wildcard feature. Sometimes, \* may be necessary.
 
 See our [test selection examples](node-selection/test-selection-examples) for more operators and examples.

--- a/website/docs/reference/node-selection/syntax.md
+++ b/website/docs/reference/node-selection/syntax.md
@@ -2,7 +2,14 @@
 title: "Syntax overview"
 ---
 
-dbt's node selection syntax makes it possible to run only specific resources in a given invocation of dbt. This selection syntax is used for the following subcommands:
+The following objects in a dbt project are called "nodes": models, data tests, sources, seeds, snapshots, and analyses. Nodes are visually represented by the circles in a dbt project's DAG (directed acyclic graph).
+
+:::info Nodes and resources
+
+We use the terms <a href="https://en.wikipedia.org/wiki/Vertex_(graph_theory)">"nodes"</a> and "resources" interchangeably.
+:::
+
+dbt's node selection syntax makes it possible to run dbt subcommands on specific resources only. This selection syntax is used for the following subcommands:
 
 | command   | argument(s)                                       |
 | :-------- | ------------------------------------------------- |
@@ -13,14 +20,9 @@ dbt's node selection syntax makes it possible to run only specific resources in 
 | ls (list) | `--select`, `--models`, `--exclude`, `--selector` |
 | compile   | `--select`, `--exclude`, `--selector`             |
 
-:::info Nodes and resources
-
-We use the terms <a href="https://en.wikipedia.org/wiki/Vertex_(graph_theory)">"nodes"</a> and "resources" interchangeably. These  encompass all the models, tests, sources, seeds, snapshots, and analyses in your project. They are the objects that make up dbt's DAG (directed acyclic graph).
-:::
-
 ## Specifying resources
 
-By default, `dbt run` executes _all_ of the models in the dependency graph; `dbt seed` creates all seeds, `dbt snapshot` performs every snapshot. The `--models` and `--select` flags are used to specify a subset of nodes to execute.
+By default, `dbt run` executes _all_ of the models in the dependency graph; `dbt seed` creates all seeds, `dbt snapshot` performs every snapshot. The `--models` and `--select` flags are used to specify a subset of nodes to execute. The `--selector`` flag specifies which [user-defined yaml selector](http://localhost:3000/reference/node-selection/yaml-selectors) to use.
 
 ### Shorthand
 

--- a/website/docs/reference/node-selection/syntax.md
+++ b/website/docs/reference/node-selection/syntax.md
@@ -22,7 +22,7 @@ dbt's node selection syntax makes it possible to run dbt subcommands on specific
 
 ## Specifying resources
 
-By default, `dbt run` executes _all_ of the models in the dependency graph; `dbt seed` creates all seeds, `dbt snapshot` performs every snapshot. The `--models` and `--select` flags are used to specify a subset of nodes to execute. The `--selector`` flag specifies which [user-defined yaml selector](http://localhost:3000/reference/node-selection/yaml-selectors) to use.
+By default, `dbt run` executes _all_ of the models in the dependency graph; `dbt seed` creates all seeds, `dbt snapshot` performs every snapshot. The `--models` and `--select` flags are used to specify a subset of nodes to execute. The `--selector`` flag specifies which [user-defined yaml selector](#yaml-selectors) to use.
 
 ### Shorthand
 

--- a/website/docs/reference/node-selection/test-selection-examples.md
+++ b/website/docs/reference/node-selection/test-selection-examples.md
@@ -2,16 +2,18 @@
 title: "Test selection examples"
 ---
 
-The test selection syntax grew out of the model selection syntax. As such, the syntax will look familiar if you wish to:
-* run tests on a particular model
-* run tests on models in a sub directory
-* run tests on all models upstream / downstream of a model, etc.
+The syntax used to select which nodes to test is based on model selection syntax. Hence, the selection syntax for testing models generally matches the selection syntax for running models:
+```
+dbt test -m <model_name>             # run tests on a particular model
+dbt test -m <path.to.models.folder>  # run tests on models in a sub directory
+dbt test -m +<model_name>+           # run tests on models upstream/downstream of a model
+```
 
-Tests have their own properties _and_ inherit the properties of the nodes they select from. This means you:
-* select tests based on the file path of the models being tested, rather than the file paths of the `.yml` files that configure the tests
-* can use selector methods that check config properties of the resources being tested
+Tests have their own properties (set in yaml files or data test `config` blocks). Tests _also_ inherit the properties of the nodes they test (i.e. select from). This enables you to select which nodes to test using:
+* the file paths of the models themselves, as opposed to paths of `.yml` files where schema tests are defined
+* the properties of a source or model
 
-Things start to get a little unfamiliar when you want to test things other than models, so we've included lots of examples below. In the future, we plan to make this syntax more intuitive.
+Selecting nodes other than models, such as sources, deviates from the usual model selection syntax, so we've listed several examples below. In the future, we plan to make test selection syntax more intuitive.
 
 ### Run schema tests only
 
@@ -71,8 +73,9 @@ $ dbt test --models config.materialized:table
 ### Run tests on all sources
 
 ```shell
-$ dbt test --models source:*
+$ dbt test --models source:\*
 ```
+`*` is a sometimes called a [wildcard](https://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm). To ensure `dbt` runs all source tests, prepend all instances of `*` with the `\`, or escape, character. "Escaping" wildcard characters is necessary both on the command line and in shell scripts.
 
 ### Run tests on one source
 
@@ -96,7 +99,7 @@ $ dbt test --models source:jaffle_shop.customers
 ### Run tests on everything _but_ sources
 
 ```shell
-$ dbt test --exclude sources:*
+$ dbt test --exclude sources:\*
 ```
 
 ### Run a specific data test

--- a/website/docs/reference/node-selection/test-selection-examples.md
+++ b/website/docs/reference/node-selection/test-selection-examples.md
@@ -9,11 +9,23 @@ dbt test -m <path.to.models.folder>  # run tests on models in a sub directory
 dbt test -m +<model_name>+           # run tests on models upstream/downstream of a model
 ```
 
-Tests have their own properties (set in yaml files or data test `config` blocks). Tests _also_ inherit the properties of the nodes they test (i.e. select from). This enables you to select which nodes to test using:
-* the file paths of the models themselves, as opposed to paths of `.yml` files where schema tests are defined
+Tests have their own properties (set in yaml files or data test `config` blocks). Tests _also_ inherit the properties of the nodes they test (i.e. select from). dbt currently requires you to select which nodes to test using:
+* the file paths of the models which tests are defined on
 * the properties of a source or model
 
-Selecting nodes other than models, such as sources, deviates from the usual model selection syntax, so we've listed several examples below. In the future, we plan to make test selection syntax more intuitive.
+Selecting tests to run on nodes other than models, such as sources, is different from the usual model selection syntax.
+
+A test is selected if the `--models` criteria includes any property of:
+
+    * the test itself (e.g. tag: or test_name: selection method)
+    * a resource (model/source/snapshot/seed) the test directly depends on
+
+By the same token, a test is not selected if the --exclude criteria includes any property of:
+
+    * the test itself
+    * a resource the test directly depends on
+
+In the future, we plan to make test selection syntax more intuitive. For now, here are several examples.
 
 ### Run schema tests only
 
@@ -73,7 +85,7 @@ $ dbt test --models config.materialized:table
 ### Run tests on all sources
 
 ```shell
-$ dbt test --models source:\*
+$ dbt test --models 'source:*'
 ```
 `*` is a sometimes called a [wildcard](https://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm). To ensure `dbt` runs all source tests, prepend all instances of `*` with the `\`, or escape, character. "Escaping" wildcard characters is necessary both on the command line and in shell scripts.
 
@@ -99,7 +111,7 @@ $ dbt test --models source:jaffle_shop.customers
 ### Run tests on everything _but_ sources
 
 ```shell
-$ dbt test --exclude sources:\*
+$ dbt test --exclude 'sources:*'
 ```
 
 ### Run a specific data test


### PR DESCRIPTION
## Description & motivation
This started with making sure I could close issue #27. The "test all sources" syntax is actually misleading for unix command lines. So, I fixed the broken syntax bits.

But, in the course of attacking this, I discovered my own understanding of test selectors was generally flawed and the documentation was a bit obscure at places. After learning what was going on, I tried to "decouple" what `--model` `--select` and `--selector` with a few more sentences of context and slightly different organization of ideas. When streamlining the language and adding more examples, I also found it useful to explain plainly what a node is.

In addition to several additions, this PR closes issue #27 .

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
