### PR TITLE
[Release] v0.21.0

### DIFF
--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-19-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-19-0.md
@@ -6,7 +6,8 @@ title: "Upgrading to 0.19.0"
 ### Resources
 
 - [Discourse](https://discourse.getdbt.com/t/1951)
-- [Changelog](https://github.com/dbt-labs/dbt/blob/dev/kiyoshi-kuromiya/CHANGELOG.md)
+- [Release notes](https://github.com/dbt-labs/dbt/releases/tag/v0.19.0)
+- [Full changelog](https://github.com/fishtown-analytics/dbt/blob/0.19.latest/CHANGELOG.md)
 
 ## Breaking changes
 

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-20-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-20-0.md
@@ -6,7 +6,8 @@ title: "Upgrading to 0.20.0"
 ### Resources
 
 - [Discourse](https://discourse.getdbt.com/t/2621)
-- [Changelog](https://github.com/fishtown-analytics/dbt/blob/develop/CHANGELOG.md)
+- [Release notes](https://github.com/dbt-labs/dbt/releases/tag/v0.20.0)
+- [Full changelog](https://github.com/fishtown-analytics/dbt/blob/0.20.latest/CHANGELOG.md)
 
 ## Breaking changes
 

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
@@ -5,7 +5,7 @@ title: "Upgrading to 0.21.0"
 
 ### Resources
 
-- [Discourse](https://discourse.getdbt.com/t/2621)
+- [Discourse](https://discourse.getdbt.com/t/3077)
 - [Release notes](https://github.com/dbt-labs/dbt/releases/tag/v0.21.0)
 - [Full changelog](https://github.com/fishtown-analytics/dbt/blob/0.21.0/CHANGELOG.md)
 

--- a/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-0-21-0.md
@@ -3,15 +3,11 @@ title: "Upgrading to 0.21.0"
 
 ---
 
-:::info Release candidate
-
-dbt v0.21.0-rc1 is currently available as a release candidate. If you have questions or encounter bugs, please let us know in [#dbt-prereleases](https://community.getdbt.com/) or by opening an issue [in GitHub](https://github.com/dbt-labs/dbt).
-
-:::
-
 ### Resources
 
-- [Changelog](https://github.com/dbt-labs/dbt/blob/0.21.latest/CHANGELOG.md)
+- [Discourse](https://discourse.getdbt.com/t/2621)
+- [Release notes](https://github.com/dbt-labs/dbt/releases/tag/v0.21.0)
+- [Full changelog](https://github.com/fishtown-analytics/dbt/blob/0.21.0/CHANGELOG.md)
 
 ## Breaking changes
 


### PR DESCRIPTION
- Remove prerelease callout from v0.21.0 migration guide
- Update/standardize links in last few migration guides
- Wait for final v0.21.0 release before merging