### PR TITLE
Adjustment for unique test for two columns.

### DIFF
--- a/website/docs/faqs/uniqueness-two-columns.md
+++ b/website/docs/faqs/uniqueness-two-columns.md
@@ -61,7 +61,7 @@ models:
   - name: orders
     tests:
       - unique:
-          column_name: "country_code || '-' || order_id"
+          column_name: "(country_code || '-' || order_id)"
 ```
 
 </File>


### PR DESCRIPTION
## Description & motivation
The example provided generates the following line when compiled into the test:

```sql
 where country_code || '-' || order_id is not null
```

In Redshift (and possibly others), the `order_id is not null` gets evaluated first, and then the line errors out as it tries to concatenate a bool with text.  Adding parens solves this.