### PR TITLE
add required macro to custom adapter guide

### DIFF
--- a/website/docs/docs/contributing/building-a-new-adapter.md
+++ b/website/docs/docs/contributing/building-a-new-adapter.md
@@ -251,6 +251,7 @@ The following macros must be implemented, but you can override their behavior fo
 - `list_schemas` ([source](https://github.com/dbt-labs/dbt/blob/HEAD/core/dbt/include/global_project/macros/adapters/common.sql#L210))
 - `rename_relation` ([source](https://github.com/dbt-labs/dbt/blob/HEAD/core/dbt/include/global_project/macros/adapters/common.sql#L185))
 - `truncate_relation` ([source](https://github.com/dbt-labs/dbt/blob/HEAD/core/dbt/include/global_project/macros/adapters/common.sql#L175))
+- `current_timestamp` ([source](https://github.com/dbt-labs/dbt/blob/HEAD/core/dbt/include/global_project/macros/adapters/common.sql#L269)) (required)
 
 ### Adapter dispatch
 


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a pull request on dbt core, etc?
-->

this macro is required for source freshness. I'm sure there are others that are left out that will be uncovered as part of https://github.com/dbt-labs/dbt-adapter-tests/issues/25.

relatedly, for the other macros, it looks like some of the source links point to the wrong line numbers. we might want to update those as well?

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

