### PR TITLE
Update redshift-profile.md

### DIFF
--- a/website/docs/reference/warehouse-profiles/redshift-profile.md
+++ b/website/docs/reference/warehouse-profiles/redshift-profile.md
@@ -23,8 +23,7 @@ company-name:
       threads: 4
       keepalives_idle: 0 # default 0, indicating the system default
       # search_path: public # optional, not recommended
-      sslmode: [optional, set the sslmode used to connect to the database]
-      sslrootcert: [optional, This parameter specifies the name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities. The default is ~/.postgresql/root.crt.]
+      sslmode: [optional, set the sslmode used to connect to the database (points to ~/.postgresql/root.crt)]
 ```
 
 </File>
@@ -68,8 +67,8 @@ my-redshift-db:
       threads: 4
       keepalives_idle: 0 # default 0, indicating the system default
       # search_path: public # optional, but not recommended
-      sslmode: [optional, set the sslmode used to connect to the database]
-      sslrootcert: [optional, This parameter specifies the name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities. The default is ~/.postgresql/root.crt.]
+      sslmode: [optional, set the sslmode used to connect to the database (points to ~/.postgresql/root.crt)]
+
 ```
 
 </File>

--- a/website/docs/reference/warehouse-profiles/redshift-profile.md
+++ b/website/docs/reference/warehouse-profiles/redshift-profile.md
@@ -23,6 +23,8 @@ company-name:
       threads: 4
       keepalives_idle: 0 # default 0, indicating the system default
       # search_path: public # optional, not recommended
+      sslmode: [optional, set the sslmode used to connect to the database]
+      sslrootcert: [optional, This parameter specifies the name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities. The default is ~/.postgresql/root.crt.]
 ```
 
 </File>
@@ -66,6 +68,8 @@ my-redshift-db:
       threads: 4
       keepalives_idle: 0 # default 0, indicating the system default
       # search_path: public # optional, but not recommended
+      sslmode: [optional, set the sslmode used to connect to the database]
+      sslrootcert: [optional, This parameter specifies the name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities. The default is ~/.postgresql/root.crt.]
 ```
 
 </File>

--- a/website/docs/reference/warehouse-profiles/redshift-profile.md
+++ b/website/docs/reference/warehouse-profiles/redshift-profile.md
@@ -23,7 +23,7 @@ company-name:
       threads: 4
       keepalives_idle: 0 # default 0, indicating the system default
       # search_path: public # optional, not recommended
-      sslmode: [optional, set the sslmode used to connect to the database (points to ~/.postgresql/root.crt)]
+      sslmode: [optional, set the sslmode used to connect to the database (in case this parameter is set, will look for ca in ~/.postgresql/root.crt)]
 ```
 
 </File>
@@ -67,7 +67,7 @@ my-redshift-db:
       threads: 4
       keepalives_idle: 0 # default 0, indicating the system default
       # search_path: public # optional, but not recommended
-      sslmode: [optional, set the sslmode used to connect to the database (points to ~/.postgresql/root.crt)]
+      sslmode: [optional, set the sslmode used to connect to the database (in case this parameter is set, will look for ca in ~/.postgresql/root.crt)]
 
 ```
 


### PR DESCRIPTION


## Description & motivation
<!---
We spend some decent amount going the source code to find out that the redshift connection handler inherits from the postgres connection handler, and as such uses the psycopg2 library to connect to redshift and thus this will work as well. We verified to connection towards our redshift with both require (and not setting the sslrootcert) and verify-full (setting the redshift certs both on the default path, as well as a different path).
-->


## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!


