### PR TITLE
Update Cloud Supported Versions to include 0.20.x

### DIFF
--- a/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-choosing-a-dbt-version.md
+++ b/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-choosing-a-dbt-version.md
@@ -25,6 +25,7 @@ The example job seen in the screenshot above belongs to the environment "Redshif
 
 At the present time, the following versions of dbt are supported:
 
+ - v0.20.x
  - v0.19.x
  - v0.18.x
  - v0.17.x


### PR DESCRIPTION
## Description & motivation
Small change to update list of supported versions in dbt cloud to include 0.20.x https://docs.getdbt.com/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-choosing-a-dbt-version


## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!