### PR TITLE
v0.20 docs: fixing it in post

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -95,7 +95,7 @@
 /docs/graph	/docs/writing-code-in-dbt/jinja-context/graph	302
 /docs/guides/migration-guide/upgrading-to-014	/docs/guides/migration-guide/upgrading-to-0-14-0	302
 /docs/guides/migration-guide/upgrading-from-0-10-to-0-11	/docs/guides/migration-guide/upgrading-to-0-11-0	302
-/docs/guides/writing-custom-schema-tests    /docs/guides/writing-generic-tests
+/docs/guides/writing-custom-schema-tests    /docs/guides/writing-custom-generic-tests
 /docs/hooks	/docs/building-a-dbt-project/hooks-operations	302
 /docs/init	/reference/commands/init	302
 /docs/install-from-source	/dbt-cli/installation	302

--- a/website/docs/reference/resource-properties/tests.md
+++ b/website/docs/reference/resource-properties/tests.md
@@ -26,13 +26,7 @@ models:
     tests:
       - [<test_name>](#test_name):
           <argument_name>: <argument_value>
-          [enabled](enabled): true | false
-          [severity](severity): error | warn
-          [tags](resource-properties/tags): [<string>]
-          [tags](resource-properties/tags): [<string>]
-          [tags](resource-properties/tags): [<string>]
-          [tags](resource-properties/tags): [<string>]
-          [tags](resource-properties/tags): [<string>]
+          <test_config>: <config-value>
 
     columns:
       - name: <column_name>
@@ -40,14 +34,7 @@ models:
           - [<test_name>](#test_name)
           - [<test_name>](#test_name):
               <argument_name>: <argument_value>
-              [enabled](enabled): true | false
-              [severity](severity): error | warn
-              [tags](resource-properties/tags): [<string>]
-              [tags](resource-properties/tags): [<string>]
-              [tags](resource-properties/tags): [<string>]
-              [tags](resource-properties/tags): [<string>]
-              [tags](resource-properties/tags): [<string>]
-
+              <test_config>: <config-value>
 ```
 
 </File>
@@ -69,9 +56,7 @@ sources:
         - [<test_name>](#test_name)
         - [<test_name>](#test_name):
             <argument_name>: <argument_value>
-            [enabled](enabled): true | false
-            [severity](severity): error | warn
-            [tags](resource-properties/tags): [<string>]
+            <test_config>: <config-value>
 
       columns:
         - name: <column_name>
@@ -79,9 +64,7 @@ sources:
             - [<test_name>](#test_name)
             - [<test_name>](#test_name):
                 <argument_name>: <argument_value>
-                [enabled](enabled): true | false
-                [severity](severity): error | warn
-                [tags](resource-properties/tags): [<string>]
+                <test_config>: <config-value>
 
 ```
 
@@ -102,9 +85,7 @@ seeds:
       - [<test_name>](#test_name)
       - [<test_name>](#test_name):
           <argument_name>: <argument_value>
-          [enabled](enabled): true | false
-          [severity](severity): error | warn
-          [tags](resource-properties/tags): [<string>]
+          <test_config>: <config-value>
 
     columns:
       - name: <column_name>
@@ -112,9 +93,7 @@ seeds:
           - [<test_name>](#test_name)
           - [<test_name>](#test_name):
               <argument_name>: <argument_value>
-              [enabled](enabled): true | false
-              [severity](severity): error | warn
-              [tags](resource-properties/tags): [<string>]
+              <test_config>: <config-value>
 
 ```
 
@@ -135,9 +114,7 @@ snapshots:
       - [<test_name>](#test_name)
       - [<test_name>](#test_name):
           <argument_name>: <argument_value>
-          [enabled](enabled): true | false
-          [severity](severity): error | warn
-          [tags](resource-properties/tags): [<string>]
+          <test_config>: <config-value>
 
     columns:
       - name: <column_name>
@@ -145,9 +122,7 @@ snapshots:
           - [<test_name>](#test_name)
           - [<test_name>](#test_name):
               <argument_name>: <argument_value>
-              [enabled](enabled): true | false
-              [severity](severity): error | warn
-              [tags](resource-properties/tags): [<string>]
+              <test_config>: <config-value>
 
 ```
 

--- a/website/docs/reference/test-configs.md
+++ b/website/docs/reference/test-configs.md
@@ -19,6 +19,9 @@ Tests can be configured in a few different ways:
 Test configs are applied hierarchically, in the order of specifity outlined above. In the case of a specific instance of a generic test, the test's `.yml` properties would take precedence over any values set in its generic SQL definition's `config()`, which in turn would take precedence over values set in `dbt_project.yml`.
 
 ## Available configurations
+
+Click the link on each configuration option to read more about what it can do.
+
 ### Test-specific configurations
 
 <Tabs


### PR DESCRIPTION
## Description & motivation

- Instead of listing every test config in test properties, just note that any configs can be supplied there. This is better than the status quo, which is me getting halfway through a copy-paste job :)
- resolves #714 (why not, we're already here)


## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!