### PR TITLE
Add semicolon to timezone example code

### DIFF
--- a/website/docs/reference/resource-configs/sql_header.md
+++ b/website/docs/reference/resource-configs/sql_header.md
@@ -118,7 +118,7 @@ select * from {{ ref('other_model') }}
 config-version: 2
 
 models:
-  +sql_header: "alter session set timezone = 'Australia/Sydney'"
+  +sql_header: "alter session set timezone = 'Australia/Sydney';"
 ```
 
 </File>


### PR DESCRIPTION
## Detailed description

The code example showing how to alter session in Snowflake to change the timezone is missing a semicolon. 

## Problem that this commit solves

If the semicolon is not included, `dbt run` will throw a syntax error because it immediately jumps to and includes the main `CREATE` statement of the model. Adding the semicolon keeps the 2 statements separate and works as intended.

## Related issue

Resolves: https://github.com/dbt-labs/docs.getdbt.com/issues/721#issuecomment-874357312

## Pre-release docs
Is this change related to an unreleased version of dbt?

- [X ] No: please ensure the base branch is `current`

