### PR TITLE
Adding release note about how spotty internet issues no longer cause “IDE session timed out” message

### DIFF
--- a/website/blog/categories.yml
+++ b/website/blog/categories.yml
@@ -15,6 +15,10 @@
   display_title: dbt tutorials
   description: Best practices in the usage of our favorite data transformation tool.
   is_featured: true    
+- name: release notes
+  display_title: Release notes
+  description: Notable updates and new features in dbt Cloud.
+  is_featured: true
 - name: dbt updates
   display_title: dbt product updates
   description: An archive of monthly product updates from the dbt Labs team.

--- a/website/blog/product-updates/release-notes/2022-03-10-ide-timeout-message.md
+++ b/website/blog/product-updates/release-notes/2022-03-10-ide-timeout-message.md
@@ -1,0 +1,17 @@
+---
+title: "Spotty internet issues no longer cause a session time out message"
+description: "We fixed an issue where a spotty internet connection could cause the “IDE session timed out” message to appear unexpectedly. People using a VPN were most likely to see this issue."
+slug: 2022-03-10-ide-timeout-message
+
+tags: [release notes]
+hide_table_of_contents: false
+
+date: 2022-03-10
+is_featured: true
+---
+
+We fixed an issue where a spotty internet connection could cause the “IDE session timed out” message to appear unexpectedly. People using a VPN were most likely to see this issue.
+
+We updated the health check logic so it now excludes client-side connectivity issues from the IDE session check. If you lose your internet connection, we no longer update the health-check state. Now, losing internet connectivity will no longer cause this unexpected message.
+
+<LoomVideo id="fdb03d5192ee465ebdde08a9b53c15bd" />


### PR DESCRIPTION
## Description & motivation

Adding new release note and Loom  describing how spotty internet issues don't cause the  “IDE session timed out” message.

## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged
-->

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist
If you added new pages (delete if not applicable):
- [ ] The page has been added to `website/sidebars.js`
- [ ] The new page has a unique filename

If you removed existing pages (delete if not applicable):
- [ ] The page has been removed from `website/sidebars.js`
- [ ] An entry has been added to `_redirects`
