### PR TITLE
add additional provider PR URL templates

### DIFF
--- a/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-configuring-repositories.md
+++ b/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-configuring-repositories.md
@@ -69,3 +69,13 @@ https://gitlab.com/<org>/<repo>/-/merge_requests/new?merge_request[source_branch
 ```
 https://bitbucket.org/<org>/<repo>/pull-requests/new?source={{source}}
 ```
+
+### AWS CodeCommit
+```
+https://console.aws.amazon.com/codesuite/codecommit/repositories/<repo>/pull-requests/new/refs/heads/{{destination}}/.../refs/heads/{{source}}
+```
+
+### Azure DevOps
+```
+https://dev.azure.com/<org>/<repo>/_git/dbt/pullrequestcreate?sourceRef={{source}}&targetRef={{destination}}
+```


### PR DESCRIPTION
## Description & motivation

I've added in examples of what PR URL templates should look like if a user is using AWS CodeCommit or Azure DevOps. I've had customers reach out with this question specifically.


## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
