### PR TITLE
require-dbt-version docs reflect post-1.0 advice

### DIFF
--- a/website/docs/reference/project-configs/require-dbt-version.md
+++ b/website/docs/reference/project-configs/require-dbt-version.md
@@ -43,7 +43,7 @@ require-dbt-version: ">= 1.0.0" # Don't put whitespace after the equality signs
 ## Examples
 
 ### Specify a minimum dbt version
-Use a `>=` operator for a minimum boundary. In this example, this project will run with any version of dbt greater than or equal to 1.0.0.
+Use a `>=` operator for a minimum boundary. In the following example, this project will run with any version of dbt greater than or equal to 1.0.0.
 
 
 <File name='dbt_project.yml'>
@@ -56,7 +56,7 @@ require-dbt-version: ">=1.0.0"
 
 
 ### Pin to a range
-Use a comma separated list for an upper and lower bound. In this example, this project will run with dbt 1.x.x.
+Use a comma separated list for an upper and lower bound. In the following example, this project will run with dbt 1.x.x.
 
 <File name='dbt_project.yml'>
 
@@ -82,7 +82,9 @@ require-dbt-version: ">=1.0.0,<2.0.0"
 With the release of major version 1.0 of dbt Core, pinning to a specific patch is discouraged.
 :::
 
-Use an exact version number. In this example, this project will only run with dbt v0.21.1. 
+While you can restrict your project to run only with an exact version of dbt Core, we do not recommend this for dbt Core v1.0.0 and higher. 
+
+In the following example, the project will only run with dbt v0.21.1. 
 
 <File name='dbt_project.yml'>
 

--- a/website/docs/reference/project-configs/require-dbt-version.md
+++ b/website/docs/reference/project-configs/require-dbt-version.md
@@ -14,7 +14,7 @@ require-dbt-version: version-range | [version-range]
 
 You can use `require-dbt-version` to restrict your project to only work with a range of dbt versions. 
 
-When you set this configuration, dbt sends a helpful error message for any user who attempts to run the project with an unsupported version of dbt. This can be useful for maintaining package compatibility when your project is dependent on certain package functionality. [dbt-utils](https://github.com/dbt-labs/dbt-utils) is a common package for which you might want to specify a version. Setting this configuration might also help your whole team remain synchronized on the same version of dbt for local development.
+When you set this configuration, dbt sends a helpful error message for any user who attempts to run the project with an unsupported version of dbt. This can be useful for package maintainers (such as [dbt-utils](https://github.com/dbt-labs/dbt-utils)) to ensure that users' dbt version is compatible with the package. Setting this configuration might also help your whole team remain synchronized on the same version of dbt for local development, to avoid compatibility issues from changed behaviour.
 
 If this configuration is not specified, no version check will occur.
 

--- a/website/docs/reference/project-configs/require-dbt-version.md
+++ b/website/docs/reference/project-configs/require-dbt-version.md
@@ -12,9 +12,9 @@ require-dbt-version: version-range | [version-range]
 
 ## Definition
 
-Optionally specify a range of dbt versions that a project is compatible with.
+You can use `require-dbt-version` to restrict your project to only work with a range of dbt versions. 
 
-By using this configuration, dbt will throw a helpful error message if a user tries to run your project with an unsupported version of dbt. This is especially useful for packages (like [dbt-utils](https://github.com/dbt-labs/dbt-utils)). Additionally, this can help ensure that your whole team is synchronized on the same version of dbt for local development.
+When you set this configuration, dbt sends a helpful error message for any user who attempts to run the project with an unsupported version of dbt. This can be useful for maintaining package compatibility when your project is dependent on certain package functionality. [dbt-utils](https://github.com/dbt-labs/dbt-utils) is a common package for which you might want to specify a version. Setting this configuration might also help your whole team remain synchronized on the same version of dbt for local development.
 
 If this configuration is not specified, no version check will occur.
 

--- a/website/docs/reference/project-configs/require-dbt-version.md
+++ b/website/docs/reference/project-configs/require-dbt-version.md
@@ -78,7 +78,7 @@ require-dbt-version: ">=1.0.0,<2.0.0"
 
   
 ### Require a specific dbt version
-:::Not recommended
+:::caution Not recommended
 With the release of major version 1.0 of dbt Core, pinning to a specific patch is discouraged.
 :::
 

--- a/website/docs/reference/project-configs/require-dbt-version.md
+++ b/website/docs/reference/project-configs/require-dbt-version.md
@@ -50,7 +50,6 @@ Use a `>=` operator for a minimum boundary. In this example, this project will r
 
 ```yml
 require-dbt-version: ">=1.0.0"
-
 ```
 
 </File>
@@ -78,8 +77,8 @@ require-dbt-version: ">=1.0.0,<2.0.0"
 </File>
 
   
-### Require a specific dbt version (not recommended)
-:::caution
+### Require a specific dbt version
+:::Not recommended
 With the release of major version 1.0 of dbt Core, pinning to a specific patch is discouraged.
 :::
 
@@ -89,7 +88,6 @@ Use an exact version number. In this example, this project will only run with db
 
 ```yml
 require-dbt-version: 0.21.1
-
 ```
 
 </File>

--- a/website/docs/reference/project-configs/require-dbt-version.md
+++ b/website/docs/reference/project-configs/require-dbt-version.md
@@ -26,15 +26,15 @@ If this configuration is not specified, no version check will occur.
 
 :::info YAML Quoting
 
-This configuration needs to be interpolated by the yaml parser as a string. As such, you should quote the value of the configuration. For example. Also take care to get the spacing correct.
+This configuration needs to be interpolated by the yaml parser as a string. As such, you should quote the value of the configuration, taking care to avoid whitespace. For example:
 ```yml
 # ✅ These will work
-require-dbt-version: ">=0.16.0"
-require-dbt-version: '>=0.16.0'
+require-dbt-version: ">=1.0.0" # Double quotes are OK
+require-dbt-version: '>=1.0.0' # So are single quotes
 
 # ❌ These will not work
-require-dbt-version: >=0.16.0
-require-dbt-version: ">= 0.16.0"
+require-dbt-version: >=1.0.0 # No quotes? No good
+require-dbt-version: ">= 1.0.0" # Don't put whitespace after the equality signs
 ```
 
 :::
@@ -42,40 +42,27 @@ require-dbt-version: ">= 0.16.0"
 
 ## Examples
 
-### Require a specific dbt version
-Use an exact version number. In this example, this project will only run with dbt v0.16.0 supported.
-
-<File name='dbt_project.yml'>
-
-```yml
-require-dbt-version: 0.16.0
-
-```
-
-</File>
-
 ### Specify a minimum dbt version
-Use a `>=` operator for a minimum boundary. In this example, this project will run with any version of dbt greater than or equal to 0.16.0.
+Use a `>=` operator for a minimum boundary. In this example, this project will run with any version of dbt greater than or equal to 1.0.0.
 
 
 <File name='dbt_project.yml'>
 
 ```yml
-require-dbt-version: ">=0.16.0"
+require-dbt-version: ">=1.0.0"
 
 ```
 
 </File>
 
 
-### Pin to a minor dbt version using a range
-Use a comma separated list for an upper and lower bound. In this example, this project will run with dbt 0.16.x.
+### Pin to a range
+Use a comma separated list for an upper and lower bound. In this example, this project will run with dbt 1.x.x.
 
 <File name='dbt_project.yml'>
 
 ```yml
-require-dbt-version: ">=0.16.0,<0.17.0"
-
+require-dbt-version: [">=1.0.0", "<2.0.0"]
 ```
 
 </File>
@@ -85,24 +72,39 @@ OR
 <File name='dbt_project.yml'>
 
 ```yml
-require-dbt-version: [">=0.16.0", "<0.17.0"]
-
+require-dbt-version: ">=1.0.0,<2.0.0"
 ```
 
 </File>
 
+  
+### Require a specific dbt version (not recommended)
+:::caution
+With the release of major version 1.0 of dbt Core, pinning to a specific patch is discouraged.
+:::
+
+Use an exact version number. In this example, this project will only run with dbt v0.21.1. 
+
+<File name='dbt_project.yml'>
+
+```yml
+require-dbt-version: 0.21.1
+
+```
+
+</File>
 
 ## Invalid dbt versions
 
 If the version of dbt used to invoke a project disagrees with the specified `require-dbt-version` in the project or _any_ of the included packages, then dbt will fail immediately with the following error:
 ```
 $ dbt compile
-Running with dbt=0.17.0
+Running with dbt=0.21.0
 Encountered an error while reading the project:
 Runtime Error
   This version of dbt is not supported with the 'my_project' package.
-    Installed version of dbt: =0.16.0
-    Required version of dbt for 'my_project': ['>=0.16.0', '<0.17.0']
+    Installed version of dbt: =0.21.0
+    Required version of dbt for 'my_project': ['>=1.0.0', '<2.0.0']
   Check the requirements for the 'my_project' package, or run dbt again with --no-version-check
 ```
 
@@ -111,7 +113,7 @@ Runtime Error
 To suppress failures to to incompatible dbt versions, supply the `--no-version-check` flag to `dbt run`.
 ```
 $ dbt run --no-version-check
-Running with dbt=0.17.0
+Running with dbt=0.21.0
 Found 13 models, 2 tests, 1 archives, 0 analyses, 204 macros, 2 operations....
 ```
 
@@ -119,4 +121,4 @@ See [global configs](global-configs#checking-version-compatibility) for usage de
 
 ## Recommendation
 * This is a recommended configuration
-* You should pin your required dbt version to a minor release (see above [example](#pin-to-a-minor-dbt-version-using-a-range))
+* Before v1, you should pin your required dbt version to a minor release. After v1, you should pin to a major release (see above [example](#pin-to-a-range))


### PR DESCRIPTION
## Description & motivation
With the release of 1.0, our recommendations for require-dbt-version have changed - users can safely pin to major versions instead of minor (or, heaven forbid, a specific patch). 

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
