### PR TITLE
Docs - cannot use `env_vars` in the `vars` block

### DIFF
--- a/website/docs/reference/dbt-jinja-functions/env_var.md
+++ b/website/docs/reference/dbt-jinja-functions/env_var.md
@@ -3,7 +3,7 @@ title: "env_var"
 id: "env_var"
 ---
 
-The `env_var` function can be used to incorporate Environment Variables from the system into your dbt project. This `env_var` function can be used in your `profiles.yml` file, the `dbt_project.yml` file, the `sources.yml` file, your `schema.yml` files, and in model `.sql` files. Essentially `env_var` is available anywhere dbt processes jinja code.
+The `env_var` function can be used to incorporate Environment Variables from the system into your dbt project. This `env_var` function can be used in your `profiles.yml` file, the `dbt_project.yml` file (with the exception of the `vars` block), the `sources.yml` file, your `schema.yml` files, and in model `.sql` files. Essentially `env_var` is available anywhere dbt processes jinja code. 
 
 When used in a `profiles.yml` file (to avoid putting credentials on a server), it can be used like this:
 


### PR DESCRIPTION
Document an exception where `env_vars` is not rendered in the `vars` block of a `dbt_project.yml` file.

re: https://github.com/dbt-labs/dbt/issues/3105#issuecomment-779761596

## Description & motivation

From @jtcohen6 's comment on https://github.com/dbt-labs/dbt/issues/3105#issuecomment-779761596 - jinja isn't rendered in the `vars` block in a `dbt_project.yml` file. The docs currently say you can use `env_var` anywhere in the `dbt_project.yml`

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

