### PR TITLE
add redirect to fix README in <1.0.0 versions

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -113,6 +113,7 @@
 /docs/model-selection-syntax	/reference/node-selection/syntax	302
 /docs/modules	/docs/writing-code-in-dbt/jinja-context/modules	302
 /docs/on-run-end-context	/docs/writing-code-in-dbt/jinja-context/on-run-end-context	302
+/docs/overview	/docs/introduction	302
 /docs/package-management	/docs/building-a-dbt-project/package-management	302
 /docs/profile	/docs/available-adapters	302
 /docs/profile-bigquery	/reference/warehouse-profiles/bigquery-profile	302


### PR DESCRIPTION
## Description & motivation
The `README` in pre 1.0.0 `dbt-core` links to a page that no longer exists.  This redirect fixes that broken link in older versions of `dbt-core`.  The `README` will have the correct link as of 1.0.0.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist

