### PR TITLE
Update cloud-import-a-project-by-git-url.md

### DIFF
--- a/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-import-a-project-by-git-url.md
+++ b/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-import-a-project-by-git-url.md
@@ -3,7 +3,7 @@ title: "Importing a project by git URL"
 id: "cloud-import-a-project-by-git-url"
 ---
 
-In dbt Cloud. You can import a git repository from any valid git URL that points to a dbt project. There are a couple of important considerations to keep in mind when doing this:
+In dbt Cloud, you can import a git repository from any valid git URL that points to a dbt project. There are a couple of important considerations to keep in mind when doing this:
 
 ## Git protocols
 You must use the `git@...` or `ssh:..`. version of your git URL, not the `https://...` version. dbt Cloud uses the SSH protocol to clone repositories, so dbt Cloud will be unable to clone repos supplied with the HTTP protocol.


### PR DESCRIPTION
fix typo in punctuation

## Description & motivation
Fix typo on page "Importing a project by git URL" in the dbt Cloud docs

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [X] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
