### PR TITLE
Add SLA definition to source freshness doc

### DIFF
--- a/website/docs/docs/dbt-cloud/using-dbt-cloud/cloud-snapshotting-source-freshness.md
+++ b/website/docs/docs/dbt-cloud/using-dbt-cloud/cloud-snapshotting-source-freshness.md
@@ -12,7 +12,7 @@ The functionality documented here is available in dbt Cloud. Don't have an accou
 
 ## Data Source Freshness
 
-dbt Cloud provides a helpful interface around dbt's [source data freshness](using-sources#snapshotting-source-data-freshness) calculations. When a dbt Cloud job is configured to snapshot source data freshness, dbt Cloud will render a user interface showing you the state of the most recent snapshot. This interface is intended to help you determine if your source data freshness is meeting the SLAs that you've defined for your organization.
+dbt Cloud provides a helpful interface around dbt's [source data freshness](using-sources#snapshotting-source-data-freshness) calculations. When a dbt Cloud job is configured to snapshot source data freshness, dbt Cloud will render a user interface showing you the state of the most recent snapshot. This interface is intended to help you determine if your source data freshness is meeting the [SLAs](https://en.wikipedia.org/wiki/Service-level_agreement) that you've defined for your organization.
 
 <Lightbox src="/img/docs/dbt-cloud/using-dbt-cloud/3c3c1ca-Screen_Shot_2019-03-21_at_11.05.28_AM.png" title="Data Sources in dbt Cloud"/>
 


### PR DESCRIPTION
## Description & motivation
[Someone was confused](https://getdbt.slack.com/archives/CBSQTAPLG/p1625599824210100) about what SLA stood for in the source freshness docs. This adds a link to the wiki definition

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [x] No: please ensure the base branch is `current`
