### PR TITLE
add note about deploy keys for the same repo

### DIFF
--- a/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-import-a-project-by-git-url.md
+++ b/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-import-a-project-by-git-url.md
@@ -11,6 +11,8 @@ You must use the `git@...` or `ssh:..`. version of your git URL, not the `https:
 ## Managing Deploy Keys
 After importing a project by Git URL, dbt Cloud will generate a Deploy Key for your repository. You must provide this Deploy Key in the Repository configuration of your Git host. This Deploy Key should be be configured to allow *read and write access* to the specified repositories.
 
+**Note**: Each dbt Cloud project will generate a different deploy key when connected to a repo, even if two projects are connected to the same repo. Both deploy keys will need to be supplied to your git provider.
+
 ### GitHub
 
 :::info Use GitHub?


### PR DESCRIPTION
## Description & motivation
In the last day, I had two users confused about the fact that dbt Cloud generates a new deploy key for each connection that's made with a repo, even if the repo is the same for multiple projects. This note clarifies that each projects generates a unique deploy key that will need to be supplied to the git provider.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [X] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
