### PR TITLE
fix typo in docs

### DIFF
--- a/website/docs/docs/building-a-dbt-project/documentation.md
+++ b/website/docs/docs/building-a-dbt-project/documentation.md
@@ -87,7 +87,7 @@ To declare a docs block, use the jinja `docs` tag. Docs blocks must be uniquely 
 
 This table contains clickstream events from the marketing website.
 
-The events in this table are recorded by \[Snowplow](http://github.com/snowplow/snowplow) and piped into the warehouse on an hourly basis. The following pages of the marketing site are tracked:
+The events in this table are recorded by [Snowplow](http://github.com/snowplow/snowplow) and piped into the warehouse on an hourly basis. The following pages of the marketing site are tracked:
  - /
  - /about
  - /team


### PR DESCRIPTION
remove backslash that breaks markdown link syntax

## Description & motivation
remove backslash that breaks markdown link syntax

## Before and after

**Before:** 

![image](https://user-images.githubusercontent.com/29500178/142208806-d4214d55-1139-40aa-8afa-072f0336a963.png)

**After:** 
![image](https://user-images.githubusercontent.com/29500178/142208946-fca37014-85aa-4560-89de-304432b37ee1.png)
