### PR TITLE
fix spacing in markdown list

### DIFF
--- a/website/docs/reference/warehouse-profiles/rockset-profile.md
+++ b/website/docs/reference/warehouse-profiles/rockset-profile.md
@@ -11,10 +11,10 @@ Certain core functionality may vary. If you would like to report a bug, request 
 ## Overview of dbt-rockset
 
 **Maintained by:** Rockset, Inc.      
-**Source:** [Github](https://github.com/rockset/dbt-rockset  )
+**Source:** [Github](https://github.com/rockset/dbt-rockset)  
 **Core version:** v0.19.2 and newer    
 **dbt Cloud:** Not Supported  
-**dbt Slack channel:** [Slack](https://getdbt.slack.com/archives/C02J7AZUAMN  )
+**dbt Slack channel:** [Slack](https://getdbt.slack.com/archives/C02J7AZUAMN)
 
 The easiest way to install is to use pip:
 


### PR DESCRIPTION
## Description & motivation
Core version is not being set on its own line in the current released docs. See the attached image 
<img width="590" alt="Screen Shot 2021-10-13 at 9 48 46 AM" src="https://user-images.githubusercontent.com/10038323/137177878-2a54a3ed-679f-4ba8-86dc-18386ebf080c.png">

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [X] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
