### PR TITLE
adds caveats to Rockset profile page

### DIFF
--- a/website/docs/reference/warehouse-profiles/rockset-profile.md
+++ b/website/docs/reference/warehouse-profiles/rockset-profile.md
@@ -50,5 +50,5 @@ incremental | YES | Creates a [collection](https://rockset.com/docs/collections/
 
 ## Caveats
 1. `unique_key` is not supported with incremental, unless it is set to [_id](https://rockset.com/docs/special-fields/#the-_id-field), which acts as a natural `unique_key` in Rockset anyway.
-2. The `table` materialization is slower in Rockset than most because due to Rockset's architecture as a low-latency, real-time database, creating new collections requires provisioning hot storage to index and serve fresh data.
+2. The `table` materialization is slower in Rockset than most due to Rockset's architecture as a low-latency, real-time database. Creating new collections requires provisioning hot storage to index and serve fresh data, which takes about a minute.
 3. Rockset queries have a two-minute timeout. Any model which runs a query that takes longer to execute than two minutes will fail.

--- a/website/docs/reference/warehouse-profiles/rockset-profile.md
+++ b/website/docs/reference/warehouse-profiles/rockset-profile.md
@@ -47,3 +47,8 @@ view | YES | Creates a [view](https://rockset.com/docs/views/#gatsby-focus-wrapp
 table | YES | Creates a [collection](https://rockset.com/docs/collections/#gatsby-focus-wrapper).
 ephemeral | YES | Executes queries using CTEs.
 incremental | YES | Creates a [collection](https://rockset.com/docs/collections/#gatsby-focus-wrapper) if it doesn't exist, and then writes results to it.
+
+## Caveats
+1. `unique_key` is not supported with incremental, unless it is set to [_id](https://rockset.com/docs/special-fields/#the-_id-field), which acts as a natural `unique_key` in Rockset anyway.
+2. The `table` materialization is slower in Rockset than most because due to Rockset's architecture as a low-latency, real-time database, creating new collections requires provisioning hot storage to index and serve fresh data.
+3. Rockset queries have a two-minute timeout. Any model which runs a query that takes longer to execute than two minutes will fail.


### PR DESCRIPTION
## Description & motivation
Amy suggested that adding this kind of section to our profile page would be a good idea, and she pointed us to the Spark profile page which has something similar.


## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [X] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
