### PR TITLE
Update require-dbt-version.md

### DIFF
--- a/website/docs/reference/project-configs/require-dbt-version.md
+++ b/website/docs/reference/project-configs/require-dbt-version.md
@@ -110,7 +110,7 @@ Runtime Error
 
 To suppress failures to to incompatible dbt versions, supply the `--no-version-check` flag to `dbt run`.
 ```
-$ dbt run --no-version check
+$ dbt run --no-version-check
 Running with dbt=0.17.0
 Found 13 models, 2 tests, 1 archives, 0 analyses, 204 macros, 2 operations....
 ```


### PR DESCRIPTION
Correct name of option used in cli

## Description & motivation

Docs are missing `-` in name of option used in cli, PR is fixing that.

## Pre-release docs

Is this change related to an unreleased version of dbt?
- [x] No: please ensure the base branch is `current`

