### PR TITLE
Replace links to Jinja & Agate docs

### DIFF
--- a/website/docs/docs/building-a-dbt-project/jinja-macros.md
+++ b/website/docs/docs/building-a-dbt-project/jinja-macros.md
@@ -4,12 +4,12 @@ id: "jinja-macros"
 ---
 
 ## Related reference docs
-* [Jinja Template Designer Documentation](https://jinja.palletsprojects.com/en/2.11.x/templates/) (external link)
+* [Jinja Template Designer Documentation](https://jinja.palletsprojects.com/page/templates/) (external link)
 * [dbt Jinja context](dbt-jinja-functions)
 * [Macro properties](macro-properties)
 
 ## Overview
-In dbt, you can combine SQL with [Jinja](https://jinja.palletsprojects.com/en/2.10.x/), a templating language.
+In dbt, you can combine SQL with [Jinja](https://jinja.palletsprojects.com), a templating language.
 
 Using Jinja turns your dbt project into a programming environment for SQL, giving you the ability to do things that aren't normally possible in SQL. For example, with Jinja you can:
 * Use control structures (e.g. `if` statements and `for` loops) in SQL

--- a/website/docs/faqs/jinja-whitespace.md
+++ b/website/docs/faqs/jinja-whitespace.md
@@ -3,6 +3,6 @@ title: My compiled SQL has a lot of spaces and new lines, how can I get rid of i
 ---
 This is known as "whitespace control".
 
-Use a minus sign (`-`, e.g. `{{- ... -}}`, `{%- ... %}`, `{#- ... -#}`) at the start or end of a block to strip whitespace before or after the block (more docs [here](https://jinja.palletsprojects.com/en/2.10.x/templates/#whitespace-control)). Check out the [tutorial on using Jinja](using-jinja#use-whitespace-control-to-tidy-up-compiled-code) for an example.
+Use a minus sign (`-`, e.g. `{{- ... -}}`, `{%- ... %}`, `{#- ... -#}`) at the start or end of a block to strip whitespace before or after the block (more docs [here](https://jinja.palletsprojects.com/page/templates/#whitespace-control)). Check out the [tutorial on using Jinja](using-jinja#use-whitespace-control-to-tidy-up-compiled-code) for an example.
 
 Take caution: it's easy to fall down a rabbit hole when it comes to whitespace control!

--- a/website/docs/faqs/which-jinja-docs.md
+++ b/website/docs/faqs/which-jinja-docs.md
@@ -4,6 +4,6 @@ title: Which docs should I use when writing Jinja or creating a macro?
 
 If you are stuck with a Jinja issue, it can get confusing where to check for more information. We recommend you check (in order):
 
-1. [Jinja's Template Designer Docs](https://jinja.palletsprojects.com/en/2.11.x/templates/): This is the best reference for most of the Jinja you'll use
+1. [Jinja's Template Designer Docs](https://jinja.palletsprojects.com/page/templates/): This is the best reference for most of the Jinja you'll use
 2. [Our Jinja function reference](dbt-jinja-functions): This documents any additional functionality we've added to Jinja in dbt.
-3. [Agate's table docs](https://agate.readthedocs.io/en/1.1.0/api/table.html): If you're operating on the result of a query, dbt will pass it back to you as an agate table. This means that the methods you call on the table belong to the Agate library rather than Jinja or dbt.
+3. [Agate's table docs](https://agate.readthedocs.io/page/api/table.html): If you're operating on the result of a query, dbt will pass it back to you as an agate table. This means that the methods you call on the table belong to the Agate library rather than Jinja or dbt.

--- a/website/docs/reference/dbt-jinja-functions.md
+++ b/website/docs/reference/dbt-jinja-functions.md
@@ -2,7 +2,7 @@
 title: "dbt Jinja Functions"
 ---
 
-In addition to the standard Jinja library ([docs](https://jinja.palletsprojects.com/en/2.11.x/templates/)), we've added additional functions and variables to the Jinja context that are useful when working with a dbt project:
+In addition to the standard Jinja library ([docs](https://jinja.palletsprojects.com/page/templates/)), we've added additional functions and variables to the Jinja context that are useful when working with a dbt project:
 * [adapter](adapter)
 * [as_bool](as_bool)
 * [as_native](as_native)

--- a/website/docs/reference/dbt-jinja-functions/run_query.md
+++ b/website/docs/reference/dbt-jinja-functions/run_query.md
@@ -8,7 +8,7 @@ The `run_query` macro provides a convenient way to run queries and fetch their r
 __Args__:
  * `sql`: The SQL query to execute
 
-Returns a [Table](https://agate.readthedocs.io/en/1.3.1/api/table.html) object with the result of the query. If the specified query does not return results (eg. a DDL, DML, or maintenance query), then the return value will be `none`.
+Returns a [Table](https://agate.readthedocs.io/page/api/table.html) object with the result of the query. If the specified query does not return results (eg. a DDL, DML, or maintenance query), then the return value will be `none`.
 
 **Note:** The `run_query` macro will not begin a transaction automatically - if you wish to run your query inside of a transaction, please use `begin` and `commit ` statements as appropriate.
 

--- a/website/docs/reference/dbt-jinja-functions/statement-blocks.md
+++ b/website/docs/reference/dbt-jinja-functions/statement-blocks.md
@@ -31,7 +31,7 @@ __Args__:
 Once the statement block has executed, the result set is accessible via the `load_result` function. The result object includes three keys:
 - `response`: Structured object containing metadata returned from the database, which varies by adapter. E.g. success `code`, number of `rows_affected`, total `bytes_processed`, etc. Comparable to `adapter_response` in the [Result object](dbt-classes#result-objects).
 - `data`: Pythonic representation of data returned by query (arrays, tuples, dictionaries).
-- `table`: [Agate](https://agate.readthedocs.io/en/1.1.0/api/table.html) table representation of data returned by query.
+- `table`: [Agate](https://agate.readthedocs.io/page/api/table.html) table representation of data returned by query.
 
 <Changelog>
 

--- a/website/docs/tutorial/using-jinja.md
+++ b/website/docs/tutorial/using-jinja.md
@@ -128,7 +128,7 @@ group by 1
 
 </File>
 
-We can use [whitespace control](https://jinja.palletsprojects.com/en/2.10.x/templates/#whitespace-control) to tidy up our code:
+We can use [whitespace control](https://jinja.palletsprojects.com/page/templates/#whitespace-control) to tidy up our code:
 
 <File name='models/order_payment_method_amounts.sql'>
 

--- a/website/docs/tutorial/using-jinja.md
+++ b/website/docs/tutorial/using-jinja.md
@@ -236,7 +236,7 @@ The command line gives us back the following:
 | -------------- | --------- |
 | payment_method | Text      |
 ```
-This is actually an [Agate table](https://agate.readthedocs.io/en/1.1.0/api/table.html). To get the payment methods back as a list, we need to do some further transformation.
+This is actually an [Agate table](https://agate.readthedocs.io/page/api/table.html). To get the payment methods back as a list, we need to do some further transformation.
 
 ```sql
 {% macro get_payment_methods() %}


### PR DESCRIPTION
## Description & motivation
Change all links to Jinja and Agate docs to permanently link to the latest version. This means something like https://jinja.palletsprojects.com/page/templates/ instead of https://jinja.palletsprojects.com/en/2.11.x/templates/. Updated so we don't have to keep changing it as they release new versions.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!