### PR TITLE
Update Materialize profile

### DIFF
--- a/website/docs/reference/warehouse-profiles/materialize-profile.md
+++ b/website/docs/reference/warehouse-profiles/materialize-profile.md
@@ -49,9 +49,12 @@ dbt-materialize:
 
 Type | Supported? | Details
 -----|------------|----------------
+source | YES | Creates a [source](https://materialize.com/docs/sql/create-source/).
 view | YES | Creates a [view](https://materialize.com/docs/sql/create-view/#main).
 materializedview | YES | Creates a [materialized view](https://materialize.com/docs/sql/create-materialized-view/#main).
 table | YES | Creates a [materialized view](https://materialize.com/docs/sql/create-materialized-view/#main). (Actual table support pending [#5266](https://github.com/MaterializeInc/materialize/issues/5266))
+index | YES | Creates an [index](https://materialize.com/docs/sql/create-index/#main).
+sink | YES | Creates a [sink](https://materialize.com/docs/sql/create-sink/#main).
 ephemeral | YES | Executes queries using CTEs.
 incremental | NO | Use the `materializedview` materialization instead. Materialized views will always return up-to-date results without manual or configured refreshes. For more information, check out [Materialize documentation](https://materialize.com/docs/).
 
@@ -61,5 +64,5 @@ Running [`dbt seed`](commands/seed) will create a static materialized view from 
 
 ## Resources
 
+- [dbt and Materialize guide](https://materialize.com/docs/guides/dbt/)
 - [Get started](https://github.com/MaterializeInc/materialize/blob/main/play/wikirecent-dbt/README.md) using dbt and Materialize together
-- [Materialize docs about dbt](https://materialize.com/docs/third-party/dbt/)


### PR DESCRIPTION
## Description & motivation
The latest versions of the `dbt-materialize` plugin have introduced new materialization types that are undocumented in the official profile. 

We've also added a guide to the Materialize docs that can help users get started, now linked under "Resources".

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
