### PR TITLE
adding Account Viewier permission set

### DIFF
--- a/website/docs/docs/dbt-cloud/access-control/enterprise-permissions.md
+++ b/website/docs/docs/dbt-cloud/access-control/enterprise-permissions.md
@@ -46,21 +46,16 @@ Account Admins have unrestricted access to dbt Cloud accounts. Users with Accoun
 - **License restrictions:** must have a developer license
 
 Account Viewers have read only access to dbt Cloud accounts. Users with Account Viewer permissions can: 
-- View account settings
-- View authentication providers
-- View Billing information
-- View Database Connections
-- View Database Credentials
-- View Environment configurations
-- View Groups
-- View Invitations for New Users
-- View Jobs
-- View License assignments
-- View Memboers
-- View permission sets applied to projects (taking a guess here)
-- View Projects
+- View all projects in an account
+- View Account Settings
 - View Repositories
-- View Historical Job runs
+- View Connections
+- View Environments
+- View Jobs
+- View Groups
+- View Group Memberships
+- View notification settings
+- View account-level artifacts
 
 ### Admin
 - **Has permissions on:** Authorized projects

--- a/website/docs/docs/dbt-cloud/access-control/enterprise-permissions.md
+++ b/website/docs/docs/dbt-cloud/access-control/enterprise-permissions.md
@@ -41,6 +41,27 @@ Account Admins have unrestricted access to dbt Cloud accounts. Users with Accoun
 - Use the IDE
 - Run and cancel jobs
 
+### Account Viewer
+- **Has permissions on:** Authorized projects, account-level settings
+- **License restrictions:** must have a developer license
+
+Account Viewers have read only access to dbt Cloud accounts. Users with Account Viewer permissions can: 
+- View account settings
+- View authentication providers
+- View Billing information
+- View Database Connections
+- View Database Credentials
+- View Environment configurations
+- View Groups
+- View Invitations for New Users
+- View Jobs
+- View License assignments
+- View Memboers
+- View permission sets applied to projects (taking a guess here)
+- View Projects
+- View Repositories
+- View Historical Job runs
+
 ### Admin
 - **Has permissions on:** Authorized projects
 - **License restrictions:** must have a developer license


### PR DESCRIPTION
Adding the Account Viewer permission set in our enterprise documentation. @drewbanin I have a couple of things to confirm: 

1 -  question on the `permissions_read` from your list. I have that described as "View permission sets applied to projects" - any better way to describe this?
2 - This permission set is for use with Developer licenses only, correct?