### PR TITLE
Fix heading indentation

### DIFF
--- a/website/docs/docs/guides/getting-help.md
+++ b/website/docs/docs/guides/getting-help.md
@@ -18,7 +18,7 @@ We're committed to making more errors searchable, so it's worth checking if ther
 #### Experiment!
 If the question you have is "What happens when I do `X`", try doing `X` and see what happens! Assuming you have a solid dev environment set up, making mistakes in development won't affect your end users
 
-## 2. Take a few minutes to formulate your question well
+### 2. Take a few minutes to formulate your question well
 Explaining the problems you are facing clearly will help others help you.
 <!--- To-do:
 We've also included some examples of well-asked questions below.-->


### PR DESCRIPTION
## Description & motivation
Heading indentation was off:
<img width="178" alt="Screen Shot 2021-07-23 at 2 10 44 PM" src="https://user-images.githubusercontent.com/20294432/126823789-8a656ecb-cdfc-4a6c-aa66-00f1bd557377.png">
## To-do before merge

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [x] No: please ensure the base branch is `current`
