### PR TITLE
Mark dbt clean as CLI only

### DIFF
--- a/website/docs/reference/dbt-commands.md
+++ b/website/docs/reference/dbt-commands.md
@@ -19,7 +19,7 @@ For information about selecting models on the command line, consult the docs on 
 - [test](commands/test): executes tests defined in a project
 - [deps](deps): downloads dependencies for a project
 - [snapshot](snapshot): executes "snapshot" jobs defined in a project
-- [clean](clean): deletes artifacts present in the dbt project
+- [clean](clean) (CLI only): deletes artifacts present in the dbt project
 - [seed](seed): loads CSV files into the database
 - [docs](cmd-docs) : generates documentation for a project
 - [source](commands/source): provides tools for working with source data (including validating that sources are "fresh")


### PR DESCRIPTION
## Description & motivation

Our docs do not indicate that `dbt clean` is CLI only, implying that it will work on the RPC server and thus in dbt Cloud.
However, `clean` is not a supported method in the RPC server, so you get an error when running it via dbt Cloud.

![Screenshot](https://user-images.githubusercontent.com/6146772/113004922-fe488780-9141-11eb-879d-5bfa0dc9a436.png)

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist

_No applicable sections here._
