### PR TITLE
Add toggles to differentiate between modern and legacy node selection syntax

### DIFF
--- a/website/docs/reference/node-selection/defer.md
+++ b/website/docs/reference/node-selection/defer.md
@@ -17,10 +17,32 @@ Defer requires that a manifest from a previous dbt invocation be passed to the `
 
 ### Usage
 
-```shell
-$ dbt run --select [...] --defer --state path/to/artifacts
-$ dbt test --select [...] --defer --state path/to/artifacts
-```
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
+
+  ```shell
+  $ dbt run --select [...] --defer --state path/to/artifacts
+  $ dbt test --select [...] --defer --state path/to/artifacts
+  ```
+
+</TabItem>
+<TabItem value="legacy">
+
+  ```shell
+  $ dbt run --models [...] --defer --state path/to/artifacts
+  $ dbt test --models [...] --defer --state path/to/artifacts
+  ```
+
+</TabItem>
+</Tabs>
+
+
 
 When the `--defer` flag is provided, dbt will resolve `ref` calls differently depending on two criteria:
 1. Is the referenced node included in the model selection criteria of the current run?
@@ -43,7 +65,6 @@ In my local development environment, I create all models in my target schema, `d
 I access the dbt-generated [artifacts](artifacts) (namely `manifest.json`) from a production run, and copy them into a local directory called `prod-run-artifacts`.
 
 ### run
-
 I've been working on `model_b`:
 
 <File name='models/model_b.sql'>
@@ -53,13 +74,17 @@ select
 
     id,
     count(*)
-    
+
 from {{ ref('model_a') }}
 group by 1
 ```
 
 I want to test my changes. Nothing exists in my development schema, `dev_alice`.
 
+### test
+:::info
+Before dbt v0.21, use the `--models` flag instead of `--select`.
+:::
 </File>
 
 <Tabs
@@ -80,15 +105,15 @@ $ dbt run --select model_b
 
 ```sql
 create or replace view dev_me.model_b as (
-    
+
     select
 
         id,
         count(*)
-        
+
     from dev_alice.model_a
     group by 1
-    
+
 )
 ```
 
@@ -107,15 +132,15 @@ $ dbt run --select model_b --defer --state prod-run-artifacts
 
 ```sql
 create or replace view dev_me.model_b as (
-    
+
     select
 
         id,
         count(*)
-        
+
     from prod.model_a
     group by 1
-    
+
 )
 ```
 
@@ -125,8 +150,6 @@ Because `model_a` is unselected, dbt will check to see if `dev_alice.model_a` ex
 
 </TabItem>
 </Tabs>
-
-### test
 
 I also have a `relationships` test that establishes referential integrity between `model_a` and `model_b`:
 
@@ -146,6 +169,10 @@ models:
 ```
 
 (A bit silly, since all the data in `model_b` had to come from `model_a`, but suspend your disbelief.)
+
+:::info
+Before dbt v0.21, use the `--models` flag instead of `--select`.
+:::
 
 </File>
 

--- a/website/docs/reference/node-selection/exclude.md
+++ b/website/docs/reference/node-selection/exclude.md
@@ -5,9 +5,29 @@ title: "Exclude"
 ### Excluding models
 dbt provides an `--exclude` flag with the same semantics as `--select`. Models specified with the `--exclude` flag will be removed from the set of models selected with `--select`.
 
-```bash
-$ dbt run --select my_package.*+ --exclude my_package.a_big_model+
-```
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
+
+  ```bash
+  $ dbt run --select my_package.*+ --exclude my_package.a_big_model+
+  ```
+
+</TabItem>
+<TabItem value="legacy">
+
+  ```bash
+  $ dbt run --models my_package.*+ --exclude my_package.a_big_model+
+  ```
+
+</TabItem>
+</Tabs>
+
 
 Exclude a specific resource by its name or lineage:
 

--- a/website/docs/reference/node-selection/graph-operators.md
+++ b/website/docs/reference/node-selection/graph-operators.md
@@ -5,11 +5,33 @@ title: "Graph operators"
 ### The "plus" operator
 If placed at the front of the model selector, `+` will select all parents of the selected model. If placed at the end of the string, `+` will select all children of the selected model.
 
-```bash
-$ dbt run --select my_model+          # select my_model and all children
-$ dbt run --select +my_model          # select my_model and all parents
-$ dbt run --select +my_model+         # select my_model, and all of its parents and children
-```
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
+
+  ```bash
+  $ dbt run --select my_model+          # select my_model and all children
+  $ dbt run --select +my_model          # select my_model and all parents
+  $ dbt run --select +my_model+         # select my_model, and all of its parents and children
+  ```
+
+</TabItem>
+<TabItem value="legacy">
+
+  ```bash
+  $ dbt run --models my_model+          # select my_model and all children
+  $ dbt run --models +my_model          # select my_model and all parents
+  $ dbt run --models +my_model+         # select my_model, and all of its parents and children
+  ```
+
+</TabItem>
+</Tabs>
+
 
 ### The "n-plus" operator
 <Changelog>New in v0.18.0</Changelog>
@@ -17,11 +39,33 @@ $ dbt run --select +my_model+         # select my_model, and all of its parents 
 You can adjust the behavior of the `+` operator by quantifying the number of edges
 to step through.
 
-```bash
-$ dbt run --select my_model+1          # select my_model and its first-degree children
-$ dbt run --select 2+my_model          # select my_model, its first-degree parents, and its second-degree parents ("grandparents")
-$ dbt run --select 3+my_model+4        # select my_model, its parents up to the 3rd degree, and its children down to the 4th degree
-```
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
+
+  ```bash
+  $ dbt run --select my_model+1          # select my_model and its first-degree children
+  $ dbt run --select 2+my_model          # select my_model, its first-degree parents, and its second-degree parents ("grandparents")
+  $ dbt run --select 3+my_model+4        # select my_model, its parents up to the 3rd degree, and its children down to the 4th degree
+  ```
+
+</TabItem>
+<TabItem value="legacy">
+
+  ```bash
+  $ dbt run --models my_model+1          # select my_model and its first-degree children
+  $ dbt run --models 2+my_model          # select my_model, its first-degree parents, and its second-degree parents ("grandparents")
+  $ dbt run --models 3+my_model+4        # select my_model, its parents up to the 3rd degree, and its children down to the 4th degree
+  ```
+
+</TabItem>
+</Tabs>
+
 
 ### The "at" operator
 The `@` operator is similar to `+`, but will also include _the parents of the children of the selected model_. This is useful in continuous integration environments where you want to build a model and all of its children, but the _parents_ of those children might not exist in the database yet. The selector `@snowplow_web_page_context` will build all three models shown in the diagram below.
@@ -31,7 +75,27 @@ The `@` operator is similar to `+`, but will also include _the parents of the ch
 ### The "star" operator
 The `*` operator matches all models within a package or directory.
 
-```bash
-$ dbt run --select snowplow.*      # run all of the models in the snowplow package
-$ dbt run --select finance.base.*  # run all of the models in models/finance/base
-```
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
+
+  ```bash
+  $ dbt run --select snowplow.*      # run all of the models in the snowplow package
+  $ dbt run --select finance.base.*  # run all of the models in models/finance/base
+  ```
+
+</TabItem>
+<TabItem value="legacy">
+
+  ```bash
+  $ dbt run --models snowplow.*      # run all of the models in the snowplow package
+  $ dbt run --models finance.base.*  # run all of the models in models/finance/base
+  ```
+
+</TabItem>
+</Tabs>

--- a/website/docs/reference/node-selection/methods.md
+++ b/website/docs/reference/node-selection/methods.md
@@ -204,11 +204,33 @@ The `test_name` method is used to select tests based on the name of the generic 
 that defines it. For more information about how generic tests are defined, read about
 [tests](building-a-dbt-project/tests).
 
-```bash
-$ dbt test --select test_name:unique            # run all instances of the `unique` test
-$ dbt test --select test_name:equality          # run all instances of the `dbt_utils.equality` test
-$ dbt test --select test_name:range_min_max     # run all instances of a custom schema test defined in the local project, `range_min_max`
-```
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
+
+  ```bash
+  $ dbt test --select test_name:unique            # run all instances of the `unique` test
+  $ dbt test --select test_name:equality          # run all instances of the `dbt_utils.equality` test
+  $ dbt test --select test_name:range_min_max     # run all instances of a custom schema test defined in the local project, `range_min_max`
+  ```
+
+</TabItem>
+<TabItem value="legacy">
+
+
+  ```bash
+  $ dbt test --models test_name:unique            # run all instances of the `unique` test
+  $ dbt test --models test_name:equality          # run all instances of the `dbt_utils.equality` test
+  $ dbt test --models test_name:range_min_max     # run all instances of a custom schema test defined in the local project, `range_min_max`
+  ```
+
+</TabItem>
+</Tabs>
 
 ### The "state" method
 <Changelog>

--- a/website/docs/reference/node-selection/methods.md
+++ b/website/docs/reference/node-selection/methods.md
@@ -8,21 +8,69 @@ syntax `method:value`.
 ### The "tag" method
 The `tag:` method is used to select models that match a specified [tag](resource-configs/tags).
 
-```bash
-$ dbt run --select tag:nightly    # run all models with the `nightly` tag
-```
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
+
+  ```bash
+  $ dbt run --select tag:nightly    # run all models with the `nightly` tag
+  ```
+
+</TabItem>
+<TabItem value="legacy">
+
+  ```bash
+  $ dbt run --models tag:nightly    # run all models with the `nightly` tag
+  ```
+
+</TabItem>
+</Tabs>
 
 ### The "source" method
 The `source` method is used to select models that select from a specified [source](using-sources). Use in conjunction with the `+` operator.
 
-```bash
-$ dbt run --select source:snowplow+    # run all models that select from Snowplow sources
-```
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
+
+  ```bash
+  $ dbt run --select source:snowplow+    # run all models that select from Snowplow sources
+  ```
+
+</TabItem>
+<TabItem value="legacy">
+
+  ```bash
+  $ dbt run --models source:snowplow+    # run all models that select from Snowplow sources
+  ```
+
+</TabItem>
+</Tabs>
 
 ### The "path" method
 The `path` method is used to select models located at or under a specific path.
 While the `path` prefix is not explicitly required, it may be used to make
 selectors unambiguous.
+
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
+
 
 ```bash
 # These two selectors are equivalent
@@ -34,6 +82,22 @@ dbt run --select path:models/staging/github/stg_issues.sql
 dbt run --select models/staging/github/stg_issues.sql
 ```
 
+</TabItem>
+<TabItem value="legacy">
+
+
+```bash
+# These two selectors are equivalent
+dbt run --models path:models/staging/github
+dbt run --models models/staging/github
+
+# These two selectors are equivalent
+dbt run --models path:models/staging/github/stg_issues.sql
+dbt run --models models/staging/github/stg_issues.sql
+```
+</TabItem>
+</Tabs>
+
 ### The "package" method
 <Changelog>New in v0.18.0</Changelog>
 
@@ -41,33 +105,97 @@ The `package` method is used to select models defined within the root project
 or an installed dbt package. While the `package:` prefix is not explicitly required, it may be used to make
 selectors unambiguous.
 
-```bash
-# These three selectors are equivalent
-dbt run --select package:snowplow
-dbt run --select snowplow
-dbt run --select snowplow.*
-```
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
+
+  ```bash
+  # These three selectors are equivalent
+  dbt run --select package:snowplow
+  dbt run --select snowplow
+  dbt run --select snowplow.*
+  ```
+
+</TabItem>
+<TabItem value="legacy">
+
+
+  ```bash
+  # These three selectors are equivalent
+  dbt run --models package:snowplow
+  dbt run --models snowplow
+  dbt run --models snowplow.*
+  ```
+
+</TabItem>
+</Tabs>
 
 ### The "config" method
 <Changelog>New in v0.18.0</Changelog>
 
 The `config` method is used to select models that match a specified [node config](configs-and-properties).
 
-```bash
-$ dbt run --select config.materialized:incremental    # run all models that are materialized incrementally
-$ dbt run --select config.schema:audit                # run all models that are created in the `audit` schema
-$ dbt run --select config.cluster_by:geo_country      # run all models clustered by `geo_country`
-```
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
+
+  ```bash
+  $ dbt run --select config.materialized:incremental    # run all models that are materialized incrementally
+  $ dbt run --select config.schema:audit                # run all models that are created in the `audit` schema
+  $ dbt run --select config.cluster_by:geo_country      # run all models clustered by `geo_country`
+  ```
+
+</TabItem>
+<TabItem value="legacy">
+
+  ```bash
+  $ dbt run --models config.materialized:incremental    # run all models that are materialized incrementally
+  $ dbt run --models config.schema:audit                # run all models that are created in the `audit` schema
+  $ dbt run --models config.cluster_by:geo_country      # run all models clustered by `geo_country`
+  ```
+
+</TabItem>
+</Tabs>
 
 ### The "test_type" method
 <Changelog>New in v0.18.0</Changelog>
 
 The `test_type` method is used to select tests based on their type, `schema` or `data`:
 
-```bash
-$ dbt test --select test_type:schema        # run all schema tests
-$ dbt test --select test_type:data          # run all data tests
-```
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
+
+  ```bash
+  $ dbt test --select test_type:schema        # run all schema tests
+  $ dbt test --select test_type:data          # run all data tests
+  ```
+
+</TabItem>
+<TabItem value="legacy">
+
+  ```bash
+  $ dbt test --models test_type:schema        # run all schema tests
+  $ dbt test --models test_type:data          # run all data tests
+  ```
+
+</TabItem>
+</Tabs>
 
 ### The "test_name" method
 <Changelog>New in v0.18.0</Changelog>
@@ -96,11 +224,32 @@ The `state` method is used to select nodes by comparing them against a previous 
 
 `state:modified`: All new nodes, plus any changes to existing nodes.
 
-```bash
-$ dbt test --select state:new            # run all tests on new models + and new tests on old models
-$ dbt run --select state:modified        # run all models that have been modified
-$ dbt ls --select state:modified         # list all modified nodes (not just models)
-```
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
+
+  ```bash
+  $ dbt test --select state:new            # run all tests on new models + and new tests on old models
+  $ dbt run --select state:modified        # run all models that have been modified
+  $ dbt ls --select state:modified         # list all modified nodes (not just models)
+  ```
+
+</TabItem>
+<TabItem value="legacy">
+
+  ```bash
+  $ dbt test --models state:new            # run all tests on new models + and new tests on old models
+  $ dbt run --models state:modified        # run all models that have been modified
+  $ dbt ls --select state:modified         # This really is still --select! list all modified nodes (not just models)
+  ```
+
+</TabItem>
+</Tabs>
 
 Because state comparison is complex, and everyone's project is different, dbt supports subselectors that include a subset of the full `modified` criteria:
 - `state:modified.body`: Changes to node body (e.g. model SQL, seed values)
@@ -116,8 +265,29 @@ Remember that `state:modified` includes _all_ of the criteria above, as well as 
 
 The `exposure` method is used to select parent resources of a specified [exposure](exposure-properties). Use in conjunction with the `+` operator.
 
-```bash
-$ dbt run --select +exposure:weekly_kpis                # run all models that feed into the weekly_kpis exposure
-$ dbt test --select +exposure:*                         # test all resources upstream of all exposures
-$ dbt ls --select +exposure:* --resource-type source    # list all sources upstream of all exposures
-```
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
+
+  ```bash
+  $ dbt run --select +exposure:weekly_kpis                # run all models that feed into the weekly_kpis exposure
+  $ dbt test --select +exposure:*                         # test all resources upstream of all exposures
+  $ dbt ls --select +exposure:* --resource-type source    # list all sources upstream of all exposures
+  ```
+
+</TabItem>
+<TabItem value="legacy">
+
+  ```bash
+  $ dbt run --models +exposure:weekly_kpis                # run all models that feed into the weekly_kpis exposure
+  $ dbt test --models +exposure:*                         # test all resources upstream of all exposures
+  $ dbt ls --select +exposure:* --resource-type source    # This really is still --select! list all sources upstream of all exposures
+  ```
+
+</TabItem>
+</Tabs>

--- a/website/docs/reference/node-selection/putting-it-together.md
+++ b/website/docs/reference/node-selection/putting-it-together.md
@@ -2,24 +2,71 @@
 title: "Putting it together"
 ---
 
-```bash
-$ dbt run --select my_package.*+      # select all models in my_package and their children
-$ dbt run --select +some_model+       # select some_model and all parents and children
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
 
-$ dbt run --select tag:nightly+       # select "nightly" models and all children
-$ dbt run --select +tag:nightly+      # select "nightly" models and all parents and children
+  ```bash
+  $ dbt run --select my_package.*+      # select all models in my_package and their children
+  $ dbt run --select +some_model+       # select some_model and all parents and children
 
-$ dbt run --select @source:snowplow   # build all models that select from snowplow sources, plus their parents
+  $ dbt run --select tag:nightly+       # select "nightly" models and all children
+  $ dbt run --select +tag:nightly+      # select "nightly" models and all parents and children
 
-$ dbt test --select config.incremental_strategy:insert_overwrite,test_name:unique   # execute all `unique` tests that select from models using the `insert_overwrite` incremental strategy
-```
+  $ dbt run --select @source:snowplow   # build all models that select from snowplow sources, plus their parents
+
+  $ dbt test --select config.incremental_strategy:insert_overwrite,test_name:unique   # execute all `unique` tests that select from models using the `insert_overwrite` incremental strategy
+  ```
+
+</TabItem>
+<TabItem value="legacy">
+
+  ```bash
+  $ dbt run --models my_package.*+      # select all models in my_package and their children
+  $ dbt run --models +some_model+       # select some_model and all parents and children
+
+  $ dbt run --models tag:nightly+       # select "nightly" models and all children
+  $ dbt run --models +tag:nightly+      # select "nightly" models and all parents and children
+
+  $ dbt run --models @source:snowplow   # build all models that select from snowplow sources, plus their parents
+
+  $ dbt test --models config.incremental_strategy:insert_overwrite,test_name:unique   # execute all `unique` tests that select from models using the `insert_overwrite` incremental strategy
+  ```
+
+</TabItem>
+</Tabs>
 
 This can get complex! Let's say I want a nightly run of models that build off snowplow data
 and feed exports, while _excluding_ the biggest incremental models (and one other model, to boot).
 
-```bash
-$ dbt run --select @source:snowplow,tag:nightly models/export --exclude package:snowplow,config.materialized:incremental export_performance_timing
-```
+
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
+
+  ```bash
+  $ dbt run --select @source:snowplow,tag:nightly models/export --exclude package:snowplow,config.materialized:incremental export_performance_timing
+  ```
+
+</TabItem>
+<TabItem value="legacy">
+
+  ```bash
+  $ dbt run --models @source:snowplow,tag:nightly models/export --exclude package:snowplow,config.materialized:incremental export_performance_timing
+  ```
+
+</TabItem>
+</Tabs>
 
 This command selects all models that:
 * Select from snowplow sources, plus their parents, _and_ are tagged "nightly"

--- a/website/docs/reference/node-selection/set-operators.md
+++ b/website/docs/reference/node-selection/set-operators.md
@@ -4,13 +4,33 @@ title: "Set operators"
 
 ### Unions
 Providing multiple space-delineated arguments to the `--select`, `--exclude`, or `--selector` flags selects
-the union of them all. If a resource is included in at least one selector, it will be 
+the union of them all. If a resource is included in at least one selector, it will be
 included in the final set.
 
 Run snowplow_sessions, all ancestors of snowplow_sessions, fct_orders, and all ancestors of fct_orders:
-```bash
-$ dbt run --select +snowplow_sessions +fct_orders
-```
+
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
+
+  ```bash
+  $ dbt run --select +snowplow_sessions +fct_orders
+  ```
+
+</TabItem>
+<TabItem value="legacy">
+
+  ```bash
+  $ dbt run --models +snowplow_sessions +fct_orders
+  ```
+
+</TabItem>
+</Tabs>
 
 ### Intersections
 <Changelog>New in v0.18.0</Changelog>
@@ -19,16 +39,77 @@ If multiple arguments to `--select`, `--exclude`, and `--select` can be comma-se
 dbt will select only resources which satisfy _all_ arguments.
 
 Run all the common ancestors of snowplow_sessions and fct_orders:
-```bash
-$ dbt run --select +snowplow_sessions,+fct_orders
-```
+
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
+
+  ```bash
+  $ dbt run --select +snowplow_sessions,+fct_orders
+  ```
+
+</TabItem>
+<TabItem value="legacy">
+
+  ```bash
+  $ dbt run --models +snowplow_sessions,+fct_orders
+  ```
+
+</TabItem>
+</Tabs>
+
 
 Run all the common descendents of stg_invoices and stg_accounts:
-```bash
-$ dbt run --select stg_invoices+,stg_accounts+
-```
+
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
+
+  ```bash
+  $ dbt run --select stg_invoices+,stg_accounts+
+  ```
+
+</TabItem>
+<TabItem value="legacy">
+
+  ```bash
+  $ dbt run --models stg_invoices+,stg_accounts+
+  ```
+
+</TabItem>
+</Tabs>
 
 Run models that are in the marts/finance subdirectory *and* tagged nightly:
-```bash
-$ dbt run --select marts.finance,tag:nightly
-```
+
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
+
+  ```bash
+  $ dbt run --select marts.finance,tag:nightly
+  ```
+
+</TabItem>
+<TabItem value="legacy">
+
+  ```bash
+  $ dbt run --models marts.finance,tag:nightly
+  ```
+
+</TabItem>
+</Tabs>

--- a/website/docs/reference/node-selection/syntax.md
+++ b/website/docs/reference/node-selection/syntax.md
@@ -17,7 +17,7 @@ dbt's node selection syntax makes it possible to run only specific resources in 
 
 :::info Nodes and resources
 
-We use the terms <a href="https://en.wikipedia.org/wiki/Vertex_(graph_theory)">"nodes"</a> and "resources" interchangeably. These  encompass all the models, tests, sources, seeds, snapshots, and analyses in your project. They are the objects that make up dbt's DAG (directed acyclic graph).
+We use the terms <a href="https://en.wikipedia.org/wiki/Vertex_(graph_theory)">"nodes"</a> and "resources" interchangeably. These  encompass all the models, tests, sources, seeds, snapshots, exposures, and analyses in your project. They are the objects that make up dbt's DAG (directed acyclic graph).
 :::
 
 ## Specifying resources
@@ -52,28 +52,83 @@ The `--select` flag accepts one or more arguments. Each argument can be one of:
 4. a selection method (`path:`, `tag:`, `config:`, `test_type:`, `test_name:`)
 
 Examples:
-```bash
-$ dbt run --select my_dbt_project_name   # runs all models in your project
-$ dbt run --select my_dbt_model          # runs a specific model
-$ dbt run --select path.to.my.models     # runs all models in a specific directory
-$ dbt run --select my_package.some_model # run a specific model in a specific package
-$ dbt run --select tag:nightly           # run models with the "nightly" tag
-$ dbt run --select path/to/models        # run models contained in path/to/models
-$ dbt run --select path/to/my_model.sql  # run a specific model by its path
-```
+
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
+
+  ```bash
+  $ dbt run --select my_dbt_project_name   # runs all models in your project
+  $ dbt run --select my_dbt_model          # runs a specific model
+  $ dbt run --select path.to.my.models     # runs all models in a specific directory
+  $ dbt run --select my_package.some_model # run a specific model in a specific package
+  $ dbt run --select tag:nightly           # run models with the "nightly" tag
+  $ dbt run --select path/to/models        # run models contained in path/to/models
+  $ dbt run --select path/to/my_model.sql  # run a specific model by its path
+  ```
+
+</TabItem>
+
+<TabItem value="legacy">
+
+  ```bash
+  $ dbt run --models my_dbt_project_name   # runs all models in your project
+  $ dbt run --models my_dbt_model          # runs a specific model
+  $ dbt run --models path.to.my.models     # runs all models in a specific directory
+  $ dbt run --models my_package.some_model # run a specific model in a specific package
+  $ dbt run --models tag:nightly           # run models with the "nightly" tag
+  $ dbt run --models path/to/models        # run models contained in path/to/models
+  $ dbt run --models path/to/my_model.sql  # run a specific model by its path
+  ```
+
+</TabItem>
+
+</Tabs>
 
 dbt supports a shorthand language for defining subsets of nodes. This language uses the characters `+`, `@`, `*`, and `,`.
 
-```bash
-# multiple arguments can be provided to --select
-$ dbt run --select my_first_model my_second_model
 
-# these arguments can be projects, models, directory paths, tags, or sources
-$ dbt run --select tag:nightly my_model finance.base.*
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
 
-# use methods and intersections for more complex selectors
-$ dbt run --select path:marts/finance,tag:nightly,config.materialized:table
-```
+  ```bash
+  # multiple arguments can be provided to --select
+  $ dbt run --select my_first_model my_second_model
+
+  # these arguments can be projects, models, directory paths, tags, or sources
+  $ dbt run --select tag:nightly my_model finance.base.*
+
+  # use methods and intersections for more complex selectors
+  $ dbt run --select path:marts/finance,tag:nightly,config.materialized:table
+  ```
+</TabItem>
+
+<TabItem value="legacy">
+
+  ```bash
+  # multiple arguments can be provided to --select
+  $ dbt run --models my_first_model my_second_model
+
+  # these arguments can be projects, models, directory paths, tags, or sources
+  $ dbt run --models tag:nightly my_model finance.base.*
+
+  # use methods and intersections for more complex selectors
+  $ dbt run --models path:marts/finance,tag:nightly,config.materialized:table
+  ```
+</TabItem>
+
+</Tabs>
 
 As your selection logic gets more complex, and becomes unwieldly to type out as command-line arguments,
 consider using a [yaml selector](yaml-selectors). You can use a predefined definition with the `--selector` flag.

--- a/website/docs/reference/node-selection/test-selection-examples.md
+++ b/website/docs/reference/node-selection/test-selection-examples.md
@@ -34,104 +34,318 @@ We've included lots of examples below:
 
 Run generic (schema) tests only:
 
-```shell
-$ dbt test --select test_type:schema
-```
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
+
+  ```bash
+  $ dbt test --select test_type:schema
+  ```
+
+</TabItem>
+<TabItem value="legacy">
+
+  ```bash
+  $ dbt test --models test_type:schema
+  ```
+
+</TabItem>
+</Tabs>
 
 Run bespoke (data) tests only:
 
-```shell
-$ dbt test --select test_type:data
-```
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
+
+  ```bash
+  $ dbt test --select test_type:data
+  ```
+
+</TabItem>
+<TabItem value="legacy">
+
+  ```bash
+  $ dbt test --models test_type:data
+  ```
+
+</TabItem>
+</Tabs>
 
 In both cases, `test_type` checks a property of the test itself. These are forms of "direct" test selection.
 
 ### Indirect selection
 
-```shell
-$ dbt test --select customers
-$ dbt test --select orders
-```
+
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
+
+  ```bash
+  $ dbt test --select customers
+  $ dbt test --select orders
+  ```
+
+</TabItem>
+<TabItem value="legacy">
+
+  ```bash
+  $ dbt test --models customers
+  $ dbt test --models orders
+  ```
+
+</TabItem>
+</Tabs>
 
 These are examples of "indirect" selection: `customers` and `orders` select models (whether by name or path). Any tests defined on `customers` or `orders` will be selected indirectly, and thereby included.
 
 If a test depends on both `customers` _and_ `orders` (e.g. a `relationships` test between them), it will _not_ be selected indirectly in the example above. Instead, it would only be selected indirectly if both parents are selected:
 
-```shell
-$ dbt test --select customers orders
-```
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
+
+  ```bash
+  $ dbt test --select customers orders
+  ```
+
+</TabItem>
+<TabItem value="legacy">
+
+  ```bash
+  $ dbt test --models customers orders
+  ```
+
+</TabItem>
+</Tabs>
+
+
 
 Or if you pass the `--greedy` flag:
-```shell
-$ dbt test --select customers --greedy
-$ dbt test --select orders --greedy
-```
 
-### Syntax examples
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
+
+  ```bash
+  $ dbt test --select customers --greedy
+  $ dbt test --select orders --greedy
+  ```
+
+</TabItem>
+<TabItem value="legacy">
+
+  ```bash
+  $ dbt test --models customers --greedy
+  $ dbt test --models orders --greedy
+  ```
+
+</TabItem>
+</Tabs>
+
+ ### Syntax examples
 
 The following examples should feel somewhat familiar if you're used to executing `dbt run` with the `--select` option to build parts of your DAG:
 
-```shell
-# Run tests on a model (indirect selection)
-$ dbt test --select customers
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
 
-# Run tests on all models in the models/staging/jaffle_shop directory (indirect selection)
-$ dbt test --select staging.jaffle_shop
+  ```bash
+  # Run tests on a model (indirect selection)
+  $ dbt test --select customers
 
-# Run tests downstream of a model (note this will select those tests directly!)
-$ dbt test --select stg_customers+
+  # Run tests on all models in the models/staging/jaffle_shop directory (indirect selection)
+  $ dbt test --select staging.jaffle_shop
 
-# Run tests upstream of a model (indirect selection)
-$ dbt test --select +stg_customers
+  # Run tests downstream of a model (note this will select those tests directly!)
+  $ dbt test --select stg_customers+
 
-# Run tests on all models with a particular tag (direct + indirect)
-$ dbt test --select tag:my_model_tag
+  # Run tests upstream of a model (indirect selection)
+  $ dbt test --select +stg_customers
 
-# Run tests on all models with a particular materialization (indirect selection)
-$ dbt test --select config.materialized:table
+  # Run tests on all models with a particular tag (direct + indirect)
+  $ dbt test --select tag:my_model_tag
 
-```
+  # Run tests on all models with a particular materialization (indirect selection)
+  $ dbt test --select config.materialized:table
 
-The same principle can be extended to tests defined on other resource types. In these cases, we will execute all tests defined on certain sources via the `source:` selection method:
+  ```
 
-```shell
-# tests on all sources
-$ dbt test --select source:*
+</TabItem>
+<TabItem value="legacy">
 
-# tests on one source
-$ dbt test --select source:jaffle_shop
+  ```bash
+  # Run tests on a model (indirect selection)
+  $ dbt test --models customers
 
-# tests on one source table
-$ dbt test --select source:jaffle_shop.customers
+  # Run tests on all models in the models/staging/jaffle_shop directory (indirect selection)
+  $ dbt test --models staging.jaffle_shop
 
-# tests on everything _except_ sources
-$ dbt test --exclude source:*
-```
+  # Run tests downstream of a model (note this will select those tests directly!)
+  $ dbt test --models stg_customers+
 
-### More complex selection
+  # Run tests upstream of a model (indirect selection)
+  $ dbt test --models +stg_customers
+
+  # Run tests on all models with a particular tag (direct + indirect)
+  $ dbt test --models tag:my_model_tag
+
+  # Run tests on all models with a particular materialization (indirect selection)
+  $ dbt test --models config.materialized:table
+
+  ```
+
+</TabItem>
+</Tabs>
+
+ The same principle can be extended to tests defined on other resource types. In these cases, we will execute all tests defined on certain sources via the `source:` selection method:
+
+ <Tabs
+   defaultValue="modern"
+   values={[
+     { label: 'v0.21.0 and later', value: 'modern', },
+     { label: 'v0.20.x and earlier', value: 'legacy', }
+   ]
+ }>
+ <TabItem value="modern">
+
+   ```bash
+   # tests on all sources
+   $ dbt test --select source:*
+
+   # tests on one source
+   $ dbt test --select source:jaffle_shop
+
+   # tests on one source table
+   $ dbt test --select source:jaffle_shop.customers
+
+   # tests on everything _except_ sources
+   $ dbt test --exclude source:*
+   ```
+
+ </TabItem>
+ <TabItem value="legacy">
+
+   ```bash
+   # tests on all sources
+   $ dbt test --models source:*
+
+   # tests on one source
+   $ dbt test --models source:jaffle_shop
+
+   # tests on one source table
+   $ dbt test --models source:jaffle_shop.customers
+
+   # tests on everything _except_ sources
+   $ dbt test --exclude source:*
+   ```
+
+</TabItem>
+</Tabs>
+
+ ### More complex selection
 
 Through the combination of direct and indirect selection, there are many ways to accomplish the same outcome. Let's say we have a data test named `assert_total_payment_amount_is_positive` that depends on a model named `payments`. All of the following would manage to select and execute that test specifically:
 
-```shell
-$ dbt test --select assert_total_payment_amount_is_positive # directly select the test by name
-$ dbt test --select payments,test_type:data # indirect selection, v0.18.0
-$ dbt test --select payments --data  # indirect selection, earlier versions
-```
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
 
-As long as you can select a common property of a group of resources, indirect selection allows you to execute all the tests on those resources, too. In the example above, we saw it was possible to test all table-materialized models. This principle can be extended to other resource types, too:
+  ```bash
+  $ dbt test --select assert_total_payment_amount_is_positive # directly select the test by name
+  $ dbt test --select payments,test_type:data # indirect selection, v0.18.0
+  $ dbt test --select payments --data  # indirect selection, earlier versions
+  ```
 
-```shell
-# Run tests on all models with a particular materialization
-$ dbt test --select config.materialized:table
+</TabItem>
+<TabItem value="legacy">
 
-# Run tests on all seeds, which use the 'seed' materialization
-$ dbt test --select config.materialized:seed
+  ```bash
+  $ dbt test --models assert_total_payment_amount_is_positive # directly select the test by name
+  $ dbt test --models payments,test_type:data # indirect selection, v0.18.0
+  $ dbt test --models payments --data  # indirect selection, earlier versions
+  ```
 
-# Run tests on all snapshots, which use the 'snapshot' materialization
-$ dbt test --select config.materialized:snapshot
-```
+</TabItem>
+</Tabs>
 
-Note that this functionality may change in future versions of dbt.
+ As long as you can select a common property of a group of resources, indirect selection allows you to execute all the tests on those resources, too. In the example above, we saw it was possible to test all table-materialized models. This principle can be extended to other resource types, too:
+
+
+ <Tabs
+   defaultValue="modern"
+   values={[
+     { label: 'v0.21.0 and later', value: 'modern', },
+     { label: 'v0.20.x and earlier', value: 'legacy', }
+   ]
+ }>
+ <TabItem value="modern">
+
+ ```bash
+ # Run tests on all models with a particular materialization
+ $ dbt test --select config.materialized:table
+
+ # Run tests on all seeds, which use the 'seed' materialization
+ $ dbt test --select config.materialized:seed
+
+ # Run tests on all snapshots, which use the 'snapshot' materialization
+ $ dbt test --select config.materialized:snapshot
+ ```
+
+ </TabItem>
+ <TabItem value="legacy">
+
+   ```bash
+   # Run tests on all models with a particular materialization
+   $ dbt test --models config.materialized:table
+
+   # Run tests on all seeds, which use the 'seed' materialization
+   $ dbt test --models config.materialized:seed
+
+   # Run tests on all snapshots, which use the 'snapshot' materialization
+   $ dbt test --models config.materialized:snapshot
+   ```
+
+</TabItem>
+</Tabs>
+
+ Note that this functionality may change in future versions of dbt.
 
 ### Run tests on tagged columns
 
@@ -154,9 +368,29 @@ models:
 
 </File>
 
-```shell
-$ dbt test --select tag:my_column_tag
-```
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
+
+  ```bash
+  $ dbt test --select tag:my_column_tag
+  ```
+
+</TabItem>
+<TabItem value="legacy">
+
+  ```bash
+  $ dbt test --models tag:my_column_tag
+  ```
+
+</TabItem>
+</Tabs>
+
 
 Currently, tests "inherit" tags applied to columns, sources, and source tables. They do _not_ inherit tags applied to models, seeds, or snapshots. In all likelihood, those tests would still be selected indirectly, because the tag selects its parent. This is a subtle distinction, and it may change in future versions of dbt.
 
@@ -182,6 +416,26 @@ models:
 </File>
 
 
-```shell
-$ dbt test --select tag:my_test_tag
-```
+
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
+
+  ```bash
+  $ dbt test --select tag:my_test_tag
+  ```
+
+</TabItem>
+<TabItem value="legacy">
+
+  ```bash
+  $ dbt test --models tag:my_test_tag
+  ```
+
+</TabItem>
+</Tabs>

--- a/website/docs/reference/node-selection/yaml-selectors.md
+++ b/website/docs/reference/node-selection/yaml-selectors.md
@@ -38,7 +38,7 @@ Each `definition` is comprised of one or more arguments, which can be one of the
 * **CLI-style:** strings, representing CLI-style) arguments
 * **Key-value:** pairs in the form `method: value`
 * **Full YAML:** fully specified dictionaries with items for `method`, `value`, operator-equivalent keywords, and support for `exclude`
-    
+
 Use `union` and `intersection` to organize multiple arguments.
 
 ### CLI-style
@@ -76,7 +76,7 @@ definition:
   parents_depth: 1     # if parents: true, degrees to include
 
   childrens_parents: true | false     # @ operator
-  
+
   greedy: true | false  # include all tests selected indirectly? false by default
 ```
 
@@ -89,7 +89,7 @@ definition:
 
 #### Exclude
 
-The `exclude` keyword is only supported by fully-qualified dictionaries. 
+The `exclude` keyword is only supported by fully-qualified dictionaries.
 It may be passed as an argument to each dictionary, or as
 an item in a `union`. The following are equivalent:
 
@@ -110,7 +110,7 @@ an item in a `union`. The following are equivalent:
 ```
 
 Note: The `exclude` argument in YAML selectors is subtly different from
-the `--exclude` CLI argument. Here, `exclude` _always_ returns a [set difference](https://en.wikipedia.org/wiki/Complement_(set_theory)), 
+the `--exclude` CLI argument. Here, `exclude` _always_ returns a [set difference](https://en.wikipedia.org/wiki/Complement_(set_theory)),
 and it is always applied _last_ within its scope.
 
 This gets us more intricate subset definitions than what's available on the CLI,
@@ -140,9 +140,29 @@ See [test selection examples](test-selection-examples) for more details about gr
 ## Example
 
 Here are two ways to represent:
-```
-$ dbt run --select @source:snowplow,tag:nightly models/export --exclude package:snowplow,config.materialized:incremental export_performance_timing
-```
+
+<Tabs
+  defaultValue="modern"
+  values={[
+    { label: 'v0.21.0 and later', value: 'modern', },
+    { label: 'v0.20.x and earlier', value: 'legacy', }
+  ]
+}>
+<TabItem value="modern">
+
+  ```bash
+  $ dbt run --select @source:snowplow,tag:nightly models/export --exclude package:snowplow,config.materialized:incremental export_performance_timing
+  ```
+
+</TabItem>
+<TabItem value="legacy">
+
+  ```bash
+  $ dbt run --models @source:snowplow,tag:nightly models/export --exclude package:snowplow,config.materialized:incremental export_performance_timing
+  ```
+
+</TabItem>
+</Tabs>
 
 <Tabs
   defaultValue="cli_style"


### PR DESCRIPTION
## Description & motivation
A lot of users who aren't on 0.21.0 yet are running into issues where they try to use the `--select` flag. There were some warnings on the main selection page but not enough for people who were linked in directly from Google etc. 

I know we've been talking about how we version our docs in the long term and this isn't scalable to everywhere, but node selection is a high-visibility, high-confusion area of change so I think this is a good balance!

I haven't done any changes to the state selection caveats page because it's all soooo version-dependent already and is a bit confusing. I'm hoping people who are digging into that are power users enough to debug their issue if they get into trouble. 

Feel free to merge this while I'm away if it looks good 👍 

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
