### PR TITLE
broken link dbt github project

### DIFF
--- a/website/docs/docs/guides/custom-generic-tests.md
+++ b/website/docs/docs/guides/custom-generic-tests.md
@@ -9,7 +9,7 @@ id: "writing-custom-generic-tests"
 
 </Changelog>
 
-dbt ships with [Not Null](resource-properties/tests#not-null), [Unique](resource-properties/tests#unique), [Relationships](resource-properties/tests#relationships), and [Accepted Values](resource-properties/tests#accepted-values) generic tests. (These used to be called "schema tests," and you'll still see that name in some places.) Under the hood, these generic tests are defined as `test` blocks (like macros) in a globally accessible dbt project. You can find the source code for these tests [here](https://github.com/dbt-labs/dbt/tree/develop/core/dbt/include/global_project/macros/generic_tests).
+dbt ships with [Not Null](resource-properties/tests#not-null), [Unique](resource-properties/tests#unique), [Relationships](resource-properties/tests#relationships), and [Accepted Values](resource-properties/tests#accepted-values) generic tests. (These used to be called "schema tests," and you'll still see that name in some places.) Under the hood, these generic tests are defined as `test` blocks (like macros) in a globally accessible dbt project. You can find the source code for these tests [here](https://github.com/dbt-labs/dbt-core/tree/main/core/dbt/include/global_project/macros/generic_test_sql).
 
 :::info
 There are tons of generic tests defined in open source packages, such as [dbt-utils](https://hub.getdbt.com/dbt-labs/dbt_utils/latest/) and [dbt-expectations](https://hub.getdbt.com/calogica/dbt_expectations/latest/) — the test you're looking for might already be here!


### PR DESCRIPTION
## Description & motivation
Broken link in docs

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [] No: please ensure the base branch is `current`
- [x] Unsure: we'll let you know!
