### PR TITLE
Add link to dbt cloud signup

### DIFF
--- a/website/docs/tutorial/1-setting-up.md
+++ b/website/docs/tutorial/1-setting-up.md
@@ -114,7 +114,7 @@ In order to let dbt connect to your warehouse, you'll need generate a keyfile. T
 ## Choose the way you want to develop
 There’s two main ways of working with dbt:
 
-1. Edit files and run projects using the web-based Integrated Development Environment (IDE) in **dbt Cloud**.
+1. Edit files and run projects using the web-based Integrated Development Environment (IDE) in **dbt Cloud**. [Create a dbt Cloud account here](https://www.getdbt.com/signup/).
 2. Edit files locally using a code editor, and run projects using the Command Line Interface (**dbt CLI**).
 
 To use the CLI, it's important that you know some basics of your terminal. In particular, you should understand `cd`, `ls` and `pwd` to navigate through the directory structure of your computer easily. As such, if you are new to programming, we recommend using **dbt Cloud** for this tutorial.


### PR DESCRIPTION
## Description & motivation
Add link to direct readers to sign up for dbt Cloud.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
