### PR TITLE
Fix a typo in the Jinja documentation

### DIFF
--- a/website/docs/docs/building-a-dbt-project/jinja-macros.md
+++ b/website/docs/docs/building-a-dbt-project/jinja-macros.md
@@ -43,7 +43,7 @@ Here's an example of a dbt model that leverages Jinja:
 select
     order_id,
     {% for payment_method in payment_methods %}
-    sum(case when payment_method = '{{payment_method}}' then amount end) as {{payment_method}}_amount,
+    sum(case when payment_method = {{payment_method}} then amount end) as {{payment_method}}_amount,
     {% endfor %}
     sum(amount) as total_amount
 from app_data.payments


### PR DESCRIPTION
Update case statement in an example to remove ' from the jinja example because it's incorrect per how dbt operates and actually generates an error

## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a pull request on dbt core, etc?
-->

## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged
-->

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist
If you added new pages (delete if not applicable):
- [ ] The page has been added to `website/sidebars.js`
- [ ] The new page has a unique filename

If you removed existing pages (delete if not applicable):
- [ ] The page has been removed from `website/sidebars.js`
- [ ] An entry has been added to `_redirects`
