### PR TITLE
correct small typo

### DIFF
--- a/website/docs/reference/resource-properties/tests.md
+++ b/website/docs/reference/resource-properties/tests.md
@@ -144,7 +144,7 @@ This feature is not implemented for analyses.
 
 ## Description
 
-The `tests` property defines assertions about a column, table, or view. The property contains a list of generic tests (referenced by name), which can include the four built-in generic tests available in dbt. It can also includes any arguments or [configurations](test-configs) passed to those tests.
+The `tests` property defines assertions about a column, table, or view. The property contains a list of generic tests (referenced by name), which can include the four built-in generic tests available in dbt. It can also include any arguments or [configurations](test-configs) passed to those tests.
 
 Once these tests are defined, you can validate their correctness by running `dbt test`.
 


### PR DESCRIPTION
## Description & motivation
Just noticed a small typo in the documentation. Change "can also includes" to "can also include" :)
