### PR TITLE
Update Slim CI docs with troubleshooting for "defer to self" case

### DIFF
--- a/website/docs/docs/dbt-cloud/using-dbt-cloud/cloud-enabling-continuous-integration-with-github.md
+++ b/website/docs/docs/dbt-cloud/using-dbt-cloud/cloud-enabling-continuous-integration-with-github.md
@@ -46,8 +46,7 @@ When the run is complete, dbt Cloud will update the PR in GitHub or MR in GitLab
 
 With Slim CI, you don't have to rebuild and test all your models. You can instruct dbt Cloud to run jobs on only modified or new resources.
 
-When creating or editing a job in dbt Cloud, you can set your execution settings to defer to a previous run state. Use the drop drop menu to select which production job you want to defer to.
-
+When creating or editing a job in dbt Cloud, you can set your execution settings to defer to a previous run state. Use the drop drop menu to select which **production** job you want to defer to. 
 
 <Lightbox src="/img/docs/dbt-cloud/using-dbt-cloud/ci-deferral.png" title="Jobs that run
 on pull requests may select &quot;self&quot; or another job from the same project for deferral and comparison"/>
@@ -83,3 +82,9 @@ Confirm that you'd like to disconnect your repository. You should then see a new
 <Lightbox src="/img/docs/dbt-cloud/using-dbt-cloud/Enabling-CI/repo-config.png" title="Configure repo"/>
 
 Select the `GitHub` or `GitLab` tab and reselect your repository. That should complete the setup and enable you to use webhooks in your jobs configuration.
+
+### Error messages that refer to schemas from previous PRs
+
+If you receive a schema-related error message referencing a *previous* PR, this is usually an indicator that you are not using a production job for your deferral and are instead using *self*.  If the prior PR has already been merged, the prior PR's schema may have been dropped by the time the Slim CI job for the current PR is kicked off.
+
+To fix this issue, select a production job run to defer to instead of self.


### PR DESCRIPTION
## Description & motivation
It is possible for a customer to set Slim CI jobs to defer to SELF -- in doing so, this will produce an error message that references the immediate prior PR.  Adding details on troubleshooting and fixing this issue.


## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!