### PR TITLE
Use 'develop' branch for dbt repo links

### DIFF
--- a/website/docs/docs/contributing/building-a-new-adapter.md
+++ b/website/docs/docs/contributing/building-a-new-adapter.md
@@ -15,7 +15,7 @@ This guide will walk you through the first two steps, and provide some resources
 
 ## Scaffolding a new adapter
 
-dbt comes equipped with a script which will automate a lot of the legwork in building a new adapter. This script will generate a standard folder structure, set up the various import dependencies and references, and create namespace packages so the plugin can interact with dbt. You can find this script in the dbt repo in dbt's [scripts/](https://github.com/fishtown-analytics/dbt/blob/releases/0.19.0/core/scripts/create_adapter_plugins.py) directory.
+dbt comes equipped with a script which will automate a lot of the legwork in building a new adapter. This script will generate a standard folder structure, set up the various import dependencies and references, and create namespace packages so the plugin can interact with dbt. You can find this script in the dbt repo in dbt's [scripts/](https://github.com/fishtown-analytics/dbt/blob/develop/core/scripts/create_adapter_plugins.py) directory.
 
 Example usage:
 
@@ -239,18 +239,18 @@ dbt implements specific SQL operations using jinja macros. While reasonable defa
 
 ### Required macros
 
-The following macros must be implemented, but you can override their behavior for your adapter using the "adapter macro" pattern described below. Macros marked (required) do not have a valid default implementation, and are required for dbt to operate.
+The following macros must be implemented, but you can override their behavior for your adapter using the "dispatch" pattern described below. Macros marked (required) do not have a valid default implementation, and are required for dbt to operate.
 
-- `alter_column_type` ([source](https://github.com/fishtown-analytics/dbt/blob/65090678562597b933bbebafbf02bb98375d0166/core/dbt/include/global_project/macros/adapters/common.sql#L170))
-- `check_schema_exists` ([source](https://github.com/fishtown-analytics/dbt/blob/65090678562597b933bbebafbf02bb98375d0166/core/dbt/include/global_project/macros/adapters/common.sql#L254))
-- `create_schema` ([source](https://github.com/fishtown-analytics/dbt/blob/65090678562597b933bbebafbf02bb98375d0166/core/dbt/include/global_project/macros/adapters/common.sql#L51))
-- `drop_relation` ([source](https://github.com/fishtown-analytics/dbt/blob/65090678562597b933bbebafbf02bb98375d0166/core/dbt/include/global_project/macros/adapters/common.sql#L194))
-- `drop_schema` ([source](https://github.com/fishtown-analytics/dbt/blob/65090678562597b933bbebafbf02bb98375d0166/core/dbt/include/global_project/macros/adapters/common.sql#L61))
-- `get_columns_in_relation` ([source](https://github.com/fishtown-analytics/dbt/blob/65090678562597b933bbebafbf02bb98375d0166/core/dbt/include/global_project/macros/adapters/common.sql#L125)) (required)
-- `list_relations_without_caching` ([source](https://github.com/fishtown-analytics/dbt/blob/65090678562597b933bbebafbf02bb98375d0166/core/dbt/include/global_project/macros/adapters/common.sql#L270)) (required)
-- `list_schemas` ([source](https://github.com/fishtown-analytics/dbt/blob/65090678562597b933bbebafbf02bb98375d0166/core/dbt/include/global_project/macros/adapters/common.sql#L240))
-- `rename_relation` ([source](https://github.com/fishtown-analytics/dbt/blob/65090678562597b933bbebafbf02bb98375d0166/core/dbt/include/global_project/macros/adapters/common.sql#L215))
-- `truncate_relation` ([source](https://github.com/fishtown-analytics/dbt/blob/65090678562597b933bbebafbf02bb98375d0166/core/dbt/include/global_project/macros/adapters/common.sql#L205))
+- `alter_column_type` ([source](https://github.com/fishtown-analytics/dbt/blob/develop/core/dbt/include/global_project/macros/adapters/common.sql#140))
+- `check_schema_exists` ([source](https://github.com/fishtown-analytics/dbt/blob/develop/core/dbt/include/global_project/macros/adapters/common.sql#224))
+- `create_schema` ([source](https://github.com/fishtown-analytics/dbt/blob/develop/core/dbt/include/global_project/macros/adapters/common.sql#L21))
+- `drop_relation` ([source](https://github.com/fishtown-analytics/dbt/blob/develop/core/dbt/include/global_project/macros/adapters/common.sql#L164))
+- `drop_schema` ([source](https://github.com/fishtown-analytics/dbt/blob/develop/core/dbt/include/global_project/macros/adapters/common.sql#L31))
+- `get_columns_in_relation` ([source](https://github.com/fishtown-analytics/dbt/blob/develop/core/dbt/include/global_project/macros/adapters/common.sql#L95)) (required)
+- `list_relations_without_caching` ([source](https://github.com/fishtown-analytics/dbt/blob/develop/core/dbt/include/global_project/macros/adapters/common.sql#L240)) (required)
+- `list_schemas` ([source](https://github.com/fishtown-analytics/dbt/blob/develop/core/dbt/include/global_project/macros/adapters/common.sql#L210))
+- `rename_relation` ([source](https://github.com/fishtown-analytics/dbt/blob/develop/core/dbt/include/global_project/macros/adapters/common.sql#L185))
+- `truncate_relation` ([source](https://github.com/fishtown-analytics/dbt/blob/develop/core/dbt/include/global_project/macros/adapters/common.sql#L175))
 
 ### Adapter dispatch
 

--- a/website/docs/docs/guides/debugging-schema-names.md
+++ b/website/docs/docs/guides/debugging-schema-names.md
@@ -16,9 +16,7 @@ You can also follow along via this video:
 Do a file search to check if you have a macro named `generate_schema_name` in the `macros` directory of your project.
 
 #### I do not have a macro named `generate_schema_name` in my project
-This means that you are using dbt's default implementation of the macro, as defined [here](https://github.com/fishtown-analytics/dbt/blob/dev/kiyoshi-kuromiya/core/dbt/include/global_project/macros/etc/get_custom_schema.sql#L17-L30)
-
-<!--- CC note: this link is going to keep going out of date --->
+This means that you are using dbt's default implementation of the macro, as defined [here](https://github.com/fishtown-analytics/dbt/blob/develop/core/dbt/include/global_project/macros/etc/get_custom_schema.sql#L17-L30)
 
 ```sql
 {% macro generate_schema_name(custom_schema_name, node) -%}
@@ -46,7 +44,7 @@ If your `generate_schema_name` macro looks like so:
     {{ generate_schema_name_for_env(custom_schema_name, node) }}
 {%- endmacro %}
 ```
-Your project is switching out the `generate_schema_name` macro for another macro, `generate_schema_name_for_env`. Similar to the above example, this is a macro which is defined in dbt's global project, [here](https://github.com/fishtown-analytics/dbt/blob/dev/kiyoshi-kuromiya/core/dbt/include/global_project/macros/etc/get_custom_schema.sql#L43-L56).
+Your project is switching out the `generate_schema_name` macro for another macro, `generate_schema_name_for_env`. Similar to the above example, this is a macro which is defined in dbt's global project, [here](https://github.com/fishtown-analytics/dbt/blob/develop/core/dbt/include/global_project/macros/etc/get_custom_schema.sql#L43-L56).
 
 ```sql
 {% macro generate_schema_name_for_env(custom_schema_name, node) -%}

--- a/website/docs/reference/dbt-jinja-functions/log.md
+++ b/website/docs/reference/dbt-jinja-functions/log.md
@@ -10,7 +10,7 @@ __Args__:
 
 Logs a line to either the log file or stdout.
 
-([Source on Github](https://github.com/fishtown-analytics/dbt/blob/development/dbt/context/common.py#L151))
+([Source on Github](https://github.com/fishtown-analytics/dbt/blob/develop/core/dbt/context/base.py#L432))
 
 ```sql
 

--- a/website/docs/reference/profiles.yml.md
+++ b/website/docs/reference/profiles.yml.md
@@ -106,7 +106,7 @@ config:
 
 We want to build the best version of dbt possible, and a crucial part of that is understanding how users work with dbt. To this end, we've added some simple event tracking to dbt (using Snowplow). We do not track credentials, model contents or model names (we consider these private, and frankly none of our business).
 
-Usage statistics are fired when dbt is invoked and when models are run. These events contain basic platform information (OS + python version). The schemas for these events can be seen [here](https://github.com/fishtown-analytics/dbt/tree/development/events/schemas/com.fishtownanalytics)
+Usage statistics are fired when dbt is invoked and when models are run. These events contain basic platform information (OS + python version). You can see all the event definitions in  [`tracking.py`](https://github.com/fishtown-analytics/dbt/blob/develop/core/dbt/tracking.py).
 
 By default this is turned on – you can opt out of event tracking at any time by adding the following to your `profiles.yml` file:
 ```yaml

--- a/website/docs/reference/resource-configs/full_refresh.md
+++ b/website/docs/reference/resource-configs/full_refresh.md
@@ -67,7 +67,7 @@ Optionally set a resource to always or never full-refresh.
 `full_refresh` config will take precedence over the presence or absence of the `--full-refresh` flag.
 - If the `full_refresh` config is `none` or omitted, the resource will use the value of the `--full-refresh` flag.
 
-This logic is encoded in the [`should_full_refresh()`](https://github.com/fishtown-analytics/dbt/blob/dev/marian-anderson/core/dbt/include/global_project/macros/materializations/helpers.sql#L68) macro.
+This logic is encoded in the [`should_full_refresh()`](https://github.com/fishtown-analytics/dbt/blob/develop/core/dbt/include/global_project/macros/materializations/helpers.sql#L68) macro.
 
 ## Usage
 

--- a/website/docs/reference/resource-configs/strategy.md
+++ b/website/docs/reference/resource-configs/strategy.md
@@ -131,8 +131,8 @@ This is a **required configuration**. There is no default value.
 
 ### Advanced: define and use custom snapshot strategy
 Behind the scenes, snapshot strategies are implemented as macros, named `snapshot_<strategy>_strategy`
-* [Source code](https://github.com/fishtown-analytics/dbt/blob/dev/octavius-catto/core/dbt/include/global_project/macros/materializations/snapshot/strategies.sql#L66) for the timestamp strategy
-* [Source code](https://github.com/fishtown-analytics/dbt/blob/dev/octavius-catto/core/dbt/include/global_project/macros/materializations/snapshot/strategies.sql#L122) for the check strategy
+* [Source code](https://github.com/fishtown-analytics/dbt/blob/develop/core/dbt/include/global_project/macros/materializations/snapshot/strategies.sql#L66) for the timestamp strategy
+* [Source code](https://github.com/fishtown-analytics/dbt/blob/develop/core/dbt/include/global_project/macros/materializations/snapshot/strategies.sql#L133) for the check strategy
 
 It's possible to implement your own snapshot strategy by adding a macro with the same naming pattern to your project. For example, you might choose to create a strategy which records hard deletes, named `timestamp_with_deletes`.
 

--- a/website/docs/reference/resource-properties/freshness.md
+++ b/website/docs/reference/resource-properties/freshness.md
@@ -160,7 +160,7 @@ where {{ filter }}
 {% endif %}
 ```
 
-_[Source code](https://github.com/fishtown-analytics/dbt/blob/dev/octavius-catto/core/dbt/include/global_project/macros/adapters/common.sql#L294)_
+_[Source code](https://github.com/fishtown-analytics/dbt/blob/develop/core/dbt/include/global_project/macros/adapters/common.sql#L262)_
 
 </TabItem>
 


### PR DESCRIPTION
## Description & motivation

We're trying a new branch management strategy in the dbt repo that includes a long-lived `develop` branch, which will persist beyond specific minor versions.

This PR updates all dbt repo links to `develop` branch and, as necessary, the linked line. Of course, there is a good chance that code in the `develop` branch will change, and the relevant line will move around. I'd rather folks be linked to the wrong line than be looking at outdated code. Barring significant refactoring work, the linked function or macro should still be searchable in the same file.