### PR TITLE
libvips Error troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ We recommend locally rendering changes made to the docs site so you can review y
 8. Before pushing your changes to a branch, check that all links work by using the `make build` script.
 
 Advisory: 
-- Currently an `npm install` produces a number of depedency warnings, in particular several claiming that `docusaurus/core` is missing. Rest assured, this message is a red herring. As of writing this, no 2.0.0 package exists, so you won't have much luck trying to install it. Feel free to ignore those warnings.
+- Currently an `npm install` produces a number of dependency warnings, in particular several claiming that `docusaurus/core` is missing. Rest assured, this message is a red herring. As of writing this, no 2.0.0 package exists, so you won't have much luck trying to install it. Feel free to ignore those warnings.
 - If you run into an `fatal error: 'vips/vips8' file not found` error when you run `npm install`, you may need to run `brew install vips`. Warning: this one will take a while -- go ahead and grab some coffee!
 
 You can also check out [this Loom video](https://www.loom.com/share/7037780b86eb4f16953664b8f15f1e21) that I recorded for co-workers — it covers setting up docs.getdbt.com locally, and adding a page with links and images. Heads up — this was very much something I did on the fly, so is not super polished!

--- a/README.md
+++ b/README.md
@@ -16,16 +16,18 @@ We welcome contributions from community members to this repo:
 
 We recommend locally rendering changes made to the docs site so you can review your proposed modifications. Our setup instructions use [homebrew](https://brew.sh/):
 
-0. If applicable, install [Xcode CLTs](https://developer.apple.com/download/more/); you'll likely need an AppleID for this.
-1. Install `node`: `brew install node`
-2. Clone this repo: `git clone git@github.com:fishtown-analytics/docs.getdbt.com.git`
-3. `cd` into the repo: `cd docs.getdbt.com`
-4. `cd` into the `website` subdirectory: `cd website`
-5. Install the required node packages: `npm install`
-6. Build the website: `npm start`
-7. Before pushing your changes to a branch, check that all links work by using the `make build` script.
+0. If applicable, install [Xcode Command Line Tools](https://developer.apple.com/download/more/); you'll likely need an AppleID for this. You will also need [homebrew](https://brew.sh/). 
+2. Install `node`: `brew install node`
+3. Clone this repo: `git clone git@github.com:fishtown-analytics/docs.getdbt.com.git`
+4. `cd` into the repo: `cd docs.getdbt.com`
+5. `cd` into the `website` subdirectory: `cd website`
+6. Install the required node packages: `npm install`
+7. Build the website: `npm start`
+8. Before pushing your changes to a branch, check that all links work by using the `make build` script.
 
-Advisory: Currently an `npm install` produces a number of depedency warnings, in particular several claiming that `docusaurus/core` is missing. Rest assured, this message is a red herring. As of writing this, no 2.0.0 package exists, so you won't have much luck trying to install it. Feel free to ignore those warnings.
+Advisory: 
+- Currently an `npm install` produces a number of depedency warnings, in particular several claiming that `docusaurus/core` is missing. Rest assured, this message is a red herring. As of writing this, no 2.0.0 package exists, so you won't have much luck trying to install it. Feel free to ignore those warnings.
+- If you run into an `fatal error: 'vips/vips8' file not found` error when you run `npm install`, you may need to run `brew install vips`. Warning: this one will take a while -- go ahead and grab some coffee!
 
 You can also check out [this Loom video](https://www.loom.com/share/7037780b86eb4f16953664b8f15f1e21) that I recorded for co-workers — it covers setting up docs.getdbt.com locally, and adding a page with links and images. Heads up — this was very much something I did on the fly, so is not super polished!
 


### PR DESCRIPTION
Adding a note to the readme about explicitly installing homebrew, and possibly needing libvips

## Description & motivation
Ran into the following error when running `npm install`. Based on [this thing on the Internet](https://github.com/lovell/sharp/issues/1882), installed vips from homebrew and was able to get started. Updated the Readme to help folks if they get stuck here. 
  
![Screen Shot 2021-06-15 at 11 02 52 AM](https://user-images.githubusercontent.com/7892219/122103991-0f617600-cdcc-11eb-9fe1-8b23e7dc7e92.png)

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist
Readme change, no pages added or removed ✅ 
