### PR TITLE
Update Azure devops section to recommend using a service user

### DIFF
--- a/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-import-a-project-by-git-url.md
+++ b/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-import-a-project-by-git-url.md
@@ -65,7 +65,7 @@ You're all set! Once support handles your request, your project is set up and yo
 
 ### Azure DevOps
 
-To add a deploy key to an Azure DevOps account, navigate to the "SSH public keys" page in the User Settings of your Azure DevOps account.
+To add a deploy key to an Azure DevOps account, navigate to the "SSH public keys" page in the User Settings of your user's Azure DevOps account or a service user's account. If possible, we recommend using a service user to migrate concerns of a user leaving. 
 
 <Lightbox src="/img/docs/dbt-cloud/cloud-configuring-dbt-cloud/52bfdaa-Screen_Shot_2020-03-09_at_4.13.20_PM.png" title="Navigate to the 'SSH public keys' settings page" />
 

--- a/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-import-a-project-by-git-url.md
+++ b/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-import-a-project-by-git-url.md
@@ -65,7 +65,7 @@ You're all set! Once support handles your request, your project is set up and yo
 
 ### Azure DevOps
 
-To add a deploy key to an Azure DevOps account, navigate to the "SSH public keys" page in the User Settings of your user's Azure DevOps account or a service user's account. If possible, we recommend using a service user to mitigate issues like a user leaving the company. 
+To add a deploy key to an Azure DevOps account, navigate to the "SSH public keys" page in the User Settings of your user's Azure DevOps account or a service user's account. We recommend using a dedicated service user for the integration to ensure that dbt Cloud's connection to Azure DevOps is not interrupted by changes to user permissions.
 
 <Lightbox src="/img/docs/dbt-cloud/cloud-configuring-dbt-cloud/52bfdaa-Screen_Shot_2020-03-09_at_4.13.20_PM.png" title="Navigate to the 'SSH public keys' settings page" />
 

--- a/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-import-a-project-by-git-url.md
+++ b/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-import-a-project-by-git-url.md
@@ -65,7 +65,7 @@ You're all set! Once support handles your request, your project is set up and yo
 
 ### Azure DevOps
 
-To add a deploy key to an Azure DevOps account, navigate to the "SSH public keys" page in the User Settings of your user's Azure DevOps account or a service user's account. If possible, we recommend using a service user to migrate concerns of a user leaving. 
+To add a deploy key to an Azure DevOps account, navigate to the "SSH public keys" page in the User Settings of your user's Azure DevOps account or a service user's account. If possible, we recommend using a service user to mitigate issues like a user leaving the company. 
 
 <Lightbox src="/img/docs/dbt-cloud/cloud-configuring-dbt-cloud/52bfdaa-Screen_Shot_2020-03-09_at_4.13.20_PM.png" title="Navigate to the 'SSH public keys' settings page" />
 


### PR DESCRIPTION
## Description & motivation
I've had a few clients who didn't realize that they should use a service user to associate the SSH key to. This caused unnecessary headaches where they had to backtrack or they lost connection because the user left. 

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

