### PR TITLE
Feature/add in mention of Snowflake Partner Connect

### DIFF
--- a/website/docs/docs/dbt-cloud/cloud-quickstart.md
+++ b/website/docs/docs/dbt-cloud/cloud-quickstart.md
@@ -53,3 +53,7 @@ Now that dbt Cloud is able to clone your dbt repo and connect to your warehouse,
 Job schedules can be configured from the job creation interface. You can either schedule your job using the visual editor, or you can enter a custom cron syntax for your job.
 
 <Lightbox src="/img/docs/dbt-cloud/dbt-quickstart-new-job-schedule.png" title="Setting a job schedule"/>
+
+## Alternatives
+
+If you are interested in trialing dbt Cloud with Snowflake, you can use [Snowflake Partner Connect](https://docs.snowflake.com/en/user-guide/ecosystem-partner-connect.html) to spin up a dbt Cloud account with all of the key objects created (deployment and development environments, git repository, and sample job). All you need is a Snowflake Account with access to the ACCOUNTADMIN role to go into Partner Connect and find the dbt tile to set up a dedicated environment for test driving. 


### PR DESCRIPTION
## Description & motivation
This will add in a mention to the quickstart about Snowflake Partner Connect (as discussed in dbt Labs slack). 

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
