### PR TITLE
Update cloud-overview with contextual links

### DIFF
--- a/website/docs/docs/dbt-cloud/cloud-overview.md
+++ b/website/docs/docs/dbt-cloud/cloud-overview.md
@@ -3,7 +3,11 @@ title: "Overview"
 id: "cloud-overview"
 ---
 
-[dbt Cloud](https://www.getdbt.com/signup/) is a hosted service that helps data analysts and engineers productionize dbt deployments. It comes equipped with turnkey support for scheduling jobs, CI/CD, serving documentation, monitoring & alerting, and an Integrated Developer Environment (IDE). dbt Cloud’s generous Developer (free) plan and deep integration with dbt Core make it well suited for data teams small and large alike.  
+[dbt Cloud](https://www.getdbt.com/product/) is a hosted service that helps data analysts and engineers productionize dbt deployments. It comes equipped with turnkey support for scheduling jobs, CI/CD, serving documentation, monitoring & alerting, and an Integrated Developer Environment (IDE).
+
+dbt Cloud’s generous Developer (free) plan and deep integration with dbt Core make it well suited for data teams small and large alike.  
+
+[Get started with dbt Cloud](https://www.getdbt.com/signup/)
 
 
 ### Develop dbt projects


### PR DESCRIPTION
## Description & motivation
Updated `dbt cloud` link to point to product page (instead of signup page) so readers can learn more about dbt cloud. 

Added link that more clearly points to sign up if reader wants to try out dbt cloud.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
