### PR TITLE
Clarify docs blocks should replace markdown in yml

### DIFF
--- a/website/docs/docs/building-a-dbt-project/documentation.md
+++ b/website/docs/docs/building-a-dbt-project/documentation.md
@@ -105,7 +105,7 @@ Docs blocks should be placed in files with a `.md` file extension. By default, d
 
 
 ### Usage
-To use a docs block, reference it from your `schema.yml` file with the [doc()](doc) function. Using the examples above, the `table_events` docs can be included in the `schema.yml` file as shown below:
+To use a docs block, reference it from your `schema.yml` file with the [doc()](doc) function in place of a markdown string. Using the examples above, the `table_events` docs can be included in the `schema.yml` file as shown below:
 
 <File name='schema.yml'>
 


### PR DESCRIPTION
## Description & motivation
<!---
While it can be inferred from the example, make it explicit that docs blocks would be used where you would normally have a `<markdown_string>` input.
-->

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [x] No: please ensure the base branch is `current`