### PR TITLE
Add generalized pip installation method

### DIFF
--- a/website/docs/docs/available-adapters.md
+++ b/website/docs/docs/available-adapters.md
@@ -9,7 +9,7 @@ dbt connects to and runs SQL against your database, warehouse, platform, or quer
 
 Most adapters can be installed from PyPi using `pip`. The installation will include `dbt-core` and any other required dependencies, which may include other adapter plugins. Read more about [installing dbt](dbt-cli/install/overview).
 
-Some vendor or community adapters may not exist in PyPi. However, you can still install an adapter hosted on GitHub with `pip install`, by replacing MAINTAINER_NAME with the person or company maintaining the adapter on GitHub and ADAPTER_NAME with the git repository's name (these can be taken directly from the package's url):
+Some vendor or community adapters may not exist in PyPi. However, you can still install an adapter hosted on GitHub with `pip install`, by replacing MAINTAINER_NAME with the person or company maintaining the adapter on GitHub and ADAPTER_NAME with the git repository's name (these can be taken directly from the adapter's url):
 
 ```shell
 pip install git+https://github.com/MAINTAINER_NAME/ADAPTER_NAME.git

--- a/website/docs/docs/available-adapters.md
+++ b/website/docs/docs/available-adapters.md
@@ -12,7 +12,7 @@ Most adapters can be installed from PyPi using `pip`. The installation will incl
 Some vendor or community adapters may not exist in PyPi. However, an adapter hosted on GitHub can still be installed with `pip`:
 
 ```shell
-pip install git+https://github.com/{MAINTAINER_NAME}/{ADAPTER_NAME}.git
+pip install git+https://github.com/MAINTAINER_NAME/ADAPTER_NAME.git
 ```
 
 ### dbt Labs Supported

--- a/website/docs/docs/available-adapters.md
+++ b/website/docs/docs/available-adapters.md
@@ -57,7 +57,7 @@ These adapter plugins are contributed and maintained by members of the community
 | ClickHouse             | [Profile Setup](clickhouse-profile)   | ClickHouse 20.11+         | `pip install dbt-clickhouse` |
 | Athena                 | [Profile Setup](athena-profile)       | Athena engine version 2   | `pip install git+https://github.com/Tomme/dbt-athena.git` |
 
-Community-supported plugins are works in progress, and all users are encouraged to contribute by testing and writing code. If you're interested in contributing:
+Community-supported plugins are works in progress, and anyone is welcome to contribute by testing and writing code. If you're interested in contributing:
 - Join both the dedicated #adapter-ecosystem channel in [dbt Slack](https://community.getdbt.com/) and the channel for your adapter's data store (e.g. #db-sqlserver, #db-athena) 
 - Check out the open issues in the plugin's source repository
 

--- a/website/docs/docs/available-adapters.md
+++ b/website/docs/docs/available-adapters.md
@@ -5,7 +5,15 @@ id: "available-adapters"
 
 dbt connects to and runs SQL against your database, warehouse, platform, or query engine. It works by using a dedicated **adapter** for each technology. All the adapters listed below are open source and free to use, just like dbt.
 
-Any adapter can be installed from PyPi using `pip`. The installation will include `dbt-core` and any other required dependencies, which may include other adapter plugins. Read more about [installing dbt](dbt-cli/install/overview).
+### Installation
+
+Most adapters can be installed from PyPi using `pip`. The installation will include `dbt-core` and any other required dependencies, which may include other adapter plugins. Read more about [installing dbt](dbt-cli/install/overview).
+
+Some vendor or community adapters may not exist in PyPi. However, an adapter hosted on GitHub can still be installed with `pip`:
+
+```shell
+pip install git+https://github.com/{MAINTAINER_NAME}/{ADAPTER_NAME}.git
+```
 
 ### dbt Labs Supported
 
@@ -39,7 +47,7 @@ These adapter plugins are built and maintained by the same people who build and 
 
 These adapter plugins are contributed and maintained by members of the community 🌱
 
-| Adapter for            | Documentation                         | Notes                     | Install from PyPI            |
+| Adapter for            | Documentation                         | Notes                     | Install with pip             |
 |------------------------|---------------------------------------|---------------------------|------------------------------|
 | SQL Server & Azure SQL | [Profile Setup](mssql-profile)        | SQL Server 2016 and later | `pip install dbt-sqlserver`  |
 | Azure Synapse          | [Profile Setup](azuresynapse-profile) | Azure Synapse 10+         | `pip install dbt-synapse`    |
@@ -50,7 +58,7 @@ These adapter plugins are contributed and maintained by members of the community
 | Athena                 | [Profile Setup](athena-profile)       | Athena engine version 2   | `pip install git+https://github.com/Tomme/dbt-athena.git` |
 
 Community-supported plugins are works in progress, and all users are encouraged to contribute by testing and writing code. If you're interested in contributing:
-- Join the dedicated channel in [dbt Slack](https://community.getdbt.com/) (e.g. #db-sqlserver, #db-athena)
+- Join both the dedicated #adapter-ecosystem channel in [dbt Slack](https://community.getdbt.com/) and the channel for your adapter's data store (e.g. #db-sqlserver, #db-athena) 
 - Check out the open issues in the plugin's source repository
 
 Note that, while no community plugins are currently supported in dbt Cloud, we expect this to change in the near future.

--- a/website/docs/docs/available-adapters.md
+++ b/website/docs/docs/available-adapters.md
@@ -9,7 +9,7 @@ dbt connects to and runs SQL against your database, warehouse, platform, or quer
 
 Most adapters can be installed from PyPi using `pip`. The installation will include `dbt-core` and any other required dependencies, which may include other adapter plugins. Read more about [installing dbt](dbt-cli/install/overview).
 
-Some vendor or community adapters may not exist in PyPi. However, an adapter hosted on GitHub can still be installed with `pip`:
+Some vendor or community adapters may not exist in PyPi. However, you can still install an adapter hosted on GitHub with `pip install`, by replacing MAINTAINER_NAME with the person or company maintaining the adapter on GitHub and ADAPTER_NAME with the git repository's name (these can be taken directly from the package's url):
 
 ```shell
 pip install git+https://github.com/MAINTAINER_NAME/ADAPTER_NAME.git


### PR DESCRIPTION
Oh hai community team 👋 

## Description & motivation
Was prompted by a question in [community Slack](https://getdbt.slack.com/archives/CBSQTAPLG/p1644358335472189?thread_ts=1644346925.356309&cid=CBSQTAPLG). A community member inquired how non-PyPi hosted adapters can be installed. We were missing an explicit reference to this on the page (prior to this PR there does exist an implicit reference at the bottom of the community adapter table)

- added `git+` installation method to adapter installation page
- generalized some language to be more inclusive
- added a reference to the #adapter-ecosystem channel for future contributors

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [X] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist
: