### PR TITLE
v0.19.0 deprecated config-version: 1

### DIFF
--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-19-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-19-0.md
@@ -20,6 +20,10 @@ Please be aware of the following changes in v0.19.0:
 
 See the docs below for more details. We don't expect these to require action in most projects.
 
+#### Deprecations
+
+Removed support for `config-version: 1` of dbt_project.yml, which was deprecated in v0.17.0. Use `config-version: 2` in all projects and installed packages. Otherwise, dbt will raise an error. See docs on [config-version](config-version) and the [v0.17.0 Migration Guide](upgrading-to-0-17-0) for details.
+
 ### For dbt plugin maintainers
 
 (You know who you are!)

--- a/website/docs/reference/project-configs/config-version.md
+++ b/website/docs/reference/project-configs/config-version.md
@@ -20,4 +20,4 @@ Specify your `dbt_project.yml` as using the v2 structure.
 </Changelog>
 
 ## Default
-Without this configuration, dbt will assume your `dbt_project.yml` uses the version 1 syntax, which will be deprecated in a future release.
+Without this configuration, dbt will assume your `dbt_project.yml` uses the version 1 syntax, which was deprecated in dbt v0.19.0.


### PR DESCRIPTION
This was mentioned in the [discourse post](https://discourse.getdbt.com/t/release-v0-19-0-kiyoshi-kuromiya/1951/2), but missing from the [release notes](https://github.com/fishtown-analytics/dbt/releases/tag/v0.19.0) and [migration guide](https://docs.getdbt.com/docs/guides/migration-guide/upgrading-to-0-19-0/). That's on me. I've now updated both.