### PR TITLE
Add dbt-materialize adapter docs

### DIFF
--- a/website/docs/docs/available-adapters.md
+++ b/website/docs/docs/available-adapters.md
@@ -21,6 +21,14 @@ In addition to maintaining `dbt-core`, [Fishtown Analytics](https://github.com/f
 
 Adapters distributed with "core" are ready to use when you [install dbt](dbt-cli/installation). For "plugin" adapters, check each page for specific installation instructions.
 
+### Vendor Supported
+
+These adapter plugins are built and maintained by the same people who build and maintain the complementary data technology.
+
+| Adapter for  | Documentation |
+| ------------ | ------------- |
+| Materialize ([dbt-materialize](https://github.com/MaterializeInc/materialize/blob/main/misc/dbt-materialize))  | [Profile Setup](materialize-profile) |
+
 ### Community Supported
 
 These adapter plugins are contributed and maintained by members of the community 🌱

--- a/website/docs/reference/warehouse-profiles/materialize-profile.md
+++ b/website/docs/reference/warehouse-profiles/materialize-profile.md
@@ -20,7 +20,7 @@ The easiest way to install is to use pip:
 
 ## Connecting to Materialize with **dbt-materialize**
 
-The dbt profile for Materialize is nearly identical to the [profile configuration for Postgres](profile-postgres):
+The dbt profile for Materialize is nearly identical to the [profile configuration for Postgres](postgres-profile):
 
 <File name='profiles.yml'>
 

--- a/website/docs/reference/warehouse-profiles/materialize-profile.md
+++ b/website/docs/reference/warehouse-profiles/materialize-profile.md
@@ -51,12 +51,11 @@ view | YES | Creates a [view](https://materialize.com/docs/sql/create-view/#main
 materializedview | YES | Creates a [materialized view](https://materialize.com/docs/sql/create-materialized-view/#main).
 table | YES | Creates a [materialized view](https://materialize.com/docs/sql/create-materialized-view/#main). (Actual table support pending [#5266](https://github.com/MaterializeInc/materialize/issues/5266))
 ephemeral | YES | Executes queries using CTEs.
-incremental | NO | Use the `materializedview` materialization instead! dbt's incremental models are valuable because they only spend your time and money transforming your new data as it arrives. Luckily, this is exactly what Materialize's materialized views were built to do! Better yet, materialized views will always return up-to-date results without manual or configured refreshes. For more information, check out [Materialize documentation](https://materialize.com/docs/).
+incremental | NO | Use the `materializedview` materialization instead. Materialized views will always return up-to-date results without manual or configured refreshes. For more information, check out [Materialize documentation](https://materialize.com/docs/).
 
 ### Seeds
 
-[`dbt seed`](https://docs.getdbt.com/reference/commands/seed/) will create a static materialized
-view from a CSV file. You will not be able to add to or update this view after it has been created. If you want to rerun `dbt seed`, you must first drop existing views manually with `drop view`.
+Running [`dbt seed`](commands/seed) will create a static materialized view from a CSV file. You will not be able to add to or update this view after it has been created. If you want to rerun `dbt seed`, you must first drop existing views manually with `drop view`.
 
 ## Resources
 

--- a/website/docs/reference/warehouse-profiles/materialize-profile.md
+++ b/website/docs/reference/warehouse-profiles/materialize-profile.md
@@ -4,7 +4,7 @@ title: "Materialize Profile"
 
 :::info Vendor-supported plugin
 
-Certain core functionality may vary. If would like to report a bug, request a feature, or contribute, you can check out the linked repository and open an issue.
+Certain core functionality may vary. If you would like to report a bug, request a feature, or contribute, you can check out the linked repository and open an issue.
 
 :::
 

--- a/website/docs/reference/warehouse-profiles/materialize-profile.md
+++ b/website/docs/reference/warehouse-profiles/materialize-profile.md
@@ -1,10 +1,10 @@
 ---
-title: "ClickHouse Profile"
+title: "Materialize Profile"
 ---
 
 :::info Vendor-supported plugin
 
-Certain core functionality may vary. If would like to report a bug, request a feature, or contribute, you can see the source code and open an issue in the repository below.
+Certain core functionality may vary. If would like to report a bug, request a feature, or contribute, you can check out the linked repository and open an issue.
 
 :::
 
@@ -51,14 +51,14 @@ view | YES | Creates a [view](https://materialize.com/docs/sql/create-view/#main
 materializedview | YES | Creates a [materialized view](https://materialize.com/docs/sql/create-materialized-view/#main).
 table | YES | Creates a [materialized view](https://materialize.com/docs/sql/create-materialized-view/#main). (Actual table support pending [#5266](https://github.com/MaterializeInc/materialize/issues/5266))
 ephemeral | YES | Executes queries using CTEs.
-incremental | NO | Use the `materializedview` materialization instead! dbt's incremental models are valuable because they only spend your time and money transforming your new data as it arrives. Luckily, this is exactly what Materialize's materialized views were built to do! Better yet, our materialized views will always return up-to-date results without manual or configured refreshes. For more information, check out [our documentation](https://materialize.com/docs/).
+incremental | NO | Use the `materializedview` materialization instead! dbt's incremental models are valuable because they only spend your time and money transforming your new data as it arrives. Luckily, this is exactly what Materialize's materialized views were built to do! Better yet, materialized views will always return up-to-date results without manual or configured refreshes. For more information, check out [Materialize documentation](https://materialize.com/docs/).
 
 ### Seeds
 
 [`dbt seed`](https://docs.getdbt.com/reference/commands/seed/) will create a static materialized
-view from a CSV file. You will not be able to add to or update this view after it has been created.
+view from a CSV file. You will not be able to add to or update this view after it has been created. If you want to rerun `dbt seed`, you must first drop existing views manually with `drop view`.
 
 ## Resources
 
-- [Interactive demo](https://github.com/MaterializeInc/materialize/blob/main/play/wikirecent-dbt/README.md) using dbt and Materialize together
+- [Get started](https://github.com/MaterializeInc/materialize/blob/main/play/wikirecent-dbt/README.md) using dbt and Materialize together
 - [Materialize docs about dbt](https://materialize.com/docs/third-party/dbt/)

--- a/website/docs/reference/warehouse-profiles/materialize-profile.md
+++ b/website/docs/reference/warehouse-profiles/materialize-profile.md
@@ -1,0 +1,64 @@
+---
+title: "ClickHouse Profile"
+---
+
+:::info Vendor-supported plugin
+
+Certain core functionality may vary. If would like to report a bug, request a feature, or contribute, you can see the source code and open an issue in the repository below.
+
+:::
+
+## Overview of dbt-materialize
+
+**Maintained by:** Materialize, Inc.      
+**Source:** https://github.com/MaterializeInc/materialize/blob/main/misc/dbt-materialize    
+**Core version:** v0.18.1 and newer    
+
+The easiest way to install is to use pip:
+
+    pip install dbt-materialize
+
+## Connecting to Materialize with **dbt-materialize**
+
+The dbt profile for Materialize is nearly identical to the [profile configuration for Postgres](profile-postgres):
+
+<File name='profiles.yml'>
+
+```yaml
+dbt-materialize:
+  target: dev
+  outputs:
+    dev:
+      type: materialize
+      threads: 1
+      host: [host]
+      port: [port]
+      user: [user]
+      pass: [password]
+      dbname: [database]
+      schema: [name of your dbt schema]
+```
+
+</File>
+
+## Supported Features
+
+### Materializations
+
+Type | Supported? | Details
+-----|------------|----------------
+view | YES | Creates a [view](https://materialize.com/docs/sql/create-view/#main).
+materializedview | YES | Creates a [materialized view](https://materialize.com/docs/sql/create-materialized-view/#main).
+table | YES | Creates a [materialized view](https://materialize.com/docs/sql/create-materialized-view/#main). (Actual table support pending [#5266](https://github.com/MaterializeInc/materialize/issues/5266))
+ephemeral | YES | Executes queries using CTEs.
+incremental | NO | Use the `materializedview` materialization instead! dbt's incremental models are valuable because they only spend your time and money transforming your new data as it arrives. Luckily, this is exactly what Materialize's materialized views were built to do! Better yet, our materialized views will always return up-to-date results without manual or configured refreshes. For more information, check out [our documentation](https://materialize.com/docs/).
+
+### Seeds
+
+[`dbt seed`](https://docs.getdbt.com/reference/commands/seed/) will create a static materialized
+view from a CSV file. You will not be able to add to or update this view after it has been created.
+
+## Resources
+
+- [Interactive demo](https://github.com/MaterializeInc/materialize/blob/main/play/wikirecent-dbt/README.md) using dbt and Materialize together
+- [Materialize docs about dbt](https://materialize.com/docs/third-party/dbt/)

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -441,6 +441,7 @@ module.exports = {
         "reference/warehouse-profiles/azuresynapse-profile",
         "reference/warehouse-profiles/dremio-profile",
         "reference/warehouse-profiles/clickhouse-profile",
+        "reference/warehouse-profiles/materialize-profile",
       ],
     },
     {


### PR DESCRIPTION
cc @JLDLaughlin

## Description & motivation
- Add docs for [`dbt-materialize`](https://github.com/MaterializeInc/materialize/blob/main/misc/dbt-materialize/README.md) adapter. I copy-pasted the notes about Materializations and Seeds, which are wonderful; let me know if you feel strongly about excluding these here, and linking out to the other docs instead, so as to avoid stagnation.
- Add `dbt-materialize` to list of Available Adapters under a new "Vendor Supported" section. Open to feedback on the language here.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist
If you added new pages (delete if not applicable):
- [x] The page has been added to `website/sidebars.js`
- [x] The new page has a unique filename