### PR TITLE
update the adapter page about dbt init

### DIFF
--- a/website/docs/docs/contributing/building-a-new-adapter.md
+++ b/website/docs/docs/contributing/building-a-new-adapter.md
@@ -316,6 +316,11 @@ While much of dbt's adapter-specific functionality can be modified in adapter ma
 
 </File>
 
+### Enabling dbt init 
+
+In order to enable the [dbt init command](/reference/commands/init), make sure to include a sample profile file. The filepath will be `dbt/adapters/<adapter_name>/sample_profiles.yml`. This will assure that users can create a new dbt project with the command. 
+For sample profiles, check out this [example](https://github.com/dbt-labs/dbt/blob/develop/plugins/postgres/dbt/include/postgres/sample_profiles.yml).
+
 ### Testing your new adapter
 
 You can use a pre-configured [dbt adapter test suite](https://github.com/fishtown-analytics/dbt-adapter-tests) to test that your new adapter works. These tests include much of dbt's basic functionality, with the option to override or disable functionality that may not be supported on your adapter.

--- a/website/docs/docs/contributing/building-a-new-adapter.md
+++ b/website/docs/docs/contributing/building-a-new-adapter.md
@@ -316,10 +316,12 @@ While much of dbt's adapter-specific functionality can be modified in adapter ma
 
 </File>
 
-### Enabling dbt init 
+### Other files
 
-In order to enable the [dbt init command](/reference/commands/init), make sure to include a sample profile file. The filepath will be `dbt/adapters/<adapter_name>/sample_profiles.yml`. This will assure that users can create a new dbt project with the command. 
+In order to enable the [dbt init command](/reference/commands/init), make sure to include a sample profile file. The filepath will be `dbt/adapters/<adapter_name>/sample_profiles.yml`. This will assure that users can create a new dbt project with the `dbt init` command. 
 For sample profiles, check out this [example](https://github.com/dbt-labs/dbt/blob/develop/plugins/postgres/dbt/include/postgres/sample_profiles.yml).
+
+To assure that `dbt --version` provides the latest dbt core version the adapter supports, be sure include a `__version__.py` file. The filepath will be `dbt/adapters/<adapter_name>/__version__.py`. We recommend using the latest dbt core version and as the adapter is made compatiable with later versions, this file will need to be updated. For a sample file, check out this [example](https://github.com/dbt-labs/dbt/blob/develop/plugins/snowflake/dbt/adapters/snowflake/__version__.py).
 
 ### Testing your new adapter
 

--- a/website/docs/docs/contributing/building-a-new-adapter.md
+++ b/website/docs/docs/contributing/building-a-new-adapter.md
@@ -323,6 +323,8 @@ For sample profiles, check out this [example](https://github.com/dbt-labs/dbt/bl
 
 To assure that `dbt --version` provides the latest dbt core version the adapter supports, be sure include a `__version__.py` file. The filepath will be `dbt/adapters/<adapter_name>/__version__.py`. We recommend using the latest dbt core version and as the adapter is made compatiable with later versions, this file will need to be updated. For a sample file, check out this [example](https://github.com/dbt-labs/dbt/blob/develop/plugins/snowflake/dbt/adapters/snowflake/__version__.py).
 
+It should be noted that both of these files are included in the bootstrapped output of the `create_adapter_plugins.py` so when using that script, these files will be included.
+
 ### Testing your new adapter
 
 You can use a pre-configured [dbt adapter test suite](https://github.com/fishtown-analytics/dbt-adapter-tests) to test that your new adapter works. These tests include much of dbt's basic functionality, with the option to override or disable functionality that may not be supported on your adapter.

--- a/website/docs/docs/contributing/building-a-new-adapter.md
+++ b/website/docs/docs/contributing/building-a-new-adapter.md
@@ -318,7 +318,7 @@ While much of dbt's adapter-specific functionality can be modified in adapter ma
 
 ### Other files
 
-In order to enable the [dbt init command](/reference/commands/init), make sure to include a sample profile file. The filepath will be `dbt/adapters/<adapter_name>/sample_profiles.yml`. This will assure that users can create a new dbt project with the `dbt init` command. 
+In order to enable the [dbt init command](/reference/commands/init), make sure to include a sample profile file. The filepath will be `dbt/include/<adapter_name>/sample_profiles.yml`. This will assure that users can create a new dbt project with the `dbt init` command.
 For sample profiles, check out this [example](https://github.com/dbt-labs/dbt/blob/develop/plugins/postgres/dbt/include/postgres/sample_profiles.yml).
 
 To assure that `dbt --version` provides the latest dbt core version the adapter supports, be sure include a `__version__.py` file. The filepath will be `dbt/adapters/<adapter_name>/__version__.py`. We recommend using the latest dbt core version and as the adapter is made compatiable with later versions, this file will need to be updated. For a sample file, check out this [example](https://github.com/dbt-labs/dbt/blob/develop/plugins/snowflake/dbt/adapters/snowflake/__version__.py).


### PR DESCRIPTION
## Description & motivation
I've noticed that with new adapters, folks are forgetting to include the sample profile that makes it easy to use dbt init so wanted to include it in the docs. 


## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!


