### PR TITLE
Update installation.md

### DIFF
--- a/website/docs/dbt-cli/installation.md
+++ b/website/docs/dbt-cli/installation.md
@@ -107,7 +107,7 @@ These operating systems require additional pre-installation setup. After running
 sudo apt-get install git libpq-dev python-dev python3-pip
 sudo apt-get remove python-cffi
 sudo pip install --upgrade cffi
-pip install cryptography==1.7.2
+pip install cryptography~=3.4
 ```
 
 #### CentOS


### PR DESCRIPTION
The cryptography library recommended here for Debian is 2 major releases behind.
Python 2 support was deprecated in cryptography [v3.4](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#34---2021-02-07)

## Description & motivation
Helps others that use "Additional steps by operating system" to use current dependencies
