### PR TITLE
Fix broken link in dbt-api

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -262,6 +262,7 @@
 /reference/declaring-properties /reference/configs-and-properties	302
 /reference/dbt-artifacts	/reference/artifacts/dbt-artifacts	302
 /reference/environments	/dbt-cloud/api	302
+/reference/events	/reference/events-logging	302
 /reference/jobs	/dbt-cloud/api	302
 /reference/model-selection-syntax    /reference/node-selection/syntax 302
 /reference/project-configs/on-run-end	/reference/project-configs/on-run-start-on-run-end	302

--- a/website/docs/docs/running-a-dbt-project/dbt-api.md
+++ b/website/docs/docs/running-a-dbt-project/dbt-api.md
@@ -9,4 +9,4 @@ It _is_ possible to import and invoke dbt as a Python module. This API is still 
 
 We aim to contract and document an increasing number of Python interfaces within `dbt-core`. Today, those interfaces are:
 - [Adapter plugin](building-a-new-adapter) classes and methods. These are liable to change in minor versions _only_, and we will aim for backwards compatibility whenever possible.
-- [Events](events), Python objects that dbt emits as log messages.
+- [Events](events-logging), Python objects that dbt emits as log messages.


### PR DESCRIPTION
- Fix `events` link to `events-logging`
- Add redirect for anyone who's saved the old bad link (I think this is the right thing to do here?)