### PR TITLE
Removing WIP warnings for adapter config pages

### DIFF
--- a/website/docs/reference/resource-configs/bigquery-configs.md
+++ b/website/docs/reference/resource-configs/bigquery-configs.md
@@ -3,11 +3,6 @@ title: "BigQuery configurations"
 id: "bigquery-configs"
 ---
 
-:::caution Heads up!
-These docs are a work in progress.
-
-:::
-
 <!----
 To-do:
 - use the reference doc structure for this article/split into separate articles

--- a/website/docs/reference/resource-configs/redshift-configs.md
+++ b/website/docs/reference/resource-configs/redshift-configs.md
@@ -2,10 +2,6 @@
 title: "Redshift configurations"
 id: "redshift-configs"
 ---
-:::caution Heads up!
-These docs are a work in progress.
-
-:::
 
 <!----
 To-do:

--- a/website/docs/reference/resource-configs/snowflake-configs.md
+++ b/website/docs/reference/resource-configs/snowflake-configs.md
@@ -3,11 +3,6 @@ title: "Snowflake configurations"
 id: "snowflake-configs"
 ---
 
-:::caution Heads up!
-These docs are a work in progress.
-
-:::
-
 <!----
 To-do:
 - use the reference doc structure for this article / split into separate articles

--- a/website/docs/reference/resource-configs/spark-configs.md
+++ b/website/docs/reference/resource-configs/spark-configs.md
@@ -3,11 +3,6 @@ title: "Apache Spark configurations"
 id: "spark-configs"
 ---
 
-:::caution Heads up!
-These docs are a work in progress.
-
-:::
-
 <!----
 To-do:
 - use the reference doc structure for this article/split into separate articles


### PR DESCRIPTION
## Description & motivation
We've shown a WIP warning on [adapter-specific config pages](https://docs.getdbt.com/reference/resource-configs/bigquery-configs) for I think forever? 

![image](https://user-images.githubusercontent.com/77362861/123698204-7c8cf680-d823-11eb-94f3-d2c391d2bcba.png)

Noted by [Drew and Jerco in Slack](https://fishtownanalytics.slack.com/archives/C665H756K/p1624908290017100) that it's OK to remove the WIP warning (from BigQuery, Redshift, Snowflake, Spark config pages).

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!