### PR TITLE
Adding Google site verification

### DIFF
--- a/website/google18df7e5e81c2dcae.html
+++ b/website/google18df7e5e81c2dcae.html
@@ -1,0 +1,1 @@
+google-site-verification: google18df7e5e81c2dcae.html

--- a/website/google18df7e5e81c2dcae.html
+++ b/website/google18df7e5e81c2dcae.html
@@ -1,1 +1,0 @@
-google-site-verification: google18df7e5e81c2dcae.html

--- a/website/src/pages/google18df7e5e81c2dcae.html.js
+++ b/website/src/pages/google18df7e5e81c2dcae.html.js
@@ -1,0 +1,5 @@
+import React from 'react';
+function Page() {
+    return <>google-site-verification: google18df7e5e81c2dcae.html</>
+}
+export default Page;


### PR DESCRIPTION
## Description & motivation
We are trying to add Google Search Console to docs, but first we have to verify that we own the site. This PR adds an HTML file to the root of /website/ that Google will use to verify our site.

(This worked locally, not entirely sure it will work in preview or production, so this PR is still draft).

## Pre-release docs
Is this change related to an unreleased version of dbt?
No
