### PR TITLE
Update dbt-project-yml-context.md

### DIFF
--- a/website/docs/reference/dbt-jinja-functions/dbt-project-yml-context.md
+++ b/website/docs/reference/dbt-jinja-functions/dbt-project-yml-context.md
@@ -20,7 +20,6 @@ and `snapshots:` keys in the `dbt_project.yml` file.
 - [vars](var) (_Note: only variables defined with `--vars` are availabe_)
 - [builtins](builtins)
 - [dbt_version](dbt_version)
-- [project_name](project_name)
 
 
 ### Example configuration


### PR DESCRIPTION
## Description & motivation
The `project_name` is not available in the `dbt_project.yml` context. 
'project_name' is available in: query headers, hooks, models, and macro execution

## To-do before merge
See: https://github.com/fishtown-analytics/dbt/pull/2085

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist
