### PR TITLE
Add vertica adapter

### DIFF
--- a/website/docs/docs/available-adapters.md
+++ b/website/docs/docs/available-adapters.md
@@ -35,14 +35,15 @@ These adapter plugins are built and maintained by the same people who build and 
 
 These adapter plugins are contributed and maintained by members of the community 🌱
 
-| Adapter for            | Documentation                         | Notes                     | Install from PyPI            |
-|------------------------|---------------------------------------|---------------------------|------------------------------|
-| SQL Server & Azure SQL | [Profile Setup](mssql-profile)        | SQL Server 2016 and later | `pip install dbt-sqlserver`  |
-| Azure Synapse          | [Profile Setup](azuresynapse-profile) | Azure Synapse 10+         | `pip install dbt-synapse`    |
-| Exasol Analytics       | [Profile Setup](exasol-profile)       | Exasol 6.x and later      | `pip install dbt-exasol`     |
-| Oracle Database        | [Profile Setup](oracle-profile)       | Oracle 11+                | `pip install dbt-oracle`     |
-| Dremio                 | [Profile Setup](dremio-profile)       | Dremio 4.7+               | `pip install dbt-dremio`     |
-| ClickHouse             | [Profile Setup](clickhouse-profile)   | ClickHouse 20.11+         | `pip install dbt-clickhouse` |
+| Adapter for            | Documentation                                              | Notes                     | Install from PyPI            |
+|:-----------------------|:-----------------------------------------------------------|:--------------------------|:-----------------------------|
+| SQL Server & Azure SQL | [Profile Setup](mssql-profile)                             | SQL Server 2016 and later | `pip install dbt-sqlserver`  |
+| Azure Synapse          | [Profile Setup](azuresynapse-profile)                      | Azure Synapse 10+         | `pip install dbt-synapse`    |
+| Exasol Analytics       | [Profile Setup](exasol-profile)                            | Exasol 6.x and later      | `pip install dbt-exasol`     |
+| Oracle Database        | [Profile Setup](oracle-profile)                            | Oracle 11+                | `pip install dbt-oracle`     |
+| Dremio                 | [Profile Setup](dremio-profile)                            | Dremio 4.7+               | `pip install dbt-dremio`     |
+| ClickHouse             | [Profile Setup](clickhouse-profile)                        | ClickHouse 20.11+         | `pip install dbt-clickhouse` |
+| Vertica                | [Profile Setup](https://github.com/andyreagan/dbt-vertica) |                           | `pip install dbt-verrtica`   |
 
 Community-supported plugins are works in progress, and all users are encouraged to contribute by testing and writing code. If you're interested in contributing:
 - Join the dedicated channel in [dbt Slack](https://community.getdbt.com/) (e.g. #db-sqlserver, #db-athena)


### PR DESCRIPTION
Version on pypi at `dbt-verrtica` (two r's) is up to date with `dbt`, working with version 0.21.0.

## Description & motivation

Vertica users can now see that it is supported.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [x] No: please ensure the base branch is `current`