### PR TITLE
Changes ahead of 0.20.0rc1 announcement

### DIFF
--- a/website/docs/docs/building-a-dbt-project/exposures.md
+++ b/website/docs/docs/building-a-dbt-project/exposures.md
@@ -5,7 +5,8 @@ id: "exposures"
 
 <Changelog>
 
-* Exposures are new in `v0.18.1`
+* **v0.18.1**: Exposures are new!
+* **v0.20.0**: Exposures support `tags` and `meta` properties
 
 </Changelog>
 
@@ -61,6 +62,11 @@ _Optional:_
 - **url**
 - **maturity**: one of `high`, `medium`, `low`
 - **owner**: name
+
+_General properties (optional)_
+- **description**
+- **tags**
+- **meta**
 
 We plan to add more subtypes and optional properties in future releases.
 

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-20-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-20-0.md
@@ -3,8 +3,8 @@ title: "Upgrading to 0.20.0"
 
 ---
 
-:::info Beta
-`dbt v0.20.0b1` is currently available as a beta prerelease. Please help us by testing, and post in [#dbt-prereleases](https://getdbt.slack.com/archives/C016X6ABVUK) with questions or issues.
+:::info Prerelease
+`dbt v0.20.0rc1` is currently available. Please help us by testing, and post in [#dbt-prereleases](https://getdbt.slack.com/archives/C016X6ABVUK) with questions or issues.
 :::
 
 ### Resources
@@ -13,13 +13,10 @@ title: "Upgrading to 0.20.0"
 
 ## Breaking changes
 
-### For dbt users
-
-Schema test macros are now `test` blocks, which we're going to start calling "generic tests." There is backwards compatibility for schema test macros prefixed `test_`, and you can still use them without switching to test blocks (though we hope you will soon!). The biggest breaking change is that _all_ tests now return a set of failing rows, rather than a single numeric value. This resolved a longstanding inconsistency between schema tests and data tests.
-
-### For dbt plugin maintainers
-
-Macro dispatch now includes "parent" adapter implementations before using the default implementation. If you maintain an adapter plugin that inherits from another adapter (e.g. `dbt-redshift` inherits from `dbt-postgres`), `adapter.dispatch()` will now look for prefixed macros in the following order: `redshift__`, `postgres__`, `default__`.
+- Schema test macros are now `test` blocks, which we're going to start calling "generic tests." There is backwards compatibility for schema test macros prefixed `test_`, and you can still use them without switching to test blocks (though we hope you will soon!). The biggest breaking change is that _all_ tests now return a set of failing rows, rather than a single numeric value. This resolved a longstanding inconsistency between schema tests and data tests.
+- **For package maintainers (and some users):** The syntax for `adapter.dispatch()` has changed; see linked documentation below.
+- **For adapter plugin maintainers:** Macro dispatch now includes "parent" adapter implementations before using the default implementation. If you maintain an adapter plugin that inherits from another adapter (e.g. `dbt-redshift` inherits from `dbt-postgres`), `adapter.dispatch()` will now look for prefixed macros in the following order: `redshift__`, `postgres__`, `default__`.
+- **For artifact users:** The [manifest](manifest-json) and [run_results](run-results-json) now use a v2 schema. What changed: there are a handful of new properties in the manifest; the number of failures for a test has been moved to a new property `failures`, so that `message` can be the human-readable failure message.
 
 ## New and changed documentation
 
@@ -31,9 +28,11 @@ Macro dispatch now includes "parent" adapter implementations before using the de
 - [Writing custom generic tests](custom-generic-tests)
 
 ### Elsewhere in Core
+- [Parsing](parsing): rework of partial parsing, introduction of experimental parser
 - The [graph](graph) Jinja context variable includes `exposures`
 - [Packages](package-management) can now be installed from git with a specific commit hash as the revision, or via sparse checkout if the dbt project is located in a `subdirectory`.
 - [adapter.dispatch](dispatch) supports new arguments, a new [project-level config](project-configs/dispatch-config), and includes parent adapters when searching for macro implementations.
+- [Exposures](exposure-properties) support `tags` and `meta` properties
 
 ### Plugins
 - New partition-related [BigQuery configs](bigquery-configs#additional-partition-configs): `require_partition_filter` and `partition_expiration_days`

--- a/website/docs/reference/artifacts/dbt-artifacts.md
+++ b/website/docs/reference/artifacts/dbt-artifacts.md
@@ -43,10 +43,9 @@ In the manifest, the `metadata` may also include:
 
 #### Notes:
 - The structure of dbt artifacts is canonized by [JSON schemas](https://json-schema.org/), which are hosted at **schemas.getdbt.com**.
-- As of v0.19.0, all artifacts are `v1`:
-    - https://schemas.getdbt.com/dbt/manifest/v1.json
-    - https://schemas.getdbt.com/dbt/run-results/v1.json
+- As of v0.20.0, the current schema for each artifact is:
+    - https://schemas.getdbt.com/dbt/manifest/v2.json
+    - https://schemas.getdbt.com/dbt/run-results/v2.json
     - https://schemas.getdbt.com/dbt/catalog/v1.json
     - https://schemas.getdbt.com/dbt/sources/v1.json
-- The previous `v0` schemas are also available for ease of comparison. These represent the artifact schemas as of v0.18.1. In prior versions, artifacts were not standardized or versioned.
-- Going forward, artifact versions may change in any minor version of dbt (`v0.x.0`). Artifact version updates are not guaranteed to align with each other—for instance, dbt may introduce `manifest/v2` while still using `sources/v1`. We will always include artifact schema updates as breaking changes in the release notes.
+- Artifact versions may change in any minor version of dbt (`v0.x.0`). Each artifact is versioned independently.

--- a/website/docs/reference/artifacts/manifest-json.md
+++ b/website/docs/reference/artifacts/manifest-json.md
@@ -2,7 +2,7 @@
 title: Manifest
 ---
 
-_Current schema_: [`v1`](https://schemas.getdbt.com/dbt/manifest/v1.json)
+_Current schema_: [`v2`](https://schemas.getdbt.com/dbt/manifest/v2.json)
 
 _Produced by:_
 - `dbt compile`

--- a/website/docs/reference/artifacts/other-artifacts.md
+++ b/website/docs/reference/artifacts/other-artifacts.md
@@ -10,11 +10,11 @@ This file is the skeleton of the [auto-generated dbt documentation website](docu
 
 Note: the source code for `index.json` comes from the [dbt-docs repo](https://github.com/fishtown-analytics/dbt-docs). Head over there if you want to make a bug report, suggestion, or contribution relating to the documentation site.
 
-### partial_parse.pickle
+### partial_parse.msgpack
 
 _Produced by: all commands_
 
-This file is used to store a compressed representation of files dbt has parsed. If you have [partial parsing](profiles.yml#partial_parse) enabled, dbt will use this file to identify the files that have changed and avoid re-parsing the rest.
+This file is used to store a compressed representation of files dbt has parsed. If you have [partial parsing](parsing#partial-parsing) enabled, dbt will use this file to identify the files that have changed and avoid re-parsing the rest.
 
 ### graph.gpickle
 

--- a/website/docs/reference/artifacts/run-results-json.md
+++ b/website/docs/reference/artifacts/run-results-json.md
@@ -2,7 +2,7 @@
 title: Run Results
 ---
 
-_Current schema_: [`v1`](https://schemas.getdbt.com/dbt/run-results/v1.json)
+_Current schema_: [`v2`](https://schemas.getdbt.com/dbt/run-results/v2.json)
 
 _Produced by:_
 - `dbt run`

--- a/website/docs/reference/exposure-properties.md
+++ b/website/docs/reference/exposure-properties.md
@@ -28,6 +28,8 @@ exposures:
     type: {dashboard, notebook, analysis, ml, application}
     url: <string>
     maturity: {high, medium, low}
+    [tags](resource-properties/tags): [<string>]
+    [meta](resource-properties/meta): {<dictionary>}
     owner:
       name: <string>
       email: <string>

--- a/website/docs/reference/global-cli-flags.md
+++ b/website/docs/reference/global-cli-flags.md
@@ -121,7 +121,7 @@ $ dbt --partial-parse run
 
 </File>
 
-## Partial Parsing
+## Experimental parser
 The `--use-experimental-parser` flag will statically analyze model files in your project and, if possible, extract needed information 3x faster than a full Jinja render. See [the docs on parsing](parsing#experimental-parser) for more details.
 
 <File name='Usage'>

--- a/website/docs/reference/global-cli-flags.md
+++ b/website/docs/reference/global-cli-flags.md
@@ -111,12 +111,23 @@ $ dbt --warn-error run
 </File>
 
 ## Partial Parsing
-The `--partial-parse` and `--no-partial-parse` flags can be used to configure partial parsing in your project. See [the docs on partial parsing](reference/profiles.yml.md#partial_parse) for more information on using this flag.
+The `--partial-parse` and `--no-partial-parse` flags can be used to configure partial parsing in your project, and will override the value set in `profiles.yml`. See [the docs on parsing](parsing#partial-parsing) for more details.
 
 <File name='Usage'>
 
 ```text
 $ dbt --partial-parse run
+```
+
+</File>
+
+## Partial Parsing
+The `--use-experimental-parser` flag will statically analyze model files in your project and, if possible, extract needed information 3x faster than a full Jinja render. See [the docs on parsing](parsing#experimental-parser) for more details.
+
+<File name='Usage'>
+
+```text
+$ dbt --use-experimental-parser run
 ```
 
 </File>

--- a/website/docs/reference/parsing.md
+++ b/website/docs/reference/parsing.md
@@ -1,0 +1,46 @@
+---
+id: "parsing"
+---
+
+## Related documentation
+- The `dbt parse` [command](parse)
+- Partial parsing [profile config](profiles.yml#partial_parse) and [CLI flags](global-cli-flags#partial-parsing)
+- Experimental parser CLI flag
+
+## What is parsing?
+
+At the start of every dbt invocation, dbt reads all the files in your project, extracts information, and constructs a manifest containing every object (model, source, macro, etc). For instance, dbt uses the `ref()`, `source()`, and `config()` macro calls within models to infer dependencies and construct your project's DAG.
+
+Parsing projects can be slow, especially as projects get bigger—say, more than 500 models. There are three performance optimizations that dbt offers today, to speed up parsing:
+- Partial parsing, to avoid re-parsing unchanged files in development
+- An experimental parser, to parse simple models more quickly
+- [RPC server](rpc), which parses the project at server startup/hangup and keeps a manifest in memory
+
+## Partial parsing
+
+After parsing your project, dbt stores an internal project manifest in a file called `partial_parse.msgpack`. When partial parsing is enabled, dbt will use that internal manifest to determine which files have been changed (if any) since it last parsed the project. Then, it will _only_ parse the changed files, or files related those changes.
+
+Partial parsing is off by default, and it can be enabled via [profile config](profiles.yml#partial_parse) or [CLI flags](global-cli-flags#partial-parsing). In development, partial parsing can reduce the time spent waiting at the start of a run by more than 90%, which translates to faster dev cycles and iteration.
+
+### Known limitations
+
+Use caution when enabling partial parsing in dbt, as there are known limitations today:
+- A change in environment variables does not trigger a re-parse. Files which depend on [`env_var`](env_var) may be incorrect on subsequent parses.
+- Changes to macros called within a model's `config()` block will not result in re-parsing that model.
+- A file that depends on "volatile" Jinja variables, such as [`run_started_at`](run_started_at) or [`invocation_id`](invocation_id), will quickly get stale. A file is not re-parsed in subsequent invocations if the file's contents have not changed.
+- If certain inputs change between runs, dbt will trigger a full re-parse. Today those inputs are:
+    - `--vars`
+    - `profiles.yml` content
+    - `dbt_project.yml` content
+    - installed packages
+    - dbt version
+
+## Experimental parser
+
+At parse time, dbt needs to extract the contents of `ref()`, `source()`, and `config()` from all models in the project. Traditionally, dbt has extracted those values by rendering the Jinja in every model file, which can be slow. In v0.20.0, we're trying out a new way to statically analyze model files, leveraging [`tree-sitter`](https://github.com/tree-sitter/tree-sitter), which we're calling an "experimental parser". You can see the code for an initial Jinja2 grammar here: https://github.com/fishtown-analytics/tree-sitter-jinja2.
+
+For now, the experimental parser only works with models, and models whose Jinja is limited to those three special macros (`ref`, `source`, `config`). The experimental parser is at least 3x faster than a full Jinja render. Based on testing with data from dbt Cloud, we believe the current grammar can statically parse 60% of models in the wild. So for the average project, we'd hope to see a 40% speedup in the model parser. You can check this by running `dbt parse` and `dbt parse --use-experimental-parser`, and comparing `target/perf_info.json` produced by each.
+
+The experimental parser is off by default. We believe it can offer *some* speedup to 95% of projects.
+
+**Note:** Do not use the experimental parser if you've overridden the `ref`, `source`, or `config` macro with a custom implementation.

--- a/website/docs/reference/parsing.md
+++ b/website/docs/reference/parsing.md
@@ -1,26 +1,28 @@
 ---
-id: "parsing"
+title: "Project Parsing"
 ---
 
 ## Related documentation
 - The `dbt parse` [command](parse)
 - Partial parsing [profile config](profiles.yml#partial_parse) and [CLI flags](global-cli-flags#partial-parsing)
-- Experimental parser CLI flag
+- Experimental parser [CLI flag](global-cli-flags#experimental-parser)
 
 ## What is parsing?
 
-At the start of every dbt invocation, dbt reads all the files in your project, extracts information, and constructs a manifest containing every object (model, source, macro, etc). For instance, dbt uses the `ref()`, `source()`, and `config()` macro calls within models to infer dependencies and construct your project's DAG.
+At the start of every dbt invocation, dbt reads all the files in your project, extracts information, and constructs a manifest containing every object (model, source, macro, etc). Among other things, dbt uses the `ref()`, `source()`, and `config()` macro calls within models to set properties, infer dependencies, and construct your project's DAG.
 
-Parsing projects can be slow, especially as projects get bigger—say, more than 500 models. There are three performance optimizations that dbt offers today, to speed up parsing:
-- Partial parsing, to avoid re-parsing unchanged files in development
-- An experimental parser, to parse simple models more quickly
-- [RPC server](rpc), which parses the project at server startup/hangup and keeps a manifest in memory
+Parsing projects can be slow, especially as projects get bigger—hundreds of models, thousands of files—which is frustrating ind evelopment. There are three performance optimizations that dbt offers today:
+- Partial parsing, which avoids re-parsing unchanged files between invocations
+- An experimental parser, which extracts information from simple models much more quickly
+- [RPC server](rpc), which keeps a manifest in memory, and re-parses the project at server startup/hangup
+
+These optimizations can be used in combination to reduce parse time from minutes to seconds. At the same time, each has some known limitations, so they are disabled by default.
 
 ## Partial parsing
 
 After parsing your project, dbt stores an internal project manifest in a file called `partial_parse.msgpack`. When partial parsing is enabled, dbt will use that internal manifest to determine which files have been changed (if any) since it last parsed the project. Then, it will _only_ parse the changed files, or files related those changes.
 
-Partial parsing is off by default, and it can be enabled via [profile config](profiles.yml#partial_parse) or [CLI flags](global-cli-flags#partial-parsing). In development, partial parsing can reduce the time spent waiting at the start of a run by more than 90%, which translates to faster dev cycles and iteration.
+Partial parsing is off by default, and it can be enabled via [profile config](profiles.yml#partial_parse) or [CLI flags](global-cli-flags#partial-parsing). In development, partial parsing can significantly reduce the time spent waiting at the start of a run, which translates to faster dev cycles and iteration.
 
 ### Known limitations
 
@@ -35,12 +37,16 @@ Use caution when enabling partial parsing in dbt, as there are known limitations
     - installed packages
     - dbt version
 
+If you ever get into a bad state, you can disable partial parsing and trigger a full re-parse with the `--no-partial-parse` CLI flag, or by deleting `target/partial_parse.msgpack.`
+
 ## Experimental parser
 
-At parse time, dbt needs to extract the contents of `ref()`, `source()`, and `config()` from all models in the project. Traditionally, dbt has extracted those values by rendering the Jinja in every model file, which can be slow. In v0.20.0, we're trying out a new way to statically analyze model files, leveraging [`tree-sitter`](https://github.com/tree-sitter/tree-sitter), which we're calling an "experimental parser". You can see the code for an initial Jinja2 grammar here: https://github.com/fishtown-analytics/tree-sitter-jinja2.
+At parse time, dbt needs to extract the contents of `ref()`, `source()`, and `config()` from all models in the project. Traditionally, dbt has extracted those values by rendering the Jinja in every model file, which can be slow. In v0.20.0, we're trying out a new way to statically analyze model files, leveraging [`tree-sitter`](https://github.com/tree-sitter/tree-sitter), which we're calling an "experimental parser". You can see the code for an initial Jinja2 grammar [here](https://github.com/fishtown-analytics/tree-sitter-jinja2).
 
 For now, the experimental parser only works with models, and models whose Jinja is limited to those three special macros (`ref`, `source`, `config`). The experimental parser is at least 3x faster than a full Jinja render. Based on testing with data from dbt Cloud, we believe the current grammar can statically parse 60% of models in the wild. So for the average project, we'd hope to see a 40% speedup in the model parser. You can check this by running `dbt parse` and `dbt parse --use-experimental-parser`, and comparing `target/perf_info.json` produced by each.
 
 The experimental parser is off by default. We believe it can offer *some* speedup to 95% of projects.
 
-**Note:** Do not use the experimental parser if you've overridden the `ref`, `source`, or `config` macro with a custom implementation.
+### Known Limitations
+
+Do not use the experimental parser if you've overridden the `ref`, `source`, or `config` macro with a custom implementation.

--- a/website/docs/reference/profiles.yml.md
+++ b/website/docs/reference/profiles.yml.md
@@ -52,28 +52,9 @@ config:
 
 </File>
 
+See the docs on [partial parsing](parsing#partial-parsing) for details on functionality. By default, `partial_parse` is set to `false`. To enable partial parsing for all dbt projects you run locally, specify `partial_parse: true` in your `profiles.yml` file:
 
-Partial parsing can improve the performance characteristics of dbt runs by limiting the number of files that are parsed by dbt. Here, "parsing" means reading files in a dbt project from disk and capturing `ref()` and `config()` method calls. dbt uses these method calls to determine 1) the shape of the dbt DAG and 2) the supplied configurations for dbt resources.
-
-If partial parsing is enabled and files are unchanged between invocations of dbt, then dbt does not need to re-parse these files — it can instead use the parsed representation from the _last_ invocation of dbt. If a file *has* changed between invocations of dbt, then dbt will re-parse the file and update the parsed node cache accordingly.
-
-Use caution when enabling partial parsing in dbt. If environment variables control the parsed representation of your project, then the logic executed by dbt may differ from the logic specified in your project. Partial parsing should only be used when all of the logic in your dbt project is encoded in the files inside of that project.
-
-If partial parsing is enabled and `--vars` change between runs, dbt will always re-parse.
-
-By default, `partial_parse` is set to `false`
-
-**Usage**
-To enable partial parsing for all dbt projects, specify `partial_parse: true` in your `profiles.yml` file:
-
-```yaml
-config:
-  partial_parse: True
-```
-
-You can also achieve this by using the [`--partial-parse` command line flag](global-cli-flags#partial-parsing).
-
-The value in your `profiles.yml` can be overridden with the `--partial-parse` or `--no-partial-parse` flags.
+You can also turn partial parsing on or off via [command line flags](global-cli-flags#partial-parsing). The CLI flags (`--partial-parse` or `--no-partial-parse`) will take precedence over the config set in `profiles.yml`.
 
 ## use_colors
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -396,6 +396,7 @@ module.exports = {
         },
         "reference/global-cli-flags",
         "reference/exit-codes",
+        "reference/parsing",
       ],
     },
     {


### PR DESCRIPTION
## Description & motivation

- Breaking changes in migration guide
- Parsing: partial parsing + experimental parser
- Exposures: `tags` + `meta`

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [x] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist
If you added new pages (delete if not applicable):
- [x] The page has been added to `website/sidebars.js`
- [x] The new page has a unique filename