### PR TITLE
Exception.raise_compiler_error jinja example corrected

### DIFF
--- a/website/docs/reference/dbt-jinja-functions/exceptions.md
+++ b/website/docs/reference/dbt-jinja-functions/exceptions.md
@@ -15,7 +15,7 @@ __Example usage__:
 
 ```sql
 {% if number < 0 or number > 100 %}
-  {{ exceptions.raise_compiler_error("Invalid `number`. Got: " ~ number) }}
+  {% exceptions.raise_compiler_error("Invalid `number`. Got: " ~ number) %}
 {% endif %}
 ```
 


### PR DESCRIPTION
Originally the example uses the jinja format:
`{{ exceptions.raise_compiler_error("Invalid `number`. Got: " ~ number) }}`

When attempting to write our own models using this version in a 'copy + paste' fashion the errors fail to be raised. However we found that:
`{% exceptions.raise_compiler_error("Invalid `number`. Got: " ~ number) %}`

Works as expected. I'd propose this modification to the example.

## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a pull request on dbt core, etc?
-->

## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged
-->

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist
If you added new pages (delete if not applicable):
- [ ] The page has been added to `website/sidebars.js`
- [ ] The new page has a unique filename

If you removed existing pages (delete if not applicable):
- [ ] The page has been removed from `website/sidebars.js`
- [ ] An entry has been added to `_redirects`
