### PR TITLE
Fix: Remove release notes category

### DIFF
--- a/website/blog/categories.yml
+++ b/website/blog/categories.yml
@@ -23,7 +23,3 @@
   display_title: SQL magic
   description: Stories of dbt developers making SQL sing across warehouses.
   is_featured: true
-- name: release notes
-  display_title: Release notes
-  description: Notable updates and new features in dbt Cloud.
-  is_featured: true


### PR DESCRIPTION
## Description & motivation
It's causing 404s when clicked since no posts use this category yet