### PR TITLE
Remove trailing slashes from some hard-coded links to match canonical URLs

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -136,7 +136,7 @@ module.exports = {
           items: [
             {
               label: 'Getting Started Tutorial',
-              to: '/tutorial/setting-up/',
+              to: '/tutorial/setting-up',
             },
             {
               label: 'Online Courses',

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -144,7 +144,7 @@ function Home() {
                     <div className="card__footer">
                         <Link
                           className="button button--primary"
-                          to={useBaseUrl('/faqs/all/')}>
+                          to={useBaseUrl('/faqs/all')}>
                           Get Answers
                         </Link>
                     </div>
@@ -170,7 +170,7 @@ function Home() {
                     <div className="card__footer">
                         <Link
                           className="button button--primary"
-                          to="/docs/dbt-cloud/cloud-overview/">
+                          to="/docs/dbt-cloud/cloud-overview">
                           Cloud Overview
                         </Link>
                     </div>
@@ -189,7 +189,7 @@ function Home() {
                     <div className="card__footer">
                         <Link
                           className="button button--primary"
-                          to={useBaseUrl('/dbt-cloud/api/')}>
+                          to={useBaseUrl('/dbt-cloud/api')}>
                           API docs
                         </Link>
                     </div>
@@ -256,7 +256,7 @@ function Home() {
                     <div className="card__footer">
                         <Link
                           className="button button--primary"
-                          to={useBaseUrl('/faqs/example-projects/')}>
+                          to={useBaseUrl('/faqs/example-projects')}>
                           View Projects
                         </Link>
                     </div>


### PR DESCRIPTION
## Description & motivation
This PR is an alternative (and better!) solution for the problem spelled out in [this Notion card](https://www.notion.so/fishtownanalytics/Research-Update-canonical-tags-on-docs-getdbt-com-a69bd4cd99854e869045abe640868eaa), which I had previously attempted to fix with PR #566.

Rather than add a trailing slash to all &lt;link rel="canonical"&gt; tags, this solution a) turns off link prettifying in Netlify (already pending; will go into production the next time we merge a PR and clear cache) and b) changes some hard-coded links that were written with a trailing slash to now be written WITHOUT a trailing slash. This PR includes removing the trailing slash from any hard-coded links in /website/src/pages/index.js and in docusaurus.config.js. 

It's possible we missed some links that still have trailing slashes added, but this should at least handle any URLs on the homepage and in the nav. 

tl;dr: Netlify's link prettification functionality conflicted with what Docusaurus was doing with the canonical URLs, so we turned it off; this PR is just bringing any hard-coded links in line with the canonical URL spelled out on the page. 


## To-do before merge
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] (Actually after merge) Redeploy production with cache clear


## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes
- [x] No
- [ ] Unsure
