### PR TITLE
Add footnote to meta-fields in snapshots.md

### DIFF
--- a/website/docs/docs/building-a-dbt-project/snapshots.md
+++ b/website/docs/docs/building-a-dbt-project/snapshots.md
@@ -321,7 +321,7 @@ Basically – keep your query as simple as possible! Some reasonable exceptions 
 
 ## Snapshot meta-fields
 
-Snapshot tables will be created as a clone of your source dataset, plus some additional meta-fields.
+Snapshot tables will be created as a clone of your source dataset, plus some additional meta-fields*.
 
 | Field          | Meaning | Usage |
 | -------------- | ------- | ----- |
@@ -330,7 +330,7 @@ Snapshot tables will be created as a clone of your source dataset, plus some add
 | dbt_scd_id     | A unique key generated for each snapshotted record. | This is used internally by dbt |
 | dbt_updated_at | The updated_at timestamp of the source record when this snapshot row was inserted. | This is used internally by dbt |
 
-The timestamps used for each column are subtly different depending on the strategy you use:
+*The timestamps used for each column are subtly different depending on the strategy you use:
 
 For the `timestamp` strategy, the configured `updated_at` column is used to populate the `dbt_valid_from`, `dbt_valid_to` and `dbt_updated_at` columns.
 


### PR DESCRIPTION
## Description & motivation
Added a `*` to the one-line description under the **Snapshot meta-fields section** to make sure people see the note below the table about the timestamps being different depending on the strategy. Added because I initially didn't see the note and thought the documentation was incorrect. Let me know if there's a preferred way (like a footnote<sup>1</sup>) to draw attention to something like this.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
