### PR TITLE
Prerelease: v0.21.0-b1

### DIFF
--- a/website/docs/docs/building-a-dbt-project/package-management.md
+++ b/website/docs/docs/building-a-dbt-project/package-management.md
@@ -130,7 +130,7 @@ You can also reference an [environment variables](env_var).
 
 ```yaml
 packages:
-  - git: "https://{{env_var('GIT_CREDENTIALS')}}@github.com/dbt-labs/dbt-utils.git" # git HTTPS URL
+  - git: "https://{{env_var('DBT_ENV_SECRET_GIT_CREDENTIALS')}}@github.com/dbt-labs/dbt-utils.git" # git HTTPS URL
 ```
 
 **Note**: The use of private packages is not currently supported in dbt Cloud.

--- a/website/docs/docs/building-a-dbt-project/using-sources.md
+++ b/website/docs/docs/building-a-dbt-project/using-sources.md
@@ -7,7 +7,7 @@ id: "using-sources"
 * [Source properties](source-properties)
 * [Source configurations](source-configs)
 * [`{{ source() }}` jinja function](dbt-jinja-functions/source)
-* [`source snapshot-freshness` command](commands/source)
+* [`source freshness` command](commands/source)
 
 ## Using sources
 Sources make it possible to name and describe the data loaded into your warehouse by your Extract and Load tools. By declaring these tables as sources in dbt, you can then
@@ -164,10 +164,10 @@ Additionally, the `loaded_at_field` is required to calculate freshness for a tab
 These configs are applied hierarchically, so `freshness` and `loaded_at` field values specified for a `source` will flow through to all of the `tables` defined in that source. This is useful when all of the tables in a source have the same `loaded_at_field`, as the config can just be specified once in the top-level source definition.
 
 ### Snapshotting source freshness
-To snapshot freshness information for your sources, use the `dbt source snapshot-freshness` command ([reference docs](commands/source)):
+To snapshot freshness information for your sources, use the `dbt source freshness` command ([reference docs](commands/source)):
 
 ```
-$ dbt source snapshot-freshness
+$ dbt source freshness
 ```
 
 Behind the scenes, dbt uses the freshness properties to construct a `select` query, shown below. You can find this query in the logs.

--- a/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
@@ -17,7 +17,7 @@ We’ve improved the tabbing experience in the IDE. Tabs now work much more intu
 
 #### Performance improvements and enhancements
 - We've been working on some nice improvements to tabs in our IDE. We’ve fixed deficiencies with tabs that caused users to lose work if they didn’t hit save regularly enough. Additionally, opening, closing, and the order of the tabs work much more smoothly.
-- You may have noticed that there is now a source freshness checkbox in your execution settings when you configure a job on dbt Cloud. Selecting this checkbox will run `dbt source snapshot-freshness` as the first step in your job, but it will not break subsequent steps if it fails. Updated source freshness documentation available [here](https://docs.getdbt.com/docs/dbt-cloud/using-dbt-cloud/cloud-snapshotting-source-freshness).
+- You may have noticed that there is now a source freshness checkbox in your execution settings when you configure a job on dbt Cloud. Selecting this checkbox will run `dbt source freshness` as the first step in your job, but it will not break subsequent steps if it fails. Updated source freshness documentation available [here](https://docs.getdbt.com/docs/dbt-cloud/using-dbt-cloud/cloud-snapshotting-source-freshness).
 - Added a new endpoint to allow API key rotation via `POST https://cloud.getdbt.com/api/v2/users/{user-id}/apiKey`
 
 

--- a/website/docs/docs/dbt-cloud/using-dbt-cloud/cloud-snapshotting-source-freshness.md
+++ b/website/docs/docs/dbt-cloud/using-dbt-cloud/cloud-snapshotting-source-freshness.md
@@ -20,15 +20,15 @@ dbt Cloud provides a helpful interface around dbt's [source data freshness](usin
 
 First, make sure to configure your sources to [snapshot freshness information](using-sources#snapshotting-source-data-freshness).
 
-Then, to enable source freshness snapshots in dbt Cloud, add a `dbt source snapshot-freshness` step to one of your jobs, or create a new job to snapshot source freshness.
+Then, to enable source freshness snapshots in dbt Cloud, add a `dbt source freshness` step to one of your jobs, or create a new job to snapshot source freshness.
 
 <Lightbox src="/img/docs/dbt-cloud/using-dbt-cloud/49a03cc-Screen_Shot_2019-03-06_at_10.24.15_AM.png" title="Adding a step to snapshot source freshness"/>
 
-You can add `dbt source snapshot-freshness` anywhere in your list of run steps, but note that if your source data is out of date, this step will "fail', and subsequent steps will not run. dbt Cloud will trigger email notifications (if configured) based on the end state of this step.
+You can add `dbt source freshness` anywhere in your list of run steps, but note that if your source data is out of date, this step will "fail', and subsequent steps will not run. dbt Cloud will trigger email notifications (if configured) based on the end state of this step.
 
-If you *do not* want your models to run if your source data is out of date, then it could be a good idea to run `dbt source snapshot-freshness` as the first step in your job. Otherwise, we recommend adding `dbt source snapshot-freshness` as the last step in the job, or creating a separate job just for this task.
+If you *do not* want your models to run if your source data is out of date, then it could be a good idea to run `dbt source freshness` as the first step in your job. Otherwise, we recommend adding `dbt source freshness` as the last step in the job, or creating a separate job just for this task.
 
-Another option is to select the source freshness checkbox in your execution settings when you configure a job on dbt cloud. Selecting this checkbox will run `dbt source snapshot-freshness` as the first step in your job, but it will not break subsequent steps if it fails. If you wanted your job dedicated *exclusively* to running freshness checks, you would need to use the `dbt compile` command.
+Another option is to select the source freshness checkbox in your execution settings when you configure a job on dbt cloud. Selecting this checkbox will run `dbt source freshness` as the first step in your job, but it will not break subsequent steps if it fails. If you wanted your job dedicated *exclusively* to running freshness checks, you would need to use the `dbt compile` command.
 
 <Lightbox src="/img/docs/dbt-cloud/select-source-freshness.png" title="Selecting source freshness"/>
 

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
@@ -17,3 +17,6 @@ title: "Upgrading to 0.21.0"
 - [Configuring incremental models](configuring-incremental-models): New optional configuration for incremental models, `on_schema_change`.
 - [Commands: `source`](commands/source): Renamed to `dbt source freshness`, updated selection logic.
 - [Environment variables](env_var): Add a log-scrubbing prefix, `DBT_ENV_SECRET_`
+
+### Plugins
+- [Redshift profile](redshift-profile): `ra3: true` profile property to support cross-database source definitions and read-only querying

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
@@ -5,17 +5,13 @@ title: "Upgrading to 0.21.0"
 
 ### Resources
 
-- [Discourse](https://discourse.getdbt.com/t/2621)
-- [Changelog](https://github.com/fishtown-analytics/dbt/blob/develop/CHANGELOG.md)
+- [Changelog](https://github.com/dbt-labs/dbt/blob/0.21.latest/CHANGELOG.md)
 
 ## Breaking changes
 
+- `dbt source snapshot-freshness` has been renamed to `dbt source freshness`, and its node selection logic is consistent with other commands
+
 ## New and changed documentation
 
-### Tests
-
-### Elsewhere in Core
-- [Configuring Incremental Models](configuring-incremental-models): Notes on updated configurations to incrementals, including the `on_schema_change` config.
-
-### Plugins
-
+- [Configuring incremental models](configuring-incremental-models): New optional configuration for incremental models, `on_schema_change`.
+- [Commands: `source`](commands/source): Renamed to `dbt source freshness`, updated selection logic.

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
@@ -15,3 +15,4 @@ title: "Upgrading to 0.21.0"
 
 - [Configuring incremental models](configuring-incremental-models): New optional configuration for incremental models, `on_schema_change`.
 - [Commands: `source`](commands/source): Renamed to `dbt source freshness`, updated selection logic.
+- [Environment variables](env_var): Add a log-scrubbing prefix, `DBT_ENV_SECRET_`

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
@@ -13,6 +13,7 @@ title: "Upgrading to 0.21.0"
 
 ## New and changed documentation
 
+- [Commands](dbt-commands) and [Commands: `build`](commands/build): Add `dbt build`
 - [Configuring incremental models](configuring-incremental-models): New optional configuration for incremental models, `on_schema_change`.
 - [Commands: `source`](commands/source): Renamed to `dbt source freshness`, updated selection logic.
 - [Environment variables](env_var): Add a log-scrubbing prefix, `DBT_ENV_SECRET_`

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
@@ -3,6 +3,12 @@ title: "Upgrading to 0.21.0"
 
 ---
 
+:::info Beta
+
+dbt v0.21.0-b1 is currently available as a prerelease. If you have questions or encounter bugs, please let us know in [#dbt-prereleases](https://community.getdbt.com/) or by opening an issue [in GitHub](https://github.com/dbt-labs/dbt).
+
+:::
+
 ### Resources
 
 - [Changelog](https://github.com/dbt-labs/dbt/blob/0.21.latest/CHANGELOG.md)

--- a/website/docs/faqs/snapshotting-freshness-for-one-source.md
+++ b/website/docs/faqs/snapshotting-freshness-for-one-source.md
@@ -7,13 +7,13 @@ Use the `--select` flag to snapshot freshness for specific sources. Eg:
 
 ```
 # Snapshot freshness for all Snowplow tables:
-$ dbt source snapshot-freshness --select jaffle_shop
+$ dbt source freshness --select jaffle_shop
 
 # Snapshot freshness for a particular source table:
-$ dbt source snapshot-freshness --select jaffle_shop.orders
+$ dbt source freshness --select jaffle_shop.orders
 
 # Snapshot freshness for multiple particular source tables:
-$ dbt source snapshot-freshness --select jaffle_shop.orders jaffle_shop.customers
+$ dbt source freshness --select jaffle_shop.orders jaffle_shop.customers
 ```
 
-See the [`source snapshot-freshness` command reference](commands/source) for more information.
+See the [`source freshness` command reference](commands/source) for more information.

--- a/website/docs/reference/artifacts/dbt-artifacts.md
+++ b/website/docs/reference/artifacts/dbt-artifacts.md
@@ -21,7 +21,7 @@ Most dbt commands (and corresponding RPC methods) produce artifacts:
 - [manifest](manifest-json): produced by `compile`, `run`, `test`, `docs generate`, `ls`
 - [run results](run-results-json): produced by `run`, `test`, `seed`, `snapshot`, `docs generate`
 - [catalog](catalog-json): produced by `docs generate`
-- [sources](sources-json): produced by `source snapshot-freshness`
+- [sources](sources-json): produced by `source freshness`
 
 ## Common metadata
 

--- a/website/docs/reference/artifacts/manifest-json.md
+++ b/website/docs/reference/artifacts/manifest-json.md
@@ -13,6 +13,7 @@ _Produced by:_
 - `dbt docs generate`
 - `dbt source freshness`
 - `dbt ls`
+- `dbt build`
 
 This single file contains a full representation of your dbt project's resources (models, tests, macros, etc), including all node configurations and resource properties. Even if you're only running some models or tests, all resources will appear in the manifest (unless they are disabled) with most of their properties. (A few node properties, such as `compiled_sql`, only appear for executed nodes.)
 

--- a/website/docs/reference/artifacts/manifest-json.md
+++ b/website/docs/reference/artifacts/manifest-json.md
@@ -11,7 +11,7 @@ _Produced by:_
 - `dbt seed`
 - `dbt snapshot`
 - `dbt docs generate`
-- `dbt source snapshot-freshness`
+- `dbt source freshness`
 - `dbt ls`
 
 This single file contains a full representation of your dbt project's resources (models, tests, macros, etc), including all node configurations and resource properties. Even if you're only running some models or tests, all resources will appear in the manifest (unless they are disabled) with most of their properties. (A few node properties, such as `compiled_sql`, only appear for executed nodes.)

--- a/website/docs/reference/artifacts/run-results-json.md
+++ b/website/docs/reference/artifacts/run-results-json.md
@@ -11,6 +11,7 @@ _Produced by:_
 - `dbt snapshot`
 - `dbt compile`
 - `dbt docs generate`
+- `dbt build`
 
 This file contains information about a completed invocation of dbt, including timing and status info for each node (model, test, etc) that was executed. In aggregate, many `run_results.json` can be combined to calculate average model runtime, test failure rates, the number of record changes captured by snapshots, etc.
 

--- a/website/docs/reference/artifacts/run-results-json.md
+++ b/website/docs/reference/artifacts/run-results-json.md
@@ -16,7 +16,7 @@ This file contains information about a completed invocation of dbt, including ti
 
 Note that only executed nodes appear in the run results. If you have multiple run or test steps with different critiera, each will produce different run results.
 
-Note: `dbt source snapshot-freshness` produces a different artifact, [`sources.json`](sources-json), with similar attributes.
+Note: `dbt source freshness` produces a different artifact, [`sources.json`](sources-json), with similar attributes.
 
 ### Top-level keys
 

--- a/website/docs/reference/artifacts/sources-json.md
+++ b/website/docs/reference/artifacts/sources-json.md
@@ -4,7 +4,7 @@ title: Sources
 
 _Current schema_: [`v1`](https://schemas.getdbt.com/dbt/sources/v1.json)
 
-_Produced by:_ `dbt source snapshot-freshness`
+_Produced by:_ `dbt source freshness`
 
 This file contains information about [sources with freshness checks](using-sources#snapshotting-source-data-freshness). Today, dbt Cloud uses this file to power its [Source Freshness visualization](cloud-snapshotting-source-freshness).
 

--- a/website/docs/reference/commands/build.md
+++ b/website/docs/reference/commands/build.md
@@ -3,9 +3,15 @@ title: "build"
 id: "build"
 ---
 
+:::info Beta
+
+dbt v0.21.0-b1 is currently available as a prerelease. If you have questions or encounter bugs, please let us know in [#dbt-prereleases](https://community.getdbt.com/) or by opening an issue [in GitHub](https://github.com/dbt-labs/dbt).
+
+:::
+
 <Changelog>
 
-    - Introduced in **v0.21.0**
+- Introduced in **v0.21.0**
     
 </Changelog>
 
@@ -16,6 +22,20 @@ The `dbt build` command will:
 - seed seeds
 
 In DAG order, for selected resources or an entire project.
+
+### Implementation details
+
+- The `build` task uses the same selection syntax as `run` and `test`: `--models`, `--exclude`, `--selector`, etc.
+- The `build` task will write a single [manifest](artifacts/manifest-json) and a single [run results artifact](artifacts/run-results-json). The run results will include information about all models, tests, seeds, and snapshots that were selected to build, combined into one file.
+
+### Current limitations
+
+v0.21 is currently in beta, and as such there are some limitations to `dbt build` that we're hoping to address before the final release:
+
+- A test on a resource should block that resource's other downstream children from running, and a test failure should cause those other children to `SKIP` ([dbt#3597](https://github.com/dbt-labs/dbt/issues/3597))
+- The `build` command should be supported in the [dbt Server](rpc) ([#3595](https://github.com/dbt-labs/dbt/issues/3595))
+- The `build` command should support the superset of CLI flags supported by `run`, `test`, `seed`, and `snapshot` ([dbt#3596](https://github.com/dbt-labs/dbt/issues/3596)). The `build` command should also support a `--resource-type` flag, as the `list` command does.
+- Ahead of the final v0.21 release, we're thinking about switching all commands to use `--select`, with backwards compatibility for `--models` ([dbt#3210](https://github.com/dbt-labs/dbt/issues/3210)). It doesn't make much sense to use a `--models` flag, when the whole point is building more than models.
 
 ```
 $ dbt build
@@ -45,9 +65,3 @@ Completed successfully
 
 Done. PASS=7 WARN=0 ERROR=0 SKIP=0 TOTAL=7
 ```
-
-### To come
-
-- Tests blocking downstream models from running [#3597](https://github.com/dbt-labs/dbt/issues/3597)
-- Full flag parity [#3596](https://github.com/dbt-labs/dbt/issues/3596)
-- RPC parity [#3595](https://github.com/dbt-labs/dbt/issues/3595)

--- a/website/docs/reference/commands/build.md
+++ b/website/docs/reference/commands/build.md
@@ -1,0 +1,53 @@
+---
+title: "build"
+id: "build"
+---
+
+<Changelog>
+
+    - Introduced in **v0.21.0**
+    
+</Changelog>
+
+The `dbt build` command will:
+- run models
+- test tests
+- snapshot snapshots
+- seed seeds
+
+In DAG order, for selected resources or an entire project.
+
+```
+$ dbt build
+Running with dbt=0.21.0-a1
+Found 1 model, 4 tests, 1 snapshot, 1 analysis, 341 macros, 0 operations, 1 seed file, 2 sources, 2 exposures
+
+18:49:43 | Concurrency: 1 threads (target='dev')
+18:49:43 |
+18:49:43 | 1 of 7 START seed file dbt_jcohen.my_seed............................ [RUN]
+18:49:43 | 1 of 7 OK loaded seed file dbt_jcohen.my_seed........................ [INSERT 2 in 0.09s]
+18:49:43 | 2 of 7 START view model dbt_jcohen.my_model.......................... [RUN]
+18:49:43 | 2 of 7 OK created view model dbt_jcohen.my_model..................... [CREATE VIEW in 0.12s]
+18:49:43 | 3 of 7 START test not_null_my_seed_id................................ [RUN]
+18:49:43 | 3 of 7 PASS not_null_my_seed_id...................................... [PASS in 0.05s]
+18:49:43 | 4 of 7 START test unique_my_seed_id.................................. [RUN]
+18:49:43 | 4 of 7 PASS unique_my_seed_id........................................ [PASS in 0.03s]
+18:49:43 | 5 of 7 START snapshot snapshots.my_snapshot.......................... [RUN]
+18:49:43 | 5 of 7 OK snapshotted snapshots.my_snapshot.......................... [INSERT 0 5 in 0.27s]
+18:49:43 | 6 of 7 START test not_null_my_model_id............................... [RUN]
+18:49:43 | 6 of 7 PASS not_null_my_model_id..................................... [PASS in 0.03s]
+18:49:43 | 7 of 7 START test unique_my_model_id................................. [RUN]
+18:49:43 | 7 of 7 PASS unique_my_model_id....................................... [PASS in 0.02s]
+18:49:43 |
+18:49:43 | Finished running 1 seed, 1 view model, 4 tests, 1 snapshot in 1.01s.
+
+Completed successfully
+
+Done. PASS=7 WARN=0 ERROR=0 SKIP=0 TOTAL=7
+```
+
+### To come
+
+- Tests blocking downstream models from running [#3597](https://github.com/dbt-labs/dbt/issues/3597)
+- Full flag parity [#3596](https://github.com/dbt-labs/dbt/issues/3596)
+- RPC parity [#3595](https://github.com/dbt-labs/dbt/issues/3595)

--- a/website/docs/reference/commands/source.md
+++ b/website/docs/reference/commands/source.md
@@ -3,27 +3,39 @@ title: "source"
 id: "source"
 ---
 
-The `dbt source` command provides subcommands that are useful when working with source data. This command provides one subcommand, `dbt source snapshot-freshness`.
+The `dbt source` command provides subcommands that are useful when working with source data. This command provides one subcommand, `dbt source freshness`.
 
-### dbt source snapshot-freshness
+### dbt source freshness
 
-If your dbt project is [configured with sources](using-sources), then the `dbt source snapshot-freshness` command will query all of your defined source tables, determining the "freshness" of these tables. If the tables are stale (based on the `freshness` config specified for your sources) then dbt will report a warning or error accordingly. If a source table is in a stale state, then dbt will exit with a nonzero exit code.
+<Changelog>
+
+  - **v0.21.0:** Renamed `dbt source snapshot-freshness` to `dbt source freshness`. If using an older version of dbt, the command is `snapshot-freshness`.
+
+</Changelog>
+
+If your dbt project is [configured with sources](using-sources), then the `dbt source freshness` command will query all of your defined source tables, determining the "freshness" of these tables. If the tables are stale (based on the `freshness` config specified for your sources) then dbt will report a warning or error accordingly. If a source table is in a stale state, then dbt will exit with a nonzero exit code.
 
 ### Specifying sources to snapshot
 
-By default, `dbt source snapshot-freshness` will calculate freshness information for all of the sources in your project. To snapshot freshness for a subset of these sources, use the `--select` flag.
+<Changelog>
+
+  - **v0.21.0:** Selection syntax for the `freshness` task now mirrors other tasks. Sources need to be prefixed with the `source:` selection method. In previous versions of dbt, sources were specified by name only.
+
+</Changelog>
+
+By default, `dbt source freshness` will calculate freshness information for all of the sources in your project. To snapshot freshness for a subset of these sources, use the `--select` flag.
 
 ```bash
 # Snapshot freshness for all Snowplow tables:
-$ dbt source snapshot-freshness --select snowplow
+$ dbt source freshness --select source:snowplow
 
 # Snapshot freshness for a particular source table:
-$ dbt source snapshot-freshness --select snowplow.event
+$ dbt source freshness --select source:snowplow.event
 ```
 
 ### Configuring source freshness output
 
-When `dbt source snapshot-freshness` completes, a JSON file containing information about the freshness of your sources will be saved to `target/sources.json`. An example `sources.json` will look like:
+When `dbt source freshness` completes, a JSON file containing information about the freshness of your sources will be saved to `target/sources.json`. An example `sources.json` will look like:
 
 <File name='target/sources.json'>
 
@@ -60,7 +72,7 @@ When `dbt source snapshot-freshness` completes, a JSON file containing informati
 To override the destination for this `sources.json` file, use the `-o` (or `--output`) flag:
 ```
 # Output source freshness info to a different path
-$ dbt source snapshot-freshness --output target/source_freshness.json
+$ dbt source freshness --output target/source_freshness.json
 ```
 
 ### Using source freshness

--- a/website/docs/reference/dbt-commands.md
+++ b/website/docs/reference/dbt-commands.md
@@ -27,3 +27,4 @@ For information about selecting models on the command line, consult the docs on 
 - [rpc](rpc) (CLI only): runs an RPC server that clients can submit queries to
 - [list](list) (CLI only): lists resources defined in a dbt project
 - [parse](parse) (CLI only): parses a project and writes detailed timing info
+- [build](build) (CLI only): build and test all selected resources (models, seeds, snapshots, tests)

--- a/website/docs/reference/dbt-jinja-functions/env_var.md
+++ b/website/docs/reference/dbt-jinja-functions/env_var.md
@@ -46,3 +46,16 @@ models:
 </File>
 
  This can be useful to avoid compilation errors when the environment variable isn't available.
+
+### Special env var prefixes
+
+<Changelog>
+
+  - **v0.19.0:** Introduced `DBT_ENV_CUSTOM_ENV_` prefix and artifact `metadata.env`
+  - **v0.21.0:** Introduced `DBT_ENV_SECRET_` and log scrubbing
+
+</Changelog>
+
+If environment variables are named with one of two prefixes, it will have special behavior in dbt:
+- `DBT_ENV_CUSTOM_ENV_`: Any env var named with this prefix will be included in [dbt artifacts](dbt-artifacts#common-metadata), in a `metadata.env` dictionary, with its prefix-stripped name as its key.
+- `DBT_ENV_SECRET_`: Any env var named with this prefix will be scrubbed from dbt logs and replaced with `*****`, any time its value appears in those logs (even if the env var was not called directly). While dbt already avoids logging database credentials, this is useful for other types of secrets, such as git tokens for [private packages](package-management#private-packages), or AWS keys for querying data in S3.

--- a/website/docs/reference/node-selection/syntax.md
+++ b/website/docs/reference/node-selection/syntax.md
@@ -13,6 +13,7 @@ dbt's node selection syntax makes it possible to run only specific resources in 
 | [ls (list)](commands/list)      | `--select`, `--models`, `--exclude`, `--selector`, `--resource-type` |
 | [compile](commands/compile)     | `--select`, `--exclude`, `--selector`                                |
 | [freshness](commands/source)    | `--select`, `--exclude`, `--selector`                                |
+| [build](commands/build)         | `--models`, `--exclude`, `--selector`, `--defer`                     |
 
 :::info Nodes and resources
 

--- a/website/docs/reference/node-selection/syntax.md
+++ b/website/docs/reference/node-selection/syntax.md
@@ -4,14 +4,15 @@ title: "Syntax overview"
 
 dbt's node selection syntax makes it possible to run only specific resources in a given invocation of dbt. This selection syntax is used for the following subcommands:
 
-| command   | argument(s)                                                          |
-| :-------- | -------------------------------------------------------------------- |
-| run       | `--models`, `--exclude`, `--selector`, `--defer`                     |
-| test      | `--models`, `--exclude`, `--selector`, `--defer`                     |
-| seed      | `--select`, `--exclude`, `--selector`                                |
-| snapshot  | `--select`, `--exclude`  `--selector`                                |
-| ls (list) | `--select`, `--models`, `--exclude`, `--selector`, `--resource-type` |
-| compile   | `--select`, `--exclude`, `--selector`                                |
+| command                         | argument(s)                                                          |
+| :------------------------------ | -------------------------------------------------------------------- |
+| [run](commands/run)             | `--models`, `--exclude`, `--selector`, `--defer`                     |
+| [test](commands/test)           | `--models`, `--exclude`, `--selector`, `--defer`                     |
+| [seed](commands/seed)           | `--select`, `--exclude`, `--selector`                                |
+| [snapshot](commands/snapshot)   | `--select`, `--exclude`  `--selector`                                |
+| [ls (list)](commands/list)      | `--select`, `--models`, `--exclude`, `--selector`, `--resource-type` |
+| [compile](commands/compile)     | `--select`, `--exclude`, `--selector`                                |
+| [freshness](commands/source)    | `--select`, `--exclude`, `--selector`                                |
 
 :::info Nodes and resources
 

--- a/website/docs/reference/resource-properties/freshness.md
+++ b/website/docs/reference/resource-properties/freshness.md
@@ -79,7 +79,7 @@ The time period used in the freshness calculation. One of `minute`, `hour` or `d
 ## filter
 (optional)
 
-Add a where clause to the query run by `dbt source snapshot-freshness` in order to limit data scanned.
+Add a where clause to the query run by `dbt source freshness` in order to limit data scanned.
 
 This filter *only* applies to dbt's source freshness queries - it will not impact other uses of the source table.
 
@@ -130,7 +130,7 @@ sources:
 
 </File>
 
-When running `dbt source snapshot-freshness`, the following query will be run:
+When running `dbt source freshness`, the following query will be run:
 
 <Tabs
   defaultValue="compiled"

--- a/website/docs/reference/warehouse-profiles/redshift-profile.md
+++ b/website/docs/reference/warehouse-profiles/redshift-profile.md
@@ -24,6 +24,7 @@ company-name:
       keepalives_idle: 0 # default 0, indicating the system default
       # search_path: public # optional, not recommended
       sslmode: [optional, set the sslmode used to connect to the database (in case this parameter is set, will look for ca in ~/.postgresql/root.crt)]
+      ra3: true # enables cross-database sources
 ```
 
 </File>
@@ -68,6 +69,7 @@ my-redshift-db:
       keepalives_idle: 0 # default 0, indicating the system default
       # search_path: public # optional, but not recommended
       sslmode: [optional, set the sslmode used to connect to the database (in case this parameter is set, will look for ca in ~/.postgresql/root.crt)]
+      ra3: true # enables cross-database sources
 
 ```
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -398,6 +398,7 @@ module.exports = {
           type: "category",
           label: "List of commands",
           items: [
+            "reference/commands/build",
             "reference/commands/clean",
             "reference/commands/cmd-docs",
             "reference/commands/compile",

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -67,6 +67,7 @@ module.exports = {
           type: "category",
           label: "Migration guides",
           items: [
+            "docs/guides/migration-guide/upgrading-to-0-21-0",
             "docs/guides/migration-guide/upgrading-to-0-20-0",
             "docs/guides/migration-guide/upgrading-to-0-19-0",
             "docs/guides/migration-guide/upgrading-to-0-18-0",


### PR DESCRIPTION
## Description & motivation
- Migration guide for v0.21
- First cut of `dbt build`
- Some edits for `on_schema_change` incremental model config (follow ups to #747)
- `dbt source snapshot-freshness` --> `dbt source freshness`
- Note special env var prefixes, including `DBT_ENV_SECRET_` (new)
- Redshift profile: `ra3: true` to support cross-database source definitions / read-only querying

## To-do before merge
- Wait for v0.21.0-b1 release

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [x] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist
If you added new pages (delete if not applicable):
- [x] The page has been added to `website/sidebars.js`
- [x] The new page has a unique filename