### PR TITLE
fix typo - should be `dbt test`

### DIFF
--- a/website/docs/reference/node-selection/test-selection-examples.md
+++ b/website/docs/reference/node-selection/test-selection-examples.md
@@ -70,10 +70,10 @@ $ dbt test --models customers
 $ dbt test --models staging.jaffle_shop
 
 # Run tests downstream of a model (note this will select those tests directly!)
-$ dbt tests --models stg_customers+
+$ dbt test --models stg_customers+
 
 # Run tests upstream of a model (indirect selection)
-$ dbt tests --models +stg_customers
+$ dbt test --models +stg_customers
 
 # Run tests on all models with a particular tag (direct + indirect)
 $ dbt test --models tag:my_model_tag


### PR DESCRIPTION
## Description & motivation
The documentation is incorrectly specifying `dbt tests` where should be `dbt test`

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ x] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist
If you added new pages (delete if not applicable):

If you removed existing pages (delete if not applicable):
