### PR TITLE
adding changelog notes for dbt cloud v1.1.22

### DIFF
--- a/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
@@ -6,13 +6,13 @@ description: "Changelog for the dbt Cloud application"
 ---
 ## dbt Cloud v1.1.22 (March 17, 2021)
 
-TODO - enter release summary and curate below release notes
+Rolling out a few long-term bets to ensure that our beloved dbt Cloud does not fall over for want of memory, as well as a grip of bug fixes and error messaging improvements (error messages should be helpful, not scolding or baffling, after all!)
 
 #### Enhancements
 
-- Release scribe to 100% of multi-tenant accounts
-- Updates language for sql drawer empty state
-- Reduce scribe memory usage
+- Release Scribe to 100% of multi-tenant accounts
+- Update language for SQL drawer empty state
+- Reduce Scribe memory usage
 
 #### Fixed
 
@@ -20,17 +20,17 @@ TODO - enter release summary and curate below release notes
 - Guarantee unique notification settings per account, user, and type
 - Fix for account notification settings
 - Dont show deleted projects on notifications page
-- Unicode error while decoding last_chunk
-- Show relevant errors to users and not raise RuntimeExceptions
-- Groups should be editable by non-sudo requests
-- Allow lowercase domain names in
-- Redirect auth failed errors back to enterprise-login page with error description
+- Fix unicode error while decoding last_chunk
+- Show more relevant errors to customers
+- Groups are now editable by non-sudo requests
+- Normalize domain names across inputs/outputs
+- Redirect auth failed errors back to appropriate page with error description
 
 #### Internal
 
-- Reducing scribe memory request in prod
-- Don't clobber run logs across all our dev envs
-- Refactor license_type -> strenum
+- Reducing Scribe memory request in production
+- Don't clobber run logs across all dev environments
+- Refactor license_type
 
 ## dbt Cloud v1.1.21 (March 3, 2021)
 

--- a/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
@@ -4,6 +4,34 @@ id: "cloud-changelog"
 sidebar_label: Changelog
 description: "Changelog for the dbt Cloud application"
 ---
+## dbt Cloud v1.1.22 (March 17, 2021)
+
+TODO - enter release summary and curate below release notes
+
+#### Enhancements
+
+- Release scribe to 100% of multi-tenant accounts
+- Updates language for sql drawer empty state
+- Reduce scribe memory usage
+
+#### Fixed
+
+- Fix NoSuchKey error
+- Guarantee unique notification settings per account, user, and type
+- Fix for account notification settings
+- Dont show deleted projects on notifications page
+- Unicode error while decoding last_chunk
+- Show relevant errors to users and not raise RuntimeExceptions
+- Groups should be editable by non-sudo requests
+- Allow lowercase domain names in
+- Redirect auth failed errors back to enterprise-login page with error description
+
+#### Internal
+
+- Reducing scribe memory request in prod
+- Don't clobber run logs across all our dev envs
+- Refactor license_type -> strenum
+
 ## dbt Cloud v1.1.21 (March 3, 2021)
 
 This changelog wraps up work on what we've been calling the SQL Drawer in the IDE - some design nudges, some interface adjustments, overall a cleaner and snappier experience. If you haven't dipped into the IDE in a while it's worth taking a look! Some back-end work as well, making SSO and role based admin easier and more broadly available for Enterprise level folks, along with your usual assortment of bug squashes and iterations. 


### PR DESCRIPTION
## Description & motivation
This PR contains the changelog notes for dbt Cloud v1.1.22.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
