### PR TITLE
Update cloud-enabling-continuous-integration-with-github.md

### DIFF
--- a/website/docs/docs/dbt-cloud/using-dbt-cloud/cloud-enabling-continuous-integration-with-github.md
+++ b/website/docs/docs/dbt-cloud/using-dbt-cloud/cloud-enabling-continuous-integration-with-github.md
@@ -49,7 +49,7 @@ With Slim CI, you don't have to rebuild and test all your models. You can instru
 When creating or editing a job in dbt Cloud, you can set your execution settings to defer to a previous run state. Use the drop drop menu to select which **production** job you want to defer to. 
 
 <Lightbox src="/img/docs/dbt-cloud/using-dbt-cloud/ci-deferral.png" title="Jobs that run
-on pull requests may select &quot;self&quot; or another job from the same project for deferral and comparison"/>
+on pull requests can select another job from the same project for deferral and comparison"/>
 
 When a job is selected, dbt Cloud will surface the artifacts from that job's most recent successful run. dbt will then use those artifacts to determine the set of new and modified resources. In your job commands, you can signal to dbt to run only on these modified resources and their children by including the `state:modified+` argument. 
 


### PR DESCRIPTION


## Description & motivation
We have problems with CI jobs that defer to themselves, so I want to remove this from the docs

## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged
-->

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist
If you added new pages (delete if not applicable):
- [ ] The page has been added to `website/sidebars.js`
- [ ] The new page has a unique filename

If you removed existing pages (delete if not applicable):
- [ ] The page has been removed from `website/sidebars.js`
- [ ] An entry has been added to `_redirects`
