### PR TITLE
fix to faq to include test thresholds

### DIFF
--- a/website/docs/faqs/custom-test-thresholds.md
+++ b/website/docs/faqs/custom-test-thresholds.md
@@ -2,7 +2,7 @@
 title: Can I set test failure thresholds?
 ---
 
-Yes, as of `v0.20.0`, you can use the `error_if` + `warn_if` configs to set custom failure thresholds in your tests. See [reference](reference/resource-configs/severity) for more information.
+As of `v0.20.0`, you can use the `error_if` and `warn_if` configs to set custom failure thresholds in your tests. For more details, see [reference](reference/resource-configs/severity) for more information.
 
 If you are on an earlier version of dbt consider:
 * Setting the [severity](resource-properties/tests#severity) to `warn`, or:

--- a/website/docs/faqs/custom-test-thresholds.md
+++ b/website/docs/faqs/custom-test-thresholds.md
@@ -2,8 +2,8 @@
 title: Can I set test failure thresholds?
 ---
 
-This is not currently supported in dbt natively.
+Yes, as of `v0.20.0`, you can use the `error_if` + `warn_if` configs to set custom failure thresholds in your tests. See [reference](reference/resource-configs/severity) for more information.
 
-Instead, consider:
+If you are on an earlier version of dbt consider:
 * Setting the [severity](resource-properties/tests#severity) to `warn`, or:
 * Writing a [custom generic test](custom-generic-tests) that accepts a threshold argument ([example](https://discourse.getdbt.com/t/creating-an-error-threshold-for-schema-tests/966))

--- a/website/docs/faqs/custom-test-thresholds.md
+++ b/website/docs/faqs/custom-test-thresholds.md
@@ -4,6 +4,6 @@ title: Can I set test failure thresholds?
 
 As of `v0.20.0`, you can use the `error_if` and `warn_if` configs to set custom failure thresholds in your tests. For more details, see [reference](reference/resource-configs/severity) for more information.
 
-If you are on an earlier version of dbt consider:
+For dbt `v0.19.0` and earlier, you could try these possible solutions:
 * Setting the [severity](resource-properties/tests#severity) to `warn`, or:
 * Writing a [custom generic test](custom-generic-tests) that accepts a threshold argument ([example](https://discourse.getdbt.com/t/creating-an-error-threshold-for-schema-tests/966))


### PR DESCRIPTION
## Description & motivation

Updated [this faq page](https://docs.getdbt.com/faqs/custom-test-thresholds) to reflect the fact that we can in fact now support custom test thresholds. This is a partial fix for #787 which was discovered via the truly fantastic sleuthing of @joellabes.
## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [X ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

