### PR TITLE
Update the-dbt-ide with info about dbt Cloud

### DIFF
--- a/website/docs/docs/dbt-cloud/cloud-ide/the-dbt-ide.md
+++ b/website/docs/docs/dbt-cloud/cloud-ide/the-dbt-ide.md
@@ -6,7 +6,7 @@ id: "the-dbt-ide"
 
 :::info Prerequisites
 
-To set up your account to use the IDE, consult the guide on [using the dbt IDE](using-the-dbt-ide).
+You must have a dbt Cloud account to use the IDE. Consult the guide on [using the dbt IDE](using-the-dbt-ide). Don't have an account? You can get started for free [here](https://www.getdbt.com/signup).
 
 :::
 


### PR DESCRIPTION
## Description & motivation
Update info block to make sure that reader must have a dbt Cloud account to use the IDE. Point reader to create an account if they need one.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!