### PR TITLE
Adds detail to incremental strategy code example

### DIFF
--- a/website/docs/docs/building-a-dbt-project/building-models/configuring-incremental-models.md
+++ b/website/docs/docs/building-a-dbt-project/building-models/configuring-incremental-models.md
@@ -180,6 +180,7 @@ or:
 {{
   config(
     materialized='incremental',
+    unique_key='date_day',
     incremental_strategy='insert_overwrite',
     ...
   )


### PR DESCRIPTION
## Description & motivation
Coming from a call with a prospect - they wanted to explicitly use the `insert_overwrite` strategy which was ignored (..op coalesced to a `merge`) because they were lacking a `unique_key` parameter. I think the code example lends itself to missing this detail.

## To-do before merge
Nada.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [X] No: please ensure the base branch is `current`
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ ] Unsure: we'll let you know!

## Checklist
(Default entries not applicable)