### PR TITLE
Update column_types.md  section seeds/properties.yml (as of v0.21):

### DIFF
--- a/website/docs/reference/resource-configs/column_types.md
+++ b/website/docs/reference/resource-configs/column_types.md
@@ -34,8 +34,9 @@ version: 2
 seeds:
   - name: country_codes
     config:
-      country_code: varchar(2)
-      country_name: varchar(32)
+      column_types:
+        country_code: varchar(2)
+        country_name: varchar(32)
 ```
 
 </File>


### PR DESCRIPTION
## Description & motivation
The Syntax for v0.21 was missing the column_types: line.

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a pull request on dbt core, etc?
-->

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
