### PR TITLE
Final touches for v1.0

### DIFF
--- a/website/docs/docs/building-a-dbt-project/package-management.md
+++ b/website/docs/docs/building-a-dbt-project/package-management.md
@@ -86,17 +86,28 @@ In comparison, other package installation methods are unable to handle the dupli
 <Changelog>
 
 * `v0.20.1`: Fixed handling for prerelease versions. Introduced `install-prerelease` parameter.
+* `v1.0.0`: If provided an explicit prerelease version, dbt will install it
 
 </Changelog>
 
 Some package maintainers may wish to push prerelease versions of packages to the dbt Hub, in order to test out new functionality or compatibility with a new version of dbt. A prerelease version is demarcated by a suffix, such as `a1` (first alpha), `b2` (second beta), or `rc3` (third release candidate).
 
-By default, `dbt deps` will not install prerelease versions of packages. You can enable the installation of prereleases with the `install-prerelease` parameter.
+By default, `dbt deps` will not include prerelease versions when resolving package dependencies. You can enable the installation of prereleases in one of two ways:
+- explicitly specifying a prerelease in your `version` criteria
+- setting `install-prerelease` to `true`
+
+Both of the following configurations would successfully install `0.4.5a2` of `dbt_artifacts`:
 
 ```yaml
 packages:
   - package: tailsdotcom/dbt_artifacts
     version: 0.4.5a2
+```
+
+```yaml
+packages:
+  - package: tailsdotcom/dbt_artifacts
+    version: [">=0.4.4", "<0.4.6"]
     install-prerelease: true
 ```
 

--- a/website/docs/docs/building-a-dbt-project/package-management.md
+++ b/website/docs/docs/building-a-dbt-project/package-management.md
@@ -86,15 +86,15 @@ In comparison, other package installation methods are unable to handle the dupli
 <Changelog>
 
 * `v0.20.1`: Fixed handling for prerelease versions. Introduced `install-prerelease` parameter.
-* `v1.0.0`: If provided an explicit prerelease version, dbt will install it
+* `v1.0.0`: When you provide an explicit prerelease version, dbt will install that version.
 
 </Changelog>
 
 Some package maintainers may wish to push prerelease versions of packages to the dbt Hub, in order to test out new functionality or compatibility with a new version of dbt. A prerelease version is demarcated by a suffix, such as `a1` (first alpha), `b2` (second beta), or `rc3` (third release candidate).
 
 By default, `dbt deps` will not include prerelease versions when resolving package dependencies. You can enable the installation of prereleases in one of two ways:
-- explicitly specifying a prerelease in your `version` criteria
-- setting `install-prerelease` to `true`
+- Explicitly specifying a prerelease version in your `version` criteria
+- Setting `install-prerelease` to `true`, and providing a compatible version range
 
 Both of the following configurations would successfully install `0.4.5a2` of `dbt_artifacts`:
 

--- a/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-upgrading-dbt-versions.md
+++ b/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-upgrading-dbt-versions.md
@@ -18,11 +18,42 @@ Below we try to help you answer the question of whether a known breaking change 
 
 If you use any packages from [dbt Hub](https://hub.getdbt.com/), make sure you also upgrade to a version of the package that supports the dbt version you intend to upgrade to. You can see which dbt versions a package supports by checking on the `require-dbt-version:` in the package's dbt_project.yml file on GitHub.
 
-As an example, dbt-utils version 0.7.1 supports dbt v0.20 and v0.21, as described in its [dbt_project.yml](https://github.com/dbt-labs/dbt-utils/blob/0.7.1/dbt_project.yml).
+As an example, dbt-utils version 0.7.6 supports dbt v0.20, v0.21, and v1.0, as described in its [dbt_project.yml](https://github.com/dbt-labs/dbt-utils/blob/0.7.6/dbt_project.yml).
 
 After you've changed the package version in your packages.yml file, be sure to run `dbt deps` in the IDE to install the updated version.
 
 :::
+
+<details>
+<summary>  Upgrading to v1.0.latest from v0.21 </summary>
+<br></br>
+
+:::info Universal change
+Certain configurations in dbt_project.yml have been renamed
+:::
+
+Existing projects will see non-breaking deprecation warnings. To remove the warnings, most projects can change three lines:
+
+<File name='dbt_project.yml'>
+
+```yml
+model-paths: ["models"] # formerly named "model-paths"
+seed-paths: ["data"]    # formerly named "data-paths"
+clean-targets:
+  - "target"
+  - "dbt_packages"      # formerly named "dbt_modules"
+```
+
+</File>
+
+- Do you select tests using the old names for test types? (`test_type:schema`, `test_type:data`, `--schema`, `--data`)
+- Do you have custom macro code that calls the (undocumented) global macros `column_list`, `column_list_for_create_table`, `incremental_upsert`?
+- Do you have custom scripts that parse dbt JSON artifacts?
+- (BigQuery only) Do you use dbt's legacy capabilities around ingestion-time-partitioned tables?
+
+If you believe your project might be affected, read more details in the migration guide [here](/docs/guides/migration-guide/upgrading-to-1-0-0).
+
+</details>
 
 
 <details>

--- a/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-upgrading-dbt-versions.md
+++ b/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-upgrading-dbt-versions.md
@@ -32,7 +32,7 @@ After you've changed the package version in your packages.yml file, be sure to r
 Certain configurations in dbt_project.yml have been renamed
 :::
 
-Existing projects will see non-breaking deprecation warnings. To remove the warnings, most projects can change three lines:
+Existing projects will see non-breaking deprecation warnings. You can change three lines in most projects to remove the warnings:
 
 <File name='dbt_project.yml'>
 

--- a/website/docs/docs/guides/migration-guide/upgrading-to-1-0-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-1-0-0.md
@@ -74,3 +74,4 @@ Several under-the-hood changes from past minor versions, tagged with deprecation
 - [Global configs](global-configs) have been standardized. Related updates to [global CLI flags](global-cli-flags) and [`profiles.yml`](profiles.yml).
 - [The `init` command](init) has a whole new look and feel. It's no longer just for first-time users.
 - Add `result:<status>` subselectors for smarter reruns when dbt models have errors and tests fail. See examples: [Pro-tips for Workflows](/docs/guides/best-practices.md#pro-tips-for-workflows)
+- Secret-prefixed [env vars](env_var) are now allowed only in `profiles.yml` + `packages.yml`

--- a/website/docs/docs/guides/migration-guide/upgrading-to-1-0-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-1-0-0.md
@@ -53,7 +53,7 @@ Global project macros have been reorganized, and some old unused macros have bee
 
 ### For maintainers of plugins + other integrations
 
-We've introduced a new **structured event interface**, and we've begun the transition away from legacy logging. **This includes a breaking change for adapter plugins**, requiring a very simple migration—see [`events` module README](https://github.com/dbt-labs/dbt-core/blob/HEAD/core/dbt/events/README.md#adapter-maintainers) for details. If you maintain a different kind of plugin that _needs_ legacy logging, for the time being, you can re-enable it with an env var (`DBT_ENABLE_LEGACY_LOGGER=True`); be advised that we will remove this capability in a future version of dbt Core.
+We've introduced a new [**structured event interface**](events-logging), and we've transitioned all dbt logging to use this new system. **This includes a breaking change for adapter plugins**, requiring a very simple migration—see [`events` module README](https://github.com/dbt-labs/dbt-core/blob/HEAD/core/dbt/events/README.md#adapter-maintainers) for details. If you maintain a different kind of plugin that _needs_ legacy logging, for the time being, you can re-enable it with an env var (`DBT_ENABLE_LEGACY_LOGGER=True`); be advised that we will remove this capability in a future version of dbt Core.
 
 The [**dbt RPC Server**](rpc) has been split out from `dbt-core` and is now packaged separately. Its functionality will be fully deprecated by the end of 2022, in favor of a new dbt Server. Instead of `dbt rpc`, use `dbt-rpc serve`.
 

--- a/website/docs/docs/guides/migration-guide/upgrading-to-1-0-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-1-0-0.md
@@ -3,16 +3,10 @@ title: "Upgrading to 1.0.0"
 
 ---
 
-:::info Release candidate
-
-dbt-core v1.0.0-rc1 is currently available. If you have questions or encounter bugs, please let us know in [#dbt-prereleases](https://community.getdbt.com/) or by opening an issue [in GitHub](https://github.com/dbt-labs/dbt-core).
-
-:::
-
 ### Resources
 
 - [Discourse](https://discourse.getdbt.com/t/3180)
-- [Changelog](https://github.com/dbt-labs/dbt-core/blob/HEAD/CHANGELOG.md)
+- [Changelog](https://github.com/dbt-labs/dbt-core/blob/1.0.latest/CHANGELOG.md)
 
 ## Breaking changes
 

--- a/website/docs/docs/guides/migration-guide/upgrading-to-1-0-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-1-0-0.md
@@ -47,7 +47,7 @@ Global project macros have been reorganized, and some old unused macros have bee
 
 ### For maintainers of plugins + other integrations
 
-We've introduced a new [**structured event interface**](events-logging), and we've transitioned all dbt logging to use this new system. **This includes a breaking change for adapter plugins**, requiring a very simple migration—see [`events` module README](https://github.com/dbt-labs/dbt-core/blob/HEAD/core/dbt/events/README.md#adapter-maintainers) for details. If you maintain a different kind of plugin that _needs_ legacy logging, for the time being, you can re-enable it with an env var (`DBT_ENABLE_LEGACY_LOGGER=True`); be advised that we will remove this capability in a future version of dbt Core.
+We've introduced a new [**structured event interface**](events-logging), and we've transitioned all dbt logging to use this new system. **This includes a breaking change for adapter plugins**, requiring a very simple migration. For more details, see the [`events` module README](https://github.com/dbt-labs/dbt-core/blob/HEAD/core/dbt/events/README.md#adapter-maintainers). If you maintain a different kind of plugin that _needs_ legacy logging, for the time being, you can re-enable it with an env var (`DBT_ENABLE_LEGACY_LOGGER=True`); be advised that we will remove this capability in a future version of dbt Core.
 
 The [**dbt RPC Server**](rpc) has been split out from `dbt-core` and is now packaged separately. Its functionality will be fully deprecated by the end of 2022, in favor of a new dbt Server. Instead of `dbt rpc`, use `dbt-rpc serve`.
 

--- a/website/docs/docs/running-a-dbt-project/dbt-api.md
+++ b/website/docs/docs/running-a-dbt-project/dbt-api.md
@@ -3,6 +3,10 @@ title: "Using the Python API"
 id: "dbt-api"
 ---
 
-While dbt is designed to be invoked from the command line, it _is_ possible to import and invoke dbt as a Python module. This API is liable to change in the future — as a result, it's currently undocumented.
+The primary interface into `dbt-core` is on the command line. It is designed to be invoked with commands, arguments, and flags. Starting in v1, this interface is contracted, with backwards compatibility guaranteed.
 
-Please use caution when upgrading across versions of dbt if you choose to run dbt in this manner!
+It _is_ possible to import and invoke dbt as a Python module. This API is still not contracted or documented, and it is liable to change in future versions of `dbt-core` without warning. Please use caution when upgrading across versions of dbt if you choose to run dbt in this manner!
+
+We aim to contract and document an increasing number of Python interfaces within `dbt-core`. Today, those interfaces are:
+- [Adapter plugin](building-a-new-adapter) classes and methods. These are liable to change in minor versions _only_, and we will aim for backwards compatibility whenever possible.
+- [Events](events), Python objects that dbt emits as log messages.

--- a/website/docs/reference/dbt-jinja-functions/env_var.md
+++ b/website/docs/reference/dbt-jinja-functions/env_var.md
@@ -53,13 +53,13 @@ models:
 <Changelog>
 
   - **v0.21.0:** Introduced `DBT_ENV_SECRET_` and log scrubbing
-  - **v1.0.0:** Restricted use of secret env vars to `profiles.yml` + `packages.yml`
+  - **v1.0.0:** Restricted use of secret env vars to `profiles.yml` and `packages.yml`
 
 </Changelog>
 
 For certain configurations, you can use "secret" env vars. Any env var named with the prefix `DBT_ENV_SECRET_` will be:
 - Available for use in `profiles.yml` + `packages.yml`, via the same `env_var()` function
-- Disallowed everywhere else, including `dbt_project.yml` and model SQL
+- Disallowed everywhere else, including `dbt_project.yml` and model SQL, to prevent accidentally writing these secret values to the data warehouse or metadata artifacts
 - Scrubbed from dbt logs and replaced with `*****`, any time its value appears in those logs (even if the env var was not called directly)
 
 The primary use case of secret env vars is git access tokens for [private packages](package-management#private-packages).

--- a/website/docs/reference/dbt-jinja-functions/env_var.md
+++ b/website/docs/reference/dbt-jinja-functions/env_var.md
@@ -47,18 +47,32 @@ models:
 
  This can be useful to avoid compilation errors when the environment variable isn't available.
 
-### Special env var prefixes
+
+### Secrets
+
+<Changelog>
+
+  - **v0.21.0:** Introduced `DBT_ENV_SECRET_` and log scrubbing
+  - **v1.0.0:** Restricted use of secret env vars to `profiles.yml` + `packages.yml`
+
+</Changelog>
+
+For certain configurations, you can use "secret" env vars. Any env var named with the prefix `DBT_ENV_SECRET_` will be:
+- Available for use in `profiles.yml` + `packages.yml`, via the same `env_var()` function
+- Disallowed everywhere else, including `dbt_project.yml` and model SQL
+- Scrubbed from dbt logs and replaced with `*****`, any time its value appears in those logs (even if the env var was not called directly)
+
+The primary use case of secret env vars is git access tokens for [private packages](package-management#private-packages).
+
+### Custom metadata
 
 <Changelog>
 
   - **v0.19.0:** Introduced `DBT_ENV_CUSTOM_ENV_` prefix and artifact `metadata.env`
-  - **v0.21.0:** Introduced `DBT_ENV_SECRET_` and log scrubbing
 
 </Changelog>
 
-If environment variables are named with one of two prefixes, it will have special behavior in dbt:
-- `DBT_ENV_CUSTOM_ENV_`: Any env var named with this prefix will be included in [dbt artifacts](dbt-artifacts#common-metadata), in a `metadata.env` dictionary, with its prefix-stripped name as its key.
-- `DBT_ENV_SECRET_`: Any env var named with this prefix will be scrubbed from dbt logs and replaced with `*****`, any time its value appears in those logs (even if the env var was not called directly). While dbt already avoids logging database credentials, this is useful for other types of secrets, such as git tokens for [private packages](package-management#private-packages), or AWS keys for querying data in S3.
+Any env var named with the prefix `DBT_ENV_CUSTOM_ENV_` will be included in [dbt artifacts](dbt-artifacts#common-metadata), in a `metadata.env` dictionary, with its prefix-stripped name as its key.
 
 :::info dbt Cloud Usage
 If you are using dbt Cloud, you must adhere to the naming conventions for environment variables. Environment variables in dbt Cloud must be prefixed with `DBT_` (including `DBT_ENV_CUSTOM_ENV_` or `DBT_ENV_SECRET_`). Environment variables keys are uppercased and case sensitive. When referencing `{{env_var('DBT_KEY')}}` in your project's code, the key must match exactly the variable defined in dbt Cloud's UI.

--- a/website/docs/reference/dbt-jinja-functions/flags.md
+++ b/website/docs/reference/dbt-jinja-functions/flags.md
@@ -3,7 +3,7 @@ title: "flags"
 id: "flags"
 ---
 
-The `flags` variable contains true/false values for flags provided on the command line.
+The `flags` variable contains values of flags provided on the command line.
 
 __Example usage:__
 
@@ -19,7 +19,10 @@ drop table ...
 
 </File>
 
-The list of valid flags are:
-- `flags.STRICT_MODE`: True if `--strict` (or `-S`) was provided on the command line
-- `flags.FULL_REFRESH`: True if `--full-refresh` was provided on the command line 
-- `flags.STORE_FAILURES`: True if `--store-failures` was provided on the command line
+The list of available flags is defined in the [`flags` module](https://github.com/dbt-labs/dbt-core/blob/HEAD/core/dbt/flags.py) within `dbt-core`.
+
+Recommended use cases include:
+- different materialization logic based on "run modes," such as `flags.FULL_REFRESH` and `flags.STORE_FAILURES`
+- running hooks conditionally based on the current command / task type, via `flags.WHICH`
+
+**Note:** It is _not_ recommended to use flags as an input to parse-time configurations, properties, or dependencies (`ref` + `source`). Flags are likely to change in every invocation of dbt, and their parsed values will become stale (and yield incorrect results) in subsequent invocations that have partial parsing enabled. For more details, see [the docs on parsing](parsing).

--- a/website/docs/reference/events-logging.md
+++ b/website/docs/reference/events-logging.md
@@ -3,11 +3,11 @@ title: "Events and logs"
 ---
 
 :::info New in v1.0
-While dbt has always generated logs, the eventing + structured logging system is new in v1
+While dbt has always generated logs, the eventing and structured logging system described below is new in v1.
 :::
 
 With every task that dbt performs, it generates events. It records those events as log messages, and writes them (in real time) to two places:
-- The command line console (`stdout`), to provide interactive feedback while running dbt
+- The command line terminal (`stdout`), to provide interactive feedback while running dbt.
 - The debug log file (`logs/dbt.log`), to enable detailed [debugging of errors](debugging-errors) when they occur. The text-formatted log messages in this file include all `DEBUG`-level events, as well as contextual information, such as log level and thread name. The location of this file can be configured via [the `log_path` config](log-path).
 
 <File name='CLI'>
@@ -36,26 +36,33 @@ When `json` [log formatting](global-configs#log-formatting) is enabled, dbt will
 
 Each log line will have the following JSON properties:
 
-- `log_version`: Integer indicating version
-- `type`: Always `log_line`
-- `code`: A unique identifier for each event type
-- `ts`: When the log line was printed
-- `pid`: The process ID for the running dbt invocation which produced this log message
-- `msg`: The human-friendly log message. **Note**: This message is not intended for machine consumption. Log messages are subject to change in future versions of dbt, and those changes may or may not coincide with a change in `log_version`.
-- `level`: A string representation of the log level (`debug`, `info`, `warn`, `error`)
-- [`invocation_id`](invocation_id): A unique identifier for this invocation of dbt
-- `thread_name`: The thread in which the log message was produced, helpful for tracking queries when dbt is run with multiple threads
-- `data`: A dictionary containing programmatically accessible information about the log line. The contents of this dictionary vary based on the event type which generated this log message.
-- `node_info`: If applicable, a dictionary of human- and machine-friendly information about a currently running resource
-    - `node_name`
-    - `node_path`: File path to where this resource is defined
-    - `unique_id`: The unique identifier for this resource, which can be used to look up contextual information in a [manifest](artifacts/manifest-json)
-    - `resource_type`: model, test, seed, snapshot, etc.
-    - `materialized`: view, table, incremental, etc.
-    - `node_status`: Current status of the node, as defined in [the result contract](https://github.com/dbt-labs/dbt-core/blob/HEAD/core/dbt/contracts/results.py#L61-L74)
-    - `node_started_at`: Timestamp when node processing started
-    - `node_finished_at`: Timestamp when node processing completed
-    - `type`: Always `'node_status'`
+| Field       | Description   |
+|-------------|---------------|
+| `code` | A unique identifier for each event type |
+| `data` | A dictionary containing programmatically accessible information about the log line. The contents of this ctionary vary based on the event type which generated this log message. |
+| [`invocation_id`](invocation_id) | A unique identifier for this invocation of dbt |
+| `level` | A string representation of the log level (`debug`, `info`, `warn`, `error`) |
+| `log_version` | Integer indicating version |
+| `msg` | The human-friendly log message. **Note**: This message is not intended for machine consumption. Log messages are bject to change in future versions of dbt, and those changes may or may not coincide with a change in `log_version`. |
+| `node_info` | If applicable, a dictionary of human- and machine-friendly information about a currently running resource |
+| `pid` | The process ID for the running dbt invocation which produced this log message |
+| `thread_name` | The thread in which the log message was produced, helpful for tracking queries when dbt is run with ltiple threads |
+| `ts` | When the log line was printed |
+| `type` | Always `log_line` |
+
+If available, `node_info` will include:
+
+| Field       | Description   |
+|-------------|---------------|
+| `materialized` | view, table, incremental, etc. |
+| `node_finished_at` | Timestamp when node processing completed |
+| `node_name` | Name of this model/seed/test/etc |
+| `node_path` | File path to where this resource is defined |
+| `node_started_at` | Timestamp when node processing started |
+| `node_status` | Current status of the node, as defined in [the result contract](https://github.com/dbt-labs/dbt-core/blob/HEAD/core/dbt/contracts/results.py#L61-L74) |
+| `resource_type` | model, test, seed, snapshot, etc. |
+| `type` | Always `'node_status'` |
+| `unique_id` | The unique identifier for this resource, which can be used to look up contextual information in a [manifest](artifacts/manifest-json) |
 
 ### Example
 

--- a/website/docs/reference/events-logging.md
+++ b/website/docs/reference/events-logging.md
@@ -1,6 +1,5 @@
 ---
 title: "Events and logs"
-id: "events-logs"
 ---
 
 :::info New in v1.0

--- a/website/docs/reference/events-logging.md
+++ b/website/docs/reference/events-logging.md
@@ -1,0 +1,107 @@
+---
+title: "Events and logs"
+id: "events-logs"
+---
+
+:::info New in v1.0
+While dbt has always generated logs, the eventing + structured logging system is new in v1
+:::
+
+With every task that dbt performs, it generates events. It records those events as log messages, and writes them (in real time) to two places:
+- The command line console (`stdout`), to provide interactive feedback while running dbt
+- The debug log file (`logs/dbt.log`), to enable detailed [debugging of errors](debugging-errors) when they occur. The text-formatted log messages in this file include all `DEBUG`-level events, as well as contextual information, such as log level and thread name. The location of this file can be configured via [the `log_path` config](log-path).
+
+<File name='CLI'>
+
+```bash
+21:35:48  6 of 7 OK created view model dbt_testing.name_list......................... [CREATE VIEW in 0.17s]
+```
+
+</File>
+
+<File name='logs/dbt.log'>
+
+```text
+============================== 2021-12-02 21:29:35.417263 | c83a0afc-7ed3-49e7-8c0e-797af7f9d7b6 ==============================
+21:29:35.417263 [info ] [MainThread]: Running with dbt=1.0.0-rc3
+21:29:35.417955 [debug] [MainThread]: running dbt with arguments Namespace(cls=<class 'dbt.task.run.RunTask'>, debug=None, defer=None, exclude=None, fail_fast=None, full_refresh=False, log_cache_events=False, log_format=None, partial_parse=None, printer_width=None, profile=None, profiles_dir='/Users/jerco/.dbt', project_dir=None, record_timing_info=None, rpc_method='run', select=None, selector_name=None, send_anonymous_usage_stats=None, single_threaded=False, state=None, static_parser=None, target=None, threads=None, use_colors=None, use_experimental_parser=None, vars='{}', version_check=None, warn_error=None, which='run', write_json=None)
+...
+21:29:35.814348 [debug] [Thread-1  ]: On model.my_project.my_table: BEGIN
+```
+
+</File>
+
+## Structured logging
+
+When `json` [log formatting](global-configs#log-formatting) is enabled, dbt will output produce rich, structured log information which can be piped into monitoring tools for analysis, or to power applications with dbt metadata in real time.
+
+Each log line will have the following JSON properties:
+
+- `log_version`: Integer indicating version
+- `type`: Always `log_line`
+- `code`: A unique identifier for each event type
+- `ts`: When the log line was printed
+- `pid`: The process ID for the running dbt invocation which produced this log message
+- `msg`: The human-friendly log message. **Note**: This message is not intended for machine consumption. Log messages are subject to change in future versions of dbt, and those changes may or may not coincide with a change in `log_version`.
+- `level`: A string representation of the log level (`debug`, `info`, `warn`, `error`)
+- [`invocation_id`](invocation_id): A unique identifier for this invocation of dbt
+- `thread_name`: The thread in which the log message was produced, helpful for tracking queries when dbt is run with multiple threads
+- `data`: A dictionary containing programmatically accessible information about the log line. The contents of this dictionary vary based on the event type which generated this log message.
+- `node_info`: If applicable, a dictionary of human- and machine-friendly information about a currently running resource
+    - `node_name`
+    - `node_path`: File path to where this resource is defined
+    - `unique_id`: The unique identifier for this resource, which can be used to look up contextual information in a [manifest](artifacts/manifest-json)
+    - `resource_type`: model, test, seed, snapshot, etc.
+    - `materialized`: view, table, incremental, etc.
+    - `node_status`: Current status of the node, as defined in [the result contract](https://github.com/dbt-labs/dbt-core/blob/HEAD/core/dbt/contracts/results.py#L61-L74)
+    - `node_started_at`: Timestamp when node processing started
+    - `node_finished_at`: Timestamp when node processing completed
+    - `type`: Always `'node_status'`
+
+### Example
+
+```json
+{
+	"code": "Q033",
+	"data":
+	{
+		"description": "view model dbt_testing.name_list",
+		"index": 7,
+		"total": 7
+	},
+	"invocation_id": "30206572-f52f-4b91-af6d-d2b18fdbbbb8",
+	"level": "info",
+	"log_version": 1,
+	"msg": "7 of 7 START view model dbt_testing.name_list.............................. [RUN]",
+	"node_info":
+	{
+		"materialized": "view",
+		"node_finished_at": null,
+		"node_name": "male_list_view",
+		"node_path": "human/name_list.sql",
+		"node_started_at": "2021-12-02T21:47:03.477004",
+		"node_status": "started",
+		"resource_type": "model",
+		"type": "node_status",
+		"unique_id": "model.jaffle_shop.name_list"
+	}, 
+	"pid": 81915,
+	"thread_name": "Thread-4",
+	"ts": "2021-12-02T21:47:03.480384Z",
+	"type": "log_line"
+}
+```
+
+## Python interface
+
+**Be warned:** While dbt-core v1 represents a significant step forward in the stability of the core framework, dbt-core's [python API](dbt-api) is still unstable and liable to change, with the exception of a few specific interfaces.
+
+`dbt-core` makes available a full history of events fired during an invocation, in the form of an `EVENT_HISTORY` object:
+
+```python
+from dbt.events.functions import EVENT_HISTORY
+```
+
+The Python interface into events is significantly less mature than the structured logging interface. For all use cases, we recommend parsing JSON-formatted logs.
+
+For details about how the eventing system has been implemented in dbt-core, see the [`events` module README](https://github.com/dbt-labs/dbt-core/blob/HEAD/core/dbt/events/README.md).

--- a/website/docs/reference/global-configs.md
+++ b/website/docs/reference/global-configs.md
@@ -99,16 +99,24 @@ $ dbt --debug run
 
 The `LOG_FORMAT` config specifies how dbt's logs should be formatted. If the value of this config is `json`, dbt will output fully structured logs in JSON format; otherwise, it will output text-formatted logs that are sparser for the CLI and more detailed in `logs/dbt.log`.
 
-Use `json` formatting value in conjunction with the `DEBUG` config to produce rich log information which can be piped into monitoring tools for analysis.
-
-See [structured logging](events-logging#structured-logging) for more details.
-
 <File name='Usage'>
 
 ```text
 $ dbt --log-format json run
 {"code": "A001", "data": {"v": "=1.0.0"}, "invocation_id": "1193e449-4b7a-4eb1-8e8e-047a8b3b7973", "level": "info", "log_version": 1, "msg": "Running with dbt=1.0.0", "node_info": {}, "pid": 35098, "thread_name": "MainThread", "ts": "2021-12-03T10:46:59.928217Z", "type": "log_line"}
 ```
+
+:::tip Tip: verbose structured logs
+
+Use `json` formatting value in conjunction with the `DEBUG` config to produce rich log information which can be piped into monitoring tools for analysis:
+```text
+$ dbt --debug --log-format json run
+```
+
+See [structured logging](events-logging#structured-logging) for more details.
+
+:::
+
 
 </File>
 

--- a/website/docs/reference/global-configs.md
+++ b/website/docs/reference/global-configs.md
@@ -97,24 +97,17 @@ $ dbt --debug run
 
 ## Log Formatting
 
-The `LOG_FORMAT` config specifies how dbt's logs should be formatted. The value for this flag can be one of: `text`, `json,` or `default`. Use the `json` formatting value in conjunction with `DEBUG` flag to produce rich log information which can be piped into monitoring tools for analysis.
+The `LOG_FORMAT` config specifies how dbt's logs should be formatted. If the value of this config is `json`, dbt will output fully structured logs in JSON format; otherwise, it will output text-formatted logs that are sparser for the CLI and more detailed in `logs/dbt.log`.
 
-When `json` log formatting is used, each log line will have the following JSON properties:
-- timestamp: when the log line was printed
-- message: the textual log message
-- channel: the source for the log (eg. `dbt`, or `some_module`)
-- level: an integer indicating the log level for the log line (10=info, 11=debug, ...)
-- levelname: a string representation of the log level
-- thread_name: the thread in which the log message was produced
-- process: the PID for the running dbt invocation which produced this log message
-- extra: a dictionary containing "extra" information about the log line. This contents of this dictionary vary based on the specific log message that is being emitted. This dictionary contains programmatically accessible information to contextualize the log message.
+Use `json` formatting value in conjunction with the `DEBUG` config to produce rich log information which can be piped into monitoring tools for analysis.
+
+See [structured logging](events-logging#structured-logging) for more details.
 
 <File name='Usage'>
 
 ```text
 $ dbt --log-format json run
-{"timestamp": "2019-11-24T18:51:48.683295Z", "message": "Running with dbt=0.15.0", "channel": "dbt", "level": 11, "levelname": "INFO", "thread_name": "MainThread", "process": 94207, "extra": {"run_state": "internal"}}
-{"timestamp": "2019-11-24T18:51:49.386586Z", "message": "Found 3 models, 0 tests, 1 snapshot, 0 analyses, 120 macros, 0 operations, 2 seed files, 1 source", "channel": "dbt", "level": 11, "levelname": "INFO", "thread_name": "MainThread", "process": 94207, "extra": {"run_state": "internal"}}
+{"code": "A001", "data": {"v": "=1.0.0"}, "invocation_id": "1193e449-4b7a-4eb1-8e8e-047a8b3b7973", "level": "info", "log_version": 1, "msg": "Running with dbt=1.0.0", "node_info": {}, "pid": 35098, "thread_name": "MainThread", "ts": "2021-12-03T10:46:59.928217Z", "type": "log_line"}
 ```
 
 </File>

--- a/website/docs/reference/project-configs/on-run-start-on-run-end.md
+++ b/website/docs/reference/project-configs/on-run-start-on-run-end.md
@@ -16,8 +16,10 @@ on-run-end: sql-statement | [sql-statement]
 ## Definition
 A SQL statement (or list of SQL statements) to be run at the start, or end, of the following commands:
 - `dbt run`
+- `dbt test`
 - `dbt seed`
 - `dbt snapshot`
+- `dbt build`
 
 `on-run-start` and `on-run-end` hooks can also call macros that return SQL statements
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -452,6 +452,7 @@ module.exports = {
         },
         "reference/global-cli-flags",
         "reference/global-configs",
+        "reference/events-logging",
         "reference/exit-codes",
         "reference/parsing",
       ],


### PR DESCRIPTION
Some things caught during bug bash:
- Secret env var restrictions (now limited to `profiles.yml` + `packages.yml`)
- Updated `deps` logic for package prerelease versions
- Update `on-run-*` hook behavior (include `test` + `build`)
- Update `flags`

Also, building off @emmyoop's wonderful work:
- Document new event + logging interface
- **Question:** Do we want to document `EVENT_HISTORY` at all? My sense is, in order to use it, you'd need to hook into dbt's python API for execution, and that's still an uncontracted + undocumented interface

## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged
-->

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [x] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist
If you added new pages (delete if not applicable):
- [x] The page has been added to `website/sidebars.js`
- [x] The new page has a unique filename
