### PR TITLE
Explain model timing works for Team and Enterpise

### DIFF
--- a/website/docs/docs/dbt-cloud/using-dbt-cloud/cloud-model-timing-tab.md
+++ b/website/docs/docs/dbt-cloud/using-dbt-cloud/cloud-model-timing-tab.md
@@ -4,6 +4,11 @@ id: "cloud-model-timing-tab"
 ---
 
 ### Overview
+
+:::info Model Timing
+Model Timing is only available on the Team and Multi-tenant Enterprise plans
+:::
+
 Accessed via the "run detail" page in dbt Cloud, the model timing dashboard displays the model composition, order, and run time for every job run in dbt Cloud. The top 1% of model durations are automatically highlighted for quick reference.  This visualization is displayed after the run completes.
 
 This is a very visual way to explore your run. Longest running models *may* be ripe for further exploration -- which can lead to refactoring or reducing run cadence.


### PR DESCRIPTION
## Description & motivation
The model timing tab uses the dbt cloud API. The API works for accounts on the Team or Enterprise plan, therfore the model timing tab works only for accounts on the Team and Enterprise plan. This was not explained in the docs.

## To-do before merge
N.a.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist
N.A.

If you added new pages (delete if not applicable):
- [ ] The page has been added to `website/sidebars.js`
- [ ] The new page has a unique filename

If you removed existing pages (delete if not applicable):
- [ ] The page has been removed from `website/sidebars.js`
- [ ] An entry has been added to `_redirects`
