### PR TITLE
Replace 'one-off' by 'bespoke'

### DIFF
--- a/website/docs/reference/resource-configs/store_failures.md
+++ b/website/docs/reference/resource-configs/store_failures.md
@@ -23,7 +23,7 @@ This logic is encoded in the [`should_store_failures()`](https://github.com/fish
   defaultValue="specific"
   values={[
     { label: 'Specific test', value: 'specific', },
-    { label: 'Bespoke test', value: 'bespoke', },
+    { label: 'Singular test', value: 'singular', },
     { label: 'Generic test block', value: 'generic', },
     { label: 'Project level', value: 'project', },
   ]
@@ -53,9 +53,9 @@ models:
 
 </TabItem>
 
-<TabItem value="bespoke">
+<TabItem value="singular">
 
-Configure a bespoke (data) test:
+Configure a singular (data) test:
 
 <File name='tests/<filename>.sql'>
 

--- a/website/docs/reference/resource-configs/store_failures.md
+++ b/website/docs/reference/resource-configs/store_failures.md
@@ -23,7 +23,7 @@ This logic is encoded in the [`should_store_failures()`](https://github.com/fish
   defaultValue="specific"
   values={[
     { label: 'Specific test', value: 'specific', },
-    { label: 'One-off test', value: 'one_off', },
+    { label: 'Bespoke test', value: 'bespoke', },
     { label: 'Generic test block', value: 'generic', },
     { label: 'Project level', value: 'project', },
   ]
@@ -53,9 +53,9 @@ models:
 
 </TabItem>
 
-<TabItem value="one_off">
+<TabItem value="bespoke">
 
-Configure a one-off (data) test:
+Configure a bespoke (data) test:
 
 <File name='tests/<filename>.sql'>
 


### PR DESCRIPTION
Since the documentation has changed the terminology from data test to bespoke test and uses bespoke at the main heading in the main Tests docs (https://docs.getdbt.com/docs/building-a-dbt-project/tests#bespoke-tests), it is confusing to use `one-off test` here. I'm therefore proposing to update this to use `Bespoke` here as well.

## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a pull request on dbt core, etc?
-->

## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged
-->

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [X] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist
If you added new pages (delete if not applicable):
- [ ] The page has been added to `website/sidebars.js`
- [ ] The new page has a unique filename

If you removed existing pages (delete if not applicable):
- [ ] The page has been removed from `website/sidebars.js`
- [ ] An entry has been added to `_redirects`
