### PR TITLE
Remove deprecated dbt-cloud-plugin package ref

### DIFF
--- a/website/docs/docs/running-a-dbt-project/running-dbt-in-production.md
+++ b/website/docs/docs/running-a-dbt-project/running-dbt-in-production.md
@@ -34,7 +34,6 @@ If you're interested in giving dbt Cloud a spin, you can sign up for a *forever 
 
 ### Using Airflow
 If your organization is using [Airflow](https://airflow.apache.org/), there are a number of ways you can run your dbt jobs, including:
-* Using this [dbt-cloud-plugin](https://github.com/dwallace0723/dbt-cloud-plugin/). This plugin gives you the best of both worlds -- deep integration of dbt into your existing data stack, along with all of the benefits of dbt Cloud.
 * Invoking dbt through the [BashOperator](https://airflow.apache.org/howto/operator/bash.html). In this case, be sure to install dbt into a virtual environment to avoid issues with conflicting dependencies between Airflow and dbt.
 * Installing the [airflow-dbt](https://pypi.org/project/airflow-dbt/) python package. This package uses Airflow's operator and hook concept — the source code can be found on [github](https://github.com/gocardless/airflow-dbt).
 


### PR DESCRIPTION
## Description & motivation
@mirnawong1 identified this as a stale and unsupported package, [see Slack thread](https://dbt-labs.slack.com/archives/C017GDLAF7D/p1631174499159900). Her proposal is to remove it from the docs site.

## To-do before merge
N/A

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist
N/A