### PR TITLE
keepalives_idle default is 240 in Redshift

### DIFF
--- a/website/docs/reference/warehouse-profiles/redshift-profile.md
+++ b/website/docs/reference/warehouse-profiles/redshift-profile.md
@@ -29,7 +29,7 @@ company-name:
       dbname: analytics
       schema: analytics
       threads: 4
-      keepalives_idle: 0 # default 0, indicating the system default
+      keepalives_idle: 240 # default 240 seconds
       connect_timeout: 10 # default 10 seconds
       # search_path: public # optional, not recommended
       sslmode: [optional, set the sslmode used to connect to the database (in case this parameter is set, will look for ca in ~/.postgresql/root.crt)]
@@ -75,7 +75,7 @@ my-redshift-db:
       dbname: analytics
       schema: analytics
       threads: 4
-      keepalives_idle: 0 # default 0, indicating the system default
+      keepalives_idle: 240 # default 240 seconds
       # search_path: public # optional, but not recommended
       sslmode: [optional, set the sslmode used to connect to the database (in case this parameter is set, will look for ca in ~/.postgresql/root.crt)]
       ra3: true # enables cross-database sources


### PR DESCRIPTION
Hello! Looking in [dbt-redshift connections.py](https://github.com/dbt-labs/dbt-redshift/blob/cf996eb62c6a82f1f8973fbae99b06436b15a6b6/dbt/adapters/redshift/connections.py#L51) it looks like the default for `keepalives_idle` is set to `240` which is not reflected in the docs. I assume this might have been because it inherits from Postgres where the default is 0? Please let me know if I missed something here. Thanks!

## Description & motivation

Correcting the default value as reflected in dbt-Redshift plug-in so it can be found in the docs by people looking to make adjustments.


## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ ] No: please ensure the base branch is `current`
- [x] Unsure: we'll let you know!
