### PR TITLE
Update tasks relevant to on-run-* hooks

### DIFF
--- a/website/docs/reference/project-configs/on-run-start-on-run-end.md
+++ b/website/docs/reference/project-configs/on-run-start-on-run-end.md
@@ -20,6 +20,8 @@ A SQL statement (or list of SQL statements) to be run at the start, or end, of t
 - `dbt seed`
 - `dbt snapshot`
 - `dbt build`
+- `dbt compile`
+- `dbt docs generate`
 
 `on-run-start` and `on-run-end` hooks can also call macros that return SQL statements
 


### PR DESCRIPTION
## Description & motivation
`on-run-*` hooks actually run for all "graph-runnable" tasks, including `dbt compile` + `dbt docs generate`

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!