### PR TITLE
Update/adapter profiles

### DIFF
--- a/website/docs/reference/warehouse-profiles/azuresynapse-profile.md
+++ b/website/docs/reference/warehouse-profiles/azuresynapse-profile.md
@@ -10,10 +10,12 @@ Some core functionality may be limited. If you're interested in contributing, ch
 :::
 
 ## Overview of dbt-synapse
-**Maintained by:** Community      
-**Author:** Nandan Hegde and Anders Swanson    
-**Source:** https://github.com/dbt-msft/dbt-synapse    
-**Core version:** v0.18.0 and newer    
+
+**Maintained by:** Community
+**Author:** Nandan Hegde and Anders Swanson         
+**Source:** [Github](https://github.com/dbt-msft/dbt-synapse    )
+**Core version:** v0.18.0 and newer  
+**dbt Slack channel** [Link to channel](https://getdbt.slack.com/archives/C01DRQ178LQ)    
 
 ![dbt-synapse stars](https://img.shields.io/github/stars/dbt-msft/dbt-synapse?style=for-the-badge)
 

--- a/website/docs/reference/warehouse-profiles/azuresynapse-profile.md
+++ b/website/docs/reference/warehouse-profiles/azuresynapse-profile.md
@@ -15,6 +15,7 @@ Some core functionality may be limited. If you're interested in contributing, ch
 **Author:** Nandan Hegde and Anders Swanson         
 **Source:** [Github](https://github.com/dbt-msft/dbt-synapse)
 **Core version:** v0.18.0 and newer  
+**dbt Cloud:** Not Supported
 **dbt Slack channel** [Link to channel](https://getdbt.slack.com/archives/C01DRQ178LQ)    
 
 ![dbt-synapse stars](https://img.shields.io/github/stars/dbt-msft/dbt-synapse?style=for-the-badge)

--- a/website/docs/reference/warehouse-profiles/azuresynapse-profile.md
+++ b/website/docs/reference/warehouse-profiles/azuresynapse-profile.md
@@ -13,7 +13,7 @@ Some core functionality may be limited. If you're interested in contributing, ch
 
 **Maintained by:** Community
 **Author:** Nandan Hegde and Anders Swanson         
-**Source:** [Github](https://github.com/dbt-msft/dbt-synapse    )
+**Source:** [Github](https://github.com/dbt-msft/dbt-synapse)
 **Core version:** v0.18.0 and newer  
 **dbt Slack channel** [Link to channel](https://getdbt.slack.com/archives/C01DRQ178LQ)    
 

--- a/website/docs/reference/warehouse-profiles/bigquery-profile.md
+++ b/website/docs/reference/warehouse-profiles/bigquery-profile.md
@@ -6,7 +6,8 @@ title: "BigQuery Profile"
 **Maintained by:** core dbt maintainers    
 **Author:** dbt Labs    
 **Source:** [Github](https://github.com/dbt-labs/dbt-bigquery)   
-**Core version:** v0.13.0 and newer    
+**Core version:** v0.13.0 and newer   
+**dbt Cloud:** Supported 
 **dbt Slack channel** [Link to channel](https://getdbt.slack.com/archives/C99SNSRTK)  
 
 

--- a/website/docs/reference/warehouse-profiles/bigquery-profile.md
+++ b/website/docs/reference/warehouse-profiles/bigquery-profile.md
@@ -2,6 +2,14 @@
 title: "BigQuery Profile"
 ---
 
+## Overview of dbt-bigquery
+**Maintained by:** core dbt maintainers    
+**Author:** dbt Labs    
+**Source:** [Github](https://github.com/dbt-labs/dbt-bigquery)   
+**Core version:** v0.13.0 and newer    
+**dbt Slack channel** [Link to channel](https://getdbt.slack.com/archives/C99SNSRTK)  
+
+
 ## Authentication Methods
 
 BigQuery targets can be specified using one of four methods:

--- a/website/docs/reference/warehouse-profiles/clickhouse-profile.md
+++ b/website/docs/reference/warehouse-profiles/clickhouse-profile.md
@@ -12,7 +12,8 @@ Some core functionality may be limited. If you're interested in contributing, ch
 **Maintained by:** Community      
 **Author:** Dmitriy Sokolov    
 **Source:** https://github.com/silentsokolov/dbt-clickhouse    
-**Core version:** v0.19.0 and newer    
+**Core version:** v0.19.0 and newer
+**dbt Cloud:** Not Supported    
 
 ![dbt-clickhouse stars](https://img.shields.io/github/stars/silentsokolov/dbt-clickhouse?style=for-the-badge)
 

--- a/website/docs/reference/warehouse-profiles/dremio-profile.md
+++ b/website/docs/reference/warehouse-profiles/dremio-profile.md
@@ -13,6 +13,7 @@ Some core functionality may be limited. If you're interested in contributing, ch
 **Author:** Fabrice Etanchaud (Maif-vie)    
 **Source:** https://github.com/fabrice-etanchaud/dbt-dremio    
 **Core version:** v0.18.0 and newer
+**dbt Cloud:** Not Supported
 
 ![dbt-dremio stars](https://img.shields.io/github/stars/fabrice-etanchaud/dbt-dremio?style=for-the-badge)
 

--- a/website/docs/reference/warehouse-profiles/exasol-profile.md
+++ b/website/docs/reference/warehouse-profiles/exasol-profile.md
@@ -13,6 +13,7 @@ Some core functionality may be limited. If you're interested in contributing, ch
 **Author:** Torsten Glunde, Ilija Kutle
 **Source:** https://github.com/tglunde/dbt-exasol
 **Core version:** v0.14.0 and newer
+**dbt Cloud:** Not Supported
 
 ![dbt-exasol stars](https://img.shields.io/github/stars/tglunde/dbt-exasol?style=for-the-badge)
 

--- a/website/docs/reference/warehouse-profiles/materialize-profile.md
+++ b/website/docs/reference/warehouse-profiles/materialize-profile.md
@@ -11,8 +11,9 @@ Certain core functionality may vary. If you would like to report a bug, request 
 ## Overview of dbt-materialize
 
 **Maintained by:** Materialize, Inc.      
-**Source:** https://github.com/MaterializeInc/materialize/blob/main/misc/dbt-materialize    
-**Core version:** v0.18.1 and newer    
+**Source:** [Github](https://github.com/MaterializeInc/materialize/blob/main/misc/dbt-materialize)
+**Core version:** v0.18.1 and newer  
+**dbt Slack channel** [Link to channel](https://getdbt.slack.com/archives/C01PWAH41A5)  
 
 The easiest way to install is to use pip:
 

--- a/website/docs/reference/warehouse-profiles/materialize-profile.md
+++ b/website/docs/reference/warehouse-profiles/materialize-profile.md
@@ -13,6 +13,7 @@ Certain core functionality may vary. If you would like to report a bug, request 
 **Maintained by:** Materialize, Inc.      
 **Source:** [Github](https://github.com/MaterializeInc/materialize/blob/main/misc/dbt-materialize)
 **Core version:** v0.18.1 and newer  
+**dbt Cloud:** Not Supported
 **dbt Slack channel** [Link to channel](https://getdbt.slack.com/archives/C01PWAH41A5)  
 
 The easiest way to install is to use pip:

--- a/website/docs/reference/warehouse-profiles/mssql-profile.md
+++ b/website/docs/reference/warehouse-profiles/mssql-profile.md
@@ -14,6 +14,7 @@ Some core functionality may be limited. If you're interested in contributing, ch
 **Author:** Mikael Ene           
 **Source:** [Github](https://github.com/dbt-msft/dbt-sqlserver)
 **Core version:** v0.14.0 and newer 
+**dbt Cloud:** Not Supported
 **dbt Slack channel** [Link to channel](https://getdbt.slack.com/archives/CMRMDDQ9W)  
 
 ![dbt-sqlserver stars](https://img.shields.io/github/stars/mikaelene/dbt-sqlserver?style=for-the-badge)

--- a/website/docs/reference/warehouse-profiles/mssql-profile.md
+++ b/website/docs/reference/warehouse-profiles/mssql-profile.md
@@ -9,10 +9,12 @@ Some core functionality may be limited. If you're interested in contributing, ch
 :::
 
 ## Overview of dbt-sqlserver
-**Maintained by:** Community      
-**Author:** Mikael Ene    
-**Source:** https://github.com/dbt-msft/dbt-sqlserver    
+
+**Maintained by:** Community
+**Author:** Mikael Ene           
+**Source:** [Github](https://github.com/dbt-msft/dbt-sqlserver)
 **Core version:** v0.14.0 and newer 
+**dbt Slack channel** [Link to channel](https://getdbt.slack.com/archives/CMRMDDQ9W)  
 
 ![dbt-sqlserver stars](https://img.shields.io/github/stars/mikaelene/dbt-sqlserver?style=for-the-badge)
 

--- a/website/docs/reference/warehouse-profiles/oracle-profile.md
+++ b/website/docs/reference/warehouse-profiles/oracle-profile.md
@@ -14,6 +14,7 @@ Some core functionality may be limited. If you're interested in contributing, ch
 **Author:** Vitor Avancini 
 **Source:** [Github](https://github.com/techindicium/dbt-oracle)
 **Core version:** v0.16.0 and newer  
+**dbt Cloud:** Not Supported
 **dbt Slack channel** [Link to channel](https://getdbt.slack.com/archives/C01PWH4TXLY)   
 
 ![dbt-oracle stars](https://img.shields.io/github/stars/techindicium/dbt-oracle?style=for-the-badge)

--- a/website/docs/reference/warehouse-profiles/oracle-profile.md
+++ b/website/docs/reference/warehouse-profiles/oracle-profile.md
@@ -9,10 +9,12 @@ Some core functionality may be limited. If you're interested in contributing, ch
 :::
 
 ## Overview of dbt-oracle
+
 **Maintained by:** Community
-**Author:** Vitor Avancini
-**Source:** https://github.com/techindicium/dbt-oracle
-**Core version:** v0.16.0 and newer
+**Author:** Vitor Avancini 
+**Source:** [Github](https://github.com/techindicium/dbt-oracle)
+**Core version:** v0.16.0 and newer  
+**dbt Slack channel** [Link to channel](https://getdbt.slack.com/archives/C01PWH4TXLY)   
 
 ![dbt-oracle stars](https://img.shields.io/github/stars/techindicium/dbt-oracle?style=for-the-badge)
 

--- a/website/docs/reference/warehouse-profiles/postgres-profile.md
+++ b/website/docs/reference/warehouse-profiles/postgres-profile.md
@@ -2,6 +2,12 @@
 title: "Postgres Profile"
 ---
 
+## Overview of dbt-postgres
+**Maintained by:** core dbt maintainers    
+**Author:** dbt Labs     
+**Core version:** v0.13.0 and newer    
+**dbt Slack channel** [Link to channel](https://getdbt.slack.com/archives/C0172G2E273)  
+
 ## Profile Configuration
 
 Postgres targets should be set up using the following configuration in your `profiles.yml` file.

--- a/website/docs/reference/warehouse-profiles/postgres-profile.md
+++ b/website/docs/reference/warehouse-profiles/postgres-profile.md
@@ -5,7 +5,8 @@ title: "Postgres Profile"
 ## Overview of dbt-postgres
 **Maintained by:** core dbt maintainers    
 **Author:** dbt Labs     
-**Core version:** v0.13.0 and newer    
+**Core version:** v0.13.0 and newer 
+**dbt Cloud:** Supported   
 **dbt Slack channel** [Link to channel](https://getdbt.slack.com/archives/C0172G2E273)  
 
 ## Profile Configuration

--- a/website/docs/reference/warehouse-profiles/presto-profile.md
+++ b/website/docs/reference/warehouse-profiles/presto-profile.md
@@ -11,7 +11,7 @@ Some core functionality may be limited. If you're interested in contributing, ch
 ## Overview of dbt-presto
 **Maintained by:** core dbt maintainers    
 **Author:** dbt Labs    
-**Source:** [Github](https://github.com/dbt-labs/dbt-presto )   
+**Source:** [Github](https://github.com/dbt-labs/dbt-presto)   
 **Core version:** v0.13.0 and newer    
 **dbt Slack channel** [Link to channel](https://getdbt.slack.com/archives/CNNPBQ24R)    
 

--- a/website/docs/reference/warehouse-profiles/presto-profile.md
+++ b/website/docs/reference/warehouse-profiles/presto-profile.md
@@ -12,7 +12,8 @@ Some core functionality may be limited. If you're interested in contributing, ch
 **Maintained by:** core dbt maintainers    
 **Author:** dbt Labs    
 **Source:** [Github](https://github.com/dbt-labs/dbt-presto)   
-**Core version:** v0.13.0 and newer    
+**Core version:** v0.13.0 and newer 
+**dbt Cloud:** Not Supported   
 **dbt Slack channel** [Link to channel](https://getdbt.slack.com/archives/CNNPBQ24R)    
 
 ![dbt-presto stars](https://img.shields.io/github/stars/dbt-labs/dbt-presto?style=for-the-badge)

--- a/website/docs/reference/warehouse-profiles/presto-profile.md
+++ b/website/docs/reference/warehouse-profiles/presto-profile.md
@@ -11,8 +11,9 @@ Some core functionality may be limited. If you're interested in contributing, ch
 ## Overview of dbt-presto
 **Maintained by:** core dbt maintainers    
 **Author:** dbt Labs    
-**Source:** https://github.com/dbt-labs/dbt-presto    
-**Core version:** v0.13.0 and newer     
+**Source:** [Github](https://github.com/dbt-labs/dbt-presto )   
+**Core version:** v0.13.0 and newer    
+**dbt Slack channel** [Link to channel](https://getdbt.slack.com/archives/CNNPBQ24R)    
 
 ![dbt-presto stars](https://img.shields.io/github/stars/dbt-labs/dbt-presto?style=for-the-badge)
 

--- a/website/docs/reference/warehouse-profiles/redshift-profile.md
+++ b/website/docs/reference/warehouse-profiles/redshift-profile.md
@@ -7,6 +7,7 @@ title: "Redshift Profile"
 **Author:** dbt Labs    
 **Source:** [Github](https://github.com/dbt-labs/dbt-redshift)   
 **Core version:** v0.13.0 and newer    
+**dbt Cloud:** Supported
 **dbt Slack channel** [Link to channel](https://getdbt.slack.com/archives/CJARVS0RY)  
 
 

--- a/website/docs/reference/warehouse-profiles/redshift-profile.md
+++ b/website/docs/reference/warehouse-profiles/redshift-profile.md
@@ -2,6 +2,14 @@
 title: "Redshift Profile"
 ---
 
+## Overview of dbt-redshift
+**Maintained by:** core dbt maintainers    
+**Author:** dbt Labs    
+**Source:** [Github](https://github.com/dbt-labs/dbt-redshift)   
+**Core version:** v0.13.0 and newer    
+**dbt Slack channel** [Link to channel](https://getdbt.slack.com/archives/CJARVS0RY)  
+
+
 ## Authentication Methods
 
 ### Password-based authentication

--- a/website/docs/reference/warehouse-profiles/snowflake-profile.md
+++ b/website/docs/reference/warehouse-profiles/snowflake-profile.md
@@ -2,6 +2,14 @@
 title: "Snowflake Profile"
 ---
 
+## Overview of dbt-snowflake
+**Maintained by:** core dbt maintainers    
+**Author:** dbt Labs    
+**Source:** [Github](https://github.com/dbt-labs/dbt-snowflake)   
+**Core version:** v0.13.0 and newer    
+**dbt Slack channel** [Link to channel](https://getdbt.slack.com/archives/CJN7XRF1B)  
+
+
 ## Authentication Methods
 
 ### User / Password authentication

--- a/website/docs/reference/warehouse-profiles/snowflake-profile.md
+++ b/website/docs/reference/warehouse-profiles/snowflake-profile.md
@@ -6,7 +6,8 @@ title: "Snowflake Profile"
 **Maintained by:** core dbt maintainers    
 **Author:** dbt Labs    
 **Source:** [Github](https://github.com/dbt-labs/dbt-snowflake)   
-**Core version:** v0.13.0 and newer    
+**Core version:** v0.13.0 and newer
+**dbt Cloud:** Supported    
 **dbt Slack channel** [Link to channel](https://getdbt.slack.com/archives/CJN7XRF1B)  
 
 

--- a/website/docs/reference/warehouse-profiles/spark-profile.md
+++ b/website/docs/reference/warehouse-profiles/spark-profile.md
@@ -10,11 +10,14 @@ Some core functionality may be limited. If you're interested in contributing, ch
 :::
 
 ## Overview of dbt-spark
+
 **Maintained by:** core dbt maintainers    
 **Author:** dbt Labs    
-**Source:** https://github.com/dbt-labs/dbt-spark    
+**Source:** [Github](https://github.com/dbt-labs/dbt-spark)    
 **Core version:** v0.13.0 and newer     
+**dbt Slack channel** [Link to channel](https://getdbt.slack.com/archives/CNGCW8HKL) 
 **dbt Cloud:** Preview
+
 
 ![dbt-spark stars](https://img.shields.io/github/stars/dbt-labs/dbt-spark?style=for-the-badge)
 

--- a/website/docs/reference/warehouse-profiles/spark-profile.md
+++ b/website/docs/reference/warehouse-profiles/spark-profile.md
@@ -14,9 +14,9 @@ Some core functionality may be limited. If you're interested in contributing, ch
 **Maintained by:** core dbt maintainers    
 **Author:** dbt Labs    
 **Source:** [Github](https://github.com/dbt-labs/dbt-spark)    
-**Core version:** v0.13.0 and newer     
+**Core version:** v0.13.0 and newer 
+**dbt Cloud:** Supported    
 **dbt Slack channel** [Link to channel](https://getdbt.slack.com/archives/CNGCW8HKL) 
-**dbt Cloud:** Preview
 
 
 ![dbt-spark stars](https://img.shields.io/github/stars/dbt-labs/dbt-spark?style=for-the-badge)

--- a/website/docs/reference/warehouse-profiles/trino-profile.md
+++ b/website/docs/reference/warehouse-profiles/trino-profile.md
@@ -9,10 +9,13 @@ Some core functionality may be limited. If you're interested in contributing, ch
 :::
 
 ## Overview of dbt-trino
-**Maintained by:** Community    
-**Author:** findinpath    
-**Source:** https://github.com/findinpath/dbt-trino    
-**Core version:** v0.20.0 and newer     
+
+**Maintained by:** Community
+**Author:** findinpath       
+**Source:** [Github](https://github.com/findinpath/dbt-trino)
+**Core version:** v0.20.0 and newer    
+**dbt Slack channel** [Link to channel](https://getdbt.slack.com/archives/CNNPBQ24R)   
+
 
 ![dbt-presto stars](https://img.shields.io/github/stars/findinpath/dbt-trino?style=for-the-badge)
 

--- a/website/docs/reference/warehouse-profiles/trino-profile.md
+++ b/website/docs/reference/warehouse-profiles/trino-profile.md
@@ -14,8 +14,6 @@ Some core functionality may be limited. If you're interested in contributing, ch
 **Author:** findinpath       
 **Source:** [Github](https://github.com/findinpath/dbt-trino)
 **Core version:** v0.20.0 and newer    
-**dbt Slack channel** [Link to channel](https://getdbt.slack.com/archives/CNNPBQ24R)   
-
 
 ![dbt-presto stars](https://img.shields.io/github/stars/findinpath/dbt-trino?style=for-the-badge)
 

--- a/website/docs/reference/warehouse-profiles/trino-profile.md
+++ b/website/docs/reference/warehouse-profiles/trino-profile.md
@@ -13,7 +13,8 @@ Some core functionality may be limited. If you're interested in contributing, ch
 **Maintained by:** Community
 **Author:** findinpath       
 **Source:** [Github](https://github.com/findinpath/dbt-trino)
-**Core version:** v0.20.0 and newer    
+**Core version:** v0.20.0 and newer  
+**dbt Cloud:** Not Supported  
 **dbt Slack channel** [Link to channel](https://getdbt.slack.com/archives/CNNPBQ24R)   
 
 ![dbt-presto stars](https://img.shields.io/github/stars/findinpath/dbt-trino?style=for-the-badge)

--- a/website/docs/reference/warehouse-profiles/trino-profile.md
+++ b/website/docs/reference/warehouse-profiles/trino-profile.md
@@ -14,6 +14,7 @@ Some core functionality may be limited. If you're interested in contributing, ch
 **Author:** findinpath       
 **Source:** [Github](https://github.com/findinpath/dbt-trino)
 **Core version:** v0.20.0 and newer    
+**dbt Slack channel** [Link to channel](https://getdbt.slack.com/archives/CNNPBQ24R)   
 
 ![dbt-presto stars](https://img.shields.io/github/stars/findinpath/dbt-trino?style=for-the-badge)
 


### PR DESCRIPTION
## Description & motivation
This will standardize the top of the adapter profiles as well as add in the slack channel link.

@jtcohen6 is it too early to show the new repos for our core adapters?

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

