### PR TITLE
adds hsts support for docs subdomain

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,2 +1,3 @@
 /*
   X-robots-tag: noindex
+  Strict-Transport-Security: max-age=63072000; includeSubDomains; preload


### PR DESCRIPTION
## Description & motivation
Adds HSTS header for docs subdomain to redirect all requests to HTTPs


## Pre-release docs
Is this change related to an unreleased version of dbt?
- [x] No: please ensure the base branch is `current`