### PR TITLE
Prerelease: v0.21.0-b2

### DIFF
--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
@@ -19,7 +19,7 @@ dbt v0.21.0-b2 is currently available as a prerelease. If you have questions or 
 
 ## New and changed documentation
 
-- [Commands](dbt-commands) and [Commands: `build`](commands/build): Add `dbt build`
+- [Commands](dbt-commands), [`build`](commands/build), [rpc](rpc): Add `dbt build`
 - [Configuring incremental models](configuring-incremental-models): New optional configuration for incremental models, `on_schema_change`.
 - [Commands: `source`](commands/source): Renamed to `dbt source freshness`, updated selection logic.
 - [Environment variables](env_var): Add a log-scrubbing prefix, `DBT_ENV_SECRET_`

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
@@ -5,7 +5,7 @@ title: "Upgrading to 0.21.0"
 
 :::info Beta
 
-dbt v0.21.0-b1 is currently available as a prerelease. If you have questions or encounter bugs, please let us know in [#dbt-prereleases](https://community.getdbt.com/) or by opening an issue [in GitHub](https://github.com/dbt-labs/dbt).
+dbt v0.21.0-b2 is currently available as a prerelease. If you have questions or encounter bugs, please let us know in [#dbt-prereleases](https://community.getdbt.com/) or by opening an issue [in GitHub](https://github.com/dbt-labs/dbt).
 
 :::
 
@@ -23,6 +23,7 @@ dbt v0.21.0-b1 is currently available as a prerelease. If you have questions or 
 - [Configuring incremental models](configuring-incremental-models): New optional configuration for incremental models, `on_schema_change`.
 - [Commands: `source`](commands/source): Renamed to `dbt source freshness`, updated selection logic.
 - [Environment variables](env_var): Add a log-scrubbing prefix, `DBT_ENV_SECRET_`
+- [Selection methods](node-selection/methods) and [state comparison caveats](state-comparison-caveats): Add `state:modified` subselectors, and reflect that it now includes changes to upstream macros.
 
 ### Plugins
 - [Redshift profile](redshift-profile): `ra3: true` profile property to support cross-database source definitions and read-only querying

--- a/website/docs/reference/commands/build.md
+++ b/website/docs/reference/commands/build.md
@@ -33,7 +33,6 @@ In DAG order, for selected resources or an entire project.
 v0.21 is currently in beta, and as such there are some limitations to `dbt build` that we're hoping to address before the final release:
 
 - A test on a resource should block that resource's other downstream children from running, and a test failure should cause those other children to `SKIP` ([dbt#3597](https://github.com/dbt-labs/dbt/issues/3597))
-- The `build` command should be supported in the [dbt Server](rpc) ([#3595](https://github.com/dbt-labs/dbt/issues/3595))
 - The `build` command should support the superset of CLI flags supported by `run`, `test`, `seed`, and `snapshot` ([dbt#3596](https://github.com/dbt-labs/dbt/issues/3596)). The `build` command should also support a `--resource-type` flag, as the `list` command does.
 - Ahead of the final v0.21 release, we're thinking about switching all commands to use `--select`, with backwards compatibility for `--models` ([dbt#3210](https://github.com/dbt-labs/dbt/issues/3210)). It doesn't make much sense to use a `--models` flag, when the whole point is building more than models.
 

--- a/website/docs/reference/commands/rpc.md
+++ b/website/docs/reference/commands/rpc.md
@@ -315,6 +315,24 @@ Several of the following request types accept these additional parameters:
 }
 ```
 
+### Build ([docs](build))
+
+```json
+{
+	"jsonrpc": "2.0",
+	"method": "build",
+	"id": "<request id>",
+	"params": {
+            "threads": "<int> (optional)",
+            "models": "<str> (optional)",
+            "exclude": "<str> (optional)",
+            "selector": "<str> (optional)",
+            "state": "<str> (optional)",
+            "defer": "<str> (optional)"
+        }
+}
+```
+
 ### Generate docs ([docs](cmd-docs#dbt-docs-generate))
 
 **Additional parameters:**

--- a/website/docs/reference/node-selection/methods.md
+++ b/website/docs/reference/node-selection/methods.md
@@ -83,7 +83,10 @@ $ dbt test --models test_name:range_min_max     # run all instances of a custom 
 ```
 
 ### The "state" method
-<Changelog>New in v0.18.0</Changelog>
+<Changelog>
+    - **v0.18.0** introduced `state:new` and `state:modified`
+    - **v0.21.0** introduced `modified` sub-selectors, and handling for upstream macro dependencies
+</Changelog>
 
 **N.B.** State-based selection is a powerful, complex feature. Read about [known caveats and limitations](node-selection/state-comparison-caveats) to state comparison.
 
@@ -91,17 +94,22 @@ The `state` method is used to select nodes by comparing them against a previous 
 
 `state:new`: There is no node with the same `unique_id` in the comparison manifest
 
-`state:modified`: Everything new, plus any changes to:
-* file/node contents
-* configs (`materialized`, `bind`, `transient`, `quote`, etc.)
-* descriptions (top-level and/or column-level, depending on `persist_docs`)
-* database representations (user-input `database`, `schema`, `alias`, irrespective of `target` + `generate_x_name` macros)
+`state:modified`: All new nodes, plus any changes to existing nodes.
 
 ```bash
 $ dbt test --models state:new            # run all tests on new models + and new tests on old models
 $ dbt run --models state:modified        # run all models that have been modified
-$ dbt ls --models state:modified     # list all modified nodes (not just models)
+$ dbt ls --models state:modified         # list all modified nodes (not just models)
 ```
+
+Because state comparison is complex, and everyone's project is different, dbt supports subselectors that include a subset of the full `modified` criteria:
+- `state:modified.body`: Changes to node body (e.g. model SQL, seed values)
+- `state:modified.configs`: Changes to any node configs, excluding `database`/`schema`/`alias`
+- `state:modified.relation`: Changes to `database`/`schema`/`alias` (the database representation of this node), irrespective of `target` values or `generate_x_name` macros
+- `state:modified.persisted_descriptions`: Changes to relation- or column-level `description`, _if and only if_ `persist_docs` is enabled at each level
+- `state:modified.macros`: Changes to upstream macros (whether called directly or indirectly by another macro)
+
+Remember that `state:modified` includes _all_ of the criteria above, as well as some extra resource-specific criteria: a source's `freshness` property has changed, an exposure's `maturity` has changed, etc.
 
 ### The "exposure" method
 <Changelog>New in v0.18.1</Changelog>

--- a/website/docs/reference/node-selection/methods.md
+++ b/website/docs/reference/node-selection/methods.md
@@ -109,7 +109,7 @@ Because state comparison is complex, and everyone's project is different, dbt su
 - `state:modified.persisted_descriptions`: Changes to relation- or column-level `description`, _if and only if_ `persist_docs` is enabled at each level
 - `state:modified.macros`: Changes to upstream macros (whether called directly or indirectly by another macro)
 
-Remember that `state:modified` includes _all_ of the criteria above, as well as some extra resource-specific criteria: a source's `freshness` property has changed, an exposure's `maturity` has changed, etc.
+Remember that `state:modified` includes _all_ of the criteria above, as well as some extra resource-specific criteria, such as changes to a source's `freshness` property or an exposure's `maturity` property. (View the source code for the full set of checks used when comparing [sources](https://github.com/dbt-labs/dbt/blob/9e796671dd55d4781284d36c035d1db19641cd80/core/dbt/contracts/graph/parsed.py#L660-L681), [exposures](https://github.com/dbt-labs/dbt/blob/9e796671dd55d4781284d36c035d1db19641cd80/core/dbt/contracts/graph/parsed.py#L768-L783), and [executable nodes](https://github.com/dbt-labs/dbt/blob/9e796671dd55d4781284d36c035d1db19641cd80/core/dbt/contracts/graph/parsed.py#L319-L330).)
 
 ### The "exposure" method
 <Changelog>New in v0.18.1</Changelog>

--- a/website/docs/reference/node-selection/state-comparison-caveats.md
+++ b/website/docs/reference/node-selection/state-comparison-caveats.md
@@ -10,11 +10,17 @@ dbt stores a file hash of seed files that are <1 MB in size. If the contents of 
 
 If a seed file is >1 MB in size, dbt cannot compare its contents and will raise a warning as such. Instead, dbt will use only the seed's file path to detect changes. If the file path has changed, the seed will be included in `state:modified`; if it hasn't, it won't.
 
-### Macros, vars
+### Macros
 
-Although dbt can observe modifications to macros, it cannot reliably determine  the set of downstream resources that select from a given macro. As such, macro  modifications are not reflected in `state:modified` selection criteria. dbt will raise a warning at top of runs that use the `state:` method if it detects a macro has been modified.
+<Changelog>
 
-The same principle holds true for `vars` and `env_vars`. If a model uses a `var` in its definition, dbt is unable today to identify that lineage in such a way that it could include the model in `state:modified` when the `var` value changes.
+- New in v0.21.0: dbt will mark modified any resource that depends on a changed macro, or on a macro that depends on a changed macro.
+
+</Changelog>
+
+### Vars
+
+If a model uses a `var` or `env_var` in its definition, dbt is unable today to identify that lineage in such a way that it can include the model in `state:modified` because the `var` or `env_var` value has changed. It's likely that the model will be marked modified if the change in variable results in a different configuration.
 
 ### Tests
 


### PR DESCRIPTION
## Description & motivation
The things that ~will be going~ went into v0.21.0-b2, except for https://github.com/dbt-labs/docs.getdbt.com/pull/766, which is going to be a huge docs-writing initiative in its own right.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [x] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist
If you added new pages (delete if not applicable):
- [ ] The page has been added to `website/sidebars.js`
- [ ] The new page has a unique filename

If you removed existing pages (delete if not applicable):
- [ ] The page has been removed from `website/sidebars.js`
- [ ] An entry has been added to `_redirects`
