### PR TITLE
Enhance explanation of transient table config choice

### DIFF
--- a/website/docs/reference/resource-configs/snowflake-configs.md
+++ b/website/docs/reference/resource-configs/snowflake-configs.md
@@ -10,7 +10,14 @@ To-do:
 
 ## Transient tables
 
-Snowflake supports the creation of [transient tables](https://docs.snowflake.net/manuals/user-guide/tables-temp-transient.html). Snowflake does not preserve a history for these tables, which can result in a measurable reduction of your Snowflake storage costs. Note however that transient tables do not participate in Time Travel. Weigh these tradeoffs when deciding whether or not to configure your dbt models as `transient`. **By default, all Snowflake tables created by dbt are `transient`.**
+The default table type for Snowflake is "permanent", but Snowflake also supports the creation of [transient tables](https://docs.snowflake.net/manuals/user-guide/tables-temp-transient.html). Snowflake only keeps a maximum of **one day** of [Time Travel](https://docs.snowflake.com/en/user-guide/data-time-travel.html) history for transient tables. Time Travel data storage costs may be significant for large tables so using transient tables can help minimise storage costs. Transient tables do not have a [Fail-safe](https://docs.snowflake.com/en/user-guide/data-failsafe.html) period and so do not incur the associated storage costs for Fail-safe, however this also means the data they contain is not recoverable outside the Time Travel window.
+Weigh these tradeoffs when deciding whether or not to configure your dbt models as `transient`. 
+
+:::info dbt Default
+
+By default, all Snowflake tables created by dbt are `transient`.
+
+:::
 
 ### Configuring transient tables in dbt_project.yml
 


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a pull request on dbt core, etc?
-->
This change corrects the information about transient tables and Time Travel and also now mentions the impact on Fail-safe. I've attempted to make the information about the trade-offs of using transient tables clearer, and to also make the info about the default dbt setting more prominent as this was easily missed by new users.

Specifically, the original version said that transient tables do not participate in time travel which was not correct and by default they have 1 day of time travel available. It also didn't mention that transient tables are not covered by Fail-safe, which is one of the main differences between permanent and transient tables. 

This PR relates to this issue https://github.com/dbt-labs/docs.getdbt.com/issues/963

Closes https://github.com/dbt-labs/docs.getdbt.com/issues/963

## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged
-->

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [X ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist
If you added new pages (delete if not applicable):
- [ ] The page has been added to `website/sidebars.js`
- [ ] The new page has a unique filename

If you removed existing pages (delete if not applicable):
- [ ] The page has been removed from `website/sidebars.js`
- [ ] An entry has been added to `_redirects`

Not applicable