### PR TITLE
Add available `result:` options to state selectors

### DIFF
--- a/website/docs/docs/guides/understanding-state.md
+++ b/website/docs/docs/guides/understanding-state.md
@@ -52,6 +52,7 @@ $ dbt run --select result:<status> --defer --state path/to/prod/artifacts
 ```
 
 The available options depend on the node type: 
+
 |                | model | seed | snapshot | test |
 |----------------|-------|------|------|----------|
 | `result:error`   | ✅    | ✅    | ✅    |  ✅      |

--- a/website/docs/docs/guides/understanding-state.md
+++ b/website/docs/docs/guides/understanding-state.md
@@ -57,7 +57,7 @@ The available options depend on the node type:
 |----------------|-------|------|------|----------|
 | `result:error`   | ✅    | ✅    | ✅    |  ✅      |
 | `result:success` | ✅    | ✅    | ✅     |         |
-| `result:skipped` | ✅    |      |  ✅    |        |
+| `result:skipped` | ✅    |      |  ✅    | ✅       |
 | `result:fail`    |       |      |     |   ✅       |
 | `result:warn`    |       |      |      |  ✅        |
 | `result:pass`    |       |      |      |  ✅      |

--- a/website/docs/docs/guides/understanding-state.md
+++ b/website/docs/docs/guides/understanding-state.md
@@ -51,6 +51,16 @@ After issuing one of the above commands, you can reference the results by adding
 $ dbt run --select result:<status> --defer --state path/to/prod/artifacts
 ```
 
+The available options depend on the node type: 
+|                | model | seed | snapshot | test |
+|----------------|-------|------|------|----------|
+| `result:error`   | ✅    | ✅    | ✅    |  ✅      |
+| `result:success` | ✅    | ✅    | ✅     |         |
+| `result:skipped` | ✅    |      |  ✅    |        |
+| `result:fail`    |       |      |     |   ✅       |
+| `result:warn`    |       |      |      |  ✅        |
+| `result:pass`    |       |      |      |  ✅      |
+
 ### Combining `state` and `result` selectors
 
 The state and result selectors can also be combined in a single invocation of dbt to capture errors from a previous run AND any new or modified models.


### PR DESCRIPTION
## Description & motivation
The docs for `result` selection from https://github.com/dbt-labs/dbt-core/pull/4017 currently say "use the result method" but don't say what options are available to it. I originally just listed them out, but then realised that some were unavailable in different contexts. I've made a grid showing which options should be available depending on your target node types. 

I freehanded all of this: I _think_ I've remembered all the node types and correctly mapped them, but please double check! 

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [x] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
