### PR TITLE
Document the `where` property of generic tests

### DIFF
--- a/website/docs/docs/building-a-dbt-project/tests.md
+++ b/website/docs/docs/building-a-dbt-project/tests.md
@@ -266,6 +266,7 @@ Note that, if you elect to store test failures:
 <FAQ src="test-sources" />
 <FAQ src="custom-test-thresholds" />
 <FAQ src="uniqueness-two-columns" />
+<FAQ src="generic-tests-where" />
 
 <!--
 Additional FAQs that need Discourse articles:

--- a/website/docs/faqs/generic-tests-where.md
+++ b/website/docs/faqs/generic-tests-where.md
@@ -5,7 +5,7 @@ title: Can I restrict the generic test to a subset of my model data?
 Yes! The generic tests in dbt Core accept a `where:` clause, which can contain
 SQL that restricts the data subset under test. For example, if you want to 
 allow for a lagging table when testing relationships, you could define a 
-`where:` clause like so:
+`where:` clause like so (using Snowflake's `dateadd` syntax):
 
 ```yml
 - name: agent_id

--- a/website/docs/faqs/generic-tests-where.md
+++ b/website/docs/faqs/generic-tests-where.md
@@ -1,0 +1,17 @@
+---
+title: Can I restrict the generic test to a subset of my model data?
+---
+
+Yes! The generic tests in dbt Core accept a `where:` clause, which can contain
+SQL that restricts the data subset under test. For example, if you want to 
+allow for a lagging table when testing relationships, you could define a 
+`where:` clause like so:
+
+```yml
+- name: agent_id
+  tests:
+    - relationships:
+        to: ref('dim_agents')
+        field: agent_id
+        where: "received_at <= dateadd(day, -1, getdate())"
+```

--- a/website/docs/faqs/generic-tests-where.md
+++ b/website/docs/faqs/generic-tests-where.md
@@ -2,10 +2,11 @@
 title: Can I restrict the generic test to a subset of my model data?
 ---
 
-Yes! The generic tests in dbt Core accept a `where:` clause, which can contain
-SQL that restricts the data subset under test. For example, if you want to 
-allow for a lagging table when testing relationships, you could define a 
-`where:` clause like so (using Snowflake's `dateadd` syntax):
+Yes! The generic tests in dbt Core [accept a `where:`
+clause](reference/resource-configs/where.md), which can contain SQL that
+restricts the data subset under test. For example, if you want to allow for a
+lagging table when testing relationships, you could define a `where:` clause
+like so (using Snowflake's `dateadd` syntax):
 
 ```yml
 - name: agent_id


### PR DESCRIPTION
## Description & motivation

This PR describes the `where` property of generic tests in an FAQ on the main "Tests" docs page. I'm adding it because I've found the property very useful, but information about it has been hard to find.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!