### PR TITLE
Updates to `dbt ls`

### DIFF
--- a/website/docs/reference/commands/list.md
+++ b/website/docs/reference/commands/list.md
@@ -10,7 +10,7 @@ The `dbt ls` command lists resources in your dbt project. It accepts selector ar
 ### Usage
 ```
 dbt ls
-     [--resource-type {source,analysis,model,snapshot,test,seed,default,all}]
+     [--resource-type {source,analysis,model,snapshot,test,seed,exposure,default,all}]
      [--select SELECTION_ARG [SELECTION_ARG ...]]
      [--models SELECTOR [SELECTOR ...]]
      [--exclude SELECTOR [SELECTOR ...]]

--- a/website/docs/reference/node-selection/syntax.md
+++ b/website/docs/reference/node-selection/syntax.md
@@ -4,14 +4,14 @@ title: "Syntax overview"
 
 dbt's node selection syntax makes it possible to run only specific resources in a given invocation of dbt. This selection syntax is used for the following subcommands:
 
-| command   | argument(s)                                       |
-| :-------- | ------------------------------------------------- |
-| run       | `--models`, `--exclude`, `--selector`, `--defer`  |
-| test      | `--models`, `--exclude`, `--selector`, `--defer`  |
-| seed      | `--select`, `--exclude`, `--selector`             |
-| snapshot  | `--select`, `--exclude`  `--selector`             |
-| ls (list) | `--select`, `--models`, `--exclude`, `--selector` |
-| compile   | `--select`, `--exclude`, `--selector`             |
+| command   | argument(s)                                                          |
+| :-------- | -------------------------------------------------------------------- |
+| run       | `--models`, `--exclude`, `--selector`, `--defer`                     |
+| test      | `--models`, `--exclude`, `--selector`, `--defer`                     |
+| seed      | `--select`, `--exclude`, `--selector`                                |
+| snapshot  | `--select`, `--exclude`  `--selector`                                |
+| ls (list) | `--select`, `--models`, `--exclude`, `--selector`, `--resource-type` |
+| compile   | `--select`, `--exclude`, `--selector`                                |
 
 :::info Nodes and resources
 


### PR DESCRIPTION
## Description & motivation
Closes #622 

- Adds `--resource-type` to the node selection syntaax page
- Adds `exposure` as a resource type to the dbt ls page

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [X] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
