### PR TITLE
Removes duplicate version of the prism-react-renderer

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -23,7 +23,6 @@
         "js-yaml": "^4.1.0",
         "mobx": "^6.3.7",
         "node-polyfill-webpack-plugin": "^1.1.4",
-        "prism-react-renderer": "^1.2.1",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
         "redoc": "^2.0.0-rc.57",

--- a/website/package.json
+++ b/website/package.json
@@ -21,7 +21,6 @@
     "js-yaml": "^4.1.0",
     "mobx": "^6.3.7",
     "node-polyfill-webpack-plugin": "^1.1.4",
-    "prism-react-renderer": "^1.2.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "redoc": "^2.0.0-rc.57",


### PR DESCRIPTION
## Description & motivation
Asana task: https://app.asana.com/0/1200099998847559/1201682203530869/f

Snyk flagged an outdated PrismJS package. This package is being used by the prism-react-renderer package, which is included in Docusaurus. While we are unable to edit the dependency used by the Docusaurus theme, I noticed the package in our package.json is unneeded, as it is already included in Docusaurus. This removes prism-react-renderer from our package.json, which looks like it was added when I initially upgraded Docusaurus.

Note, I do not expect this to correct the Snyk flag, as the outdated package is still used by Docusaurus. There is an open Git issue [here](https://github.com/FormidableLabs/prism-react-renderer/issues/125), and noted by Docusaurus [here](https://github.com/facebook/docusaurus/issues/6246).

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Preview
This is used for CodeBlock components, which are used on our /styles page. To test, we want to verify the CodeBlocks are still working.
https://deploy-preview-1063--docs-getdbt-com.netlify.app/styles