### PR TITLE
new docs for on_schema_change

### DIFF
--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
@@ -1,0 +1,21 @@
+---
+title: "Upgrading to 0.21.0"
+
+---
+
+### Resources
+
+- [Discourse](https://discourse.getdbt.com/t/2621)
+- [Changelog](https://github.com/fishtown-analytics/dbt/blob/develop/CHANGELOG.md)
+
+## Breaking changes
+
+## New and changed documentation
+
+### Tests
+
+### Elsewhere in Core
+- [Configuring Incremental Models](configuring-incremental-models): Notes on updated configurations to incrementals, including the `on_schema_change` config.
+
+### Plugins
+


### PR DESCRIPTION
## Description & motivation
Added documentation for new `on_schema_change` configuration options on incremental models per [3387](https://github.com/dbt-labs/dbt/pull/3387)

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [X] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
