### PR TITLE
Update service-tokens.md

### DIFF
--- a/website/docs/docs/dbt-cloud/dbt-cloud-api/service-tokens.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-api/service-tokens.md
@@ -13,7 +13,7 @@ You can use service account tokens for system-level integrations that do not run
 * Enterprise plans can apply any permission sets available to service tokens.
 * Team plans can apply Account Admin, Member, Job Admin, Read-Only, and Metadata permissions sets to service tokens.
 
-For more on permissions sets, see "[Enterprise Permissions](docs/dbt-cloud/access-control/enterprise-permissions)."
+You can assign as many permission sets as needed to one token. For more on permissions sets, see "[Enterprise Permissions](docs/dbt-cloud/access-control/enterprise-permissions)."
 
 ## Generating service account tokens
 
@@ -33,57 +33,57 @@ You can assign service account tokens any permission set available in dbt Cloud.
 
 The following permissions can be assigned to a service account token on a Team plan.
 
-**Account Admin service token**<br/>
+**Account Admin**<br/>
 Account Admin service tokens have full `read + write` access to an account, so please use them with caution.  A Team plan refers to this permission set as an "Owner role." For more on these permissions, see [Account Viewer](docs/dbt-cloud/access-control/enterprise-permissions#account-admin).
 
-**Metadata Only service token**<br/>
+**Metadata Only**<br/>
 Metadata only service tokens can authorize requests to the metadata API.
 
-**Job Admin service token**<br/>
+**Job Admin**<br/>
 Job admin service tokens can authorize requests for viewing, editing, and creating environments, triggering runs, and viewing historical runs.  
 
-**Member service token** <br/>
+**Member** <br/>
 Member service tokens can authorize requests for viewing and editing resources, triggering runs, and inviting members to the account. Tokens assigned the Member permission set will have the same permissions as a Member user. For more information about Member users, see "[Self-service permissions](/dbt-cloud/access-control/self-service-permissions)".
 
-**Read-only service token**<br/>
+**Read-onlyn**<br/>
 Read-only service tokens can authorize requests for viewing a read-only dashboard, viewing generated documentation, and viewing source freshness reports.
 
 ### Enterprise plans using service account tokens
 
 The following permissions can be assigned to a service account token on an Enterprise plan. For more details about these permissions, see "[Enterprise permissions](/docs/dbt-cloud/access-control/enterprise-permissions)."
 
-**Account Admin service token** <br/>
+**Account Admin** <br/>
 Account Admin service tokens have full `read + write` access to an account, so please use them with caution.  For more on these permissions, see [Account Viewer](docs/dbt-cloud/access-control/enterprise-permissions#account-admin).
 
-**Metadata Only service token**<br/>
+**Metadata Only**<br/>
 Metadata only service tokens can authorize requests to the metadata API.
 
-**Job Admin service token**<br/>
+**Job Admin**<br/>
 Job Admin service tokens can authorize request for viewing, editing, and creating environments, triggering runs, and viewing historical runs. For more on these permissions, see [Account Viewer](docs/dbt-cloud/access-control/enterprise-permissions#job-admin).
 
-**Account Viewer service token**<br/>
+**Account Viewer**<br/>
 Account Viewer service tokens have read only access to dbt Cloud accounts. For more on these permissions, see [Account Viewer](docs/dbt-cloud/access-control/enterprise-permissions#account-viewer) on the Enterprise Permissions page.
 
-**Admin service token** <br/>
+**Admin** <br/>
 Admin service tokens have unrestricted access to projects in dbt Cloud accounts. You have the option to grant that permission all projects in the account or grant the permission only on specific projects. For more on these permissions, see [Admin Service](docs/dbt-cloud/access-control/enterprise-permissions#admin-service) on the Enterprise Permissions page.
 
-**Git Admin service token**<br/>
+**Git Admin**<br/>
 Git admin service tokens have all the permissions listed in [Git admin](/docs/dbt-cloud/access-control/enterprise-permissions#git-admin) on the Enterprise Permissions page.
 
-**Database Admin service token**<br/>
+**Database Adminn**<br/>
 Database admin service tokens have all the permissions listed in [Database admin](/docs/dbt-cloud/access-control/enterprise-permissions#database-admin) on the Enterprise Permissions page.
 
-**Team Admin service token**<br/>
+**Team Admin**<br/>
 Team admin service tokens have all the permissions listed in [Team admin](/docs/dbt-cloud/access-control/enterprise-permissions#team-admin) on the Enterprise Permissions page.
 
-**Job Viewer service token**<br/>
+**Job Viewer**<br/>
 Job viewer admin service tokens have all the permissions listed in [Job viewer](/docs/dbt-cloud/access-control/enterprise-permissions#job-viewer) on the Enterprise Permissions page.
 
-**Developer service token**<br/>
+**Developer**<br/>
 Developer service tokens have all the permissions listed in [Developer](/docs/dbt-cloud/access-control/enterprise-permissions#developer) on the Enterprise Permissions page.
  
-**Analyst service token**<br/>
+**Analyst**<br/>
 Analyst admin service tokens have all the permissions listed in [Analyst](/docs/dbt-cloud/access-control/enterprise-permissions#analyst) on the Enterprise Permissions page.
 
-**Stakeholder service token**<br/>
+**Stakeholder**<br/>
 Stakeholder service tokens have all the permissions listed in [Stakeholder](/docs/dbt-cloud/access-control/enterprise-permissions#stakeholder) on the Enterprise Permissions page.

--- a/website/docs/docs/dbt-cloud/dbt-cloud-api/service-tokens.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-api/service-tokens.md
@@ -45,7 +45,7 @@ Job admin service tokens can authorize requests for viewing, editing, and creati
 **Member** <br/>
 Member service tokens can authorize requests for viewing and editing resources, triggering runs, and inviting members to the account. Tokens assigned the Member permission set will have the same permissions as a Member user. For more information about Member users, see "[Self-service permissions](/dbt-cloud/access-control/self-service-permissions)".
 
-**Read-onlyn**<br/>
+**Read-only**<br/>
 Read-only service tokens can authorize requests for viewing a read-only dashboard, viewing generated documentation, and viewing source freshness reports.
 
 ### Enterprise plans using service account tokens


### PR DESCRIPTION
Update how service tokens are labeled

## Description & motivation
The way this documentation is structured makes it a little confusing to realize that you can have multiple permission sets associated with a token which will be a common situation due to how our Metadata API is structured. Right now, you cannot query the Metadata API without a job id and run id which you can only obtain via the Admin API. This causes quite a few of our partner integrations to required both and I want to avoid any concerns that they need to create two service tokens to achieve the desired effects. 

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [x ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

