### PR TITLE
add Relation.include snippet

### DIFF
--- a/website/docs/reference/dbt-classes.md
+++ b/website/docs/reference/dbt-classes.md
@@ -46,6 +46,9 @@ class Relation:
 -- Return the `identifier` for this relation
 {{ relation.identifier }}
 
+-- Return relation name without the database
+{{ relation.include(database=false) }}
+
 -- Return true if the relation is a table
 {{ relation.is_table }}
 


### PR DESCRIPTION
## Description & motivation

AFAIK, [`BaseRelation.include()`](https://github.com/fishtown-analytics/dbt/blob/749f87397ec1e0a270b2e09bd8dbeb71862fdb81/core/dbt/adapters/base/relation.py#L121-L134) isn't currently documented, but it is very helpful!

I'm not sold on the example I used as the others are quite pithy. But `.include()` has more functionality that's worth addressing IMHO.