### PR TITLE
Clarify cons list for operations

### DIFF
--- a/website/docs/docs/building-a-dbt-project/building-models/materializations.md
+++ b/website/docs/docs/building-a-dbt-project/building-models/materializations.md
@@ -94,8 +94,9 @@ When using the `table` materialization, your model is rebuilt as a table on each
     * Ephemeral models can help keep your data warehouse clean by reducing clutter (also consider splitting your models across multiple schemas by [using custom schemas](using-custom-schemas).
 * **Cons:**
     * You cannot select directly from this model.
+    * Operations (e.g. macros called via `dbt run-operation` cannot `ref()` ephemeral nodes)
     * Overuse of the ephemeral materialization can also make queries harder to debug.
-* **Advice:** Use the ephemeral materialization for:
+* **Advice:**  Use the ephemeral materialization for:
     * very light-weight transformations that are early on in your DAG
     * are only used in one or two downstream models, and
     * do not need to be queried directly


### PR DESCRIPTION
dbt will throw an error:  `Operations can not ref() ephemeral nodes, but foo is ephemeral` if a macro you're using in a `run-operation` refs an ephemeral node.  Make it clearer this is expected behavior.

## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a pull request on dbt core, etc?
-->

## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged
-->

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist
If you added new pages (delete if not applicable):
- [ ] The page has been added to `website/sidebars.js`
- [ ] The new page has a unique filename

If you removed existing pages (delete if not applicable):
- [ ] The page has been removed from `website/sidebars.js`
- [ ] An entry has been added to `_redirects`
