### PR TITLE
Clarify upgrade instructions

### DIFF
--- a/website/docs/dbt-cli/install/overview.md
+++ b/website/docs/dbt-cli/install/overview.md
@@ -15,3 +15,7 @@ You can install dbt Core on the command line by using one of these recommended m
 ## About dbt adapters
 
 dbt works with a number of different databases, query engines, and other SQL-speaking technologies. It does this by using a dedicated _adapter_ for each. When you install dbt, you'll also want to install the specific adapter for your database. For more details, see the [list of available adapters](available-adapters).
+
+## Updating dbt
+
+To upgrade via `pip`, see the [pip upgrading instructions](pip#upgrading). dbt Labs provides a number of resources for understanding general best practices while upgrading your dbt project as well as detailed [migration guides](https://docs.getdbt.com/docs/guides/migration-guide/upgrading-to-1-0-0) highlighting the changes required for each minor and major release.

--- a/website/docs/dbt-cli/install/overview.md
+++ b/website/docs/dbt-cli/install/overview.md
@@ -16,6 +16,6 @@ You can install dbt Core on the command line by using one of these recommended m
 
 dbt works with a number of different databases, query engines, and other SQL-speaking technologies. It does this by using a dedicated _adapter_ for each. When you install dbt, you'll also want to install the specific adapter for your database. For more details, see the [list of available adapters](available-adapters).
 
-## Updating dbt
+## Upgrading dbt
 
 To upgrade via `pip`, see the [pip upgrading instructions](pip#upgrading). dbt Labs provides a number of resources for understanding [general best practices](https://docs.getdbt.com/blog/upgrade-dbt-without-fear) while upgrading your dbt project as well as detailed [migration guides](https://docs.getdbt.com/docs/guides/migration-guide/upgrading-to-1-0-0) highlighting the changes required for each minor and major release.

--- a/website/docs/dbt-cli/install/overview.md
+++ b/website/docs/dbt-cli/install/overview.md
@@ -18,4 +18,4 @@ dbt works with a number of different databases, query engines, and other SQL-spe
 
 ## Updating dbt
 
-To upgrade via `pip`, see the [pip upgrading instructions](pip#upgrading). dbt Labs provides a number of resources for understanding general best practices while upgrading your dbt project as well as detailed [migration guides](https://docs.getdbt.com/docs/guides/migration-guide/upgrading-to-1-0-0) highlighting the changes required for each minor and major release.
+To upgrade via `pip`, see the [pip upgrading instructions](pip#upgrading). dbt Labs provides a number of resources for understanding [general best practices](https://docs.getdbt.com/blog/upgrade-dbt-without-fear) while upgrading your dbt project as well as detailed [migration guides](https://docs.getdbt.com/docs/guides/migration-guide/upgrading-to-1-0-0) highlighting the changes required for each minor and major release.


### PR DESCRIPTION
## Description & motivation
Currently if you run dbt --version on the cli, you are directed to a url [docs.getdbt.com/docs/installation](docs.getdbt.com/docs/installation) which redirects to [https://docs.getdbt.com/dbt-cli/install/overview](https://docs.getdbt.com/dbt-cli/install/overview) and tells you that you can receive information about upgrading at that page. The issue is right now, this page is purely dedicated to installing dbt and doesn't give any information on how to upgrade. This PR adds links to some of the upgrading resources we have so that we can direct people who come here expecting upgrade information to the right place.
![image](https://user-images.githubusercontent.com/8147311/146688720-356a96b3-60c5-4294-b453-5ce716347d14.png)


