### PR TITLE
Add discourse comments

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -868,3 +868,7 @@ code {
   }
 }
 
+/* Discourse Comment Embed */
+.commentEmbed {
+  margin-top: 2rem;
+}

--- a/website/src/theme/BlogPostPage/index.js
+++ b/website/src/theme/BlogPostPage/index.js
@@ -4,17 +4,17 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React from 'react';
+import React, { useEffect } from 'react';
 import Seo from '@theme/Seo';
 import Head from '@docusaurus/Head';
 import BlogLayout from '@theme/BlogLayout';
 import BlogPostItem from '@theme/BlogPostItem';
 import BlogPostPaginator from '@theme/BlogPostPaginator';
-import {ThemeClassNames} from '@docusaurus/theme-common';
+import { ThemeClassNames } from '@docusaurus/theme-common';
 
 function BlogPostPage(props) {
-  const {content: BlogPostContents, sidebar} = props;
-  const {frontMatter, assets, metadata} = BlogPostContents;
+  const { content: BlogPostContents, sidebar } = props;
+  const { frontMatter, assets, metadata } = BlogPostContents;
   const {
     title,
     description,
@@ -24,8 +24,23 @@ function BlogPostPage(props) {
     tags,
     authors,
   } = metadata;
-  const {hide_table_of_contents: hideTableOfContents, keywords} = frontMatter;
+  const { hide_table_of_contents: hideTableOfContents, keywords } = frontMatter;
   const image = assets.image ?? frontMatter.image;
+
+  useEffect(() => {
+    window.DiscourseEmbed = {
+      discourseUrl: 'https://discourse.getdbt.com/',
+      discourseEmbedUrl: `${window.location.href}`
+    }
+    
+
+    var d = document.createElement('script');
+    d.type = 'text/javascript';
+    d.async = true;
+    d.src = DiscourseEmbed.discourseUrl + 'javascripts/embed.js';
+    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(d);
+    
+  }, [])
   return (
     <BlogLayout
       wrapperClassName={ThemeClassNames.wrapper.blogPages}
@@ -62,7 +77,7 @@ function BlogPostPage(props) {
           />
         )}
       </Seo>
-      
+
       {/* dbt Custom */}
       <Head>
         <title>{title} | dbt Developer Blog</title>
@@ -81,8 +96,13 @@ function BlogPostPage(props) {
       {(nextItem || prevItem) && (
         <BlogPostPaginator nextItem={nextItem} prevItem={prevItem} />
       )}
+
+
+      <div className="commentEmbed" id='discourse-comments'></div>
+
+
     </BlogLayout>
   );
 }
 
-export default BlogPostPage;
+export default BlogPostPage;          


### PR DESCRIPTION
## Description & motivation
Adding comments to the dev blog via Discourse embeds

How to Review:
- Preview link: [click on any blog post!](https://deploy-preview-1069--docs-getdbt-com.netlify.app/blog/)
- Below each post content, there should be an embed that says 'start discussion'! That's the discourse embed. Let me know if you all can see it 

A note about Discourse's embed functionality from the Discourse docs:

> One important thing to note with this setup is that users have to navigate to your forum to post replies. This is intentional, as we feel that the posting interface on a Discourse forum is currently much richer than what we could embed via Javascript.


Edit 4:08pm CT:
Here are the comments in action! this does create a discourse topic, but I just commented to test the system works as planned and then deleted the topic it made. Screenshots below.

## On the Website
![Screen Shot 2022-02-01 at 4 07 28 PM](https://user-images.githubusercontent.com/26210517/152059810-fd695b70-91fa-408c-87f2-ef33e80d07b9.png)

## On Discourse Topic
![Screen Shot 2022-02-01 at 4 07 21 PM](https://user-images.githubusercontent.com/26210517/152059789-2af46ebf-6ff6-4089-9a90-9c32b9c54e21.png)

