### PR TITLE
Update redshift profiles.yml example

### DIFF
--- a/website/docs/reference/warehouse-profiles/redshift-profile.md
+++ b/website/docs/reference/warehouse-profiles/redshift-profile.md
@@ -33,7 +33,7 @@ company-name:
       connect_timeout: 10 # default 10 seconds
       # search_path: public # optional, not recommended
       sslmode: [optional, set the sslmode used to connect to the database (in case this parameter is set, will look for ca in ~/.postgresql/root.crt)]
-      ra3: true # enables cross-database sources
+      ra3_node: true # enables cross-database sources
 ```
 
 </File>
@@ -78,7 +78,7 @@ my-redshift-db:
       keepalives_idle: 240 # default 240 seconds
       # search_path: public # optional, but not recommended
       sslmode: [optional, set the sslmode used to connect to the database (in case this parameter is set, will look for ca in ~/.postgresql/root.crt)]
-      ra3: true # enables cross-database sources
+      ra3_node: true # enables cross-database sources
 
 ```
 


### PR DESCRIPTION
## Description & motivation
The PR [#3408](https://github.com/dbt-labs/dbt-core/pull/3408) mentions that in order to avoid issue mentioned in [#3236](https://github.com/dbt-labs/dbt-core/issues/3236), we need to use `ra3_node` in `profiles.yml` whereas the docs specify it as `ra3`.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
