### PR TITLE
Adapter Plugin easier links for MSSQL and Synapse

### DIFF
--- a/website/docs/docs/available-adapters.md
+++ b/website/docs/docs/available-adapters.md
@@ -36,9 +36,9 @@ These adapter plugins are contributed and maintained by members of the community
 | Adapter for | Documentation | Notes | Install from PyPi |
 | ----------- | ------------- | ----- | ----------------- |
 | Microsoft SQL Server | [Profile Setup](mssql-profile) | SQL Server 2008 R2 and later | `pip install dbt-mssql` |
-| Microsoft SQL Server | [Profile Setup](mssql-profile) | SQL Server 2016 and later | `pip install dbt-sqlserver` |
+| Microsoft SQL Server | [Profile Setup](mssql-profile#overview-of-dbt-mssql) | SQL Server 2016 and later | `pip install dbt-sqlserver` |
 | Microsoft Azure Synapse DW | [Profile Setup](azuresynapse-profile) | Azure Synapse 10+ | `pip install dbt-synapse` |
-| Microsoft Azure Synapse DW | [Profile Setup](azuresynapse-profile) | Azure Synapse 10+ | `pip install dbt-azuresynapse` |
+| Microsoft Azure Synapse DW | [Profile Setup](azuresynapse-profile#overview-of-dbt-azuresynapse) | Azure Synapse 10+ | `pip install dbt-azuresynapse` |
 | Exasol Analytics | [Profile Setup](exasol-profile) | Exasol 6.x and later | `pip install dbt-exasol` |
 | Oracle Database | [Profile Setup](oracle-profile) | Oracle 11+ | `pip install dbt-oracle` |
 | Dremio | [Profile Setup](dremio-profile) | Dremio 4.7+ | `pip install dbt-dremio` |


### PR DESCRIPTION
Profile links didn't jump to the appropriate profile, this makes things a little bit easier for users!

## Description & motivation
I confused myself multiple times over the last few weeks looking at the old documentation for mssql profiles. Just realized I had to scroll down a bit. Hopefully this helps someone else out :D. Threw in the Synapse link as it looked like a similar setup, I personally only have been working with mssql 

## To-do before merge
N/A

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!


