### PR TITLE
Add information about dbt-trino adapter

### DIFF
--- a/website/docs/docs/available-adapters.md
+++ b/website/docs/docs/available-adapters.md
@@ -41,6 +41,7 @@ These adapter plugins are contributed and maintained by members of the community
 | Oracle Database        | [Profile Setup](oracle-profile)       | Oracle 11+                | `pip install dbt-oracle`     |
 | Dremio                 | [Profile Setup](dremio-profile)       | Dremio 4.7+               | `pip install dbt-dremio`     |
 | ClickHouse             | [Profile Setup](clickhouse-profile)   | ClickHouse 20.11+         | `pip install dbt-clickhouse` |
+| Trino                  | [Profile Setup](trino-profile)        | Trino 359+                | `pip install dbt-trino`      |
 
 Community-supported plugins are works in progress, and all users are encouraged to contribute by testing and writing code. If you're interested in contributing:
 - Join the dedicated channel in [dbt Slack](https://community.getdbt.com/) (e.g. #db-sqlserver, #db-athena)

--- a/website/docs/reference/warehouse-profiles/trino-profile.md
+++ b/website/docs/reference/warehouse-profiles/trino-profile.md
@@ -1,0 +1,64 @@
+---
+title: "Trino Profile"
+---
+
+:::info Community plugin
+
+Some core functionality may be limited. If you're interested in contributing, check out the source code for each repository listed below.
+
+:::
+
+## Overview of dbt-trino
+**Maintained by:** Community    
+**Author:** findinpath    
+**Source:** https://github.com/findinpath/dbt-trino    
+**Core version:** v0.20.0 and newer     
+
+![dbt-presto stars](https://img.shields.io/github/stars/findinpath/dbt-trino?style=for-the-badge)
+
+## Installation and Distribution
+
+dbt's Trino adapter is managed in its own repository, [dbt-trino](https://github.com/findinpath/dbt-trino). To use the Trino adapter, you must install the `dbt-trino` plugin:
+
+### Using pip
+The following command will install the latest version of `dbt-trino` as well as the requisite version of `dbt-core`:
+
+```
+pip install dbt-trino
+```
+
+
+## Set up a Trino Target
+
+Trino targets should be set up using the following configuration in your `profiles.yml` file.
+
+<File name='~/.dbt/profiles.yml'>
+
+```yaml
+trino:
+  target: dev
+  outputs:
+    dev:
+      type: trino
+      method: none  # optional, one of {none | ldap | kerberos}
+      user: [user]
+      password: [password]  # required if method is ldap or kerberos
+      database: [database name]
+      host: [hostname]
+      port: [port number]
+      schema: [your dbt schema]
+      threads: [1 or more]
+
+```
+
+</File>
+
+## Caveats
+
+### Unsupported Functionality
+
+Due to the nature of Trino, not all core dbt functionality is supported. The following features of dbt are not implemented on Trino:
+
+1. [Snapshots](snapshots)
+2. [Incremental models](configuring-incremental-models)
+

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -484,6 +484,7 @@ module.exports = {
         "reference/warehouse-profiles/snowflake-profile",
         "reference/warehouse-profiles/mssql-profile",
         "reference/warehouse-profiles/presto-profile",
+        "reference/warehouse-profiles/trino-profile",
         "reference/warehouse-profiles/spark-profile",
         "reference/warehouse-profiles/exasol-profile",
         "reference/warehouse-profiles/oracle-profile",


### PR DESCRIPTION
## Description & motivation
dbt-trino is a slight adaptation based on a fork from  dbt-presto plugin  

The main purpose of this adapter is to provide seamless integration between [dbt](https://www.getdbt.com/) and [trino](https://trino.io/)  

## To-do before merge

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist
If you added new pages (delete if not applicable):
- [x] The page has been added to `website/sidebars.js`
- [x] The new page has a unique filename
