### PR TITLE
Static insert_overwrite: partitions must match partition_by.data_type

### DIFF
--- a/website/docs/reference/resource-configs/bigquery-configs.md
+++ b/website/docs/reference/resource-configs/bigquery-configs.md
@@ -443,14 +443,14 @@ will reduce costs by eliminating multiple queries in the model build script.
 
 #### Static partitions
 
-To supply a static list of partitions to overwrite, use the `partitions` configuration:
+To supply a static list of partitions to overwrite, use the `partitions` configuration.
 
 <File name="models/session.sql">
 
 ```sql
 {% set partitions_to_replace = [
-  'current_date',
-  'date_sub(current_date, interval 1 day)'
+  'timestamp(current_date)',
+  'timestamp(date_sub(current_date, interval 1 day))'
 ] %}
 
 {{
@@ -481,6 +481,12 @@ with events as (
 This example model serves to replace the data in the destination table for both
 _today_ and _yesterday_ every day that it is run. It is the fastest and cheapest
 way to incrementally update a table using dbt.
+
+<Changelog>
+  - v0.19.0: With the advent of truncated timestamp partitions in BigQuery, `timestamp`-type partitions are now treated as timestamps instead of dates for the purposes of filtering. Update `partitions_to_replace` accordingly.
+</Changelog>
+
+Think of this as "full control" mode. You must ensure that expressions or literal values in the the `partitions` config have proper quoting when templated, and that they match the `partition_by.data_type` (`timestamp`, `datetime`, `date`, or `int64`). Otherwise, the filter in the incremental `merge` statement will raise an error.
 
 #### Dynamic partitions
 


### PR DESCRIPTION
Motivated by [this Slack thread](https://getdbt.slack.com/archives/C2JRRQDTL/p1614074541079900).

Now that BigQuery supports `partition by timestamp_trunc(...)`, dbt no longer wraps all `timestamp`-type partition columns in `date()`. (This is necessary to support hour-partitioned models.) Where previously users would always produce `date`-type `partitions` to filter on, `partitions` expressions must now return the same data type as `partition_by.data_type`.

IMO this makes _more_ sense than before, it's just a subtle detail that's easy to slip under the radar. The "static" `insert_overwrite` incremental strategy is also "full control" mode, where the user is expected to be thoughtful about what _exactly_ is being overwritten, because it promises to save the most $$$.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!