### PR TITLE
Modify explicit page title and description

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -55,8 +55,8 @@ console.log("DEBUG: ALGOLIA_INDEX_NAME = ", ALGOLIA_INDEX_NAME);
 module.exports = {
   baseUrl: '/',
   favicon: '/img/favicon.ico',
-  tagline: 'Your entire analytics engineering workflow',
-  title: 'docs.getdbt.com',
+  tagline: 'End user documentation, guides and technical reference for dbt (data build tool)',
+  title: 'dbt Docs',
   url: SITE_URL,
 
   themeConfig: {


### PR DESCRIPTION
## Description & motivation

An astute [Community member has pointed out ](https://getdbt.slack.com/archives/C0VLNUUTZ/p1623688726351500) that we have inconsistent capitalizations for dbt on the docs site. We think this is because of Google Search taking liberties with auto-generating page structure. This PR attempts to address this by setting an explicit title that is not a URL. 

## To-do before merge
- [x] Test locally to make sure nothing breaks 

![Screen Shot 2021-06-15 at 2 33 40 PM](https://user-images.githubusercontent.com/7892219/122131630-4e082800-cdee-11eb-9571-3c083816c607.png)


## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist
no page additions/removal