### PR TITLE
Update DocSearch api key and add appId, move keys to env

### DIFF
--- a/website/.gitignore
+++ b/website/.gitignore
@@ -10,6 +10,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,5 +1,6 @@
 
 const path = require('path');
+require('dotenv').config()
 
 /* Debugging */
 var SITE_URL;
@@ -31,19 +32,9 @@ if (!PRERELEASE) {
   }
 }
 
-var ALGOLIA_API_KEY;
-if (!process.env.ALGOLIA_API_KEY) {
-  ALGOLIA_API_KEY = '0e9665cbb272719dddc6e7113b4131a5';
-} else {
-  ALGOLIA_API_KEY = process.env.ALGOLIA_API_KEY;
-}
-
-var ALGOLIA_INDEX_NAME;
-if (!process.env.ALGOLIA_INDEX_NAME) {
-  ALGOLIA_INDEX_NAME = 'dbt';
-} else {
-  ALGOLIA_INDEX_NAME = process.env.ALGOLIA_INDEX_NAME;
-}
+let { ALGOLIA_APP_ID, ALGOLIA_API_KEY, ALGOLIA_INDEX_NAME } = process.env;
+if (!process.env.ALGOLIA_INDEX_NAME) 
+  ALGOLIA_INDEX_NAME = 'dbt'
 
 let metatags = []
 // If Not Current Branch, do not index site
@@ -80,10 +71,9 @@ module.exports = {
     announcementBar: WARNING_BANNER,
     algolia: {
       apiKey: ALGOLIA_API_KEY,
-      //debug: true,
       indexName: ALGOLIA_INDEX_NAME,
-      algoliaOptions: {
-      },
+      appId: ALGOLIA_APP_ID
+      //debug: true,
     },
     prism: {
       theme: (() => {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -33,8 +33,6 @@ if (!PRERELEASE) {
 }
 
 let { ALGOLIA_APP_ID, ALGOLIA_API_KEY, ALGOLIA_INDEX_NAME } = process.env;
-if (!process.env.ALGOLIA_INDEX_NAME) 
-  ALGOLIA_INDEX_NAME = 'dbt'
 
 let metatags = []
 // If Not Current Branch, do not index site

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -67,10 +67,12 @@ module.exports = {
       disableSwitch: true
     },
     announcementBar: WARNING_BANNER,
+    // Adding non-empty strings for Algolia config 
+    // allows Docusaurus to run locally without .env file 
     algolia: {
-      apiKey: ALGOLIA_API_KEY,
-      indexName: ALGOLIA_INDEX_NAME,
-      appId: ALGOLIA_APP_ID
+      apiKey: ALGOLIA_API_KEY ? ALGOLIA_API_KEY : 'dbt',
+      indexName: ALGOLIA_INDEX_NAME ? ALGOLIA_INDEX_NAME : 'dbt',
+      appId: ALGOLIA_APP_ID ? ALGOLIA_APP_ID : 'dbt'
       //debug: true,
     },
     prism: {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "npm-proj-1639046345358-0.7864546510616437v59piF",
+  "name": "website",
   "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
@@ -18,21 +18,22 @@
         "color": "^3.1.2",
         "core-js": "^3.15.2",
         "file-loader": "^6.2.0",
-        "fs": "^0.0.2",
+        "fs": "0.0.2",
         "gray-matter": "^4.0.3",
         "js-yaml": "^4.1.0",
-        "mobx": "^6.3.3",
+        "mobx": "^6.3.7",
         "node-polyfill-webpack-plugin": "^1.1.4",
         "prism-react-renderer": "^1.2.1",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
         "redoc": "^2.0.0-rc.57",
         "slugify": "^1.6.1",
-        "styled-components": "^5.3.0",
+        "styled-components": "^5.3.3",
         "url-loader": "^4.1.1"
       },
       "devDependencies": {
         "css-loader": "^3.4.2",
+        "dotenv": "^10.0.0",
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
         "stream-http": "^3.2.0",
@@ -6562,6 +6563,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -10521,9 +10531,9 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "node_modules/mobx": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.3.3.tgz",
-      "integrity": "sha512-JoNU50rO6d1wHwKPJqKq4rmUMbYnI9CsJmBo+Cu4exBYenFvIN77LWrZENpzW6reZPADtXMmB1DicbDSfy8Clw==",
+      "version": "6.3.8",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.3.8.tgz",
+      "integrity": "sha512-RfG2y766P1o9u9xrQht/HBXEoUPIr4B3Gjri3reLW/TuHm3I/3TfBBS0OaeMbw19RIF0AymqjDNlJgakN4ZK7g==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -15021,9 +15031,9 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.1.tgz",
-      "integrity": "sha512-JThv2JRzyH0NOIURrk9iskdxMSAAtCfj/b2Sf1WJaCUsloQkblepy1jaCLX/bYE+mhYo3unmwVSI9I5d9ncSiQ==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.3.tgz",
+      "integrity": "sha512-++4iHwBM7ZN+x6DtPPWkCI4vdtwumQ+inA/DdAsqYd4SVgUKJie5vXyzotA00ttcFdQkCng7zc6grwlfIfw+lw==",
       "dependencies": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
@@ -22222,6 +22232,12 @@
         "is-obj": "^2.0.0"
       }
     },
+    "dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "dev": true
+    },
     "duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -25259,9 +25275,9 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "mobx": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.3.3.tgz",
-      "integrity": "sha512-JoNU50rO6d1wHwKPJqKq4rmUMbYnI9CsJmBo+Cu4exBYenFvIN77LWrZENpzW6reZPADtXMmB1DicbDSfy8Clw=="
+      "version": "6.3.8",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.3.8.tgz",
+      "integrity": "sha512-RfG2y766P1o9u9xrQht/HBXEoUPIr4B3Gjri3reLW/TuHm3I/3TfBBS0OaeMbw19RIF0AymqjDNlJgakN4ZK7g=="
     },
     "mobx-react": {
       "version": "7.2.0",
@@ -28640,9 +28656,9 @@
       }
     },
     "styled-components": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.1.tgz",
-      "integrity": "sha512-JThv2JRzyH0NOIURrk9iskdxMSAAtCfj/b2Sf1WJaCUsloQkblepy1jaCLX/bYE+mhYo3unmwVSI9I5d9ncSiQ==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.3.tgz",
+      "integrity": "sha512-++4iHwBM7ZN+x6DtPPWkCI4vdtwumQ+inA/DdAsqYd4SVgUKJie5vXyzotA00ttcFdQkCng7zc6grwlfIfw+lw==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",

--- a/website/package.json
+++ b/website/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "css-loader": "^3.4.2",
+    "dotenv": "^10.0.0",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
     "stream-http": "^3.2.0",


### PR DESCRIPTION
## Description & motivation

DocSearch is migrating our account from a config repo to a new Algolia account. This adds the appId and moves new keys to an env file, rather than having them hard-coded.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [x] No: please ensure the base branch is `current`

## Preview Link
https://deploy-preview-967--docs-getdbt-com.netlify.app/