### PR TITLE
DBT-Trino update documentation

### DIFF
--- a/website/docs/reference/warehouse-profiles/trino-profile.md
+++ b/website/docs/reference/warehouse-profiles/trino-profile.md
@@ -1,27 +1,26 @@
 ---
-title: "Trino Profile"
+title: "Starburst & Trino Profile"
 ---
 
-:::info Community plugin
+:::info Vendor-supported plugin
 
-Some core functionality may be limited. If you're interested in contributing, check out the source code for each repository listed below.
+Certain core functionality may vary. If you would like to report a bug, request a feature, or contribute, you can check out the linked repository and open an issue.
 
 :::
 
 ## Overview of dbt-trino
 
-**Maintained by:** Community    
-**Author:** findinpath       
-**Source:** [Github](https://github.com/findinpath/dbt-trino)    
+**Maintained by:** Starburst Data, Inc.          
+**Source:** [Github](https://github.com/starburstdata/dbt-trino)    
 **Core version:** v0.20.0 and newer      
 **dbt Cloud:** Not Supported      
-**dbt Slack channel** [Link to channel](https://getdbt.slack.com/archives/CNNPBQ24R)       
+**dbt Slack channel** [Slack](https://getdbt.slack.com/archives/CNNPBQ24R)       
 
-![dbt-presto stars](https://img.shields.io/github/stars/findinpath/dbt-trino?style=for-the-badge)
+![dbt-presto stars](https://img.shields.io/github/stars/starburstdata/dbt-trino?style=for-the-badge)
 
 ## Installation and Distribution
 
-dbt's Trino adapter is managed in its own repository, [dbt-trino](https://github.com/findinpath/dbt-trino). To use the Trino adapter, you must install the `dbt-trino` plugin:
+dbt's Trino adapter is managed in its own repository, [dbt-trino](https://github.com/starburstdata/dbt-trino). To use the Trino adapter, you must install the `dbt-trino` plugin:
 
 ### Using pip
 The following command will install the latest version of `dbt-trino` as well as the requisite version of `dbt-core`:

--- a/website/docs/reference/warehouse-profiles/trino-profile.md
+++ b/website/docs/reference/warehouse-profiles/trino-profile.md
@@ -14,7 +14,7 @@ Certain core functionality may vary. If you would like to report a bug, request 
 **Source:** [Github](https://github.com/starburstdata/dbt-trino)    
 **Core version:** v0.20.0 and newer      
 **dbt Cloud:** Not Supported      
-**dbt Slack channel** [Slack](https://getdbt.slack.com/archives/CNNPBQ24R)       
+**dbt Slack channel:** [Slack](https://getdbt.slack.com/archives/CNNPBQ24R)       
 
 ![dbt-presto stars](https://img.shields.io/github/stars/starburstdata/dbt-trino?style=for-the-badge)
 


### PR DESCRIPTION
URLs updated
@amychen1776 

## Description & motivation
Location and ownership of dbt-trino changed.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [X] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!




