### PR TITLE
Add dependencies and steps for Debian install

### DIFF
--- a/website/docs/dbt-cli/installation.md
+++ b/website/docs/dbt-cli/installation.md
@@ -104,9 +104,10 @@ These operating systems require additional pre-installation setup. After running
 
 #### Ubuntu/Debian
 ```shell
-sudo apt-get install git libpq-dev python-dev python3-pip
+sudo apt-get install git libpq-dev python-dev python3-pip python3-dev libicu-dev
 sudo apt-get remove python-cffi
 sudo pip install --upgrade cffi
+pip install --upgrade pip PyICU
 pip install cryptography~=3.4
 ```
 


### PR DESCRIPTION
## Description & motivation
Encountered runtime ICU error when trying to install dbt on a clean Debian 10 VM - modified installation instructions.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ ] No: please ensure the base branch is `current`
- [x] Unsure: we'll let you know!