### PR TITLE
Initial docs for new adapter testing framework

### DIFF
--- a/website/dbt-versions.js
+++ b/website/dbt-versions.js
@@ -5,6 +5,10 @@ exports.versions = [
     isPrerelease: true
   },
   {
+    version: "1.1",
+    EOLDate: "2024-5-01"
+  },
+  {
     version: "1.0",
     EOLDate: "2023-12-03"
   },
@@ -19,8 +23,12 @@ exports.versions = [
 ]
 
 exports.versionedPages = [
-    {
-      "page": "docs/guides/migration-guide/upgrading-to-v1.1",
-      "firstVersion": "1.1",
-    }
+  {
+    "page": "docs/contributing/testing-a-new-adapter",
+    "firstVersion": "1.1",
+  },
+  {
+    "page": "docs/guides/migration-guide/upgrading-to-v1.1",
+    "firstVersion": "1.1",
+  }
 ]

--- a/website/docs/docs/contributing/building-a-new-adapter.md
+++ b/website/docs/docs/contributing/building-a-new-adapter.md
@@ -347,13 +347,13 @@ See examples:
 
 #### `__version__.py`
 
-To assure that `dbt --version` provides the latest dbt core version the adapter supports, be sure include a `__version__.py` file. The filepath will be `dbt/adapters/<adapter_name>/__version__.py`. We recommend using the latest dbt core version and as the adapter is made compatiable with later versions, this file will need to be updated. For a sample file, check out this [example](https://github.com/dbt-labs/dbt-core/blob/develop/plugins/snowflake/dbt/adapters/snowflake/__version__.py).
+To assure that `dbt --version` provides the latest dbt core version the adapter supports, be sure include a `__version__.py` file. The filepath will be `dbt/adapters/<adapter_name>/__version__.py`. We recommend using the latest dbt core version and as the adapter is made compatible with later versions, this file will need to be updated. For a sample file, check out this [example](https://github.com/dbt-labs/dbt-core/blob/develop/plugins/snowflake/dbt/adapters/snowflake/__version__.py).
 
 It should be noted that both of these files are included in the bootstrapped output of the `create_adapter_plugins.py` so when using that script, these files will be included.
 
 ### Testing your new adapter
 
-You can use a pre-configured [dbt adapter test suite](https://github.com/dbt-labs/dbt-adapter-tests) to test that your new adapter works. These tests include much of dbt's basic functionality, with the option to override or disable functionality that may not be supported on your adapter.
+This has moved to its own page: ["Testing a new adapter"](testing-a-new-adapter)
 
 ### Documenting your new adapter
 

--- a/website/docs/docs/contributing/testing-a-new-adapter.md
+++ b/website/docs/docs/contributing/testing-a-new-adapter.md
@@ -1,0 +1,200 @@
+---
+title: "Testing a new adapter"
+id: "testing-a-new-adapter"
+---
+
+<VersionBlock lastVersion="1.0">
+
+The previous way to test dbt adapter functionality was via a packaged suite of tests, [`pytest-dbt-adapter`](https://github.com/dbt-labs/dbt-adapter-tests). We've since deprecated that approach in favor of the new testing framework outlined in this document.
+
+</VersionBlock>
+
+dbt-core offers a standard framework for running pre-built functional tests, and defining new ones.
+
+The core testing framework is built using `pytest`, a mature and standard library for testing Python projects. It assumes a basic level of familiarity with the foundational concepts in `pytest`, such as fixtures. If this is your first time using `pytest`, we recommend you read the documentation: https://docs.pytest.org/
+
+The [`tests` module](https://github.com/dbt-labs/dbt-core/tree/HEAD/core/dbt/tests) within `dbt-core` includes basic utilities for setting up `pytest` + `dbt`. These are built into `dbt-core`, and used by all functional tests. These also make it possible to write your own tests, using the same utilities.
+
+Building on top of that foundation, we have a package of [adapter tests](https://github.com/dbt-labs/dbt-core/tree/HEAD/tests/adapter)—also located within the `dbt-core` repository, but separate from the `dbt-core` Python package. This package includes a set of basic fixtures and test cases, for use when testing 
+
+## Types of tests
+
+1. **Basic tests** that every adapter plugin is expected to pass. Given differences across data platforms, these may require slightly modification or reimplementation. Significantly overriding or disabling these tests should be with good reason, since each represents basic functionality that dbt users are accustomed to having. For example, if your adapter does not support incremental models, you should disable the test _and_ note that limitation in documentation, READMEs, and usage guides that accompany your adapter.
+
+2. **Optional tests**, for second-order functionality that is common across plugins, but not required for basic use. Your plugin can opt into these test cases by inheriting existing ones, or reimplementing them with adjustments. More tests will be added as we convert older tests defined on dbt-core and mature plugins to use the standard framework.
+
+3. **Custom tests**, for behavior that is specific to your adapter / data platform. Each data warehouse has its own specialties and idiosyncracies. We encourage you to use the same `pytest`-based framework, utilities, and fixtures to write your own custom tests for functionality that is unique to your adapter.
+
+If you run into an issue with the core framework, or the basic/optional test cases—or if you've written a custom test that you believe would be relevant and useful for other adapter plugin developers—please open an issue or PR in the `dbt-core` repository on GitHub.
+
+## Steps to get started
+
+1. Install dependencies
+2. Set up and configure pytest
+3. Define test cases
+
+### Install dependencies
+
+You should already have a virtual environment with `dbt-core` and your adapter plugin installed. You'll also need to install:
+- `pytest`
+- `dbt-tests-adapter`, the set of basic test cases
+
+During initial development, the `dbt-tests-adapter` package is not yet on PyPi, so please install it directly from GitHub:
+```bash
+pip install "git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter"
+```
+
+Or specify it in a requirements file like:
+<File name="dev_requirements.txt">
+
+```txt
+git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter
+```
+</File>
+
+### Set up and configure pytest
+
+First, set yourself up to run `pytest` by creating a file named `pytest.ini` at the root of your repository:
+
+<File name="pytest.ini">
+
+```python
+[pytest]
+filterwarnings =
+    ignore:.*'soft_unicode' has been renamed to 'soft_str'*:DeprecationWarning
+    ignore:unclosed file .*:ResourceWarning
+env_files =
+    test.env  # this allows you to use env vars from a file named test.env
+              # be sure to add "test.env" to .gitignore as well!
+testpaths =
+    tests/functional  # name per convention
+```
+
+</File>
+
+Then, create a configuration file within your tests directory. In it, you'll want to define all necessary profile configuration for connecting to your data platform in local development and continuous integration. We recommend setting these values with environment variables, since this file will be checked into version control.
+
+<File name="pytest.ini">
+
+```python
+import pytest
+import os
+
+# Import the standard functional fixtures as a plugin
+# Note: fixtures with session scope need to be local
+pytest_plugins = ["dbt.tests.fixtures.project"]
+
+# The profile dictionary, used to write out profiles.yml
+@pytest.fixture(scope="class")
+def dbt_profile_target(unique_schema):
+    return {
+        'type': '<myadapter>',
+        'threads': 1,
+        'host': os.getenv('HOST_ENV_VAR_NAME'),
+        'user': os.getenv('USER_ENV_VAR_NAME'),
+        ...
+        'schema': unique_schema  # this will be passed in by the testing framework
+                                 # and different for each test, to avoid collisions
+    }
+```
+
+</File>
+
+### Define test cases
+
+Each individual test case is defined as a class. To get started, you'll want to import all basic test cases and try running them.
+
+<File name="tests/functional/adapter/test_basic.py">
+
+```python
+import pytest
+
+from dbt.tests.adapter.basic.test_base import BaseSimpleMaterializations
+from dbt.tests.adapter.basic.test_singular_tests import BaseSingularTests
+from dbt.tests.adapter.basic.test_singular_tests_ephemeral importBaseSingularTestsEphemeral
+from dbt.tests.adapter.basic.test_empty import BaseEmpty
+from dbt.tests.adapter.basic.test_ephemeral import BaseEphemeral
+from dbt.tests.adapter.basic.test_incremental import BaseIncremental
+from dbt.tests.adapter.basic.test_generic_tests import BaseGenericTests
+from dbt.tests.adapter.basic.test_snapshot_check_cols import BaseSnapshotCheckCols
+from dbt.tests.adapter.basic.test_snapshot_timestamp import BaseSnapshotTimestamp
+
+class TestSimpleMaterializationsMyAdapter(BaseSimpleMaterializations):
+    pass
+
+
+class TestSingularTestsMyAdapter(BaseSingularTests):
+    pass
+
+
+class TestSingularTestsEphemeralMyAdapter(BaseSingularTestsEphemeral):
+    pass
+
+
+class TestEmptyMyAdapter(BaseEmpty):
+    pass
+
+
+class TestEphemeralMyAdapter(BaseEphemeral):
+    pass
+
+
+class TestIncrementalMyAdapter(BaseIncremental):
+    pass
+
+
+class TestGenericTestsMyAdapter(BaseGenericTests):
+    pass
+
+
+class TestSnapshotCheckColsMyAdapter(BaseSnapshotCheckCols):
+    pass
+
+
+class TestSnapshotTimestampMyAdapter(BaseSnapshotTimestamp):
+    pass
+```
+
+</File>
+
+
+Finally, run pytest:
+```bash
+python3 -m pytest tests/functional
+```
+
+See [docs on invoking `pytest`](https://docs.pytest.org/how-to/usage.html) for guidance and full command reference. It can be particularly helpful to use the `-s` flag (or `--capture=no`) to print output from the dbt test, and to step into an interactive debugger if you've added one.
+
+#### Reimplementing test cases
+
+You may find you need to override a specific test case to get it passing. For instance, on Redshift, we need to explicitly cast a column in the fixture input seed to use data type `varchar(64)`:
+
+<File name="tests/functional/adapter/test_basic.py">
+
+```python
+from dbt.tests.adapter.basic.files import seeds_base_csv, seeds_added_csv, seeds_newcolumns_csv
+
+# set the datatype of the name column in the 'added' seed so it
+# can hold the '_update' that's added
+schema_seed_added_yml = """
+version: 2
+seeds:
+  - name: added
+    config:
+      column_types:
+        name: varchar(64)
+"""
+
+class TestSnapshotCheckColsRedshift(BaseSnapshotCheckCols):
+    # Redshift defines the 'name' column such that it's not big enough
+    # to hold the '_update' added in the test.
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "base.csv": seeds_base_csv,
+            "added.csv": seeds_added_csv,
+            "seeds.yml": schema_seed_added_yml,
+        }
+```
+
+</File>

--- a/website/docs/docs/contributing/testing-a-new-adapter.md
+++ b/website/docs/docs/contributing/testing-a-new-adapter.md
@@ -3,13 +3,13 @@ title: "Testing a new adapter"
 id: "testing-a-new-adapter"
 ---
 
-<VersionBlock lastVersion="1.0">
+:::info
 
-The previous way to test dbt adapter functionality was via a packaged suite of tests, [`pytest-dbt-adapter`](https://github.com/dbt-labs/dbt-adapter-tests). We've since deprecated that approach in favor of the new testing framework outlined in this document.
+Previously, we offered a packaged suite of tests for dbt adapter functionality: [`pytest-dbt-adapter`](https://github.com/dbt-labs/dbt-adapter-tests). We are deprecating that suite, in favor of the newer testing framework outlined in this document. The rest of this document assumes that your plugin is compatible with dbt-core v1.1 or newer.
 
-</VersionBlock>
+:::
 
-dbt-core offers a standard framework for running pre-built functional tests, and defining new ones.
+dbt-core offers a standard framework for running pre-built functional tests, and for defining new ones.
 
 The core testing framework is built using `pytest`, a mature and standard library for testing Python projects. It assumes a basic level of familiarity with the foundational concepts in `pytest`, such as fixtures. If this is your first time using `pytest`, we recommend you read the documentation: https://docs.pytest.org/
 

--- a/website/docs/docs/contributing/testing-a-new-adapter.md
+++ b/website/docs/docs/contributing/testing-a-new-adapter.md
@@ -156,7 +156,7 @@ For the time being, this package is also located within the `dbt-core` repositor
 
 In the course of creating and maintaining your adapter, it's likely that you will end up implementing tests that fall into three broad categories:
 
-1. **Basic tests** that every adapter plugin is expected to pass, defined in `tests.adapter.basic`. Given differences across data platforms, these may require slightly modification or reimplementation. Significantly overriding or disabling these tests should be with good reason, since each represents basic functionality that dbt users are accustomed to having. For example, if your adapter does not support incremental models, you should disable the test _and_ note that limitation in documentation, READMEs, and usage guides that accompany your adapter.
+1. **Basic tests** that every adapter plugin is expected to pass, defined in `tests.adapter.basic`. Given differences across data platforms, these may require slight modification or reimplementation. Significantly overriding or disabling these tests should be with good reason, since each represents basic functionality that dbt users are accustomed to having. For example, if your adapter does not support incremental models, you should disable the test _and_ note that limitation in documentation, READMEs, and usage guides that accompany your adapter.
 
 2. **Optional tests**, for second-order functionality that is common across plugins, but not required for basic use. Your plugin can opt into these test cases by inheriting existing ones, or reimplementing them with adjustments. More tests will be added as we convert older tests defined on dbt-core and mature plugins to use the standard framework.
 
@@ -339,6 +339,10 @@ class TestSnapshotCheckColsRedshift(BaseSnapshotCheckCols):
 
 </File>
 
+As another example, the `dbt-bigquery` adapter asks users to "authorize" replacing a table with a view by supplying the `--full-refresh` flag. The reason: In the table materialization logic, a view by the same name must first be dropped; if the table query fails, the model will be missing.
+
+Knowing this possibility, the "base" test case offers a `require_full_refresh` switch on the `test_config` fixture class. For BigQuery, we'll switch it on:
+
 <File name="tests/functional/adapter/test_basic.py">
 
 ```python
@@ -346,10 +350,6 @@ import pytest
 from dbt.tests.adapter.basic.test_base import BaseSimpleMaterializations
 
 class TestSimpleMaterializationsBigQuery(BaseSimpleMaterializations):
-    # The dbt-bigquery adapter asks users to "authorize" replacing a table
-    # with a view by supplying the --full-refresh flag.
-    # Reason: In the table materialization logic, a view by the same name must
-    # first be dropped. If the table query fails, the model will be missing
     @pytest.fixture(scope="class")
     def test_config(self):
         # effect: add '--full-refresh' flag in requisite 'dbt run' step

--- a/website/docs/docs/guides/migration-guide/upgrading-to-v1.1.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-v1.1.md
@@ -22,7 +22,9 @@ There are no breaking changes for end users of dbt. We are committed to providin
 
 ### For maintainers of adapter plugins
 
-The abstractmethods `get_response` and `execute` now only return `connection.AdapterReponse` in type hints. Previously, they could return a string. We encourage you to update your methods to return an object of class `AdapterResponse`, or implement a subclass specific to your adapter. This also gives you the opportunity to add fields specific to your adapter's query execution, such as `rows_affected` or `bytes_processed`.
+We have reworked the testing suite for adapter plugin functionality. For details on the new testing suite, see: ["Testing a new adapter"](testing-a-new-adapter)
+
+The abstract methods `get_response` and `execute` now only return `connection.AdapterReponse` in type hints. Previously, they could return a string. We encourage you to update your methods to return an object of class `AdapterResponse`, or implement a subclass specific to your adapter. This also gives you the opportunity to add fields specific to your adapter's query execution, such as `rows_affected` or `bytes_processed`.
 
 ### For consumers of dbt artifacts (metadata)
 
@@ -34,7 +36,7 @@ _Note: If you're contributing docs for a new or updated feature in v1.1, please 
 
 - [**Generic tests**](resource-properties/tests) can define custom names. This is useful to "prettify" the synthetic name that dbt applies automatically. It's needed to disambiguate the case when the same generic test is defined multiple times with different configurations.
 
-### Plugins
+### For users of specific adapter plugins
 
 - **dbt-bigquery:** Support for finer-grained configuration of query timeout and retry when defining your [connection profile](bigquery-profile).
 - **dbt-spark** added support for a [`session` connection method](spark-profile#session), for use with a pySpark session, to support rapid iteration when developing advanced or experimental functionality. This connection method is not recommended for new users, and it is not supported in dbt Cloud.

--- a/website/docs/docs/guides/migration-guide/upgrading-to-v1.1.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-v1.1.md
@@ -34,6 +34,7 @@ The manifest schema version will be updated to v5. The only change is to the def
 
 _Note: If you're contributing docs for a new or updated feature in v1.1, please link those docs changes below!_
 
+- [**Incremental models**](configuring-incremental-models) can now accept a list of multiple columns as their `unique_key`, for models that need a combination of columns to uniquely identify each row. This is supported by the most common data warehouses, for incremental strategies that make use of the `unique_key` config (`merge` and `delete+insert`).
 - [**Generic tests**](resource-properties/tests) can define custom names. This is useful to "prettify" the synthetic name that dbt applies automatically. It's needed to disambiguate the case when the same generic test is defined multiple times with different configurations.
 
 ### For users of specific adapter plugins

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -111,6 +111,7 @@ const sidebarSettings = {
       items: [
         "docs/contributing/contributor-license-agreements",
         "docs/contributing/building-a-new-adapter",
+        "docs/contributing/testing-a-new-adapter",
         "docs/contributing/slack-rules-of-the-road",
       ],
     },


### PR DESCRIPTION
resolves #1256

## Description & motivation

Add page: "Testing a new adapter."

**Open question:** Where should this content live? We want to avoid duplicative work, but also provide the right info to the right people in the right place.
- docs.getdbt.com
- READMEs in test modules ([here](https://github.com/dbt-labs/dbt-core/blob/main/tests/adapter) + [here](https://github.com/dbt-labs/dbt-core/tree/main/core/dbt/tests))
- Contributing guide in dbt-core repo

The intended audience for these docs is a person creating a new(ish) adapter plugin for the first time, who wants to stand up initial testing. I think we need other docs on the foundational test framework—going over utilities, fixtures, test classes—for the benefit of OSS contributors (and plugin maintainers) writing new test cases.

**Update:** I've added a more generic example of a dbt functional test, which I could see going in its own page, &/or in [a README here](https://github.com/dbt-labs/dbt-core/tree/main/core/dbt/tests).

## Pre-release docs
Now that docs versioning has been merged, I think we should stop doing this: #1261 

## Checklist
If you added new pages (delete if not applicable):
- [x] The page has been added to `website/sidebars.js`
- [x] The new page has a unique filename