### PR TITLE
Added a note about including a deploy_token

### DIFF
--- a/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/connecting-gitlab.md
+++ b/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/connecting-gitlab.md
@@ -25,7 +25,7 @@ Once you've accepted, you should be redirected back to dbt Cloud, and you'll see
 
 <Lightbox src="/img/docs/dbt-cloud/connecting-gitlab/connected.png" title="GitLab connected" />
 
-Please note, you will need to ensure your deploy token is populated in your project settings page, in addition to your profile page. 
+Now that you've linked to your account from your Profile page, you should verify that you see your deploy token in your Project Settings page. 
 
 ## For Enterprise tier
 

--- a/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/connecting-gitlab.md
+++ b/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/connecting-gitlab.md
@@ -25,6 +25,8 @@ Once you've accepted, you should be redirected back to dbt Cloud, and you'll see
 
 <Lightbox src="/img/docs/dbt-cloud/connecting-gitlab/connected.png" title="GitLab connected" />
 
+Please note, you will need to ensure your deploy token is populated in your project settings page, in addition to your profile page. 
+
 ## For Enterprise tier
 
 Before developers can personally authenticate in GitLab, account admins need to set up a GitLab application.

--- a/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/connecting-gitlab.md
+++ b/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/connecting-gitlab.md
@@ -25,7 +25,7 @@ Once you've accepted, you should be redirected back to dbt Cloud, and you'll see
 
 <Lightbox src="/img/docs/dbt-cloud/connecting-gitlab/connected.png" title="GitLab connected" />
 
-Now that you've linked to your account from your Profile page, you should verify that you see your deploy token in your Project Settings page. 
+Now that you've linked to your account from your Profile page, you should verify that your Project Settings page also shows your deploy token. 
 
 ## For Enterprise tier
 


### PR DESCRIPTION
Added a note about having to include a deploy_token per user confusion and ticket 17870: https://dbtcloud.zendesk.com/agent/tickets/17870 - please edit if the note below needs to be made clearer

"Please note, you will need to ensure your deploy token is populated in your project settings page, in addition to your profile page."

## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a pull request on dbt core, etc?
-->

## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged
-->

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist
If you added new pages (delete if not applicable):
- [ ] The page has been added to `website/sidebars.js`
- [ ] The new page has a unique filename

If you removed existing pages (delete if not applicable):
- [ ] The page has been removed from `website/sidebars.js`
- [ ] An entry has been added to `_redirects`
