### PR TITLE
Minor edit to 1-setting-up.md for correct user credentials to run BQ jobs

### DIFF
--- a/website/docs/tutorial/1-setting-up.md
+++ b/website/docs/tutorial/1-setting-up.md
@@ -104,7 +104,7 @@ In order to let dbt connect to your warehouse, you'll need generate a keyfile. T
     * **Which API are you using?** BigQuery API
     * **Are you planning to use this API with App Engine or Compute Engine?** No
     * **Service account name:** `dbt-user`
-    * **Role:** BigQuery Job User
+    * **Role:** BigQuery Job User & BigQuery User
     * **Key type:** JSON
 3. Download the JSON file and save it in an easy-to-remember spot, with a clear filename (e.g. `dbt-user-creds.json`)
 

--- a/website/docs/tutorial/1-setting-up.md
+++ b/website/docs/tutorial/1-setting-up.md
@@ -102,6 +102,7 @@ In order to let dbt connect to your warehouse, you'll need generate a keyfile. T
 1. Go to the [BigQuery credential wizard](https://console.cloud.google.com/apis/credentials/wizard). Ensure that your new project is selected in the header bar.
 2. Generate credentials with the following options:
     * **Which API are you using?** BigQuery API
+    * **What data will you be accessing?** Application data (you'll be creating a service account)
     * **Are you planning to use this API with App Engine or Compute Engine?** No
     * **Service account name:** `dbt-user`
     * **Role:** BigQuery Job User & BigQuery User

--- a/website/docs/tutorial/1-setting-up.md
+++ b/website/docs/tutorial/1-setting-up.md
@@ -104,7 +104,7 @@ In order to let dbt connect to your warehouse, you'll need generate a keyfile. T
     * **Which API are you using?** BigQuery API
     * **Are you planning to use this API with App Engine or Compute Engine?** No
     * **Service account name:** `dbt-user`
-    * **Role:** BigQuery User
+    * **Role:** BigQuery Job User
     * **Key type:** JSON
 3. Download the JSON file and save it in an easy-to-remember spot, with a clear filename (e.g. `dbt-user-creds.json`)
 


### PR DESCRIPTION
Minor edit for the type of BQ role that is needed for the connection. I wasn't able to have a working connection with only `BigQuery User` credentials and changed to `BigQuery Job User` + `BigQuery User` instead and it worked fine.

## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a pull request on dbt core, etc?
-->

## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged
-->

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
