### PR TITLE
Switch screenshots with the DAG and tests

### DIFF
--- a/website/blog/data-ecosystem/2021-11-22-dbt-labs-pr-template.md
+++ b/website/blog/data-ecosystem/2021-11-22-dbt-labs-pr-template.md
@@ -59,7 +59,7 @@ Remember, you know more about this PR **right now** than you will in a couple of
 
 This is where we add the relevant sections from our DAG! This is one of my favorite features of dbt, as I’m a very visual learner. So when I open a PR, I take a quick look at the relevant sections of the DAG (aka dependency graph) to help me conceptualize the modeling.
 
-![test validation](/img/blog/pr-template-test-validation.png "dbt test validation")
+![dbt dag check](/img/blog/pr-template-dag-check.png "dbt DAG check")
 
 Checking for things like modularity and 1:1 relationships between sources and staging models is much easier done visually via the DAG than trying to look at code and visualize the relationships. 
 
@@ -70,7 +70,7 @@ Checking for things like modularity and 1:1 relationships between sources and st
 
 This section should show something to confirm that your model is doing what you intended it to do. This could be a [dbt test](https://docs.getdbt.com/docs/building-a-dbt-project/tests) like uniqueness or not null, or could be an ad-hoc query that you wrote to validate your data. Here is a screenshot from a test run on a local development branch:
 
-![dbt dag check](/img/blog/pr-template-dag-check.png "dbt DAG check")
+![test validation](/img/blog/pr-template-test-validation.png "dbt test validation")
 
 Adding uniqueness tests shows that you have put thought into the grain of each of your models, and then ensures that those assumptions hold true over time. 
 


### PR DESCRIPTION
## Description & motivation
The screenshots are currently swapped between the DAG and tests on the [PR Template blog post](https://docs.getdbt.com/blog/analytics-pull-request-template). This PR swaps the screenshots so they are in the relevant paragraph.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [X] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
