### PR TITLE
Clearly note source freshness task rename

### DIFF
--- a/website/docs/docs/dbt-cloud/using-dbt-cloud/cloud-snapshotting-source-freshness.md
+++ b/website/docs/docs/dbt-cloud/using-dbt-cloud/cloud-snapshotting-source-freshness.md
@@ -13,7 +13,13 @@ dbt Cloud provides a helpful interface around dbt's [source data freshness](usin
 
 First, make sure to configure your sources to [snapshot freshness information](using-sources#snapshotting-source-data-freshness).
 
-Then, to enable source freshness snapshots in dbt Cloud, add a `dbt source freshness` step to one of your jobs, or create a new job to snapshot source freshness.
+<Changelog>
+
+  - **v0.21.0:** Renamed `dbt source snapshot-freshness` to `dbt source freshness`. If using an older version of dbt, the command is `snapshot-freshness`.
+
+</Changelog>
+
+Then, to enable source freshness snapshots in dbt Cloud, add a `dbt source freshness` step to one of your jobs, or create a new job to snapshot source freshness. **Note:** If you're using an older version of dbt Core (before v0.21), you'll need to use the old name of this command instead: `dbt source snapshot-freshness`. See [`source` command docs](commands/source) for details.
 
 <Lightbox src="/img/docs/dbt-cloud/using-dbt-cloud/job-step-source-freshness.png" title="Adding a step to snapshot source freshness"/>
 

--- a/website/docs/reference/commands/source.md
+++ b/website/docs/reference/commands/source.md
@@ -5,6 +5,10 @@ id: "source"
 
 The `dbt source` command provides subcommands that are useful when working with source data. This command provides one subcommand, `dbt source freshness`.
 
+:::info
+If you're using an older version of dbt Core (before v0.21), the old name of the `freshness` subcommand was `snapshot-freshness`. (It has nothing to do with [snapshots](snapshots), which is why we renamed it.) Each time you see the command below, you'll need to specify it as `dbt source snapshot-freshness` instead of `dbt source freshness`.
+:::
+
 ### dbt source freshness
 
 <Changelog>


### PR DESCRIPTION
## Description & motivation

- Add Changelog note about `freshness` task rename to Cloud docs on enabling source freshness
- Add callout + context about task rename, since >99% of users are still on a dbt-core version that requires the old task name :)

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!