### PR TITLE
Add 'openid' scope to gcloud command

### DIFF
--- a/website/docs/reference/warehouse-profiles/bigquery-profile.md
+++ b/website/docs/reference/warehouse-profiles/bigquery-profile.md
@@ -314,10 +314,8 @@ To connect to BigQuery using the `oauth` method, follow these steps:
 
 ```shell
 gcloud auth application-default login \
-  --scopes=https://www.googleapis.com/auth/userinfo.email,\
-https://www.googleapis.com/auth/cloud-platform,\
-https://www.googleapis.com/auth/drive.readonly,\
-openid
+  --scopes=https://www.googleapis.com/auth/bigquery,\
+https://www.googleapis.com/auth/drive.readonly
 ```
 
 A browser window should open, and you should be promoted to log into your Google account. Once you've done that, dbt will use your oauth'd credentials to connect to BigQuery!

--- a/website/docs/reference/warehouse-profiles/bigquery-profile.md
+++ b/website/docs/reference/warehouse-profiles/bigquery-profile.md
@@ -316,7 +316,8 @@ To connect to BigQuery using the `oauth` method, follow these steps:
 gcloud auth application-default login \
   --scopes=https://www.googleapis.com/auth/userinfo.email,\
 https://www.googleapis.com/auth/cloud-platform,\
-https://www.googleapis.com/auth/drive.readonly
+https://www.googleapis.com/auth/drive.readonly,\
+openid
 ```
 
 A browser window should open, and you should be promoted to log into your Google account. Once you've done that, dbt will use your oauth'd credentials to connect to BigQuery!


### PR DESCRIPTION
When I run with the `gcloud auth` command as shown, I get this error:

```
ERROR: gcloud crashed (Warning): Scope has changed from "https://www.googleapis.com/auth/drive.readonly https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/accounts.reauth" to "https://www.googleapis.com/auth/accounts.reauth https://www.googleapis.com/auth/cloud-platform openid https://www.googleapis.com/auth/drive.readonly https://www.googleapis.com/auth/userinfo.email".
```

This error message shows that the `openid` scope needs to be added.  After adding this scope, the error message goes away.

See https://github.com/fishtown-analytics/dbt/issues/3040 for more context.