### PR TITLE
Add persist_docs link to policy tags

### DIFF
--- a/website/docs/reference/resource-configs/bigquery-configs.md
+++ b/website/docs/reference/resource-configs/bigquery-configs.md
@@ -345,7 +345,7 @@ models:
 
 </File>
 
-Please note that in order to apply this, [persist_docs](https://docs.getdbt.com/reference/resource-configs/persist_docs) should be enabled on your dbt_project.yml file.
+Please note that in order for policy tags to take effect, [column-level `persist_docs`](https://docs.getdbt.com/reference/resource-configs/persist_docs) must be enabled for the model, seed, or snapshot.
 
 ## Merge behavior (incremental models)
 

--- a/website/docs/reference/resource-configs/bigquery-configs.md
+++ b/website/docs/reference/resource-configs/bigquery-configs.md
@@ -345,6 +345,8 @@ models:
 
 </File>
 
+Please note that in order to apply this, [persist_docs](https://docs.getdbt.com/reference/resource-configs/persist_docs) should be enabled on your dbt_project.yml file.
+
 ## Merge behavior (incremental models)
 
 The [`incremental_strategy` config](configuring-incremental-models#what-is-an-incremental_strategy) controls how dbt builds incremental models. dbt uses a [merge statement](https://cloud.google.com/bigquery/docs/reference/standard-sql/dml-syntax) on BigQuery to refresh incremental tables.


### PR DESCRIPTION
## Description & motivation
I had issues setting up policy tags and was asked to add this link for others to see.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [X] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

