### PR TITLE
Update Synapse & Sql-Server connections information

### DIFF
--- a/website/docs/reference/warehouse-profiles/azuresynapse-profile.md
+++ b/website/docs/reference/warehouse-profiles/azuresynapse-profile.md
@@ -34,7 +34,7 @@ SQL Server credentials are supported for on-prem as well as cloud, and it is the
 <File name='profiles.yml'>
 
 ```yml
-type: sqlserver
+type: synapse
 driver: 'ODBC Driver 17 for SQL Server' (The ODBC Driver installed on your system)
 server: server-host-name or ip
 port: 1433
@@ -49,6 +49,7 @@ password: password
 
 The following [`pyodbc`-supported ActiveDirectory methods](https://docs.microsoft.com/en-us/sql/connect/odbc/using-azure-active-directory?view=sql-server-ver15#new-andor-modified-dsn-and-connection-string-keywords) are available to authenticate to Azure SQL products:
 - ActiveDirectory Password
+- Azure CLI
 - ActiveDirectory Interactive (*Windows only*)
 - ActiveDirectory Integrated (*Windows only*)
 - Service Principal (a.k.a. AAD Application)
@@ -58,6 +59,7 @@ The following [`pyodbc`-supported ActiveDirectory methods](https://docs.microsof
   defaultValue="integrated"
   values={[
     { label: 'Password', value: 'password'},
+    { label: 'CLI', value: 'cli'},
     { label: 'Interactive', value:'interactive'},
     { label: 'Integrated', value: 'integrated'},
     { label: 'Service Principal', value: 'serviceprincipal'}
@@ -71,7 +73,7 @@ Definitely not ideal, but available
 <File name='profiles.yml'>
 
 ```yml
-type: sqlserver
+type: synapse
 driver: 'ODBC Driver 17 for SQL Server' (The ODBC Driver installed on your system)
 server: server-host-name or ip
 port: 1433
@@ -85,6 +87,30 @@ password: iheartopensource
 
 </TabItem>
 
+<TabItem value="cli">
+
+First, install the [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli), then, log in:
+
+`az login`
+
+<File name='profiles.yml'>
+
+```yml
+type: synapse
+driver: 'ODBC Driver 17 for SQL Server' (The ODBC Driver installed on your system)
+server: server-host-name or ip
+port: 1433
+schema: schemaname
+authentication: CLI
+```
+This is also the preferred route for using a service principal:
+
+`az login --service-principal --username $CLIENTID --password $SECRET --tenant $TENANTID`
+
+</File>
+
+</TabItem>
+
 <TabItem value="interactive">
 
 *Windows Only* brings up the Azure AD prompt so you can MFA if need be.
@@ -92,7 +118,7 @@ password: iheartopensource
 <File name='profiles.yml'>
 
 ```yml
-type: sqlserver
+type: synapse
 driver: 'ODBC Driver 17 for SQL Server' (The ODBC Driver installed on your system)
 server: server-host-name or ip
 port: 1433
@@ -112,7 +138,7 @@ user: bill.gates@microsoft.com
 <File name='profiles.yml'>
 
 ```yml
-type: sqlserver
+type: synapse
 driver: 'ODBC Driver 17 for SQL Server' (The ODBC Driver installed on your system)
 server: server-host-name or ip
 port: 1433
@@ -131,7 +157,7 @@ authentication: ActiveDirectoryIntegrated
 <File name='profiles.yml'>
 
 ```yml
-type: sqlserver
+type: synapse
 driver: 'ODBC Driver 17 for SQL Server' (The ODBC Driver installed on your system)
 server: server-host-name or ip
 port: 1433

--- a/website/docs/reference/warehouse-profiles/mssql-profile.md
+++ b/website/docs/reference/warehouse-profiles/mssql-profile.md
@@ -12,55 +12,166 @@ Some core functionality may be limited. If you're interested in contributing, ch
 **Maintained by:** Community      
 **Author:** Mikael Ene    
 **Source:** https://github.com/dbt-msft/dbt-sqlserver    
-**Core version:** v0.14.0 and newer    
+**Core version:** v0.14.0 and newer 
 
 ![dbt-sqlserver stars](https://img.shields.io/github/stars/mikaelene/dbt-sqlserver?style=for-the-badge)
 
-Easiest install is to use pip:
+The package can be installed from PyPI with:
 
-    pip install dbt-sqlserver
-
+```python
+pip install dbt-sqlserver
+```
 On Ubuntu make sure you have the ODBC header files before installing
 
     sudo apt install unixodbc-dev
 
 ### Connecting to SQL Server with **dbt-sqlserver**
 
-#### User / password authentication
+#### standard SQL Server authentication
+SQL Server credentials are supported for on-prem as well as cloud, and it is the default authentication method for `dbt-sqlsever`
 
-Configure your dbt profile for using SQL Server authentication or Integrated Security:
+<File name='profiles.yml'>
 
-##### SQL Server authentication
-```yaml
-dbt-sqlserver:
-  target: dev
-  outputs:
-    dev:
-      type: sqlserver
-      driver: 'ODBC Driver 17 for SQL Server' (The ODBC Driver installed on your system)
-      server: server-host-name or ip
-      port: 1433
-      user: [username]
-      password: [password]
-      database: [databasename]
-      schema: [schema]
+```yml
+type: sqlserver
+driver: 'ODBC Driver 17 for SQL Server' (The ODBC Driver installed on your system)
+server: server-host-name or ip
+port: 1433
+schema: schemaname
+user: username
+password: password
 ```
 
-##### Integrated Security
-```yaml
-dbt-sqlserver:
-  target: dev
-  outputs:
-    dev:
-      type: sqlserver
-      driver: 'ODBC Driver 17 for SQL Server' (The ODBC Driver installed on your system)
-      server: server-host-name or ip
-      port: 1433
-      database: [databasename]
-      schema: [schema]
-      windows_login: True
+</File>
+
+#### Active Directory Authentication
+
+The following [`pyodbc`-supported ActiveDirectory methods](https://docs.microsoft.com/en-us/sql/connect/odbc/using-azure-active-directory?view=sql-server-ver15#new-andor-modified-dsn-and-connection-string-keywords) are available to authenticate to Azure SQL products:
+- ActiveDirectory Password
+- Azure CLI
+- ActiveDirectory Interactive (*Windows only*)
+- ActiveDirectory Integrated (*Windows only*)
+- Service Principal (a.k.a. AAD Application)
+- ~~ActiveDirectory MSI~~ (not implemented)
+
+<Tabs
+  defaultValue="integrated"
+  values={[
+    { label: 'Password', value: 'password'},
+    { label: 'CLI', value: 'cli'},
+    { label: 'Interactive', value:'interactive'},
+    { label: 'Integrated', value: 'integrated'},
+    { label: 'Service Principal', value: 'serviceprincipal'}
+    ]
+}>
+
+<TabItem value="password">
+
+Definitely not ideal, but available
+
+<File name='profiles.yml'>
+
+```yml
+type: sqlserver
+driver: 'ODBC Driver 17 for SQL Server' (The ODBC Driver installed on your system)
+server: server-host-name or ip
+port: 1433
+schema: schemaname
+authentication: ActiveDirectoryPassword
+user: bill.gates@microsoft.com
+password: iheartopensource
 ```
 
+</File>
+
+</TabItem>
+
+<TabItem value="cli">
+
+First, install the [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli), then, log in:
+
+`az login`
+
+<File name='profiles.yml'>
+
+```yml
+type: sqlserver
+driver: 'ODBC Driver 17 for SQL Server' (The ODBC Driver installed on your system)
+server: server-host-name or ip
+port: 1433
+schema: schemaname
+authentication: CLI
+```
+This is also the preferred route for using a service principal:
+
+`az login --service-principal --username $CLIENTID --password $SECRET --tenant $TENANTID`
+
+</File>
+
+</TabItem>
+
+<TabItem value="interactive">
+
+*Windows Only* brings up the Azure AD prompt so you can MFA if need be.
+
+<File name='profiles.yml'>
+
+```yml
+type: sqlserver
+driver: 'ODBC Driver 17 for SQL Server' (The ODBC Driver installed on your system)
+server: server-host-name or ip
+port: 1433
+schema: schemaname
+authentication: ActiveDirectoryInteractive
+user: bill.gates@microsoft.com
+```
+
+</File>
+
+</TabItem>
+
+<TabItem value="integrated">
+
+*Windows Only* uses your machine's credentials (might be disabled by your AAD admins)
+
+<File name='profiles.yml'>
+
+```yml
+type: sqlserver
+driver: 'ODBC Driver 17 for SQL Server' (The ODBC Driver installed on your system)
+server: server-host-name or ip
+port: 1433
+schema: schemaname
+authentication: ActiveDirectoryIntegrated
+```
+
+</File>
+
+</TabItem>
+
+<TabItem value="serviceprincipal">
+
+`client_*` and `app_*` can be used interchangeably
+
+<File name='profiles.yml'>
+
+```yml
+type: sqlserver
+driver: 'ODBC Driver 17 for SQL Server' (The ODBC Driver installed on your system)
+server: server-host-name or ip
+port: 1433
+schema: schemaname
+authentication: ServicePrincipal
+tenant_id: tenant_id
+client_id: clientid
+client_secret: clientsecret
+```
+
+</File>
+
+</TabItem>
+
+</Tabs>
 
 
 ------------------------------------------------------------


### PR DESCRIPTION
Also adding Azure CLI authentication method

## Description & motivation
The connection details for Synapse were outdated `type: sqlserver`  now becomes `type: synapse`
Also added the recommended authentication method: `Azure CLI`

## Pre-release docs
Is this change related to an unreleased version of dbt?
No

cc: @swanderz 