### PR TITLE
remove extra "might"

### DIFF
--- a/website/docs/dbt-cli/install/docker.md
+++ b/website/docs/dbt-cli/install/docker.md
@@ -5,6 +5,6 @@ description: "You can use Docker to install dbt and adapter plugins from the com
 
 By v1.0.0, dbt Core and all adapter plugins maintained by dbt Labs will be available as official Docker images,
 and available from a public registry.
-We recommend you use Docker to install in production because it includes dbt Core and all of its dependencies. You might might also use a Docker to install and develop locally if you don't have your python environment set up.
+We recommend you use Docker to install in production because it includes dbt Core and all of its dependencies. You might also use a Docker to install and develop locally if you don't have your python environment set up.
 
 More information coming soon!


### PR DESCRIPTION
## Description & motivation

There was a duplicate "might" in the docker documentation.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [X] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!