### PR TITLE
Add redirect for API docs

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -271,3 +271,4 @@
 https://tutorial.getdbt.com/*	https://docs.getdbt.com/:splat	301!
 /reference/model-selection-syntax/#test-selection-examples    /reference/node-selection/test-selection-examples 302
 /docs/building-a-dbt-project/building-models/using-custom-database  /docs/building-a-dbt-project/building-models/using-custom-databases 302
+/dbt-cloud/api  /dbt-cloud/api-v2

--- a/_redirects
+++ b/_redirects
@@ -271,4 +271,4 @@
 https://tutorial.getdbt.com/*	https://docs.getdbt.com/:splat	301!
 /reference/model-selection-syntax/#test-selection-examples    /reference/node-selection/test-selection-examples 302
 /docs/building-a-dbt-project/building-models/using-custom-database  /docs/building-a-dbt-project/building-models/using-custom-databases 302
-/dbt-cloud/api  /dbt-cloud/api-v2
+/dbt-cloud/api  /dbt-cloud/api-v2 302


### PR DESCRIPTION
## Description & motivation
This url is now broken: https://docs.getdbt.com/dbt-cloud/api
It lives here instead: https://docs.getdbt.com/dbt-cloud/api-v2