### PR TITLE
Use password key rather than pass

### DIFF
--- a/website/docs/dbt-cli/configure-your-profile.md
+++ b/website/docs/dbt-cli/configure-your-profile.md
@@ -34,7 +34,7 @@ jaffle_shop:
       type: postgres
       host: localhost
       user: alice
-      pass: <password>
+      password: <password>
       port: 5432
       dbname: jaffle_shop
       schema: dbt_alice

--- a/website/docs/docs/guides/building-packages.md
+++ b/website/docs/docs/guides/building-packages.md
@@ -87,7 +87,7 @@ mailchimp:
       type: xxx
       host: xxx
       user: xxx
-      pass: xxx
+      password: xxx
       port: xxx
       dbname: xxx
       schema: package_mailchimp # call this whatever makes sense for you

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-17-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-17-0.md
@@ -142,9 +142,9 @@ string-oriented inputs, like environment variables or command line variables.
 :::danger Heads up
 
   In dbt v0.17.1, native rendering is not enabled by default. It is possible to
-  natively render specific values using the [`as_bool`](as_bool), 
+  natively render specific values using the [`as_bool`](as_bool),
   [`as_number`](as_number), and [`as_native`](as_native) filters.
-  
+
   The examples below have been updated to reflect 0.17.1 functionality.
 
 :::
@@ -160,7 +160,7 @@ debug:
     dev:
       type: postgres
       user: "{{ env_var('DBT_USER') }}"
-      pass: "{{ env_var('DBT_PASS') }}"
+      password: "{{ env_var('DBT_PASS') }}"
       host: "{{ env_var('DBT_HOST') }}"
 
       # The port number will be coerced from a string to an integer

--- a/website/docs/reference/dbt-jinja-functions/env_var.md
+++ b/website/docs/reference/dbt-jinja-functions/env_var.md
@@ -18,7 +18,7 @@ profile:
       host: 127.0.0.1
       # IMPORTANT: Make sure to quote the entire Jinja string here
       user: "{{ env_var('DBT_USER') }}"
-      pass: "{{ env_var('DBT_PASSWORD') }}"
+      password: "{{ env_var('DBT_PASSWORD') }}"
       ....
 ```
 

--- a/website/docs/reference/dbt-jinja-functions/profiles-yml-context.md
+++ b/website/docs/reference/dbt-jinja-functions/profiles-yml-context.md
@@ -22,7 +22,7 @@ jaffle_shop:
       type: redshift
       host: "{{ env_var('DBT_HOST') }}"
       user: "{{ env_var('DBT_USER') }}"
-      pass: "{{ env_var('DBT_PASS') }}"
+      password: "{{ env_var('DBT_PASS') }}"
       port: 5439
       dbname: analytics
       schema: dbt_dbanin

--- a/website/docs/reference/warehouse-profiles/exasol-profile.md
+++ b/website/docs/reference/warehouse-profiles/exasol-profile.md
@@ -9,10 +9,10 @@ Some core functionality may be limited. If you're interested in contributing, ch
 :::
 
 ## Overview of dbt-exasol
-**Maintained by:** Community      
-**Author:** Torsten Glunde, Ilija Kutle    
-**Source:** https://github.com/tglunde/dbt-exasol    
-**Core version:** v0.14.0 and newer    
+**Maintained by:** Community
+**Author:** Torsten Glunde, Ilija Kutle
+**Source:** https://github.com/tglunde/dbt-exasol
+**Core version:** v0.14.0 and newer
 
 ![dbt-exasol stars](https://img.shields.io/github/stars/tglunde/dbt-exasol?style=for-the-badge)
 
@@ -38,7 +38,7 @@ dbt-exasol:
       threads: 1
       dsn: HOST:PORT
       user: USERNAME
-      pass: PASSWORD
+      password: PASSWORD
       dbname: db
       schema: SCHEMA
 ```

--- a/website/docs/reference/warehouse-profiles/oracle-profile.md
+++ b/website/docs/reference/warehouse-profiles/oracle-profile.md
@@ -9,10 +9,10 @@ Some core functionality may be limited. If you're interested in contributing, ch
 :::
 
 ## Overview of dbt-oracle
-**Maintained by:** Community      
-**Author:** Vitor Avancini    
-**Source:** https://github.com/techindicium/dbt-oracle    
-**Core version:** v0.16.0 and newer     
+**Maintained by:** Community
+**Author:** Vitor Avancini
+**Source:** https://github.com/techindicium/dbt-oracle
+**Core version:** v0.16.0 and newer
 
 ![dbt-oracle stars](https://img.shields.io/github/stars/techindicium/dbt-oracle?style=for-the-badge)
 
@@ -22,7 +22,7 @@ Easiest install is to use pip:
 
 You will need Oracle client driver installed. Check this [link](https://cx-oracle.readthedocs.io/en/latest/user_guide/installation.html) for the installation guide for your operating system
 
-### Connecting to Oracle with **dbt-oracle** 
+### Connecting to Oracle with **dbt-oracle**
 
 #### User / password authentication
 
@@ -39,7 +39,7 @@ dbt_oracle:
          type: oracle
          host: localhost
          user: system
-         pass: oracle
+         password: oracle
          port: 1521
          dbname: [dbname]
          schema: [schema]

--- a/website/docs/reference/warehouse-profiles/postgres-profile.md
+++ b/website/docs/reference/warehouse-profiles/postgres-profile.md
@@ -16,7 +16,7 @@ company-name:
       type: postgres
       host: [hostname]
       user: [username]
-      pass: [password]
+      password: [password]
       port: [port]
       dbname: [database name]
       schema: [dbt schema]

--- a/website/docs/reference/warehouse-profiles/redshift-profile.md
+++ b/website/docs/reference/warehouse-profiles/redshift-profile.md
@@ -16,7 +16,7 @@ company-name:
       type: redshift
       host: hostname.region.redshift.amazonaws.com
       user: username
-      pass: password1
+      password: password1
       port: 5439
       dbname: analytics
       schema: analytics


### PR DESCRIPTION
## Description & motivation
I believe that `password` is the more accepted key here (`pass` acts as an alias for password for _some_ adapters)

- [postgres alias for pass to password](https://github.com/fishtown-analytics/dbt/blob/develop/plugins/postgres/dbt/adapters/postgres/connections.py#L29)
- [Redshift only has password, not pass, but I believe that it inherits pass from the PostgresCredentials class](https://github.com/fishtown-analytics/dbt/blob/develop/plugins/redshift/dbt/adapters/redshift/connections.py#L41)
- [Snowflake does not allow pass, as far as I can tell](https://github.com/fishtown-analytics/dbt/blob/develop/plugins/snowflake/dbt/adapters/snowflake/connections.py#L35)


I'd prefer to document the more accepted key!


## Pre-release docs
Is this change related to an unreleased version of dbt?
- [x] No: please ensure the base branch is `current`


## To check
- Should we update the [exasol](https://docs.getdbt.com/reference/warehouse-profiles/exasol-profile) and [oracle](https://docs.getdbt.com/reference/warehouse-profiles/oracle-profile) profiles?
    - [exasol aliases pass to password](https://github.com/tglunde/dbt-exasol/blob/master/dbt/adapters/exasol/connections.py#L35)
    - [as does exasol](https://github.com/techindicium/dbt-oracle/blob/develop/dbt/adapters/oracle/connections.py#L29)


☝️ going up update those now