### PR TITLE
allow trailing slashes in relative links; reject absolute internal links

### DIFF
--- a/website/src/components/link/index.js
+++ b/website/src/components/link/index.js
@@ -39,7 +39,7 @@ function findSource(source_href) {
     var stripped_source_href = source_href.replace(/.md$/, '');
 
     // Remove trailing slash if present
-    stripped_source_href = source_href.replace(/\/$/, '');
+    stripped_source_href = stripped_source_href.replace(/\/$/, '');
 
     if (!stripped_source_href.startsWith('/')) {
         stripped_source_href = '/' + stripped_source_href;

--- a/website/src/components/link/index.js
+++ b/website/src/components/link/index.js
@@ -35,10 +35,16 @@ docsFiles.keys().forEach(function(key, i) {
 });
 
 function findSource(source_href) {
-    var stripped_source_href = source_href.replace(/.md$/, '')
+    // remove trailing .md if present
+    var stripped_source_href = source_href.replace(/.md$/, '');
+
+    // Remove trailing slash if present
+    stripped_source_href = source_href.replace(/\/$/, '');
+
     if (!stripped_source_href.startsWith('/')) {
         stripped_source_href = '/' + stripped_source_href;
     }
+
     var found = null;
     for (var source in sources) {
         var stripped_source = source.replace(/.md$/, '')
@@ -79,6 +85,7 @@ function expandRelativeLink(href, ignoreInvalid) {
     }
 
     var isExternal = !!link.match(/https?:/) || !!link.match(/:/);
+    var isInternal = !!link.match(/docs.getdbt.com\//);
 
     var sourceLink = findSource(link);
     if (sourceLink) {
@@ -90,6 +97,11 @@ function expandRelativeLink(href, ignoreInvalid) {
         return {
             bad: false,
             link: `${slugs[link].permalink}#${hash}`
+        }
+    } else if (isInternal) {
+        return {
+            bad: true,
+            link: href
         }
     } else if (!isExternal && !href.startsWith('/')) {
         if (ENV.DOCS_ENV == 'build' && !ignoreInvalid) {


### PR DESCRIPTION
## Description & motivation
This PR updates the link checker to:
 - allow relative links with trailing slashes (eg. `docs/available-adapters`, or `docs/available-adapters/#fishtown-supported`)
 - disallow absolute links to docs.getdbt.com urls (eg. `https://docs.getdbt.com/docs/available-adapters`)

## To-do before merge
- **DO NOT MERGE THIS PR UNTIL UNIT TESTS ARE WRITTEN FOR THE LINK COMPONENT**
- Might need to adjust some links with these checks in place

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!