### PR TITLE
Fishtown -> dbt Labs on enterprise permissions page

### DIFF
--- a/website/docs/docs/dbt-cloud/access-control/enterprise-permissions.md
+++ b/website/docs/docs/dbt-cloud/access-control/enterprise-permissions.md
@@ -161,7 +161,7 @@ static/
 
 ## How to Set Up RBAC Groups in dbt Cloud
  
-- **If you are on a Fishtown Hosted dbt Cloud instance:**
+- **If you are on a dbt Labs Hosted dbt Cloud instance:**
 Contact support via the Intercom button or support@getdbt.com to turn on this feature. 
 - **If you are on a customer deployed dbt Cloud instance:**
 Contact your account manager for instructions on how to turn on this feature.


### PR DESCRIPTION
## Description & motivation
Found a place that still referred to Fishtown instead of dbt Labs

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!