### PR TITLE
adding changelog notes for dbt Cloud 1.1.19 release

### DIFF
--- a/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
@@ -4,6 +4,30 @@ id: "cloud-changelog"
 sidebar_label: Changelog
 description: "Changelog for the dbt Cloud application"
 ---
+## dbt Cloud v1.1.19 (February 3, 2021)
+
+TODO - Add release summary and curate below notes
+
+#### Enhancements
+
+- add dbt 0.19.0
+- Allow service tokens to create connections
+- Add integration for service token UI and API
+- Authorize requests that supply a service token
+
+#### Fixed
+
+- Add logic to show the entered service token name prior to the request completing
+- Fixed endlessly running rpc queries with non working cancel button on ide refresh
+
+#### Internal
+
+- Add filters to scribe verification script
+- Set dd_agent_host host for run and develop pods.
+- Reduce dbt version constraint to use codex
+- Generate service tokens
+- Add API endpoints for service tokens
+
 ## dbt Cloud v1.1.18 (January 20, 2021)
 
 Most notable things here are around foundational work toward future feature releases, as well as strong assurances of future stability for dbt Cloud, and ensuring future sales tax compliance (which we understand turns out to be quite important!) - turns out to be a quite future-looking release!

--- a/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
@@ -6,27 +6,27 @@ description: "Changelog for the dbt Cloud application"
 ---
 ## dbt Cloud v1.1.19 (February 3, 2021)
 
-TODO - Add release summary and curate below notes
+The latest release of dbt (Oh Nineteen Oh) is now available for your enjoyment on dbt Cloud! We're also releasing some service token pieces here, though they're not quite ready for wide release yet. Moving forward, Oh Nineteen Oh will probably end up being the minimum version required to run the Metadata API & Metadata Toolkit, so, this is a big release! 
 
 #### Enhancements
 
-- add dbt 0.19.0
-- Allow service tokens to create connections
-- Add integration for service token UI and API
-- Authorize requests that supply a service token
+- Added dbt 0.19.0 :heart_eyes_cat:
+- Allowed account-wide service tokens to create connections
+- Added integration for service token UI and API
+- Authorized requests that supply a service token
 
 #### Fixed
 
-- Add logic to show the entered service token name prior to the request completing
-- Fixed endlessly running rpc queries with non working cancel button on ide refresh
+- Added logic to show the entered service token name prior to the request completing
+- Fixed endlessly running rpc queries with non-working cancel button on IDE refresh
 
 #### Internal
 
-- Add filters to scribe verification script
+- Added filters to Scribe verification script
 - Set dd_agent_host host for run and develop pods.
-- Reduce dbt version constraint to use codex
-- Generate service tokens
-- Add API endpoints for service tokens
+- Adjusted dbt version constraint to use Metadata API
+- Generated service tokens
+- Added API endpoints for service tokens
 
 ## dbt Cloud v1.1.18 (January 20, 2021)
 


### PR DESCRIPTION
## Description & motivation
This PR contains the changelog release notes for the dbt Cloud v1.1.19 release.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

