### PR TITLE
[Minor] Correct file name for models example given

### DIFF
--- a/website/docs/docs/building-a-dbt-project/seeds.md
+++ b/website/docs/docs/building-a-dbt-project/seeds.md
@@ -61,7 +61,7 @@ Done. PASS=1 ERROR=0 SKIP=0 TOTAL=1
 
 3. Refer to seeds in downstream models using the `ref` function.
 
-<File name='models/orders.csv'>
+<File name='models/orders.sql'>
 
 ```sql
 -- This refers to the table created from seeds/country_codes.csv


### PR DESCRIPTION
## Description & motivation
### Description

After uploading the data using seeds, the next step is to create a `.sql` file in models folder and run it.
But according to existing documentation the file name under models is `orders.csv` which contains a sql code which I think is wrong. 
Because .csv file can't be run and also dbt cloud won't show preview option either.

Hence the correction. If not corrected users following the guide would end up creating `orders.csv` with a sql code inside models folder and can't complete the seed learning section.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ ✅] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

