### PR TITLE
polished firebolt configs and profiles pages

### DIFF
--- a/website/docs/reference/resource-configs/firebolt-configs.md
+++ b/website/docs/reference/resource-configs/firebolt-configs.md
@@ -3,23 +3,21 @@ title: "Firebolt configurations"
 id: "firebolt-configs"
 ---
 
-## Using dbt-firebolt
 
-
-
-### Model Configuration for Fact Tables
+## Model Configuration for Fact Tables
 
 A dbt model can be created as a Firebolt fact table and configured using the following syntax:
 
 <Tabs
-  groupId="config-languages"
+  groupId="config-fact"
   defaultValue="project-yaml"
   values={[
     { label: 'Project file', value: 'project-yaml', },
+    { label: 'Property file', value: 'property-yaml', },
     { label: 'Config block', value: 'config', },
   ]
 }>
-
+  
 <TabItem value="project-yaml">
 <File name='dbt_project.yml'>
 
@@ -39,8 +37,28 @@ models:
 </File>
 </TabItem>
 
+<TabItem value="property-yaml">
+<File name='models/properties.yml'>
+
+```yaml
+models:
+  - name: <model-name>
+    config:
+      materialized: table
+      table_type: fact
+      primary_index: [ <column-name>, ... ]
+      indexes:
+        - type: aggregating | join
+          key_column: [ <column-name>, ... ]
+          aggregation: [ <agg-sql>, ... ]
+        ...
+```
+
+</File>
+</TabItem>
+    
 <TabItem value="config">
-<File name='models/<model_name.sql>'>
+<File name='models/<model_name>.sql'>
 
 ```jinja
 {{ config(
@@ -75,7 +93,8 @@ models:
 | `key_column`      | Sets the grouping of the aggregating index using the inputted list of column names from the model. |
 | `aggregation`     | Sets the aggregations on the aggregating index using the inputted list of SQL agg expressions. |
 
-#### Example of a Fact Table With an Aggregating Index (Config Block Syntax)
+  
+#### Example of a Fact Table With an Aggregating Index
 
 ```
 {{ config(
@@ -92,7 +111,8 @@ models:
 ) }}
 ```
 
-### Model Configuration for Dimension Tables
+  
+## Model Configuration for Dimension Tables
 
 A dbt model can be materialized as a Firebolt dimension table and configured using the following syntax:
 
@@ -126,7 +146,6 @@ models:
 
 <TabItem value="property-yaml">
 <File name='models/properties.yml'>
-Property file syntax
 
 ```yaml
 models:
@@ -147,8 +166,6 @@ models:
 <TabItem value="config">
 <File name='models/<model_name>.sql'>
 
-Config block syntax
-
 ```jinja
 {{ config(
     materialized = "table",
@@ -168,6 +185,7 @@ Config block syntax
 </TabItem>
 </Tabs>
 
+  
 #### Dimension Table Configurations
 
 | Configuration      | Description                                                                               |
@@ -179,7 +197,8 @@ Config block syntax
 | `join_column`      | Sets the join key of the join index using the inputted column name from the model. |
 | `dimension_column` | Sets the columns to be loaded into memory on the join index using the inputted list of column names from the mode. |
 
-#### Example of a Dimension Table With a Join Index (Config Block Syntax)
+  
+#### Example of a Dimension Table With a Join Index
 
 ```
 {{ config(
@@ -195,21 +214,25 @@ Config block syntax
 ) }}
 ```
 
-### How Aggregating Indexes and Join Indexes Are Named
+  
+## How Aggregating Indexes and Join Indexes Are Named
 
 In dbt-firebolt, you do not provide names for aggregating indexes and join indexes; they are named programmatically. dbt will generate index names using the following convention:
+  
 ```
 <table-name>__<key-column>__<index-type>_<unix-timestamp-at-execution>
 ```
 
 For example, a join index could be named `my_users__id__join_1633504263` and an aggregating index could be named `my_orders__order_date__aggregating_1633504263`.
 
-### Managing Ingestion via External Tables
+  
+## Managing Ingestion via External Tables
 
 `dbt-firebolt` supports dbt's [external tables feature](https://docs.getdbt.com/reference/resource-properties/external), which allows dbt to manage the table ingestion process from S3 into Firebolt. This is an optional feature but can be highly convenient depending on your use case.
 
 More information on using external tables including properly configuring IAM can be found in the Firebolt [documentation](https://docs.firebolt.io/sql-reference/commands/ddl-commands#create-external-table).
 
+  
 #### Installation of External Tables Package
 
 To install and use `dbt-external-tables` with Firebolt, you must:
@@ -232,3 +255,38 @@ To install and use `dbt-external-tables` with Firebolt, you must:
 
 3. Pull in the `packages.yml` dependencies by calling `dbt deps`.
 
+  
+#### Using External Tables
+
+To use external tables, you must define a table as `external` in your `dbt_project.yml` file. Every external table must contain the fields `url`, `type`, and `object_pattern`. Note that the Firebolt external table specification requires fewer fields than what is specified in the dbt documentation.
+
+In addition to specifying the columns, an external table may specify partitions. Partitions are not columns and they cannot have the same name as columns. To avoid yaml parsing errors, remember to encase string literals (such as the `url` and `object_pattern` values) in single quotation marks.
+
+  
+#### dbt_project.yml Syntax For an External Table
+
+```yml
+sources:
+  - name: firebolt_external
+    schema: "{{ target.schema }}"
+    loader: S3
+
+    tables:
+      - name: <table-name>
+        external:
+          url: 's3://<bucket_name>/'
+          object_pattern: '<regex>'
+          type: '<type>'
+          credentials:
+            internal_role_arn: arn:aws:iam::id:<role>/<bucket-name>
+            external_role_id: <external-id>
+          object_pattern: '<regex>'
+          compression: '<compression-type>'
+          partitions:
+            - name: <partition-name>
+              data_type: <partition-type>
+              regex: '<partition-definition-regex>'
+          columns:
+            - name: <column-name>
+              data_type: <type>
+```

--- a/website/docs/reference/resource-configs/firebolt-configs.md
+++ b/website/docs/reference/resource-configs/firebolt-configs.md
@@ -4,6 +4,16 @@ id: "firebolt-configs"
 ---
 
 
+## Setting `quote_columns`
+
+To prevent a warning, make sure to explicitly set a value for `quote_columns` in your `dbt_project.yml`. See the [doc on quote_columns](https://docs.getdbt.com/reference/resource-configs/quote_columns) for more information.
+
+```yaml
+seeds:
+  +quote_columns: false  #or `true` if you have csv column headers with spaces
+```
+
+
 ## Model Configuration for Fact Tables
 
 A dbt model can be created as a Firebolt fact table and configured using the following syntax:

--- a/website/docs/reference/warehouse-profiles/firebolt-profile.md
+++ b/website/docs/reference/warehouse-profiles/firebolt-profile.md
@@ -10,8 +10,8 @@ Some core functionality may be limited. If you're interested in contributing, ch
 
 **Maintained by:** Firebolt  
 **Author:** Anders Swanson and Eric Ford     
-**Source:** [Github](https://github.com/firebolt-db/dbt-firebolt)  
-**dbt Slack channel:** [Slack](https://getdbt.slack.com/archives/C02PYT5CXN0)  
+**Source:** [GitHub](https://github.com/firebolt-db/dbt-firebolt)  
+**dbt Slack channel:** [#db-firebolt](https://getdbt.slack.com/archives/C02PYT5CXN0)  
 **dbt Cloud:** Not Supported  
 
 ![dbt-firebolt stars](https://img.shields.io/github/stars/firebolt-db/dbt-firebolt?style=for-the-badge)
@@ -21,10 +21,11 @@ The package can be installed from PyPI with:
 ```
 pip install dbt-firebolt
 ```
-For more complete information including Firebolt feature support, see the [README](https://github.com/firebolt-db/dbt-firebolt/blob/main/README.md)
+
+For other information including Firebolt feature support, see the [GitHub README](https://github.com/firebolt-db/dbt-firebolt/blob/main/README.md).
 
 
-### Connecting to Firebolt
+## Connecting to Firebolt
 
 To connect to Firebolt from dbt, you'll need to add a [profile](https://docs.getdbt.com/dbt-cli/configure-your-profile) to your `profiles.yml` file. A Firebolt profile conforms to the following syntax:
 
@@ -42,7 +43,6 @@ To connect to Firebolt from dbt, you'll need to add a [profile](https://docs.get
       schema: <tablename-prefix>
       jar_path: <path-to-local-jdbc-driver>
       threads: 1
-
       #optional fields
       engine_name: <engine-name>
       host: <hostname>
@@ -60,13 +60,14 @@ To connect to Firebolt from dbt, you'll need to add a [profile](https://docs.get
 | `user`                   | Yes | Your Firebolt username. |
 | `password`               | Yes | Your Firebolt password. |
 | `database`               | Yes | The name of your Firebolt database. |
-| `schema`                 | Yes | A string to prefix the names of generated tables with, if using the [custom schemas workaround below](https://github.com/firebolt-db/dbt-firebolt#supporting-concurrent-development). |
+| `schema`                 | Yes | A string to prefix the names of generated tables with, if using the [custom schemas workaround](https://docs.getdbt.com/reference/warehouse-profiles/firebolt-profile#supporting-concurrent-development). |
 | `jar_path`               | Yes | The path to your JDBC driver on your local drive. |
 | `threads`                | Yes | Must be set to `1`. Multi-threading is not currently supported. |
 | `engine_name`            | No | The name (not the URL) of the Firebolt engine to use. If omitted, it will use your default engine. |
 | `host`                   | No | The host name of the connection. For all customers it is `api.app.firebolt.io`, which will be used if omitted. |
 | `account_name`           | No | The account name (not the account ID). If omitted, it will use your default account. |
 
+      
 #### Troubleshooting Connections
 
 If you encounter issues connecting to Firebolt from dbt, make sure the following criteria are met:
@@ -77,8 +78,7 @@ If you encounter issues connecting to Firebolt from dbt, make sure the following
 - If there is more than one account associated with your credentials, you must specify an account.
 
 
-
-#### Supporting Concurrent Development
+## Supporting Concurrent Development
 
 In dbt, database schemas are used to compartmentalize developer environments so that concurrent development does not cause table name collisions. Firebolt, however, does not currently support database schemas (it is on the roadmap). To work around this, we recommend that you add the following macro to your project. This macro will take the `schema` field of your `profiles.yml` file and use it as a table name prefix.
 


### PR DESCRIPTION
## Description & motivation
* Made header sizes consistent
* Added missing property file tab to fact table configs code examples
* Removed extraneous file names for dimension table configs code examples that were causing rendering issues
* Added missing subsections to external tables section
* Added missing section on `quote_columns`
* Other small polish

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
