### PR TITLE
Update bigquery-profile.md

### DIFF
--- a/website/docs/reference/warehouse-profiles/bigquery-profile.md
+++ b/website/docs/reference/warehouse-profiles/bigquery-profile.md
@@ -315,7 +315,8 @@ To connect to BigQuery using the `oauth` method, follow these steps:
 ```shell
 gcloud auth application-default login \
   --scopes=https://www.googleapis.com/auth/bigquery,\
-https://www.googleapis.com/auth/drive.readonly
+https://www.googleapis.com/auth/drive.readonly, \
+https://www.googleapis.com/auth/iam.test
 ```
 
 A browser window should open, and you should be promoted to log into your Google account. Once you've done that, dbt will use your oauth'd credentials to connect to BigQuery!

--- a/website/docs/reference/warehouse-profiles/bigquery-profile.md
+++ b/website/docs/reference/warehouse-profiles/bigquery-profile.md
@@ -315,7 +315,7 @@ To connect to BigQuery using the `oauth` method, follow these steps:
 ```shell
 gcloud auth application-default login \
   --scopes=https://www.googleapis.com/auth/bigquery,\
-https://www.googleapis.com/auth/drive.readonly, \
+https://www.googleapis.com/auth/drive.readonly,\
 https://www.googleapis.com/auth/iam.test
 ```
 


### PR DESCRIPTION
Adding https://www.googleapis.com/auth/iam.test scope to gcloud auth application-default login to get rid of the following error
```shell
These credentials will be used by any library that requests Application Default Credentials (ADC).
/Users/sova/google-cloud-sdk/lib/third_party/google/auth/_default.py:69: UserWarning: Your application has authenticated using end user credentials from Google Cloud SDK without a quota project. You might receive a "quota exceeded" or "API not enabled" error. We recommend you rerun `gcloud auth application-default login` and make sure a quota project is added. Or you can use service accounts instead. For more information about service accounts, see https://cloud.google.com/docs/authentication/
  warnings.warn(_CLOUD_SDK_CREDENTIALS_WARNING)
ERROR: (gcloud.auth.application-default.login) User [*********] does not have permission to access projects instance [********:testIamPermissions] (or it may not exist): Request had insufficient authentication scopes
```