### PR TITLE
Update using-custom-schemas.md

### DIFF
--- a/website/docs/docs/building-a-dbt-project/building-models/using-custom-schemas.md
+++ b/website/docs/docs/building-a-dbt-project/building-models/using-custom-schemas.md
@@ -114,6 +114,8 @@ If you want to use this pattern, you'll need a `generate_schema_name` macro in y
 
 </File>
 
+**Note:** When using this macro, you'll need to set the target name in your job specifically to "prod" if you want custom schemas to be applied.
+
 ## generate_schema_name arguments
 
 | Argument | Description | Example |


### PR DESCRIPTION
## Description & motivation
I just wanted to add a note here regarding the custom schema macro because I had customer struggling with this. If you want custom schemas to be applied in a job when using the macro, you must set the target name to "prod".

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [X] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
