### PR TITLE
add caveats to private packages section

### DIFF
--- a/website/docs/docs/building-a-dbt-project/package-management.md
+++ b/website/docs/docs/building-a-dbt-project/package-management.md
@@ -122,9 +122,7 @@ packages:
   - git: "https://{{env_var('GIT_CREDENTIALS')}}@github.com/fishtown-analytics/dbt-utils.git" # git HTTPS URL
 ```
 
-**Please note**:
-  - We recommend using the [git URL](http://localhost:3000/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-import-a-project-by-git-url#github) clone strategy in order to use private packages. If you'd like to use the Github app clone strategy, please contact support.
-  - We don't yet support the use of private packages with Gitlab or dbt Cloud managed repositories.
+**Note**: The use of private packages is not currently supported in dbt Cloud.
 
 ### Local packages
 Packages that you have stored locally can be installed by specifying the path to the project, like so:

--- a/website/docs/docs/building-a-dbt-project/package-management.md
+++ b/website/docs/docs/building-a-dbt-project/package-management.md
@@ -122,6 +122,10 @@ packages:
   - git: "https://{{env_var('GIT_CREDENTIALS')}}@github.com/fishtown-analytics/dbt-utils.git" # git HTTPS URL
 ```
 
+**Please note**:
+  - We recommend using the [git URL](http://localhost:3000/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-import-a-project-by-git-url#github) clone strategy in order to use private packages. If you'd like to use the Github app clone strategy, please contact support.
+  - We don't yet support the use of private packages with Gitlab or dbt Cloud managed repositories.
+
 ### Local packages
 Packages that you have stored locally can be installed by specifying the path to the project, like so:
 


### PR DESCRIPTION
## Description & motivation
After a discussion re: the use of private packages in dbt Cloud, we decided it would be best to add a few caveats to this in the documentation. Relevant slack thread is here: https://fishtownanalytics.slack.com/archives/C017GDLAF7D/p1622829542183800

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [X] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
