### PR TITLE
[Prerelease] Prep for 0.21.0-rc1

### DIFF
--- a/website/docs/docs/building-a-dbt-project/building-models/configuring-incremental-models.md
+++ b/website/docs/docs/building-a-dbt-project/building-models/configuring-incremental-models.md
@@ -112,7 +112,7 @@ If your incremental model logic has changed, the transformations on your new row
 To force dbt to rebuild the entire incremental model from scratch, use the `--full-refresh` flag on the command line. This flag will cause dbt to drop the existing target table in the database before rebuilding it for all-time.
 
 ```bash
-$ dbt run --full-refresh --models my_incremental_model+
+$ dbt run --full-refresh --select my_incremental_model+
 ```
 It's also advisable to rebuild any downstream models, as indicated by the trailing `+`.
 

--- a/website/docs/docs/building-a-dbt-project/documentation.md
+++ b/website/docs/docs/building-a-dbt-project/documentation.md
@@ -185,7 +185,7 @@ From a docs page, you can click the green button in the bottom-right corner of t
 
 <Lightbox src="/img/docs/building-a-dbt-project/testing-and-documentation/ec77c45-Screen_Shot_2018-08-14_at_6.31.56_PM.png" title="Opening the DAG mini-map"/>
 
-In this example, the `fct_subscription_transactions` model only has one direct parent. By clicking the "Expand" button in the top-right corner of the window, we can pivot the graph horizontally and view the full lineage for our model. This lineage is filterable using the `--models` and `--exclude` flags, which are consistent with the semantics of [model selection syntax](node-selection/syntax). Further, you can right-click to interact with the DAG, jump to documentation, or share links to your graph visualization with your coworkers.
+In this example, the `fct_subscription_transactions` model only has one direct parent. By clicking the "Expand" button in the top-right corner of the window, we can pivot the graph horizontally and view the full lineage for our model. This lineage is filterable using the `--select` and `--exclude` flags, which are consistent with the semantics of [model selection syntax](node-selection/syntax). Further, you can right-click to interact with the DAG, jump to documentation, or share links to your graph visualization with your coworkers.
 
 <Lightbox src="/img/docs/building-a-dbt-project/testing-and-documentation/ac97fba-Screen_Shot_2018-08-14_at_6.35.14_PM.png" title="The full lineage for a dbt model"/>
 

--- a/website/docs/docs/building-a-dbt-project/exposures.md
+++ b/website/docs/docs/building-a-dbt-project/exposures.md
@@ -74,8 +74,8 @@ We plan to add more subtypes and optional properties in future releases.
 
 Once an exposure is defined, you can run commands that reference it:
 ```
-dbt run -m +exposure:weekly_jaffle_metrics
-dbt test -m +exposure:weekly_jaffle_metrics
+dbt run -s +exposure:weekly_jaffle_metrics
+dbt test -s +exposure:weekly_jaffle_metrics
 ```
 
 When we generate our documentation site, you'll see the exposure appear:

--- a/website/docs/docs/building-a-dbt-project/snapshots.md
+++ b/website/docs/docs/building-a-dbt-project/snapshots.md
@@ -287,6 +287,8 @@ A number of other configurations are also supported (e.g. `tags` and `post-hook`
 
 Snapshots can be configured from both your `dbt_project.yml` file and a `config` block, check out the [configuration docs](snapshot-configs) for more information.
 
+Note: As of v0.21, BigQuery users can use `target_project` and `target_dataset` as aliases for `target_database` and `target_schema`, respectively.
+
 
 ### Configuration best practices
 #### Use the `timestamp` strategy where possible

--- a/website/docs/docs/contributing/building-a-new-adapter.md
+++ b/website/docs/docs/contributing/building-a-new-adapter.md
@@ -65,6 +65,14 @@ class MyAdapterCredentials(Credentials):
     @property
     def type(self):
         return 'myadapter'
+        
+    @property
+    def unique_field(self):
+        """
+        Hashed and included in anonymous telemetry to track adapter adoption.
+        Pick a field that can uniquely identify one team/organization building with this adapter
+        """
+        return self.host
 
     def _connection_keys(self):
         """

--- a/website/docs/docs/dbt-cloud/using-dbt-cloud/cloud-enabling-continuous-integration-with-github.md
+++ b/website/docs/docs/dbt-cloud/using-dbt-cloud/cloud-enabling-continuous-integration-with-github.md
@@ -57,8 +57,8 @@ As example:
 
 ```
 dbt seed --select state:modified+
-dbt run --models state:modified+
-dbt test --models state:modified+
+dbt run --select state:modified+
+dbt test --select state:modified+
 ```
 
 Because dbt Cloud manages deferral and state environment variables, there is no need to specify `--defer` or `--state` flags. **Note:** Both jobs need to be running dbt v0.18.0 or newer.

--- a/website/docs/docs/guides/best-practices.md
+++ b/website/docs/docs/guides/best-practices.md
@@ -117,8 +117,8 @@ By comparing to artifacts from a previous production run, dbt can determine
 which models are modified and build them on top of of their unmodified parents.
 
 ```bash
-dbt run -m state:modified+ --defer --state path/to/prod/artifacts
-dbt test -m state:modified+
+dbt run -s state:modified+ --defer --state path/to/prod/artifacts
+dbt test -s state:modified+
 ```
 
 To learn more, read the docs on [state](understanding-state).

--- a/website/docs/docs/guides/database-specific-guides/creating-date-partitioned-tables.md
+++ b/website/docs/docs/guides/database-specific-guides/creating-date-partitioned-tables.md
@@ -113,5 +113,5 @@ If a `dates` variable is provided (eg. on the command line with `--vars`), then 
 Here's an example of running this model for the first 3 days of 2018 as a part of a backfill:
 
 ```
-dbt run --models partitioned_yesterday --vars 'dates: "20180101, 20180103"'
+dbt run --select partitioned_yesterday --vars 'dates: "20180101, 20180103"'
 ```

--- a/website/docs/docs/guides/debugging-errors.md
+++ b/website/docs/docs/guides/debugging-errors.md
@@ -183,7 +183,7 @@ _Note: if you're using the dbt Cloud IDE to work on your dbt project, this error
 
 ### Invalid `ref` function
 ```
-$ dbt run -m customers
+$ dbt run -s customers
 Running with dbt=0.17.1
 
 Encountered an error:

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
@@ -20,6 +20,7 @@ dbt v0.21.0-b2 is currently available as a prerelease. If you have questions or 
 ## New and changed documentation
 
 - [Commands](dbt-commands), [`build`](commands/build), [rpc](rpc): Add `dbt build`
+- [Node selection syntax](node-selection/syntax) and above: Switch `--models` for `--select` across the board. (Commands which previously used the `--models` flag still support it for backwards compatibility.)
 - [Configuring incremental models](configuring-incremental-models): New optional configuration for incremental models, `on_schema_change`.
 - [Commands: `source`](commands/source): Renamed to `dbt source freshness`, updated selection logic.
 - [Environment variables](env_var): Add a log-scrubbing prefix, `DBT_ENV_SECRET_`

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
@@ -28,4 +28,5 @@ dbt v0.21.0-b2 is currently available as a prerelease. If you have questions or 
 - [`deps`](commands/deps): Add `dbt deps` logging for outdated packages
 
 ### Plugins
-- [Redshift profile](redshift-profile): `ra3: true` profile property to support cross-database source definitions and read-only querying
+- **Redshift**: [profile](redshift-profile) property `ra3: true` to support cross-database source definitions and read-only querying
+- **BigQuery**: [Snapshots](snapshots) support `target_project` and `target_dataset` config aliases

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
@@ -26,6 +26,7 @@ dbt v0.21.0-b2 is currently available as a prerelease. If you have questions or 
 - [Environment variables](env_var): Add a log-scrubbing prefix, `DBT_ENV_SECRET_`
 - [Selection methods](node-selection/methods) and [state comparison caveats](state-comparison-caveats): Add `state:modified` subselectors, and reflect that it now includes changes to upstream macros.
 - [`deps`](commands/deps): Add `dbt deps` logging for outdated packages
+- [`list`](commands/list): Add `--output-keys` flag and RPC parameter
 
 ### Plugins
 - **Postgres** [profile](postgres-profile) property `connect_timeout` now configurable. Also applicable to child plugins (e.g. `dbt-redshift`)

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
@@ -36,6 +36,7 @@ dbt v0.21.0-rc1 is currently available as a release candidate. If you have quest
 - [Configuring incremental models](configuring-incremental-models): New optional configuration for incremental models, `on_schema_change`.
 - [Environment variables](env_var): Add a log-scrubbing prefix, `DBT_ENV_SECRET_`
 - [Test `where` config](where) has been reimplemented as a macro (`get_where_subquery`) that you can optionally reimplement, too
+- [`dispatch`](dispatch) now supports reimplementing global macros residing in the `dbt` macro namespace with versions from installed packages, by leveraging `search_order` in the [`dispatch` project config](project-configs/dispatch-config)
 
 ### Plugins
 - **Postgres** [profile](postgres-profile) property `connect_timeout` now configurable. Also applicable to child plugins (e.g. `dbt-redshift`)

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
@@ -28,5 +28,6 @@ dbt v0.21.0-b2 is currently available as a prerelease. If you have questions or 
 - [`deps`](commands/deps): Add `dbt deps` logging for outdated packages
 
 ### Plugins
+- **Postgres** [profile](postgres-profile) property `connect_timeout` now configurable. Also applicable to child plugins (e.g. `dbt-redshift`)
 - **Redshift**: [profile](redshift-profile) property `ra3: true` to support cross-database source definitions and read-only querying
 - **BigQuery**: [Snapshots](snapshots) support `target_project` and `target_dataset` config aliases

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
@@ -35,6 +35,7 @@ dbt v0.21.0-rc1 is currently available as a release candidate. If you have quest
 ### Elsewhere in Core
 - [Configuring incremental models](configuring-incremental-models): New optional configuration for incremental models, `on_schema_change`.
 - [Environment variables](env_var): Add a log-scrubbing prefix, `DBT_ENV_SECRET_`
+- [Test `where` config](where) has been reimplemented as a macro (`get_where_subquery`) that you can optionally reimplement, too
 
 ### Plugins
 - **Postgres** [profile](postgres-profile) property `connect_timeout` now configurable. Also applicable to child plugins (e.g. `dbt-redshift`)

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
@@ -3,9 +3,9 @@ title: "Upgrading to 0.21.0"
 
 ---
 
-:::info Beta
+:::info Release candidate
 
-dbt v0.21.0-b2 is currently available as a prerelease. If you have questions or encounter bugs, please let us know in [#dbt-prereleases](https://community.getdbt.com/) or by opening an issue [in GitHub](https://github.com/dbt-labs/dbt).
+dbt v0.21.0-rc1 is currently available as a release candidate. If you have questions or encounter bugs, please let us know in [#dbt-prereleases](https://community.getdbt.com/) or by opening an issue [in GitHub](https://github.com/dbt-labs/dbt).
 
 :::
 
@@ -15,19 +15,26 @@ dbt v0.21.0-b2 is currently available as a prerelease. If you have questions or 
 
 ## Breaking changes
 
-- `dbt source snapshot-freshness` has been renamed to `dbt source freshness`, and its node selection logic is consistent with other commands
+- `dbt source snapshot-freshness` has been renamed to `dbt source freshness`. Its node selection logic is now consistent with other tasks. In order to check freshness for a specific source, you must prefix it with `source:`.
+- Two dbt JSON artifacts have a new schema: [`manifest.json`](manifest-json) (new default node properties) and [`sources.json`](sources-json) (now includes timing information).
 
 ## New and changed documentation
 
+### Tasks
 - [Commands](dbt-commands), [`build`](commands/build), [rpc](rpc): Add `dbt build`
-- [Node selection syntax](node-selection/syntax), [commands](dbt-commands): Switch `--models` for `--select` across the board. (Commands which previously used the `--models` flag still support it for backwards compatibility.)
-- [YAML selectors](yaml-selectors#default) now support an optional `default` property. If set, dbt will use custom selection criteria for commands that do not specify their own selection/exclusion flags.
-- [Configuring incremental models](configuring-incremental-models): New optional configuration for incremental models, `on_schema_change`.
-- [Commands: `source`](commands/source): Renamed to `dbt source freshness`, updated selection logic.
-- [Environment variables](env_var): Add a log-scrubbing prefix, `DBT_ENV_SECRET_`
-- [Selection methods](node-selection/methods) and [state comparison caveats](state-comparison-caveats): Add `state:modified` subselectors, and reflect that it now includes changes to upstream macros.
+- [Commands: `source`](commands/source): Renamed to `dbt source freshness`.
 - [`deps`](commands/deps): Add `dbt deps` logging for outdated packages
 - [`list`](commands/list): Add `--output-keys` flag and RPC parameter
+
+## Selection
+- [Commands: `source`](commands/source): Updated selection logic to match other tasks. When selecting a specific source to check freshness, you must prefix it with `source:`.
+- [Node selection syntax](node-selection/syntax), [commands](dbt-commands): Switch `--models` for `--select` across the board. (Commands which previously used the `--models` flag still support it for backwards compatibility.)
+- [YAML selectors](yaml-selectors#default) now support an optional `default` property. If set, dbt will use custom selection criteria for commands that do not specify their own selection/exclusion flags.
+- [Selection methods](node-selection/methods) and [state comparison caveats](state-comparison-caveats): Add `state:modified` subselectors, and reflect that it now includes changes to upstream macros.
+
+### Elsewhere in Core
+- [Configuring incremental models](configuring-incremental-models): New optional configuration for incremental models, `on_schema_change`.
+- [Environment variables](env_var): Add a log-scrubbing prefix, `DBT_ENV_SECRET_`
 
 ### Plugins
 - **Postgres** [profile](postgres-profile) property `connect_timeout` now configurable. Also applicable to child plugins (e.g. `dbt-redshift`)

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
@@ -31,4 +31,4 @@ dbt v0.21.0-b2 is currently available as a prerelease. If you have questions or 
 ### Plugins
 - **Postgres** [profile](postgres-profile) property `connect_timeout` now configurable. Also applicable to child plugins (e.g. `dbt-redshift`)
 - **Redshift**: [profile](redshift-profile) property `ra3: true` to support cross-database source definitions and read-only querying
-- **BigQuery**: [Snapshots](snapshots) support `target_project` and `target_dataset` config aliases
+- **BigQuery**: [profile](bigquery-profile) property `execution_project` now configurable. [Snapshots](snapshots) support `target_project` and `target_dataset` config aliases.

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
@@ -32,6 +32,7 @@ dbt v0.21.0-rc1 is currently available as a release candidate. If you have quest
 - [Node selection syntax](node-selection/syntax), [commands](dbt-commands): Switch `--models` for `--select` across the board. (Commands which previously used the `--models` flag still support it for backwards compatibility.)
 - [YAML selectors](yaml-selectors#default) now support an optional `default` property. If set, dbt will use custom selection criteria for commands that do not specify their own selection/exclusion flags.
 - [Selection methods](node-selection/methods) and [state comparison caveats](state-comparison-caveats): Add `state:modified` subselectors, and reflect that it now includes changes to upstream macros.
+- [Test selection examples](test-selection-examples) includes more discussion of indirect selection (a change in v0.20), and the optional "greedy" flag/property (new in v0.21), which you can optionally set to include tests that have a mix of selected + unselected parents
 
 ### Elsewhere in Core
 - [Configuring incremental models](configuring-incremental-models): New optional configuration for incremental models, `on_schema_change`.

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
@@ -17,6 +17,7 @@ dbt v0.21.0-rc1 is currently available as a release candidate. If you have quest
 
 - `dbt source snapshot-freshness` has been renamed to `dbt source freshness`. Its node selection logic is now consistent with other tasks. In order to check freshness for a specific source, you must prefix it with `source:`.
 - Two dbt JSON artifacts have a new schema: [`manifest.json`](manifest-json) (new default node properties) and [`sources.json`](sources-json) (now includes timing information).
+- **Snowflake:** Turn off transactions and turn on autocommit by default. Explicitly specify `begin` and `commit` for DML statements in incremental and snapshot materializations. Note that this may affect user-space code that depends on transactions.
 
 ## New and changed documentation
 

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
@@ -20,7 +20,8 @@ dbt v0.21.0-b2 is currently available as a prerelease. If you have questions or 
 ## New and changed documentation
 
 - [Commands](dbt-commands), [`build`](commands/build), [rpc](rpc): Add `dbt build`
-- [Node selection syntax](node-selection/syntax) and above: Switch `--models` for `--select` across the board. (Commands which previously used the `--models` flag still support it for backwards compatibility.)
+- [Node selection syntax](node-selection/syntax), [commands](dbt-commands): Switch `--models` for `--select` across the board. (Commands which previously used the `--models` flag still support it for backwards compatibility.)
+- [YAML selectors](yaml-selectors#default) now support an optional `default` property. If set, dbt will use custom selection criteria for commands that do not specify their own selection/exclusion flags.
 - [Configuring incremental models](configuring-incremental-models): New optional configuration for incremental models, `on_schema_change`.
 - [Commands: `source`](commands/source): Renamed to `dbt source freshness`, updated selection logic.
 - [Environment variables](env_var): Add a log-scrubbing prefix, `DBT_ENV_SECRET_`

--- a/website/docs/faqs/run-downstream-of-seed.md
+++ b/website/docs/faqs/run-downstream-of-seed.md
@@ -7,5 +7,5 @@ You can run models downstream of a seed using the [model selection syntax](node-
 For example, the following would run all models downstream of a seed named `country_codes`:
 
 ```
-$ dbt run --models country_codes+
+$ dbt run --select country_codes+
 ```

--- a/website/docs/faqs/run-one-model.md
+++ b/website/docs/faqs/run-one-model.md
@@ -2,11 +2,11 @@
 title: How do I run one model at a time?
 ---
 
-To run one model, use the `--models` flag (or `-m` flag), followed by the name of the model:
+To run one model, use the `--select` flag (or `-m` flag), followed by the name of the model:
 
 
 ```
-$ dbt run --models customers
+$ dbt run --select customers
 ```
 
 Check out the [model selection syntax documentation](node-selection/syntax) for more operators and examples.

--- a/website/docs/faqs/run-one-model.md
+++ b/website/docs/faqs/run-one-model.md
@@ -2,7 +2,7 @@
 title: How do I run one model at a time?
 ---
 
-To run one model, use the `--select` flag (or `-m` flag), followed by the name of the model:
+To run one model, use the `--select` flag (or `-s` flag), followed by the name of the model:
 
 
 ```

--- a/website/docs/faqs/running-models-downstream-of-source.md
+++ b/website/docs/faqs/running-models-downstream-of-source.md
@@ -6,7 +6,7 @@ To run models downstream of a source, use the `source:` selector:
 ```
 $ dbt run --select source:jaffle_shop+
 ```
-(You can also use the `-m` shorthand here instead of `--select`)
+(You can also use the `-s` shorthand here instead of `--select`)
 
 To run models downstream of one source table:
 

--- a/website/docs/faqs/running-models-downstream-of-source.md
+++ b/website/docs/faqs/running-models-downstream-of-source.md
@@ -4,14 +4,14 @@ title: How do I run models downstream of one source?
 To run models downstream of a source, use the `source:` selector:
 
 ```
-$ dbt run --models source:jaffle_shop+
+$ dbt run --select source:jaffle_shop+
 ```
-(You can also use the `-m` shorthand here instead of `--models`)
+(You can also use the `-m` shorthand here instead of `--select`)
 
 To run models downstream of one source table:
 
 ```
-$ dbt run --models source:jaffle_shop.orders+
+$ dbt run --select source:jaffle_shop.orders+
 ```
 
 Check out the [model selection syntax](node-selection/syntax) for more examples!

--- a/website/docs/faqs/sql-errors.md
+++ b/website/docs/faqs/sql-errors.md
@@ -6,7 +6,7 @@ Or:
 
 If there's a mistake in your SQL, dbt will return the error that your database returns.
 ```shell-session
-$ dbt run --models customers
+$ dbt run --select customers
 Running with dbt=0.15.0
 Found 3 models, 9 tests, 0 snapshots, 0 analyses, 133 macros, 0 operations, 0 seed files, 0 sources
 

--- a/website/docs/faqs/test-one-model.md
+++ b/website/docs/faqs/test-one-model.md
@@ -2,7 +2,7 @@
 title: How do I test one model at a time?
 ---
 
-Running tests on one model looks very similar to running a model: use the `--select` flag (or `-m` flag), followed by the name of the model:
+Running tests on one model looks very similar to running a model: use the `--select` flag (or `-s` flag), followed by the name of the model:
 ```
 dbt test --select customers
 ```

--- a/website/docs/faqs/test-one-model.md
+++ b/website/docs/faqs/test-one-model.md
@@ -2,9 +2,9 @@
 title: How do I test one model at a time?
 ---
 
-Running tests on one model looks very similar to running a model: use the `--models` flag (or `-m` flag), followed by the name of the model:
+Running tests on one model looks very similar to running a model: use the `--select` flag (or `-m` flag), followed by the name of the model:
 ```
-dbt test --models customers
+dbt test --select customers
 ```
 
 Check out the [model selection syntax documentation](node-selection/syntax) for full syntax, and [test selection examples](test-selection-examples) in particular.

--- a/website/docs/faqs/test-sources.md
+++ b/website/docs/faqs/test-sources.md
@@ -5,7 +5,7 @@ title: How do I run tests on sources only?
 It is possible! You need to use the `source:` selection method:
 
 ```
-$ dbt test --models source:*
+$ dbt test --select source:*
 ```
 
 Check out the [model selection syntax documentation](node-selection/test-selection-examples) for more operators and examples.

--- a/website/docs/faqs/testing-sources.md
+++ b/website/docs/faqs/testing-sources.md
@@ -7,7 +7,7 @@ To run tests on all sources, use the following command:
 ```
 $ dbt test --select source:*
 ```
-(You can also use the `-m` shorthand here instead of `--select`)
+(You can also use the `-s` shorthand here instead of `--select`)
 
 To run tests on one source (and all of its tables):
 

--- a/website/docs/faqs/testing-sources.md
+++ b/website/docs/faqs/testing-sources.md
@@ -5,20 +5,20 @@ title: How do I run tests on just my sources?
 To run tests on all sources, use the following command:
 
 ```
-$ dbt test --models source:*
+$ dbt test --select source:*
 ```
-(You can also use the `-m` shorthand here instead of `--models`)
+(You can also use the `-m` shorthand here instead of `--select`)
 
 To run tests on one source (and all of its tables):
 
 ```
-$ dbt test --models source:jaffle_shop
+$ dbt test --select source:jaffle_shop
 ```
 
 And, to run tests on one source table only:
 
 ```
-$ dbt test --models source:jaffle_shop.orders
+$ dbt test --select source:jaffle_shop.orders
 ```
 
 Yep, we know this syntax is a little less than ideal, so we're hoping to improve it in a future release. Check out the [model selection syntax](node-selection/syntax) for more examples!

--- a/website/docs/reference/artifacts/sources-json.md
+++ b/website/docs/reference/artifacts/sources-json.md
@@ -23,3 +23,5 @@ Each entry in `results` is a dictionary with the following keys:
 - `criteria`: The freshness threshold(s) for this source, defined in the project.
 - `status`: The freshness status of this source, based on `max_loaded_at_time_ago_in_s` + `criteria`, reported on the CLI. One of `pass`, `warn`, or `error` if the query succeeds, `runtime error` if the query fails.
 - `adapter_response`: Dictionary of information returned from the database, which varies by adapter. Not populated by source freshness checks, as of v0.19.0; we plan to fix in a future release ([dbt#2580](https://github.com/dbt-labs/dbt/issues/2580)).
+- `execution_time`: Total time spent checking freshness for this source
+- `timing`: Array that breaks down execution time into steps (`compile` + `execute`)

--- a/website/docs/reference/commands/build.md
+++ b/website/docs/reference/commands/build.md
@@ -25,7 +25,6 @@ In DAG order, for selected resources or an entire project.
 
 ### Implementation details
 
-- The `build` task uses the same selection syntax as `run` and `test`: `--models`, `--exclude`, `--selector`, etc.
 - The `build` task will write a single [manifest](artifacts/manifest-json) and a single [run results artifact](artifacts/run-results-json). The run results will include information about all models, tests, seeds, and snapshots that were selected to build, combined into one file.
 
 ### Current limitations
@@ -34,7 +33,6 @@ v0.21 is currently in beta, and as such there are some limitations to `dbt build
 
 - A test on a resource should block that resource's other downstream children from running, and a test failure should cause those other children to `SKIP` ([dbt#3597](https://github.com/dbt-labs/dbt/issues/3597))
 - The `build` command should support the superset of CLI flags supported by `run`, `test`, `seed`, and `snapshot` ([dbt#3596](https://github.com/dbt-labs/dbt/issues/3596)). The `build` command should also support a `--resource-type` flag, as the `list` command does.
-- Ahead of the final v0.21 release, we're thinking about switching all commands to use `--select`, with backwards compatibility for `--models` ([dbt#3210](https://github.com/dbt-labs/dbt/issues/3210)). It doesn't make much sense to use a `--models` flag, when the whole point is building more than models.
 
 ```
 $ dbt build

--- a/website/docs/reference/commands/list.md
+++ b/website/docs/reference/commands/list.md
@@ -23,7 +23,7 @@ See [resource selection syntax](node-selection/syntax) for more information on h
 **Arguments**:
 - `--resource-type`: This flag limits the "resource types" that dbt will return in the `dbt ls` command. By default, the following resources are included in the results of `dbt ls`: models, snapshots, seeds, tests, and sources.
 - `--select`: This flag specifies one or more selection-type arguments used to filter the nodes returned by the `dbt ls` command
-- `--models`: Like the `--select` flag, this flag is used to select nodes. It implies `--resource-type=model`, and will only return models in the results of the `dbt ls` command.
+- `--models`: Like the `--select` flag, this flag is used to select nodes. It implies `--resource-type=model`, and will only return models in the results of the `dbt ls` command. Supported for backwards compatibility only.
 - `--exclude`: Specify selectors that should be _excluded_ from the list of returned nodes.
 - `--selector`: This flag specifies one or more named selectors, defined in a `selectors.yml` file.
 - `--output`: This flag controls the format of output from the `dbt ls` command.
@@ -34,7 +34,7 @@ Note that the `dbt ls` command does not include models which are disabled or sch
 
 **Listing models by package**
 ```
-$ dbt ls --models snowplow.*
+$ dbt ls --select snowplow.*
 snowplow.snowplow_base_events
 snowplow.snowplow_base_web_page_context
 snowplow.snowplow_id_map
@@ -62,7 +62,7 @@ model.my_project.events_categorized
 
 **Listing JSON output**
 ```
-$ dbt ls --models snowplow.* --output json
+$ dbt ls --select snowplow.* --output json
 {"name": "snowplow_events", "resource_type": "model", "package_name": "snowplow",  ...}
 {"name": "snowplow_page_views", "resource_type": "model", "package_name": "snowplow",  ...}
 ...
@@ -70,7 +70,7 @@ $ dbt ls --models snowplow.* --output json
 
 **Listing file paths**
 ```
-dbt ls --models snowplow.* --output path
+dbt ls --select snowplow.* --output path
 models/base/snowplow_base_events.sql
 models/base/snowplow_base_web_page_context.sql
 models/identification/snowplow_id_map.sql

--- a/website/docs/reference/commands/list.md
+++ b/website/docs/reference/commands/list.md
@@ -16,6 +16,7 @@ dbt ls
      [--exclude SELECTOR [SELECTOR ...]]
      [--selector YML_SELECTOR_NAME [YML_SELECTOR_NAME ...]]
      [--output {json,name,path,selector}]
+     [--output-keys KEY_NAME [KEY_NAME]]
 ```
 
 See [resource selection syntax](node-selection/syntax) for more information on how to select resources in dbt
@@ -27,6 +28,7 @@ See [resource selection syntax](node-selection/syntax) for more information on h
 - `--exclude`: Specify selectors that should be _excluded_ from the list of returned nodes.
 - `--selector`: This flag specifies one or more named selectors, defined in a `selectors.yml` file.
 - `--output`: This flag controls the format of output from the `dbt ls` command.
+- `--output-keys`: If `--output json`, this flag controls which node properties are included in the output.
 
 Note that the `dbt ls` command does not include models which are disabled or schema tests which depend on models which are disabled. All returned resources will have a `config.enabled` value of `true`.
 
@@ -65,6 +67,14 @@ model.my_project.events_categorized
 $ dbt ls --select snowplow.* --output json
 {"name": "snowplow_events", "resource_type": "model", "package_name": "snowplow",  ...}
 {"name": "snowplow_page_views", "resource_type": "model", "package_name": "snowplow",  ...}
+...
+```
+
+**Listing JSON output with custom keys**
+```
+$ dbt ls --select snowplow.* --output json --output-keys name description
+{"name": "snowplow_events", "description": "This is a pretty cool model",  ...}
+{"name": "snowplow_page_views", "description": "This model is even cooler",  ...}
 ...
 ```
 

--- a/website/docs/reference/commands/rpc.md
+++ b/website/docs/reference/commands/rpc.md
@@ -332,6 +332,27 @@ Several of the following request types accept these additional parameters:
 }
 ```
 
+### List project resources ([docs](cmd-docs#dbt-docs-generate))
+
+**Additional parameters:**
+ - `resource_types`: Filter selected resources by type
+ - `output_keys`: Specify which node properties to include in output
+
+ ```json
+ {
+ 	"jsonrpc": "2.0",
+ 	"method": "build",
+ 	"id": "<request id>",
+ 	"params": {
+         "select": "<str> (optional)",
+         "exclude": "<str> (optional)",
+         "selector": "<str> (optional)",
+         "resource_types": ["<list> (optional)"],
+         "output_keys": ["<list> (optional)"],
+     }
+ }
+ ```
+
 ### Generate docs ([docs](cmd-docs#dbt-docs-generate))
 
 **Additional parameters:**

--- a/website/docs/reference/commands/rpc.md
+++ b/website/docs/reference/commands/rpc.md
@@ -107,7 +107,7 @@ The `poll` endpoint will return the status, logs, and results (if available) for
         "elapsed_time": 0.8381369113922119,
         "logs": [],
         "tags": {
-            "command": "run --models my_model",
+            "command": "run --select my_model",
             "branch": "abc123"
         },
         "status": "success"
@@ -152,7 +152,7 @@ The `ps` methods lists running and completed processes executed by the RPC serve
                 "elapsed": 1.107261,
                 "timeout": null,
                 "tags": {
-                    "command": "run --models my_model",
+                    "command": "run --select my_model",
                     "branch": "feature/add-models"
                 }
             }
@@ -191,7 +191,7 @@ All RPC requests accept the following parameters in addition to the parameters l
 ### Running a task with CLI syntax
 
 **Parameters:**
- - `cli`: A dbt command (eg. `run --models abc+ --exclude +def`) to run (required)
+ - `cli`: A dbt command (eg. `run --select abc+ --exclude +def`) to run (required)
 
 ```json
 {
@@ -199,7 +199,7 @@ All RPC requests accept the following parameters in addition to the parameters l
     "method": "cli_args",
     "id": "<request id>",
     "params": {
-        "cli": "run --models abc+ --exclude +def",
+        "cli": "run --select abc+ --exclude +def",
         "task_tags": {
             "branch": "feature/my-branch",
             "commit": "c0ff33b01"
@@ -210,8 +210,7 @@ All RPC requests accept the following parameters in addition to the parameters l
 
 Several of the following request types accept these additional parameters:
 - `threads`: The number of [threads](configure-your-profile#understanding-threads) to use when compiling (optional)
-- `models`: The space-delimited set of models to compile, run, or test (optional)
-- `select`: The space-delimeted set of resources to seed or snapshot (optional)
+- `select`: The space-delimeted set of resources to execute (optional). (`models` is also supported on some request types for backwards compatibility.)
 - `selector`: The name of a predefined [YAML selector](node-selection/yaml-selectors) that defines the set of resources to execute (optional)
 - `exclude`: The space-delimited set of resources to exclude from compiling, running, testing, seeding, or snapshotting (optional)
 - `state`: The filepath of artifacts to use when establishing [state](understanding-state) (optional)
@@ -225,7 +224,7 @@ Several of the following request types accept these additional parameters:
 	"id": "<request id>",
 	"params": {
             "threads": "<int> (optional)",
-            "models": "<str> (optional)",
+            "select": "<str> (optional)",
             "exclude": "<str> (optional)",
             "selector": "<str> (optional)",
             "state": "<str> (optional)"
@@ -245,7 +244,7 @@ Several of the following request types accept these additional parameters:
 	"id": "<request id>",
 	"params": {
             "threads": "<int> (optional)",
-            "models": "<str> (optional)",
+            "select": "<str> (optional)",
             "exclude": "<str> (optional)",
             "selector": "<str> (optional)",
             "state": "<str> (optional)",
@@ -267,7 +266,7 @@ Several of the following request types accept these additional parameters:
 	"id": "<request id>",
 	"params": {
             "threads": "<int> (optional)",
-            "models": "<str> (optional)",
+            "select": "<str> (optional)",
             "exclude": "<str> (optional)",
             "selector": "<str> (optional)",
             "state": "<str> (optional)",
@@ -324,7 +323,7 @@ Several of the following request types accept these additional parameters:
 	"id": "<request id>",
 	"params": {
             "threads": "<int> (optional)",
-            "models": "<str> (optional)",
+            "select": "<str> (optional)",
             "exclude": "<str> (optional)",
             "selector": "<str> (optional)",
             "state": "<str> (optional)",

--- a/website/docs/reference/commands/test.md
+++ b/website/docs/reference/commands/test.md
@@ -5,14 +5,14 @@ id: "test"
 
 `dbt test` runs tests defined on models, sources, snapshots, and seeds. It expects that you have already created those resources through the appropriate commands.
 
-The tests to run can be selected using the `--models` flag discussed [here](node-selection/syntax).
+The tests to run can be selected using the `--select` flag discussed [here](node-selection/syntax).
 
 ```bash
 # run tests for one_specific_model
-dbt test --models one_specific_model
+dbt test --select one_specific_model
 
 # run tests for all models in package
-dbt test --models some_package.*
+dbt test --select some_package.*
 
 # run only custom data tests
 dbt test --data
@@ -21,10 +21,10 @@ dbt test --data
 dbt test --schema
 
 # run custom data tests for one_specific_model
-dbt test --data --models one_specific_model
+dbt test --data --select one_specific_model
 
 # run schema tests for one_specific_model
-dbt test --schema --models one_specific_model
+dbt test --schema --select one_specific_model
 ```
 
 For more information on writing tests, see the [Testing Documentation](building-a-dbt-project/tests).

--- a/website/docs/reference/dbt-commands.md
+++ b/website/docs/reference/dbt-commands.md
@@ -12,19 +12,20 @@ For information about selecting models on the command line, consult the docs on 
 
 **Available commands:**
 
-- [debug](debug) (CLI only): debugs dbt connections and projects
-- [init](init) (CLI only): initializes a new dbt project
-- [compile](compile): compiles (but does not run) the models in a project
-- [run](run): runs the models in a project
-- [test](commands/test): executes tests defined in a project
-- [deps](deps): downloads dependencies for a project
-- [snapshot](snapshot): executes "snapshot" jobs defined in a project
+- [build](build): build and test all selected resources (models, seeds, snapshots, tests)
 - [clean](clean) (CLI only): deletes artifacts present in the dbt project
-- [seed](seed): loads CSV files into the database
+- [compile](compile): compiles (but does not run) the models in a project
+- [debug](debug) (CLI only): debugs dbt connections and projects
+- [deps](deps): downloads dependencies for a project
 - [docs](cmd-docs) : generates documentation for a project
-- [source](commands/source): provides tools for working with source data (including validating that sources are "fresh")
-- [run-operation](run-operation): runs arbitrary maintenance SQL against the database
-- [rpc](rpc) (CLI only): runs an RPC server that clients can submit queries to
+- [init](init) (CLI only): initializes a new dbt project
 - [list](list) (CLI only): lists resources defined in a dbt project
 - [parse](parse) (CLI only): parses a project and writes detailed timing info
-- [build](build) (CLI only): build and test all selected resources (models, seeds, snapshots, tests)
+- [run](run): runs the models in a project
+- [seed](seed): loads CSV files into the database
+- [snapshot](snapshot): executes "snapshot" jobs defined in a project
+- [source](commands/source): provides tools for working with source data (including validating that sources are "fresh")
+- [test](commands/test): executes tests defined in a project
+- [rpc](rpc) (CLI only): runs an RPC server that clients can submit queries to
+- [run-operation](run-operation): runs arbitrary maintenance SQL against the database
+

--- a/website/docs/reference/dbt-jinja-functions/dispatch.md
+++ b/website/docs/reference/dbt-jinja-functions/dispatch.md
@@ -7,6 +7,7 @@ title: "dispatch"
 - **v0.18.0:** Introduced `dispatch` as a replacement for deprecated `adapter_macro`
 - **v0.19.2:** Limited rendering context for `dispatch` arguments. Includes backwards compatibility for widely used packages.
 - **v0.20.0:** Parent adapters' macro implementations are included in search order. Formalized supported arguments.
+- **v0.21.0:** All dispatched macros in the dbt global project include `dbt` namespace
     
 </Changelog>
 
@@ -148,6 +149,24 @@ Adapter prefixes still matter: dbt will only ever look for implementations that 
 As someone installing a package, this functionality makes it possible for me to change the behavior of another, more complex macro (`dbt_utils.surrogate_key`) by reimplementing and overriding one of its modular components.
 
 As a package maintainer, this functionality enables users of my package to extend, reimplement, or override default behavior, without needing to fork the package's source code.
+
+### Overriding global macros
+
+I maintain an internal utility package at my organization, named `my_org_dbt_helpers`. I use this package to reimplement built-in dbt macros on behalf of all my dbt-using colleagues, who work across a number of dbt projects.
+
+My package can define custom versions of any dispatched global macro I choose, from `generate_schema_name` to `test_unique`. I can define a new default version of that macro (e.g. `default__generate_schema_name`), or custom versions for specific data warehouse adapters (e.g. `spark__generate_schema_name`).
+
+Each root project installing my package simply needs to include the [project-level `dispatch` config](project-configs/dispatch-config) that searches my package ahead of `dbt` for the `dbt` global namespace:
+
+<File name='dbt_project.yml'>
+
+```yml
+dispatch:
+  - macro_namespace: dbt
+    search_order: ['my_project', 'my_org_dbt_helpers', 'dbt']
+```
+
+</File>
 
 ## For adapter plugin maintainers
 

--- a/website/docs/reference/global-cli-flags.md
+++ b/website/docs/reference/global-cli-flags.md
@@ -99,7 +99,7 @@ $ dbt --strict run
 
 ## Warnings as Errors
 
-The `--warn-error` flag converts dbt warnings into errors. If dbt would normally warn, it will instead raise an error. Examples include `--models` selectors that selects nothing, deprecations, configurations with no associated models, invalid test configurations, or tests and freshness checks that are configured to return warnings.
+The `--warn-error` flag converts dbt warnings into errors. If dbt would normally warn, it will instead raise an error. Examples include `--select` selectors that selects nothing, deprecations, configurations with no associated models, invalid test configurations, or tests and freshness checks that are configured to return warnings.
 
 <File name='Usage'>
 

--- a/website/docs/reference/node-selection/defer.md
+++ b/website/docs/reference/node-selection/defer.md
@@ -18,8 +18,8 @@ Defer requires that a manifest from a previous dbt invocation be passed to the `
 ### Usage
 
 ```shell
-$ dbt run --models [...] --defer --state path/to/artifacts
-$ dbt test --models [...] --defer --state path/to/artifacts
+$ dbt run --select [...] --defer --state path/to/artifacts
+$ dbt test --select [...] --defer --state path/to/artifacts
 ```
 
 When the `--defer` flag is provided, dbt will resolve `ref` calls differently depending on two criteria:
@@ -73,7 +73,7 @@ I want to test my changes. Nothing exists in my development schema, `dev_alice`.
 <TabItem value="no_defer">
 
 ```shell
-$ dbt run --models model_b
+$ dbt run --select model_b
 ```
 
 <File name='target/run/my_project/model_b.sql'>
@@ -100,7 +100,7 @@ Unless I had previously run `model_a` into this development environment, `dev_al
 <TabItem value="yes_defer">
 
 ```shell
-$ dbt run --models model_b --defer --state prod-run-artifacts
+$ dbt run --select model_b --defer --state prod-run-artifacts
 ```
 
 <File name='target/run/my_project/model_b.sql'>
@@ -160,7 +160,7 @@ models:
 <TabItem value="no_defer">
 
 ```shell
-dbt test --models model_b
+dbt test --select model_b
 ```
 
 <File name='target/compiled/.../relationships_model_b_id__id__ref_model_a_.sql'>
@@ -185,7 +185,7 @@ The `relationships` test requires both `model_a` and `model_b`. Because I did no
 <TabItem value="yes_defer">
 
 ```shell
-dbt test --models model_b --defer --state prod-run-artifacts
+dbt test --select model_b --defer --state prod-run-artifacts
 ```
 
 <File name='target/compiled/.../relationships_model_b_id__id__ref_model_a_.sql'>

--- a/website/docs/reference/node-selection/exclude.md
+++ b/website/docs/reference/node-selection/exclude.md
@@ -3,10 +3,10 @@ title: "Exclude"
 ---
 
 ### Excluding models
-dbt provides an `--exclude` flag with the same semantics as `--models`. Models specified with the `--exclude` flag will be removed from the set of models selected with `--models`.
+dbt provides an `--exclude` flag with the same semantics as `--select`. Models specified with the `--exclude` flag will be removed from the set of models selected with `--select`.
 
 ```bash
-$ dbt run --models my_package.*+ --exclude my_package.a_big_model+
+$ dbt run --select my_package.*+ --exclude my_package.a_big_model+
 ```
 
 Exclude a specific resource by its name or lineage:

--- a/website/docs/reference/node-selection/graph-operators.md
+++ b/website/docs/reference/node-selection/graph-operators.md
@@ -6,9 +6,9 @@ title: "Graph operators"
 If placed at the front of the model selector, `+` will select all parents of the selected model. If placed at the end of the string, `+` will select all children of the selected model.
 
 ```bash
-$ dbt run --models my_model+          # select my_model and all children
-$ dbt run --models +my_model          # select my_model and all parents
-$ dbt run --models +my_model+         # select my_model, and all of its parents and children
+$ dbt run --select my_model+          # select my_model and all children
+$ dbt run --select +my_model          # select my_model and all parents
+$ dbt run --select +my_model+         # select my_model, and all of its parents and children
 ```
 
 ### The "n-plus" operator
@@ -18,9 +18,9 @@ You can adjust the behavior of the `+` operator by quantifying the number of edg
 to step through.
 
 ```bash
-$ dbt run --models my_model+1          # select my_model and its first-degree children
-$ dbt run --models 2+my_model          # select my_model, its first-degree parents, and its second-degree parents ("grandparents")
-$ dbt run --models 3+my_model+4        # select my_model, its parents up to the 3rd degree, and its children down to the 4th degree
+$ dbt run --select my_model+1          # select my_model and its first-degree children
+$ dbt run --select 2+my_model          # select my_model, its first-degree parents, and its second-degree parents ("grandparents")
+$ dbt run --select 3+my_model+4        # select my_model, its parents up to the 3rd degree, and its children down to the 4th degree
 ```
 
 ### The "at" operator
@@ -32,6 +32,6 @@ The `@` operator is similar to `+`, but will also include _the parents of the ch
 The `*` operator matches all models within a package or directory.
 
 ```bash
-$ dbt run --models snowplow.*      # run all of the models in the snowplow package
-$ dbt run --models finance.base.*  # run all of the models in models/finance/base
+$ dbt run --select snowplow.*      # run all of the models in the snowplow package
+$ dbt run --select finance.base.*  # run all of the models in models/finance/base
 ```

--- a/website/docs/reference/node-selection/methods.md
+++ b/website/docs/reference/node-selection/methods.md
@@ -9,14 +9,14 @@ syntax `method:value`.
 The `tag:` method is used to select models that match a specified [tag](resource-configs/tags).
 
 ```bash
-$ dbt run --models tag:nightly    # run all models with the `nightly` tag
+$ dbt run --select tag:nightly    # run all models with the `nightly` tag
 ```
 
 ### The "source" method
 The `source` method is used to select models that select from a specified [source](using-sources). Use in conjunction with the `+` operator.
 
 ```bash
-$ dbt run --models source:snowplow+    # run all models that select from Snowplow sources
+$ dbt run --select source:snowplow+    # run all models that select from Snowplow sources
 ```
 
 ### The "path" method
@@ -26,12 +26,12 @@ selectors unambiguous.
 
 ```bash
 # These two selectors are equivalent
-dbt run --models path:models/staging/github
-dbt run --models models/staging/github
+dbt run --select path:models/staging/github
+dbt run --select models/staging/github
 
 # These two selectors are equivalent
-dbt run --models path:models/staging/github/stg_issues.sql
-dbt run --models models/staging/github/stg_issues.sql
+dbt run --select path:models/staging/github/stg_issues.sql
+dbt run --select models/staging/github/stg_issues.sql
 ```
 
 ### The "package" method
@@ -43,9 +43,9 @@ selectors unambiguous.
 
 ```bash
 # These three selectors are equivalent
-dbt run --models package:snowplow
-dbt run --models snowplow
-dbt run --models snowplow.*
+dbt run --select package:snowplow
+dbt run --select snowplow
+dbt run --select snowplow.*
 ```
 
 ### The "config" method
@@ -54,9 +54,9 @@ dbt run --models snowplow.*
 The `config` method is used to select models that match a specified [node config](config).
 
 ```bash
-$ dbt run --models config.materialized:incremental    # run all models that are materialized incrementally
-$ dbt run --models config.schema:audit                # run all models that are created in the `audit` schema
-$ dbt run --models config.cluster_by:geo_country      # run all models clustered by `geo_country`
+$ dbt run --select config.materialized:incremental    # run all models that are materialized incrementally
+$ dbt run --select config.schema:audit                # run all models that are created in the `audit` schema
+$ dbt run --select config.cluster_by:geo_country      # run all models clustered by `geo_country`
 ```
 
 ### The "test_type" method
@@ -65,8 +65,8 @@ $ dbt run --models config.cluster_by:geo_country      # run all models clustered
 The `test_type` method is used to select tests based on their type, `schema` or `data`:
 
 ```bash
-$ dbt test --models test_type:schema        # run all schema tests
-$ dbt test --models test_type:data          # run all data tests
+$ dbt test --select test_type:schema        # run all schema tests
+$ dbt test --select test_type:data          # run all data tests
 ```
 
 ### The "test_name" method
@@ -77,9 +77,9 @@ that defines it. For more information about how generic tests are defined, read 
 [tests](building-a-dbt-project/tests).
 
 ```bash
-$ dbt test --models test_name:unique            # run all instances of the `unique` test
-$ dbt test --models test_name:equality          # run all instances of the `dbt_utils.equality` test
-$ dbt test --models test_name:range_min_max     # run all instances of a custom schema test defined in the local project, `range_min_max`
+$ dbt test --select test_name:unique            # run all instances of the `unique` test
+$ dbt test --select test_name:equality          # run all instances of the `dbt_utils.equality` test
+$ dbt test --select test_name:range_min_max     # run all instances of a custom schema test defined in the local project, `range_min_max`
 ```
 
 ### The "state" method
@@ -97,9 +97,9 @@ The `state` method is used to select nodes by comparing them against a previous 
 `state:modified`: All new nodes, plus any changes to existing nodes.
 
 ```bash
-$ dbt test --models state:new            # run all tests on new models + and new tests on old models
-$ dbt run --models state:modified        # run all models that have been modified
-$ dbt ls --models state:modified         # list all modified nodes (not just models)
+$ dbt test --select state:new            # run all tests on new models + and new tests on old models
+$ dbt run --select state:modified        # run all models that have been modified
+$ dbt ls --select state:modified         # list all modified nodes (not just models)
 ```
 
 Because state comparison is complex, and everyone's project is different, dbt supports subselectors that include a subset of the full `modified` criteria:
@@ -117,7 +117,7 @@ Remember that `state:modified` includes _all_ of the criteria above, as well as 
 The `exposure` method is used to select parent resources of a specified [exposure](exposure-properties). Use in conjunction with the `+` operator.
 
 ```bash
-$ dbt run --models +exposure:weekly_kpis                # run all models that feed into the weekly_kpis exposure
-$ dbt test --models +exposure:*                         # test all resources upstream of all exposures
+$ dbt run --select +exposure:weekly_kpis                # run all models that feed into the weekly_kpis exposure
+$ dbt test --select +exposure:*                         # test all resources upstream of all exposures
 $ dbt ls --select +exposure:* --resource-type source    # list all sources upstream of all exposures
 ```

--- a/website/docs/reference/node-selection/putting-it-together.md
+++ b/website/docs/reference/node-selection/putting-it-together.md
@@ -3,22 +3,22 @@ title: "Putting it together"
 ---
 
 ```bash
-$ dbt run --models my_package.*+      # select all models in my_package and their children
-$ dbt run --models +some_model+       # select some_model and all parents and children
+$ dbt run --select my_package.*+      # select all models in my_package and their children
+$ dbt run --select +some_model+       # select some_model and all parents and children
 
-$ dbt run --models tag:nightly+       # select "nightly" models and all children
-$ dbt run --models +tag:nightly+      # select "nightly" models and all parents and children
+$ dbt run --select tag:nightly+       # select "nightly" models and all children
+$ dbt run --select +tag:nightly+      # select "nightly" models and all parents and children
 
-$ dbt run --models @source:snowplow   # build all models that select from snowplow sources, plus their parents
+$ dbt run --select @source:snowplow   # build all models that select from snowplow sources, plus their parents
 
-$ dbt test --models config.incremental_strategy:insert_overwrite,test_name:unique   # execute all `unique` tests that select from models using the `insert_overwrite` incremental strategy
+$ dbt test --select config.incremental_strategy:insert_overwrite,test_name:unique   # execute all `unique` tests that select from models using the `insert_overwrite` incremental strategy
 ```
 
 This can get complex! Let's say I want a nightly run of models that build off snowplow data
 and feed exports, while _excluding_ the biggest incremental models (and one other model, to boot).
 
 ```bash
-$ dbt run --models @source:snowplow,tag:nightly models/export --exclude package:snowplow,config.materialized:incremental export_performance_timing
+$ dbt run --select @source:snowplow,tag:nightly models/export --exclude package:snowplow,config.materialized:incremental export_performance_timing
 ```
 
 This command selects all models that:

--- a/website/docs/reference/node-selection/set-operators.md
+++ b/website/docs/reference/node-selection/set-operators.md
@@ -3,32 +3,32 @@ title: "Set operators"
 ---
 
 ### Unions
-Providing multiple space-delineated arguments to the `--models`, `--exclude`, or `--selector` flags selects
+Providing multiple space-delineated arguments to the `--select`, `--exclude`, or `--selector` flags selects
 the union of them all. If a resource is included in at least one selector, it will be 
 included in the final set.
 
 Run snowplow_sessions, all ancestors of snowplow_sessions, fct_orders, and all ancestors of fct_orders:
 ```bash
-$ dbt run --models +snowplow_sessions +fct_orders
+$ dbt run --select +snowplow_sessions +fct_orders
 ```
 
 ### Intersections
 <Changelog>New in v0.18.0</Changelog>
 
-If multiple arguments to `--models`, `--exclude`, and `--select` can be comma-separated (with no whitespace in between),
+If multiple arguments to `--select`, `--exclude`, and `--select` can be comma-separated (with no whitespace in between),
 dbt will select only resources which satisfy _all_ arguments.
 
 Run all the common ancestors of snowplow_sessions and fct_orders:
 ```bash
-$ dbt run --models +snowplow_sessions,+fct_orders
+$ dbt run --select +snowplow_sessions,+fct_orders
 ```
 
 Run all the common descendents of stg_invoices and stg_accounts:
 ```bash
-$ dbt run --models stg_invoices+,stg_accounts+
+$ dbt run --select stg_invoices+,stg_accounts+
 ```
 
 Run models that are in the marts/finance subdirectory *and* tagged nightly:
 ```bash
-$ dbt run --models marts.finance,tag:nightly
+$ dbt run --select marts.finance,tag:nightly
 ```

--- a/website/docs/reference/node-selection/state-comparison-caveats.md
+++ b/website/docs/reference/node-selection/state-comparison-caveats.md
@@ -24,15 +24,15 @@ If a model uses a `var` or `env_var` in its definition, dbt is unable today to i
 
 ### Tests
 
-The command `dbt test -m state:modified` will include both:
+The command `dbt test -s state:modified` will include both:
 - tests that select from a new/modified resource
 - tests that are themselves new or modified
 
 As long as you're adding or changing tests at the same time that you're adding or changing the resources (models, seeds, snapshots) they select from, all should work the way you expect with "simple" state selection:
 
 ```shell
-$ dbt run -m state:modified
-$ dbt test -m state:modified
+$ dbt run -s state:modified
+$ dbt test -s state:modified
 ```
 
 This can get complicated, however. If you add a new test without modifying its underlying model, or add a test that selects from a new model and an old unmodified one, you may need to test a model without having first run it.
@@ -40,8 +40,8 @@ This can get complicated, however. If you add a new test without modifying its u
 In v0.18.0, you needed to handle this by building the unmodified models needed for modified tests:
 
 ```shell
-$ dbt run -m state:modified @state:modified,1+test_type:data
-$ dbt test -m state:modified
+$ dbt run -s state:modified @state:modified,1+test_type:data
+$ dbt test -s state:modified
 ```
 
 In v0.19.0, dbt added support for deferring upstream references when testing. If a test selects from a model that doesn't exist as a database object in your current environment, dbt will look to the other environment instead—the one defined in your state manifest. This enables you to use "simple" state selection without risk of query failure, but it may have some surprising consequences for tests with multiple parents. For instance, if you have a `relationships` test that depends on one modified model and one unmodified model, the test query will select from data "across" two different environments. If you limit or sample your data in development and CI, it may not make much sense to test for referential integrity, knowing there's a good chance of mismatch.
@@ -49,8 +49,8 @@ In v0.19.0, dbt added support for deferring upstream references when testing. If
 If you're a frequent user of `relationships` tests or data tests, or frequently find yourself adding tests without modifying their underlying models, consider tweaking the selection criteria of your CI job. For instance:
 
 ```shell
-$ dbt run -m state:modified
-$ dbt test -m state:modified --exclude test_name:relationships
+$ dbt run -s state:modified
+$ dbt test -s state:modified --exclude test_name:relationships
 ```
 
 ### False positives

--- a/website/docs/reference/node-selection/syntax.md
+++ b/website/docs/reference/node-selection/syntax.md
@@ -6,14 +6,14 @@ dbt's node selection syntax makes it possible to run only specific resources in 
 
 | command                         | argument(s)                                                          |
 | :------------------------------ | -------------------------------------------------------------------- |
-| [run](commands/run)             | `--models`, `--exclude`, `--selector`, `--defer`                     |
-| [test](commands/test)           | `--models`, `--exclude`, `--selector`, `--defer`                     |
+| [run](commands/run)             | `--select`, `--exclude`, `--selector`, `--defer`                     |
+| [test](commands/test)           | `--select`, `--exclude`, `--selector`, `--defer`                     |
 | [seed](commands/seed)           | `--select`, `--exclude`, `--selector`                                |
 | [snapshot](commands/snapshot)   | `--select`, `--exclude`  `--selector`                                |
-| [ls (list)](commands/list)      | `--select`, `--models`, `--exclude`, `--selector`, `--resource-type` |
+| [ls (list)](commands/list)      | `--select`, `--exclude`, `--selector`, `--resource-type` |
 | [compile](commands/compile)     | `--select`, `--exclude`, `--selector`                                |
 | [freshness](commands/source)    | `--select`, `--exclude`, `--selector`                                |
-| [build](commands/build)         | `--models`, `--exclude`, `--selector`, `--defer`                     |
+| [build](commands/build)         | `--select`, `--exclude`, `--selector`, `--defer`                     |
 
 :::info Nodes and resources
 
@@ -22,11 +22,15 @@ We use the terms <a href="https://en.wikipedia.org/wiki/Vertex_(graph_theory)">"
 
 ## Specifying resources
 
-By default, `dbt run` executes _all_ of the models in the dependency graph; `dbt seed` creates all seeds, `dbt snapshot` performs every snapshot. The `--models` and `--select` flags are used to specify a subset of nodes to execute.
+By default, `dbt run` executes _all_ of the models in the dependency graph; `dbt seed` creates all seeds, `dbt snapshot` performs every snapshot. The `--select` flag is used to specify a subset of nodes to execute.
+
+:::info
+Before dbt v0.21, certain commands (notably `run`, `test`, and `compile`) used a flag called `--models` instead of `--select`. The two were functionally identical. Those commands still support the `--models` flag for backwards compatibility.
+:::
 
 ### How does selection work?
 
-1. dbt gathers all the resources that are matched by one or more of the `--models`/`--select` criteria, in the order of selection methods (e.g. `tag:`), then graph operators (e.g. `+`), then finally set operators (unions, intersections, exclusions).
+1. dbt gathers all the resources that are matched by one or more of the `--select` criteria, in the order of selection methods (e.g. `tag:`), then graph operators (e.g. `+`), then finally set operators (unions, intersections, exclusions).
 
 2. The selected resources may be models, sources, seeds, snapshots, tests. (Tests can also be selected "indirectly" via their parents; see [test selection examples](test-selection-examples) for details.)
 
@@ -34,14 +38,13 @@ By default, `dbt run` executes _all_ of the models in the dependency graph; `dbt
 
 ### Shorthand
 
-Select models to run or test: `--models`, `--model`, `-m`
-Select resources to list, seed, or snapshot: `--select`, `-s`
+Select resources to build (run, test, seed, snapshot) or check freshness: `--select`, `-s`
 
 ### Examples
 
-By default, `dbt run` will execute _all_ of the models in the dependency graph. During development (and deployment), it is useful to specify only a subset of models to run. Use the `--models` flag with `dbt run` to select a subset of models to run. Note that the following arguments (`--models`, `--exclude`, and `--selector`) also apply to `dbt test`!
+By default, `dbt run` will execute _all_ of the models in the dependency graph. During development (and deployment), it is useful to specify only a subset of models to run. Use the `--select` flag with `dbt run` to select a subset of models to run. Note that the following arguments (`--select`, `--exclude`, and `--selector`) also apply to `dbt test`!
 
-The `--models` and `--select` flags accept one or more arguments. Each argument can be one of:
+The `--select` flag accepts one or more arguments. Each argument can be one of:
 
 1. a package name
 2. a model name
@@ -50,24 +53,24 @@ The `--models` and `--select` flags accept one or more arguments. Each argument 
 
 Examples:
 ```bash
-$ dbt run --models my_dbt_project_name   # runs all models in your project
-$ dbt run --models my_dbt_model          # runs a specific model
-$ dbt run --models path.to.my.models     # runs all models in a specific directory
-$ dbt run --models my_package.some_model # run a specific model in a specific package
-$ dbt run --models tag:nightly           # run models with the "nightly" tag
-$ dbt run --models path/to/models        # run models contained in path/to/models
-$ dbt run --models path/to/my_model.sql  # run a specific model by its path
+$ dbt run --select my_dbt_project_name   # runs all models in your project
+$ dbt run --select my_dbt_model          # runs a specific model
+$ dbt run --select path.to.my.models     # runs all models in a specific directory
+$ dbt run --select my_package.some_model # run a specific model in a specific package
+$ dbt run --select tag:nightly           # run models with the "nightly" tag
+$ dbt run --select path/to/models        # run models contained in path/to/models
+$ dbt run --select path/to/my_model.sql  # run a specific model by its path
 ```
 
 dbt supports a shorthand language for defining subsets of nodes. This language uses the characters `+`, `@`, `*`, and `,`.
 
 ```bash
-# multiple arguments can be provided to --models
-$ dbt run --models my_first_model my_second_model
+# multiple arguments can be provided to --select
+$ dbt run --select my_first_model my_second_model
 
 # these arguments can be projects, models, directory paths, tags, or sources
-$ dbt run --models tag:nightly my_model finance.base.*
+$ dbt run --select tag:nightly my_model finance.base.*
 
 # use methods and intersections for more complex selectors
-$ dbt run --models path:marts/finance,tag:nightly,config.materialized:table
+$ dbt run --select path:marts/finance,tag:nightly,config.materialized:table
 ```

--- a/website/docs/reference/node-selection/syntax.md
+++ b/website/docs/reference/node-selection/syntax.md
@@ -76,5 +76,5 @@ $ dbt run --select path:marts/finance,tag:nightly,config.materialized:table
 ```
 
 As your selection logic gets more complex, and becomes unwieldly to type out as command-line arguments,
-consider using a [yaml selector](yaml-selector). You can use a predefined definition with the `--selector` flag.
+consider using a [yaml selector](yaml-selectors). You can use a predefined definition with the `--selector` flag.
 Note that when you're using `--selector`, most other flags (namely `--select` and `--exclude`) will be ignored.

--- a/website/docs/reference/node-selection/syntax.md
+++ b/website/docs/reference/node-selection/syntax.md
@@ -42,14 +42,14 @@ Select resources to build (run, test, seed, snapshot) or check freshness: `--sel
 
 ### Examples
 
-By default, `dbt run` will execute _all_ of the models in the dependency graph. During development (and deployment), it is useful to specify only a subset of models to run. Use the `--select` flag with `dbt run` to select a subset of models to run. Note that the following arguments (`--select`, `--exclude`, and `--selector`) also apply to `dbt test`!
+By default, `dbt run` will execute _all_ of the models in the dependency graph. During development (and deployment), it is useful to specify only a subset of models to run. Use the `--select` flag with `dbt run` to select a subset of models to run. Note that the following arguments (`--select`, `--exclude`, and `--selector`) also apply to other dbt tasks, such as `test` and `build`.
 
 The `--select` flag accepts one or more arguments. Each argument can be one of:
 
 1. a package name
 2. a model name
 3. a fully-qualified path to a directory of models
-4. a selector method (`path:`, `tag:`, `config:`, `test_type:`, `test_name:`)
+4. a selection method (`path:`, `tag:`, `config:`, `test_type:`, `test_name:`)
 
 Examples:
 ```bash
@@ -74,3 +74,7 @@ $ dbt run --select tag:nightly my_model finance.base.*
 # use methods and intersections for more complex selectors
 $ dbt run --select path:marts/finance,tag:nightly,config.materialized:table
 ```
+
+As your selection logic gets more complex, and becomes unwieldly to type out as command-line arguments,
+consider using a [yaml selector](yaml-selector). You can use a predefined definition with the `--selector` flag.
+Note that when you're using `--selector`, most other flags (namely `--select` and `--exclude`) will be ignored.

--- a/website/docs/reference/node-selection/syntax.md
+++ b/website/docs/reference/node-selection/syntax.md
@@ -10,10 +10,10 @@ dbt's node selection syntax makes it possible to run only specific resources in 
 | [test](commands/test)           | `--select`, `--exclude`, `--selector`, `--defer`                     |
 | [seed](commands/seed)           | `--select`, `--exclude`, `--selector`                                |
 | [snapshot](commands/snapshot)   | `--select`, `--exclude`  `--selector`                                |
-| [ls (list)](commands/list)      | `--select`, `--exclude`, `--selector`, `--resource-type` |
+| [ls (list)](commands/list)      | `--select`, `--exclude`, `--selector`, `--resource-type`             |
 | [compile](commands/compile)     | `--select`, `--exclude`, `--selector`                                |
 | [freshness](commands/source)    | `--select`, `--exclude`, `--selector`                                |
-| [build](commands/build)         | `--select`, `--exclude`, `--selector`, `--defer`                     |
+| [build](commands/build)         | `--select`, `--exclude`, `--selector`, `--resource-type`, `--defer`  |
 
 :::info Nodes and resources
 

--- a/website/docs/reference/node-selection/test-selection-examples.md
+++ b/website/docs/reference/node-selection/test-selection-examples.md
@@ -14,10 +14,13 @@ Unlike other resource types, tests can also be selected **indirectly**. If a sel
 <Changelog>
 
 * `v0.20.0`: Test selection is no longer greedy for indirect inclusion (ALL parents must be selected for the test to be selected). It is still greedy for indirect exclusion (if ANY parent is excluded, the test is excluded).
+* `v0.21.0`: Introduce `--greedy` flag (and `greedy` selector property), to optionally include tests that are indirectly selected and have an unselected parent.
 
 </Changelog>
 
 This can be complex for tests with multiple parents (e.g. `relationships`, or custom tests that `ref()` multiple models). To prevent tests from running when they aren't wanted, a test will be indirectly selected only if **ALL** of its parents are included by the selection criteria. If any parent is missing, that test won't run. On the other hand, if **ANY** parent is excluded, the test will be aggressively excluded as well.
+
+Starting in dbt v0.21, dbt will warn you about tests that have not been indirectly selected because they have at least one unselected parent. You may optionally include them by turning on "greedy" selection: pass the `--greedy` flag, or define a `greedy` property in [yaml selectors](yaml-selectors). When enabled, dbt will include tests that have ANY parent selected, even if other parents are not selected.
 
 We've included lots of examples below:
 
@@ -56,6 +59,12 @@ If a test depends on both `customers` _and_ `orders` (e.g. a `relationships` tes
 
 ```shell
 $ dbt test --select customers orders
+```
+
+Or if you pass the `--greedy` flag:
+```shell
+$ dbt test --select customers --greedy
+$ dbt test --select orders --greedy
 ```
 
 ### Syntax examples

--- a/website/docs/reference/node-selection/test-selection-examples.md
+++ b/website/docs/reference/node-selection/test-selection-examples.md
@@ -32,13 +32,13 @@ We've included lots of examples below:
 Run generic (schema) tests only:
 
 ```shell
-$ dbt test --models test_type:schema
+$ dbt test --select test_type:schema
 ```
 
 Run bespoke (data) tests only:
 
 ```shell
-$ dbt test --models test_type:data
+$ dbt test --select test_type:data
 ```
 
 In both cases, `test_type` checks a property of the test itself. These are forms of "direct" test selection.
@@ -46,8 +46,8 @@ In both cases, `test_type` checks a property of the test itself. These are forms
 ### Indirect selection
 
 ```shell
-$ dbt test --models customers
-$ dbt test --models orders
+$ dbt test --select customers
+$ dbt test --select orders
 ```
 
 These are examples of "indirect" selection: `customers` and `orders` select models (whether by name or path). Any tests defined on `customers` or `orders` will be selected indirectly, and thereby included.
@@ -55,31 +55,31 @@ These are examples of "indirect" selection: `customers` and `orders` select mode
 If a test depends on both `customers` _and_ `orders` (e.g. a `relationships` test between them), it will _not_ be selected indirectly in the example above. Instead, it would only be selected indirectly if both parents are selected:
 
 ```shell
-$ dbt test --models customers orders
+$ dbt test --select customers orders
 ```
 
 ### Syntax examples
 
-The following examples should feel somewhat familiar if you're used to executing `dbt run` with the `--models` option to build parts of your DAG:
+The following examples should feel somewhat familiar if you're used to executing `dbt run` with the `--select` option to build parts of your DAG:
 
 ```shell
 # Run tests on a model (indirect selection)
-$ dbt test --models customers
+$ dbt test --select customers
 
 # Run tests on all models in the models/staging/jaffle_shop directory (indirect selection)
-$ dbt test --models staging.jaffle_shop
+$ dbt test --select staging.jaffle_shop
 
 # Run tests downstream of a model (note this will select those tests directly!)
-$ dbt test --models stg_customers+
+$ dbt test --select stg_customers+
 
 # Run tests upstream of a model (indirect selection)
-$ dbt test --models +stg_customers
+$ dbt test --select +stg_customers
 
 # Run tests on all models with a particular tag (direct + indirect)
-$ dbt test --models tag:my_model_tag
+$ dbt test --select tag:my_model_tag
 
 # Run tests on all models with a particular materialization (indirect selection)
-$ dbt test --models config.materialized:table
+$ dbt test --select config.materialized:table
 
 ```
 
@@ -87,13 +87,13 @@ The same principle can be extended to tests defined on other resource types. In 
 
 ```shell
 # tests on all sources
-$ dbt test --models source:*
+$ dbt test --select source:*
 
 # tests on one source
-$ dbt test --models source:jaffle_shop
+$ dbt test --select source:jaffle_shop
 
 # tests on one source table
-$ dbt test --models source:jaffle_shop.customers
+$ dbt test --select source:jaffle_shop.customers
 
 # tests on everything _except_ sources
 $ dbt test --exclude source:*
@@ -104,22 +104,22 @@ $ dbt test --exclude source:*
 Through the combination of direct and indirect selection, there are many ways to accomplish the same outcome. Let's say we have a data test named `assert_total_payment_amount_is_positive` that depends on a model named `payments`. All of the following would manage to select and execute that test specifically:
 
 ```shell
-$ dbt test --models assert_total_payment_amount_is_positive # directly select the test by name
-$ dbt test --models payments,test_type:data # indirect selection, v0.18.0
-$ dbt test --models payments --data  # indirect selection, earlier versions
+$ dbt test --select assert_total_payment_amount_is_positive # directly select the test by name
+$ dbt test --select payments,test_type:data # indirect selection, v0.18.0
+$ dbt test --select payments --data  # indirect selection, earlier versions
 ```
 
 As long as you can select a common property of a group of resources, indirect selection allows you to execute all the tests on those resources, too. In the example above, we saw it was possible to test all table-materialized models. This principle can be extended to other resource types, too:
 
 ```shell
 # Run tests on all models with a particular materialization
-$ dbt test --models config.materialized:table
+$ dbt test --select config.materialized:table
 
 # Run tests on all seeds, which use the 'seed' materialization
-$ dbt test --models config.materialized:seed
+$ dbt test --select config.materialized:seed
 
 # Run tests on all snapshots, which use the 'snapshot' materialization
-$ dbt test --models config.materialized:snapshot
+$ dbt test --select config.materialized:snapshot
 ```
 
 Note that this functionality may change in future versions of dbt.
@@ -146,7 +146,7 @@ models:
 </File>
 
 ```shell
-$ dbt test --models tag:my_column_tag
+$ dbt test --select tag:my_column_tag
 ```
 
 Currently, tests "inherit" tags applied to columns, sources, and source tables. They do _not_ inherit tags applied to models, seeds, or snapshots. In all likelihood, those tests would still be selected indirectly, because the tag selects its parent. This is a subtle distinction, and it may change in future versions of dbt.
@@ -174,5 +174,5 @@ models:
 
 
 ```shell
-$ dbt test --models tag:my_test_tag
+$ dbt test --select tag:my_test_tag
 ```

--- a/website/docs/reference/node-selection/yaml-selectors.md
+++ b/website/docs/reference/node-selection/yaml-selectors.md
@@ -6,7 +6,7 @@ title: "YAML Selectors"
 
 - **v0.18.0**: Introduced YAML selectors
 - **v0.19.0**: Added optional `description` property. Selectors appear in `manifest.json` under a new `selectors` key.
-- **v0.21.0**: Added optional `default` property
+- **v0.21.0**: Added optional `default` + `greedy` properties
 
 </Changelog>
 
@@ -76,6 +76,8 @@ definition:
   parents_depth: 1     # if parents: true, degrees to include
 
   childrens_parents: true | false     # @ operator
+  
+  greedy: true | false  # include all tests selected indirectly? false by default
 ```
 
 The `*` operator to select all nodes can be written as:
@@ -113,6 +115,27 @@ and it is always applied _last_ within its scope.
 
 This gets us more intricate subset definitions than what's available on the CLI,
 where we can only pass one "yeslist" (`--select`) and one "nolist" (`--exclude`).
+
+#### Greedy
+
+As a general rule, dbt will indirectly select tests if they touch resources that you're selecting directly,
+but not tests that also touch unselected resources (e.g. a `relationships` test, with one parent selected and one parent
+not selected). Starting in v0.21, you can optionally turn this on by setting `greedy: true` for a specific criterion:
+
+```yml
+- union:
+    - method: fqn
+      value: model_a
+      greedy: true  # will include all tests that touch model_a
+    - method: fqn
+      value: model_b
+      greedy: false  # default: will not include tests touching model_b
+                     # if they have other unselected parents
+```
+
+In CLI-based selection, dbt will warn you about tests that aren't greedily included. Here, you're in "full control" mode—dbt will not warn you about which tests your yaml selector definition does or does not include. Remember that you can always use [`list`](commands/list) to check.
+
+See [test selection examples](test-selection-examples) for more details about greediness and indirect selection.
 
 ## Example
 

--- a/website/docs/reference/node-selection/yaml-selectors.md
+++ b/website/docs/reference/node-selection/yaml-selectors.md
@@ -5,18 +5,19 @@ title: "YAML Selectors"
 <Changelog>
 
 - **v0.18.0**: Introduced YAML selectors
-- **v0.19.0**: Added optional `description` property. Selectors appear as in `manifest.json`.
+- **v0.19.0**: Added optional `description` property. Selectors appear in `manifest.json` under a new `selectors` key.
+- **v0.21.0**: Added optional `default` property
 
 </Changelog>
 
-Write model selectors in YAML, save them with a human-friendly name, and reference them using the `--selector` flag.
+Write resource selectors in YAML, save them with a human-friendly name, and reference them using the `--selector` flag.
 By recording selectors in a top-level `selectors.yml` file:
 
 * **Legibility:** complex selection criteria are composed of dictionaries and arrays
 * **Version control:** selector definitions are stored in the same git repository as the dbt project
 * **Reusability:** selectors can be referenced in multiple job definitions, and their definitions are extensible (via YAML anchors)
 
-Selectors live in a top-level file named `selectors.yml`. Each has a `name`, a `definition`, and an optional `description`:
+Selectors live in a top-level file named `selectors.yml`. Each must have a `name` and a `definition`, and can optionally define a `description` and [`default` flag](#default).
 
 <File name='selectors.yml'>
 
@@ -26,9 +27,12 @@ selectors:
     definition: ...
   - name: nodes_to_a_grecian_urn
     description: Attic shape with a fair attitude
+    default: true
     definition: ...
 ```
 </File>
+
+## Definitions
 
 Each `definition` is comprised of one or more arguments, which can be one of the following:
 * **CLI-style:** strings, representing CLI-style) arguments
@@ -37,7 +41,7 @@ Each `definition` is comprised of one or more arguments, which can be one of the
     
 Use `union` and `intersection` to organize multiple arguments.
 
-#### CLI-style
+### CLI-style
 ```yml
 definition:
   'tag:nightly'
@@ -46,7 +50,7 @@ definition:
 This simple syntax supports use of the `+`, `@`, and `*` operators. It does
 not support `exclude`.
 
-#### Key-value
+### Key-value
 ```yml
 definition:
   tag: nightly
@@ -54,7 +58,7 @@ definition:
 
 This simple syntax does not support any operators or `exclude`.
 
-#### Full YAML
+### Full YAML
 
 This is the most thorough syntax, which can include graph and set operators.
 
@@ -110,7 +114,7 @@ and it is always applied _last_ within its scope.
 This gets us more intricate subset definitions than what's available on the CLI,
 where we can only pass one "yeslist" (`--select`) and one "nolist" (`--exclude`).
 
-### Example
+## Example
 
 Here are two ways to represent:
 ```
@@ -181,4 +185,46 @@ selectors:
 Then in our job definition:
 ```bash
 $ dbt run --selector nightly_diet_snowplow
+```
+
+## Default
+
+Starting in v0.21, selectors may define a boolean `default` property. If a selector has `default: true`, dbt will use this selector's criteria when tasks do not define their own selection criteria.
+
+Let's say we define a default selector that only selects resources defined in our root project:
+```yml
+selectors:
+  - name: root_project_only
+    description: >
+        Only resources from the root project.
+        Excludes resources defined in installed packages.
+    default: true
+    definition:
+      method: project
+      value: <my_root_project_name>
+```
+
+If I run an "unqualified" command, dbt will use the selection criteria defined in `root_project_only`—that is, dbt will only build / freshness check / generate compiled SQL for resources defined in my root project.
+```
+$ dbt build
+$ dbt source freshness
+$ dbt docs generate
+```
+
+If I run a command that defines its own selection criteria (via `--select`, `--exclude`, or `--selector`), dbt will ignore the default selector and use the flag criteria instead. It will not try to combine the two.
+```
+$ dbt run --select  model_a
+$ dbt run --exclude model_a
+```
+
+Only one selector may set `default: true` for a given invocation; otherwise, dbt will return an error. You may use a Jinja expression to adjust the value of `default` depending on the environment, however:
+
+```yml
+selectors:
+  - name: default_for_dev
+    default: "{{ target.name == 'dev' | as_bool }}"
+    definition: ...
+  - name: default_for_prod
+    default: "{{ target.name == 'prod' | as_bool }}"
+    definition: ...
 ```

--- a/website/docs/reference/node-selection/yaml-selectors.md
+++ b/website/docs/reference/node-selection/yaml-selectors.md
@@ -108,13 +108,13 @@ the `--exclude` CLI argument. Here, `exclude` _always_ returns a [set difference
 and it is always applied _last_ within its scope.
 
 This gets us more intricate subset definitions than what's available on the CLI,
-where we can only pass one "yeslist" (`--models`, `--select`) and one "nolist" (`--exclude`).
+where we can only pass one "yeslist" (`--select`) and one "nolist" (`--exclude`).
 
 ### Example
 
 Here are two ways to represent:
 ```
-$ dbt run --models @source:snowplow,tag:nightly models/export --exclude package:snowplow,config.materialized:incremental export_performance_timing
+$ dbt run --select @source:snowplow,tag:nightly models/export --exclude package:snowplow,config.materialized:incremental export_performance_timing
 ```
 
 <Tabs

--- a/website/docs/reference/resource-configs/tags.md
+++ b/website/docs/reference/resource-configs/tags.md
@@ -57,7 +57,7 @@ seeds:
 Apply a tag (or list of tags) to a model, seed, or snapshot.
 
 These tags can be used as part of the [resource selection syntax](node-selection/syntax), when running the following commands:
-- `dbt run --models tag:my_tag`
+- `dbt run --select tag:my_tag`
 - `dbt seed --select tag:my_tag`
 - `dbt snapshot --select tag:my_tag`
 

--- a/website/docs/reference/resource-configs/where.md
+++ b/website/docs/reference/resource-configs/where.md
@@ -6,8 +6,11 @@ datatype: string
 <Changelog>
 
 * `v0.20.0`: Introduced `where` config
+* `v0.21.0`: Reimplemented `where` config with `get_where_subquery` macro
 
 </Changelog>
+
+### Definition
 
 Filter the resource being tested (model, source, seed, or snapshot).
 
@@ -20,9 +23,11 @@ where my_column is null
 If the `where` config is set to `where date_column = current_date`, then the test query will be updated to:
 ```sql
 select *
-from (select * from my_model where date_column = current_date) my_model
+from (select * from my_model where date_column = current_date) dbt_subquery
 where my_column is null
 ```
+
+### Examples
 
 <Tabs
   defaultValue="specific"
@@ -114,3 +119,15 @@ tests:
 </TabItem>
 
 </Tabs>
+
+### Custom logic
+
+As of v0.21, dbt defines a [`get_where_subquery` macro](https://github.com/dbt-labs/dbt/blob/develop/core/dbt/include/global_project/macros/etc/where_subquery.sql).
+
+dbt replaces `{{ model }}` in generic test definitions with `{{ get_where_subquery(relation) }}`, where `relation` is a `ref()` or `source()` for the resource being tested. The default implementation of this macro returns:
+- `{{ relation }}` when the `where` config is not defined (`ref()` or `source()`)
+- `(select * from {{ relation }} where {{ where }}) dbt_subquery` when the `where` config is defined
+
+You can override this behavior by:
+- Defining a custom `get_where_subquery` in your root project
+- Defining a custom `<adapter>__get_where_subquery` [dispatch candidate](dispatch) in your package or adapter plugin

--- a/website/docs/reference/resource-properties/quote.md
+++ b/website/docs/reference/resource-properties/quote.md
@@ -161,7 +161,7 @@ sources:
 Without `quote: true`, the following error will occur:
 
 ```
-$ dbt test -m source:stripe.*
+$ dbt test -s source:stripe.*
 Running with dbt=0.16.1
 Found 7 models, 22 tests, 0 snapshots, 0 analyses, 130 macros, 0 operations, 0 seed files, 4 sources
 

--- a/website/docs/reference/resource-properties/tags.md
+++ b/website/docs/reference/resource-properties/tags.md
@@ -194,5 +194,5 @@ models:
 Then, use the `tag:` selector to run the tests on a particular column.
 
 ```
-$ dbt test --models tag:pii
+$ dbt test --select tag:pii
 ```

--- a/website/docs/reference/warehouse-profiles/bigquery-profile.md
+++ b/website/docs/reference/warehouse-profiles/bigquery-profile.md
@@ -13,7 +13,7 @@ BigQuery targets can be specified using one of four methods:
 
 For local development, we recommend using the oauth method. If you're scheduling dbt on a server, you should use the service account auth method instead.
 
-BigQuery targets should be set up using the following configuration in your `profiles.yml` file.
+BigQuery targets should be set up using the following configuration in your `profiles.yml` file. There are a number of [optional configurations](#optional-configurations) you may specify as well.
 
 ### OAuth via gcloud
 
@@ -33,10 +33,7 @@ my-bigquery-db:
       project: [GCP project id]
       dataset: [the name of your dbt dataset] # You can also use "schema" here
       threads: [1 or more]
-      timeout_seconds: 300
-      location: US # Optional, one of US or EU
-      priority: interactive
-      retries: 1
+      [<optional_config>](#optional-configurations): <value>
 ```
 
 </File>
@@ -74,14 +71,11 @@ my-bigquery-db:
       project: [GCP project id]
       dataset: [the name of your dbt dataset] # You can also use "schema" here
       threads: [1 or more]
-      timeout_seconds: 300
-      location: US # Optional, one of US or EU
-      priority: interactive
-      retries: 1
       refresh_token: [token]
       client_id: [client id]
       client_secret: [client secret]
       token_uri: [redirect URI]
+      [<optional_config>](#optional-configurations): <value>
 ```
 
 </File>
@@ -104,11 +98,8 @@ my-bigquery-db:
       project: [GCP project id]
       dataset: [the name of your dbt dataset] # You can also use "schema" here
       threads: [1 or more]
-      timeout_seconds: 300
-      location: US # Optional, one of US or EU
-      priority: interactive
-      retries: 1
       token: [temporary access token] # refreshed + updated by external process
+      [<optional_config>](#optional-configurations): <value>
 ```
 
 </File>
@@ -132,9 +123,7 @@ my-bigquery-db:
       dataset: [the name of your dbt dataset]
       threads: [1 or more]
       keyfile: [/path/to/bigquery/keyfile.json]
-      timeout_seconds: 300
-      priority: interactive
-      retries: 1
+      [<optional_config>](#optional-configurations): <value>
 ```
 
 </File>
@@ -161,8 +150,7 @@ my-bigquery-db:
       project: [GCP project id]
       dataset: [the name of your dbt dataset]
       threads: [1 or more]
-      timeout_seconds: 300
-      priority: interactive
+      [<optional_config>](#optional-configurations): <value>
 
       # These fields come from the service account json keyfile
       keyfile_json:
@@ -181,11 +169,23 @@ my-bigquery-db:
 
 </File>
 
-## Configuration options
+## Optional configurations
 
 ### Priority
 
 The `priority` for the BigQuery jobs that dbt executes can be configured with the `priority` configuration in your BigQuery profile. The `priority` field can be set to one of `batch` or `interactive`. For more information on query priority, consult the [BigQuery documentation](https://cloud.google.com/bigquery/docs/running-queries).
+
+```yaml
+my-profile:
+  target: dev
+  outputs:
+    dev:
+      type: bigquery
+      method: oauth
+      project: abc-123
+      dataset: my_dataset
+      priority: interactive
+```
 
 ### Timeouts
 
@@ -195,7 +195,19 @@ BigQuery supports query timeouts. By default, the timeout is set to 300 seconds.
  Operation did not complete within the designated timeout.
 ```
 
-To change this timeout, use the `timeout_seconds` option shown in the BigQuery profile configuration above.
+To change this timeout, use the `timeout_seconds` configuration:
+
+```yaml
+my-profile:
+  target: dev
+  outputs:
+    dev:
+      type: bigquery
+      method: oauth
+      project: abc-123
+      dataset: my_dataset
+      timeout_seconds: 600 # 10 minutes
+```
 
 ### Retries
 
@@ -296,6 +308,27 @@ For a general overview of this process, see the official docs for [Creating Shor
 
 <FAQ src="bq-impersonate-service-account-why" />
 <FAQ src="bq-impersonate-service-account-setup" />
+
+### Execution project
+<Changelog>New in v0.21.0</Changelog>
+
+By default, dbt will use the specified `project`/`database` as both:
+1. The location to materialize resources (models, seeds, snapshots, etc), unless they specify a custom `project`/`database` config
+2. The GCP project that receives the bill for query costs or slot usage
+
+Optionally, you may specify an `execution_project` to bill for query execution, instead of the `project`/`database` where you materialize most resources.
+
+```yaml
+my-profile:
+  target: dev
+  outputs:
+    dev:
+      type: bigquery
+      method: oauth
+      project: abc-123
+      dataset: my_dataset
+      execution_project: buck-stops-here-456
+```
 
 ## Required permissions
 

--- a/website/docs/reference/warehouse-profiles/postgres-profile.md
+++ b/website/docs/reference/warehouse-profiles/postgres-profile.md
@@ -22,6 +22,7 @@ company-name:
       schema: [dbt schema]
       threads: [1 or more]
       keepalives_idle: 0 # default 0, indicating the system default
+      connect_timeout: 10 # default 10 seconds
       search_path: [optional, override the default postgres search_path]
       role: [optional, set the role dbt assumes when executing queries]
       sslmode: [optional, set the sslmode used to connect to the database]

--- a/website/docs/reference/warehouse-profiles/redshift-profile.md
+++ b/website/docs/reference/warehouse-profiles/redshift-profile.md
@@ -22,6 +22,7 @@ company-name:
       schema: analytics
       threads: 4
       keepalives_idle: 0 # default 0, indicating the system default
+      connect_timeout: 10 # default 10 seconds
       # search_path: public # optional, not recommended
       sslmode: [optional, set the sslmode used to connect to the database (in case this parameter is set, will look for ca in ~/.postgresql/root.crt)]
       ra3: true # enables cross-database sources


### PR DESCRIPTION
Documentation for changes included between dbt-core v0.21.0-b2 and v0.21.0-rc1, which we're releasing today.

Incidentally resolves #803

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [x] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!