### PR TITLE
Release notes for v1.1.37

### DIFF
--- a/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
@@ -4,6 +4,70 @@ id: "cloud-changelog"
 sidebar_label: Changelog
 description: "Changelog for the dbt Cloud application"
 ---
+## dbt Cloud v1.1.37 (October 13, 2021)
+#### Enhancements
+
+- dbt 0.21.0
+
+#### Feature
+
+- Add on-submission feedback for custom environment variables
+
+#### Fixed
+
+- Surface top navigation bar above locked modal
+- Add network fail tolerance to RPC polling service
+- partner connect: sanitize schema
+- Hide locked account modal when switching to an unlocked account
+- Make ResultsTable scrollable
+
+#### Internal
+
+- Prevent filesystem request with default id
+- Revert ecr changes in CI
+- Fix docker pull in CI
+- Fix ecr login in CI
+- Push images to staging and infra root during prod builds
+- Fix how errored models are displayed in model bottleneck viz
+- Remove old django templates
+- Fix object string in error message
+- Fix frontend file list
+- Copy current schema from filesystem-api and regen types
+- Fix hijack notification
+- Remove old frontend code
+- Refactor Filesystem Entity
+- Include deleted files in GHA workflow
+- Test frontend deployment
+- Fix s3 sync
+- Setup separate frontend and backend deploys
+- File Tree using Apollo
+- [env vars] Allow for deletion of non-prefixed CustomEnvironmentVariables
+- hide env var button on create form
+- Improve model bottleneck viz event tracking
+- Fix audit log metadata typing
+- Adding proto and the message queue publisher to dbt Cloud
+- bump dbt version
+- Setup basic audit log table and pagination
+- update viz to use react query for auth
+- [env vars] Add styling to overridden values and helper text
+- Viz auth correction
+- viz auth adjustment
+- [env vars] Update pod provisioning logic re: safe env vars
+- Setup audit log table and fetch endpoint
+- [env vars] Environment table column sorting and helper text
+- Updated the link to the Change Management Standard doc
+- Remove some unnecessary codex auth logic in model bottleneck viz
+- mounting bug fix
+- Update Apollo filesystem entity state and project code clean up
+- ui: remove react-profile-password feature flag
+- fix mounting bug
+- Update FS API schema for new repository query patterns
+- Migrating dbt-cloud staging deploys to the helm-charts repo
+- Tweak language used in the stale notifications.
+- Fix if models were built in model bottleneck viz
+- Removing root expectation
+- remove old redeem-reset-password-code endpoint
+
 ## dbt Cloud v1.1.36 (September 29, 2021)
 Check out the release candidate for `dbt v0.21.0`! Also tab switching in the dbt Cloud IDE now keeps track of your scroll position - at last!
 

--- a/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-changelog.md
@@ -5,68 +5,10 @@ sidebar_label: Changelog
 description: "Changelog for the dbt Cloud application"
 ---
 ## dbt Cloud v1.1.37 (October 13, 2021)
-#### Enhancements
+dbt v0.21 is now available in dbt Cloud. The big change with this release is it introduces the `dbt build` command. `dbt build` logically does everything you'd want to do in your DAG. It runs your models, tests your tests, snapshots your snapshots, and seeds your seeds. It does this, resource by resource, from left to right across your DAG. dbt build is an opinionated task. It’s the culmination of all we’ve built- running models with resilient materializations, prioritizing data quality with tests, updating fixtures with seeds, capturing slowly changing dimensions with snapshot. Give it a try!
 
-- dbt 0.21.0
-
-#### Feature
-
-- Add on-submission feedback for custom environment variables
-
-#### Fixed
-
-- Surface top navigation bar above locked modal
-- Add network fail tolerance to RPC polling service
-- partner connect: sanitize schema
-- Hide locked account modal when switching to an unlocked account
-- Make ResultsTable scrollable
-
-#### Internal
-
-- Prevent filesystem request with default id
-- Revert ecr changes in CI
-- Fix docker pull in CI
-- Fix ecr login in CI
-- Push images to staging and infra root during prod builds
-- Fix how errored models are displayed in model bottleneck viz
-- Remove old django templates
-- Fix object string in error message
-- Fix frontend file list
-- Copy current schema from filesystem-api and regen types
-- Fix hijack notification
-- Remove old frontend code
-- Refactor Filesystem Entity
-- Include deleted files in GHA workflow
-- Test frontend deployment
-- Fix s3 sync
-- Setup separate frontend and backend deploys
-- File Tree using Apollo
-- [env vars] Allow for deletion of non-prefixed CustomEnvironmentVariables
-- hide env var button on create form
-- Improve model bottleneck viz event tracking
-- Fix audit log metadata typing
-- Adding proto and the message queue publisher to dbt Cloud
-- bump dbt version
-- Setup basic audit log table and pagination
-- update viz to use react query for auth
-- [env vars] Add styling to overridden values and helper text
-- Viz auth correction
-- viz auth adjustment
-- [env vars] Update pod provisioning logic re: safe env vars
-- Setup audit log table and fetch endpoint
-- [env vars] Environment table column sorting and helper text
-- Updated the link to the Change Management Standard doc
-- Remove some unnecessary codex auth logic in model bottleneck viz
-- mounting bug fix
-- Update Apollo filesystem entity state and project code clean up
-- ui: remove react-profile-password feature flag
-- fix mounting bug
-- Update FS API schema for new repository query patterns
-- Migrating dbt-cloud staging deploys to the helm-charts repo
-- Tweak language used in the stale notifications.
-- Fix if models were built in model bottleneck viz
-- Removing root expectation
-- remove old redeem-reset-password-code endpoint
+#### New products and features
+- We have a new beta feature, which we're calling Model Bottlenecks. It allows you to visually see how long it takes to build models in each run, so you can see clearly which models are taking the longest. If you're interested in learning more, check out #beta-feedback-model-bottlenecks in the dbt community Slack, and we can add you to the beta.
 
 ## dbt Cloud v1.1.36 (September 29, 2021)
 Check out the release candidate for `dbt v0.21.0`! Also tab switching in the dbt Cloud IDE now keeps track of your scroll position - at last!


### PR DESCRIPTION
## Description & motivation
Release notes for dbt Cloud v1.1.37.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
