### PR TITLE
fix the enabling ci url

### DIFF
--- a/website/docs/docs/dbt-cloud/cloud-overview.md
+++ b/website/docs/docs/dbt-cloud/cloud-overview.md
@@ -42,6 +42,6 @@ Continuous Integration functionality is available to accounts on the Basic Tier 
 
 :::
 
-dbt Cloud can be configured to run your dbt projects in a temporary schema when new commits are pushed to open Pull Requests. When the Cloud job completes, a status will be shown for the PR inside of GitHub. This build-on-PR functionality is a great way to catch bugs before deploying to production, and an essential tool in any analysts belt. More info on enabling CI workflows in dbt Cloud can be found [here](cloud-enabling-continuous-integration-with-github).
+dbt Cloud can be configured to run your dbt projects in a temporary schema when new commits are pushed to open Pull Requests. When the Cloud job completes, a status will be shown for the PR inside of GitHub. This build-on-PR functionality is a great way to catch bugs before deploying to production, and an essential tool in any analysts belt. More info on enabling CI workflows in dbt Cloud can be found [here](cloud-enabling-continuous-integration).
 
 <Lightbox src="/img/docs/dbt-cloud/813b88c-Screen_Shot_2019-02-08_at_4.54.41_PM.png" title=""/>

--- a/website/docs/docs/dbt-cloud/using-dbt-cloud/cloud-enabling-continuous-integration-with-github.md
+++ b/website/docs/docs/dbt-cloud/using-dbt-cloud/cloud-enabling-continuous-integration-with-github.md
@@ -1,6 +1,6 @@
 ---
 title: "Enabling CI"
-id: "cloud-enabling-continuous-integration-with-github"
+id: "cloud-enabling-continuous-integration"
 ---
 
 ## Overview

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -134,7 +134,7 @@ module.exports = {
       type: "category",
       label: "Using dbt Cloud",
       items: [
-        "docs/dbt-cloud/using-dbt-cloud/cloud-enabling-continuous-integration-with-github",
+        "docs/dbt-cloud/using-dbt-cloud/cloud-enabling-continuous-integration",
         "docs/dbt-cloud/using-dbt-cloud/cloud-generating-documentation",
         "docs/dbt-cloud/using-dbt-cloud/cloud-snapshotting-source-freshness",
         "docs/dbt-cloud/using-dbt-cloud/artifacts",


### PR DESCRIPTION
## Description & motivation
Fixing the url so it's not just pointing to github (we can enable CI jobs on both Github and Gitlab). 


## Checklist
If you added new pages (delete if not applicable):
- [x ] The page has been added to `website/sidebars.js`
- [x ] The new page has a unique filename


