### PR TITLE
Add information on version tag differences.

### DIFF
--- a/website/docs/reference/project-configs/version.md
+++ b/website/docs/reference/project-configs/version.md
@@ -31,7 +31,6 @@ version: 2  # Only 2 is accepted by current and recent versions of dbt.
  
 </File>
 
-### Definition
 A control tag that informs how dbt processes property files. For more on why 2 is required, see property file [FAQs](https://docs.getdbt.com/reference/configs-and-properties#faqs).
 
 For more on property files, see their general [documentation](https://docs.getdbt.com/reference/configs-and-properties#where-can-i-define-properties) on the same page.

--- a/website/docs/reference/project-configs/version.md
+++ b/website/docs/reference/project-configs/version.md
@@ -15,7 +15,6 @@ version: version
 
 </File>
 
-### Definition
 
 The version must be in a [semantic version](https://semver.org/) format, e.g. `1.0.0`
 

--- a/website/docs/reference/project-configs/version.md
+++ b/website/docs/reference/project-configs/version.md
@@ -32,4 +32,3 @@ version: 2  # Only 2 is accepted by current and recent versions of dbt.
 </File>
 
 
-For more on property files, see their general [documentation](https://docs.getdbt.com/reference/configs-and-properties#where-can-i-define-properties) on the same page.

--- a/website/docs/reference/project-configs/version.md
+++ b/website/docs/reference/project-configs/version.md
@@ -20,6 +20,9 @@ The version must be in a [semantic version](https://semver.org/) format, e.g. `1
 
 ##  `.yml` property file versions
 
+A version tag in a `.yml` property file provides the control tag, which informs how dbt processes property files. For more on why we require this tag, see property file [FAQs](https://docs.getdbt.com/reference/configs-and-properties#faqs).
+
+For more on property files, see their general [documentation](https://docs.getdbt.com/reference/configs-and-properties#where-can-i-define-properties) on the same page.
 <File name='<any valid filename>.yml'>
 
 ```yml

--- a/website/docs/reference/project-configs/version.md
+++ b/website/docs/reference/project-configs/version.md
@@ -31,6 +31,5 @@ version: 2  # Only 2 is accepted by current and recent versions of dbt.
  
 </File>
 
-A control tag that informs how dbt processes property files. For more on why 2 is required, see property file [FAQs](https://docs.getdbt.com/reference/configs-and-properties#faqs).
 
 For more on property files, see their general [documentation](https://docs.getdbt.com/reference/configs-and-properties#where-can-i-define-properties) on the same page.

--- a/website/docs/reference/project-configs/version.md
+++ b/website/docs/reference/project-configs/version.md
@@ -5,7 +5,7 @@ required: True
 
 dbt projects have two distinct types of the `version` tags. This field has a different meaning depending on its location.
 
-## 1. In dbt_project.yml
+## `dbt_project.yml` versions
 
 <File name='dbt_project.yml'>
 

--- a/website/docs/reference/project-configs/version.md
+++ b/website/docs/reference/project-configs/version.md
@@ -7,6 +7,7 @@ dbt projects have two distinct types of the `version` tags. This field has a dif
 
 ## `dbt_project.yml` versions
 
+The version tag in a `dbt_project` file represents the version of your dbt project. Although **this is a required parameter**, it is not currently meaningfully used by dbt. The version must be in a [semantic version](https://semver.org/) format, e.g. `1.0.0`. For more on Core versions, see "[About dbt Core versions](/docs/core-versions)."
 <File name='dbt_project.yml'>
 
 ```yml

--- a/website/docs/reference/project-configs/version.md
+++ b/website/docs/reference/project-configs/version.md
@@ -2,6 +2,11 @@
 datatype: version
 required: True
 ---
+
+dbt projects have two distinct types of the `version` tags. This field has a different meaning depending on its location.
+
+## 1. In dbt_project.yml
+
 <File name='dbt_project.yml'>
 
 ```yml
@@ -10,7 +15,22 @@ version: version
 
 </File>
 
-## Definition
+### Definition
 The version of a dbt project. Note that while **this is a required parameter**, it is not currently meaningfully used by dbt.
 
 The version must be in a [semantic version](https://semver.org/) format, e.g. `1.0.0`
+
+## 2. In yml property files
+
+<File name='<any valid filename>.yml'>
+
+```yml
+version: 2  # Only 2 is accepted by current and recent versions of dbt.
+```
+ 
+</File>
+
+### Definition
+A control tag that informs how dbt processes property files. For more on why 2 is required, see property file [FAQs](https://docs.getdbt.com/reference/configs-and-properties#faqs).
+
+For more on property files, see their general [documentation](https://docs.getdbt.com/reference/configs-and-properties#where-can-i-define-properties) on the same page.

--- a/website/docs/reference/project-configs/version.md
+++ b/website/docs/reference/project-configs/version.md
@@ -20,7 +20,7 @@ The version of a dbt project. Note that while **this is a required parameter**, 
 
 The version must be in a [semantic version](https://semver.org/) format, e.g. `1.0.0`
 
-## 2. In yml property files
+##  `.yml` property file versions
 
 <File name='<any valid filename>.yml'>
 

--- a/website/docs/reference/project-configs/version.md
+++ b/website/docs/reference/project-configs/version.md
@@ -16,7 +16,6 @@ version: version
 </File>
 
 ### Definition
-The version of a dbt project. Note that while **this is a required parameter**, it is not currently meaningfully used by dbt.
 
 The version must be in a [semantic version](https://semver.org/) format, e.g. `1.0.0`
 

--- a/website/docs/reference/project-configs/version.md
+++ b/website/docs/reference/project-configs/version.md
@@ -23,7 +23,7 @@ The version must be in a [semantic version](https://semver.org/) format, e.g. `1
 
 A version tag in a `.yml` property file provides the control tag, which informs how dbt processes property files. For more on why we require this tag, see property file [FAQs](https://docs.getdbt.com/reference/configs-and-properties#faqs).
 
-For more on property files, see their general [documentation](https://docs.getdbt.com/reference/configs-and-properties#where-can-i-define-properties) on the same page.
+For more on property files, see their general [documentation](reference/configs-and-properties#where-can-i-define-properties) on the same page.
 <File name='<any valid filename>.yml'>
 
 ```yml

--- a/website/docs/reference/project-configs/version.md
+++ b/website/docs/reference/project-configs/version.md
@@ -21,7 +21,7 @@ The version must be in a [semantic version](https://semver.org/) format, e.g. `1
 
 ##  `.yml` property file versions
 
-A version tag in a `.yml` property file provides the control tag, which informs how dbt processes property files. For more on why we require this tag, see property file [FAQs](https://docs.getdbt.com/reference/configs-and-properties#faqs).
+A version tag in a `.yml` property file provides the control tag, which informs how dbt processes property files. For more on why we require this tag, see property file [FAQs](reference/configs-and-properties#faqs).
 
 For more on property files, see their general [documentation](reference/configs-and-properties#where-can-i-define-properties) on the same page.
 <File name='<any valid filename>.yml'>


### PR DESCRIPTION
## Description & motivation
Paired documentation upgrade for [this PR here](https://github.com/dbt-labs/dbt-core/pull/4816).

For more background, see the recent Slack discussions on this.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [X] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
