### PR TITLE
fix: use underscore instead of dash for project-names

### DIFF
--- a/website/docs/docs/building-a-dbt-project/projects.md
+++ b/website/docs/docs/building-a-dbt-project/projects.md
@@ -59,7 +59,7 @@ To create a new dbt project when developing in dbt Cloud:
 To create a new dbt project, run:
 
 ```bash
-$ dbt init [project-name]
+$ dbt init [project_name]
 ```
 
 This will create a new directory in your current path (i.e. at `./[project-name]`.

--- a/website/docs/learn/2b-create-a-project-dbt-cli.md
+++ b/website/docs/learn/2b-create-a-project-dbt-cli.md
@@ -31,11 +31,11 @@ dbt should have been installed as part of the  [Setting Up](/learn/setting-up) p
 
 2. Run the `init` command:
 ```shell-session
-$ dbt init jaffle-shop
+$ dbt init jaffle_shop
 ```
 3. `cd` into your project:
 ```shell-session
-$ cd jaffle-shop
+$ cd jaffle_shop
 ```
 You can use `pwd` to confirm that you are in the right spot.
 

--- a/website/docs/tutorial/2b-create-a-project-dbt-cli.md
+++ b/website/docs/tutorial/2b-create-a-project-dbt-cli.md
@@ -40,11 +40,11 @@ dbt should have been installed as part of the  [Setting Up](/tutorial/setting-up
 
 2. Run the `init` command:
 ```shell-session
-$ dbt init jaffle-shop
+$ dbt init jaffle_shop
 ```
 3. `cd` into your project:
 ```shell-session
-$ cd jaffle-shop
+$ cd jaffle_shop
 ```
 You can use `pwd` to confirm that you are in the right spot.
 


### PR DESCRIPTION
## Description & motivation
dbt-core 1.0.2 added validation for `dbt init` command, without updating docs.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [x] No: please ensure the base branch is `current`