### PR TITLE
adding changelog for dbt Cloud 1.1.18 release

### DIFF
--- a/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
@@ -6,12 +6,12 @@ description: "Changelog for the dbt Cloud application"
 ---
 ## dbt Cloud v1.1.18 (January 20, 2021)
 
-TODO - enter release summary and curate below release notes
+Most notable things here are around foundational work toward future feature releases, as well as strong assurances of future stability for dbt Cloud, and ensuring future sales tax compliance (which we understand turns out to be quite important!) - turns out to be a quite future-looking release!
 
 #### Enhancements
 
-- Fixing and upgrading social-auth
-- add dbt spark 0.19.0rc1
+- Fixing and Upgrading social-auth
+- Add dbt Spark 0.19.0rc1
 - Adds the reconciliation of persisted file content and tab state when navigating into the IDE
 - Adds the reconciliation of persisted file content and tab state between IDE sessions
 - Read logs from scribe and stop logging to db

--- a/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
@@ -10,6 +10,7 @@ Most notable things here are around foundational work toward future feature rele
 
 #### Enhancements
 
+- Add service tokens UI (stubbed) behind a feature flag
 - Fixing and Upgrading social-auth
 - Add dbt Spark 0.19.0rc1
 - Adds the reconciliation of persisted file content and tab state when navigating into the IDE
@@ -21,6 +22,8 @@ Most notable things here are around foundational work toward future feature rele
 
 #### Fixed
 
+- Prevent social-auth from updating first or last name
+- Page through Stripe results when listing subscriptions
 - Prevent enqueueing runs in deleted projects
 - Fix IDE git actions causing open tab contents to be lost on IDE re-entry
 - Add DBT_CLOUD_CONTEXT environment variable

--- a/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
@@ -4,6 +4,38 @@ id: "cloud-changelog"
 sidebar_label: Changelog
 description: "Changelog for the dbt Cloud application"
 ---
+## dbt Cloud v1.1.18 (January 20, 2021)
+
+TODO - enter release summary and curate below release notes
+
+#### Enhancements
+
+- Fixing and upgrading social-auth
+- add dbt spark 0.19.0rc1
+- Adds the reconciliation of persisted file content and tab state when navigating into the IDE
+- Adds the reconciliation of persisted file content and tab state between IDE sessions
+- Read logs from scribe and stop logging to db
+- Upgrade social auth 3.3.3
+- Add warning logs for social auth failures
+- Add dbt 0.19.0rc1
+
+#### Fixed
+
+- Prevent enqueueing runs in deleted projects
+- Fix IDE git actions causing open tab contents to be lost on IDE re-entry
+- Add DBT_CLOUD_CONTEXT environment variable
+- Add logic to hide IP whitelist message for on-prem customers
+- fix 0.19.0rc1 run image dependencies
+
+#### Internal
+
+- Remove Mailchimp integration
+- Use the generic get_handle method in the run service
+- Clean up scribe services when finished jobs are cleaned up
+- Downgrade social auth
+- Adds an (albeit) scrappy django command to verify the content of scribe logs vs cloud
+- Adjust existing customer taxation backfill method
+
 ## dbt Cloud v1.1.17 (January 7, 2021)
 
 Tidying up this and that as we settle into 2021. No new user-facing functionality. Hope everyone had a safe and cozy New Year!


### PR DESCRIPTION
## Description & motivation
This is the changelog PR for the dbt Cloud 1.1.18 release.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

