### PR TITLE
Update 2b-create-a-project-dbt-cli.md

### DIFF
--- a/website/docs/tutorial/2b-create-a-project-dbt-cli.md
+++ b/website/docs/tutorial/2b-create-a-project-dbt-cli.md
@@ -134,6 +134,7 @@ We need to commit our changes so that our repository has up-to-date code.
 1. Link the GitHub repository you created to your dbt project by running the following commands. Make sure you use the correct git URL for your repository.
 ```shell-session
 $ git init
+$ git branch -M main
 $ git add .
 $ git commit -m "Create a dbt project"
 $ git remote add origin https://github.com/USERNAME/dbt-tutorial.git


### PR DESCRIPTION
`git init` still defaults to creating a `master` branch unless the user has previously run `git config --global init.defaultBranch main`; renaming the `master` branch to `main` is required, otherwise the `git push` will fail
