### PR TITLE
Add links to upgrade guides for 1.0

### DIFF
--- a/website/docs/docs/guides/migration-guide/upgrading-to-1-0-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-1-0-0.md
@@ -7,7 +7,7 @@ title: "Upgrading to 1.0.0"
 
 - [Discourse](https://discourse.getdbt.com/t/3180)
 - [Changelog](https://github.com/dbt-labs/dbt-core/blob/1.0.latest/CHANGELOG.md)
-- [CLI Installation guide](https://docs.getdbt.com/dbt-cli/install/overview)
+- [CLI Installation guide](/dbt-cli/install/overview)
 - [Cloud upgrade guide](https://docs.getdbt.com/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-choosing-a-dbt-version)
 
 ## Breaking changes

--- a/website/docs/docs/guides/migration-guide/upgrading-to-1-0-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-1-0-0.md
@@ -7,6 +7,8 @@ title: "Upgrading to 1.0.0"
 
 - [Discourse](https://discourse.getdbt.com/t/3180)
 - [Changelog](https://github.com/dbt-labs/dbt-core/blob/1.0.latest/CHANGELOG.md)
+- [CLI Installation guide](https://docs.getdbt.com/dbt-cli/install/overview)
+- [Cloud upgrade guide](https://docs.getdbt.com/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-choosing-a-dbt-version)
 
 ## Breaking changes
 

--- a/website/docs/docs/guides/migration-guide/upgrading-to-1-0-0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-1-0-0.md
@@ -8,7 +8,7 @@ title: "Upgrading to 1.0.0"
 - [Discourse](https://discourse.getdbt.com/t/3180)
 - [Changelog](https://github.com/dbt-labs/dbt-core/blob/1.0.latest/CHANGELOG.md)
 - [CLI Installation guide](/dbt-cli/install/overview)
-- [Cloud upgrade guide](https://docs.getdbt.com/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-choosing-a-dbt-version)
+- [Cloud upgrade guide](/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-choosing-a-dbt-version)
 
 ## Breaking changes
 


### PR DESCRIPTION
## Description & motivation
Andries [pointed out in the Slack](https://getdbt.slack.com/archives/C37J8BQEL/p1643255149180400?thread_ts=1641352341.319400&cid=C37J8BQEL) that there was no link to _how to do the upgrade_ in the upgrade guide. Now there is 👍 

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

