### PR TITLE
Rearrange docs navbar; add dropdown for Learn and Community

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -4,45 +4,45 @@ const path = require('path');
 /* Debugging */
 var SITE_URL;
 if (!process.env.CONTEXT || process.env.CONTEXT == 'production') {
-    SITE_URL = 'https://docs.getdbt.com';
+  SITE_URL = 'https://docs.getdbt.com';
 } else {
-    SITE_URL = process.env.DEPLOY_URL;
+  SITE_URL = process.env.DEPLOY_URL;
 }
 
 var GIT_BRANCH;
 if (!process.env.CONTEXT || process.env.CONTEXT == 'production') {
-    GIT_BRANCH = 'current';
+  GIT_BRANCH = 'current';
 } else {
-    GIT_BRANCH = process.env.HEAD;
+  GIT_BRANCH = process.env.HEAD;
 }
 
 var PRERELEASE = (process.env.PRERELEASE || false);
 
 var WARNING_BANNER;
 if (!PRERELEASE) {
-    WARNING_BANNER = {};
+  WARNING_BANNER = {};
 } else {
-    WARNING_BANNER = {
-        id: 'prerelease', // Any value that will identify this message.
-        content:
-          'CAUTION: Prerelease! This documentation reflects the next minor version of dbt. <a href="https://docs.getdbt.com">View current docs</a>.',
-        backgroundColor: '#ffa376', // Defaults to `#fff`.
-        textColor: '#033744', // Defaults to `#000`.
-    }
+  WARNING_BANNER = {
+    id: 'prerelease', // Any value that will identify this message.
+    content:
+      'CAUTION: Prerelease! This documentation reflects the next minor version of dbt. <a href="https://docs.getdbt.com">View current docs</a>.',
+    backgroundColor: '#ffa376', // Defaults to `#fff`.
+    textColor: '#033744', // Defaults to `#000`.
+  }
 }
 
 var ALGOLIA_API_KEY;
 if (!process.env.ALGOLIA_API_KEY) {
-    ALGOLIA_API_KEY = '0e9665cbb272719dddc6e7113b4131a5';
+  ALGOLIA_API_KEY = '0e9665cbb272719dddc6e7113b4131a5';
 } else {
-    ALGOLIA_API_KEY = process.env.ALGOLIA_API_KEY;
+  ALGOLIA_API_KEY = process.env.ALGOLIA_API_KEY;
 }
 
 var ALGOLIA_INDEX_NAME;
 if (!process.env.ALGOLIA_INDEX_NAME) {
-    ALGOLIA_INDEX_NAME = 'dbt';
+  ALGOLIA_INDEX_NAME = 'dbt';
 } else {
-    ALGOLIA_INDEX_NAME = process.env.ALGOLIA_INDEX_NAME;
+  ALGOLIA_INDEX_NAME = process.env.ALGOLIA_INDEX_NAME;
 }
 
 console.log("DEBUG: CONTEXT =", process.env.CONTEXT);
@@ -76,21 +76,21 @@ module.exports = {
 
     prism: {
       theme: (() => {
-          var theme = require('prism-react-renderer/themes/nightOwl');
-          // Add additional rule to nightowl theme in order to change
-          // the color of YAML keys (to be different than values).
-          // There weren't many Prism themes that differentiated
-          // YAML keys and values. See link:
-          // https://github.com/FormidableLabs/prism-react-renderer/tree/master/src/themes
-          theme.styles.push({
-              types: ["atrule"],
-              style: {
-                  // color chosen from the nightowl theme palette
-                  // https://github.com/FormidableLabs/prism-react-renderer/blob/master/src/themes/nightOwl.js#L83
-                  color: "rgb(255, 203, 139)"
-              }
-          });
-          return theme
+        var theme = require('prism-react-renderer/themes/nightOwl');
+        // Add additional rule to nightowl theme in order to change
+        // the color of YAML keys (to be different than values).
+        // There weren't many Prism themes that differentiated
+        // YAML keys and values. See link:
+        // https://github.com/FormidableLabs/prism-react-renderer/tree/master/src/themes
+        theme.styles.push({
+          types: ["atrule"],
+          style: {
+            // color chosen from the nightowl theme palette
+            // https://github.com/FormidableLabs/prism-react-renderer/blob/master/src/themes/nightOwl.js#L83
+            color: "rgb(255, 203, 139)"
+          }
+        });
+        return theme
       })(),
       additionalLanguages: ['bash'],
     },
@@ -135,11 +135,11 @@ module.exports = {
           position: 'right',
           items: [
             {
-              label: 'Tutorial',
+              label: 'Getting Started Tutorial',
               to: '/tutorial/setting-up/',
             },
             {
-              label: 'On Demand',
+              label: 'Online Courses',
               href: 'https://courses.getdbt.com',
             },
             {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -125,26 +125,46 @@ module.exports = {
           activeBasePath: 'docs/dbt-cloud'
         },
         {
-          to: '/tutorial/setting-up',
-          label: 'Tutorial',
-          position: 'left',
-          activeBasePath: 'tutorial'
-        },
-        {
           to: '/faqs/all',
           label: 'FAQs',
           position: 'left',
           activeBasePath: 'faqs'
         },
         {
-          href: 'https://blog.getdbt.com',
-          label: 'Blog',
+          label: 'Learn',
           position: 'right',
+          items: [
+            {
+              label: 'Tutorial',
+              to: '/tutorial/setting-up/',
+            },
+            {
+              label: 'On Demand',
+              href: 'https://courses.getdbt.com',
+            },
+            {
+              label: 'Live Courses',
+              href: 'https://learn.getdbt.com/public',
+            }
+          ],
         },
         {
-          href: 'https://github.com/fishtown-analytics/dbt',
-          label: 'GitHub',
+          label: 'Community',
           position: 'right',
+          items: [
+            {
+              label: 'dbt Slack',
+              href: 'https://community.getdbt.com/',
+            },
+            {
+              label: 'Blog',
+              href: 'https://blog.getdbt.com',
+            },
+            {
+              label: 'GitHub',
+              href: 'https://github.com/fishtown-analytics/dbt',
+            },
+          ]
         },
       ],
     },


### PR DESCRIPTION
## Description & motivation
Per [this Notion card](https://www.notion.so/fishtownanalytics/Research-Create-dropdown-menu-for-docs-navbar-f2b5c25bad4f4b5b952e73b08b3291b8), we would like to rearrange and simplify the primary navbar by consolidating "Learn" and "Community"-type links into two nav dropdowns.

## To-do before merge
Need input from @clrcrl on final verbiage.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
