### PR TITLE
Minor doc code change

### DIFF
--- a/website/docs/faqs/uniqueness-two-columns.md
+++ b/website/docs/faqs/uniqueness-two-columns.md
@@ -41,7 +41,7 @@ version: 2
 models:
   - name: orders
     columns:
-      - name: unique_id
+      - name: surrogate_key
         tests:
           - unique
 


### PR DESCRIPTION
The first approach's column name should be the same in the model definition (SQL) as well as in the schema, right?

## Description & motivation

Minor doc

## To-do before merge

## Pre-release docs
Is this change related to an unreleased version of dbt?No

## Checklist

