### PR TITLE
Update docs after organization change for package

### DIFF
--- a/website/docs/docs/building-a-dbt-project/package-management.md
+++ b/website/docs/docs/building-a-dbt-project/package-management.md
@@ -100,13 +100,13 @@ Both of the following configurations would successfully install `0.4.5a2` of `db
 
 ```yaml
 packages:
-  - package: tailsdotcom/dbt_artifacts
+  - package: brooklyn-data/dbt_artifacts
     version: 0.4.5a2
 ```
 
 ```yaml
 packages:
-  - package: tailsdotcom/dbt_artifacts
+  - package: brooklyn-data/dbt_artifacts
     version: [">=0.4.4", "<0.4.6"]
     install-prerelease: true
 ```


### PR DESCRIPTION
Fixes #1031 

Update the documentation and code snippet because the `dbt_artifact` package now belongs to a new organization.

## Description & motivation

Update the doc so that we can use the code snippets as is and not have the warning that says that the dbt_artifact package has now been moved to a new organization.
