### PR TITLE
Mention that `dbt docs generate` needs to be run before `dbt docs serve`

### DIFF
--- a/website/docs/reference/commands/cmd-docs.md
+++ b/website/docs/reference/commands/cmd-docs.md
@@ -26,7 +26,7 @@ dbt docs generate --no-compile
 ```
 
 ### dbt docs serve
-This command starts a webserver on port 8000 to serve your documentation locally. The webserver is rooted in your `target/` directory.
+This command starts a webserver on port 8000 to serve your documentation locally. Run `generate` before `serve` as `serve` depends on the catalog which `generate` produces. The webserver is rooted in your `target/` directory.
 
 **Usage:**
 ```

--- a/website/docs/reference/commands/cmd-docs.md
+++ b/website/docs/reference/commands/cmd-docs.md
@@ -26,7 +26,7 @@ dbt docs generate --no-compile
 ```
 
 ### dbt docs serve
-This command starts a webserver on port 8000 to serve your documentation locally. Run `generate` before `serve` as `serve` depends on the catalog which `generate` produces. The webserver is rooted in your `target/` directory.
+This command starts a webserver on port 8000 to serve your documentation locally. The webserver is rooted in your `target/` directory. Be sure to run `dbt docs generate` before `dbt docs serve` because the  `generate` command produces a [catalog metadata artifact](/reference/artifacts/catalog-json) that the `serve` command depends upon. You will see an error message if the catalog is missing.  
 
 **Usage:**
 ```


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a pull request on dbt core, etc?
-->
- this one really puzzled me
- docs serve wasn't working and googling the error msg didn't help
- wording of the sentence that I want to add is up for discussion
- alternative to adding this line to the docs: change DBT to implicitly running generate when user executes serve...

## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged
-->

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!