### PR TITLE
Fix/Update commands to include docs for dbt cloud

### DIFF
--- a/website/docs/reference/dbt-commands.md
+++ b/website/docs/reference/dbt-commands.md
@@ -21,7 +21,7 @@ For information about selecting models on the command line, consult the docs on 
 - [snapshot](snapshot): executes "snapshot" jobs defined in a project
 - [clean](clean): deletes artifacts present in the dbt project
 - [seed](seed): loads CSV files into the database
-- [docs](cmd-docs) (CLI only): generates documentation for a project
+- [docs](cmd-docs) : generates documentation for a project
 - [source](commands/source): provides tools for working with source data (including validating that sources are "fresh")
 - [run-operation](run-operation): runs arbitrary maintenance SQL against the database
 - [rpc](rpc) (CLI only): runs an RPC server that clients can submit queries to


### PR DESCRIPTION
## Description & motivation
We can generate docs on the IDE. 

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

