### PR TITLE
Add example for @ operator in docs

### DIFF
--- a/website/docs/reference/node-selection/graph-operators.md
+++ b/website/docs/reference/node-selection/graph-operators.md
@@ -28,6 +28,10 @@ The `@` operator is similar to `+`, but will also include _the parents of the ch
 
 <Lightbox src="/img/docs/running-a-dbt-project/command-line-interface/1643e30-Screen_Shot_2019-03-11_at_7.18.20_PM.png" title="@snowplow_web_page_context will select all of the models shown here"/>
 
+```bash
+$ dbt run --models @my_model          # select my_model, its children, and the parents of its children
+```
+
 ### The "star" operator
 The `*` operator matches all models within a package or directory.
 


### PR DESCRIPTION
## Description & motivation
Please only merge this if you find it necessary. A customer requested that I add this to the documentation, but I'm not sure that it's needed.

I received feedback that the documentation on the @ operator was not clear because there was not an example provided, as there was for the other graph operators on the page. I think maybe the key here is the comment line I added to the example, which simplifies what the @ operator does and how to use it.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [X] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!