### PR TITLE
Add v1.1 migration guide

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -97,6 +97,7 @@
 /docs/graph	/docs/writing-code-in-dbt/jinja-context/graph	302
 /docs/guides/migration-guide/upgrading-to-014	/docs/guides/migration-guide/upgrading-to-0-14-0	302
 /docs/guides/migration-guide/upgrading-from-0-10-to-0-11	/docs/guides/migration-guide/upgrading-to-0-11-0	302
+docs/guides/migration-guide/upgrading-to-1-0-0	/docs/guides/migration-guide/upgrading-to-v1.0	302
 /docs/guides/writing-custom-schema-tests    /docs/guides/writing-custom-generic-tests
 /docs/hooks	/docs/building-a-dbt-project/hooks-operations	302
 /docs/init	/reference/commands/init	302

--- a/contributing/versioningdocs.md
+++ b/contributing/versioningdocs.md
@@ -61,7 +61,7 @@ exports.versionedPages = [
       "page": "docs/available-adapters",
       "firstVersion": "0.21",
     }
-}
+]
 ```
 
 ### Properties for versioning an entire page

--- a/website/dbt-versions.js
+++ b/website/dbt-versions.js
@@ -2,6 +2,7 @@ exports.versions = [
   {
     version: "1.1",
     EOLDate: "2023-04-27",  // TODO estimated for now
+    isPrerelease: true
   },
   {
     version: "1.0",

--- a/website/dbt-versions.js
+++ b/website/dbt-versions.js
@@ -18,4 +18,9 @@ exports.versions = [
   }
 ]
 
-exports.versionedPages = []
+exports.versionedPages = [
+    {
+      "page": "docs/guides/migration-guide/upgrading-to-v1.1",
+      "firstVersion": "1.1",
+    }
+]

--- a/website/dbt-versions.js
+++ b/website/dbt-versions.js
@@ -1,8 +1,8 @@
 exports.versions = [
-  // {
-  //   version: "1.1",
-  //   EOLDate: "2023-03-18"
-  // },
+  {
+    version: "1.1",
+    EOLDate: "2023-04-27",  // TODO estimated for now
+  },
   {
     version: "1.0",
     EOLDate: "2023-12-03"

--- a/website/docs/docs/contributing/building-a-new-adapter.md
+++ b/website/docs/docs/contributing/building-a-new-adapter.md
@@ -164,14 +164,21 @@ For example:
 
 #### get_response(cls, cursor)
 
-get_response is a classmethod that gets a cursor object and returns adapter-specific information about the last executed command. Ideally, the return value is an `AdapterResponse` object that includes items such as `code`, `rows_affected`, `bytes_processed`, and a summary `_message` for logging to stdout. Or, get_response can just return a string `'OK'` if your connection cursor does not provide richer metadata.
+`get_response` is a classmethod that gets a cursor object and returns adapter-specific information about the last executed command. The return value should be an `AdapterResponse` object that includes items such as `code`, `rows_affected`, `bytes_processed`, and a summary `_message` for logging to stdout.
 
 <File name='connections.py'>
 
 ```python
     @classmethod
-    def get_response(cls, cursor):
-        return cursor.status_message
+    def get_response(cls, cursor) -> AdapterResponse:
+        code = cursor.sqlstate or "OK"
+        rows = cursor.rowcount
+        status_message = f"{code} {rows_affected}"
+        return AdapterResponse(
+            _message=status_message,
+            code=code,
+            rows_affected=rows
+        )        
 ```
 
 </File>

--- a/website/docs/docs/guides/migration-guide/upgrading-to-v1.0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-v1.0.md
@@ -1,5 +1,5 @@
 ---
-title: "Upgrading to 1.0.0"
+title: "Upgrading to v1.0"
 
 ---
 

--- a/website/docs/docs/guides/migration-guide/upgrading-to-v1.1.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-v1.1.md
@@ -1,0 +1,33 @@
+---
+title: "Upgrading to v1.1"
+
+---
+
+:::info
+v1.1 is currently available as a beta prerelease. Install it from PyPi for your adapter, if available:
+```
+pip install --pre "dbt-<adapter>~=1.1.0b1"
+```
+:::
+
+### Resources
+
+- [Changelog](https://github.com/dbt-labs/dbt-core/blob/HEAD/CHANGELOG.md)
+- [CLI Installation guide](/dbt-cli/install/overview)
+- [Cloud upgrade guide](/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-choosing-a-dbt-version)
+
+## Breaking changes
+
+There are no breaking changes for end users of dbt. We are committed to providing backwards compatibility for all versions 1.x. If you encounter an error upon upgrading, please let us know by [opening an issue](https://github.com/dbt-labs/dbt-core/issues/new).
+
+### For maintainers of adapter plugins
+
+The abstractmethods `get_response` and `execute` now only return `connection.AdapterReponse` in type hints. Previously, they could return a string. We encourage you to update your methods to return an object of class `AdapterResponse`, or implement a subclass specific to your adapter. This also gives you the opportunity to add fields specific to your adapter's query execution, such as `rows_affected` or `bytes_processed`.
+
+### For consumers of dbt artifacts (metadata)
+
+The manifest schema version will be updated to v5. The only change is to the default value of `config` for parsed nodes.
+
+## New and changed documentation
+
+_Note: If you're contributing docs for a new or updated feature in v1.1, please link those docs changes below!_

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -68,6 +68,7 @@ const sidebarSettings = {
           type: "category",
           label: "Migration guides",
           items: [
+            "docs/guides/migration-guide/upgrading-to-v1.1",
             "docs/guides/migration-guide/upgrading-to-1-0-0",
             "docs/guides/migration-guide/upgrading-to-0-21-0",
             "docs/guides/migration-guide/upgrading-to-0-20-0",

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -69,7 +69,7 @@ const sidebarSettings = {
           label: "Migration guides",
           items: [
             "docs/guides/migration-guide/upgrading-to-v1.1",
-            "docs/guides/migration-guide/upgrading-to-1-0-0",
+            "docs/guides/migration-guide/upgrading-to-v1.0",
             "docs/guides/migration-guide/upgrading-to-0-21-0",
             "docs/guides/migration-guide/upgrading-to-0-20-0",
             "docs/guides/migration-guide/upgrading-to-0-19-0",

--- a/website/src/stores/VersionContext.js
+++ b/website/src/stores/VersionContext.js
@@ -1,11 +1,12 @@
 import React, { useState, useEffect, createContext } from "react"
 import { versions } from '../../dbt-versions'
 
-const lastReleasedVersion = versions && versions.find(ver => ver.version && ver.version != "");
+const lastReleasedVersion = versions && versions.find(ver => ver.version && ver.version != "" && !ver.isPrerelease);
 
 const VersionContext = createContext({
   version: lastReleasedVersion.version,
   EOLDate: lastReleasedVersion.EOLDate || undefined, 
+  isPrerelease: lastReleasedVersion.isPrerelease || false,
   latestStableRelease: lastReleasedVersion.version,
   updateVersion: () => {},
 })
@@ -57,14 +58,14 @@ export const VersionContextProvider = ({ children }) => {
     updateVersion
   }
 
-  // Get End of Life date for current version
+  // Determine isPrerelease status + End of Life date for current version
   const currentVersion = versions.find(ver => ver.version === version)
   if(currentVersion)
     context.EOLDate = currentVersion.EOLDate
+    context.isPrerelease = currentVersion?.isPrerelease
   
   // Get latest stable release
-  const latestStableRelease = versions.find(ver => new Date(ver.EOLDate) > new Date())
-  if(latestStableRelease?.version)
+  const latestStableRelease = versions.find(ver => !ver?.isPrerelease)
     context.latestStableRelease = latestStableRelease.version
 
   return (

--- a/website/src/theme/DocPage/index.js
+++ b/website/src/theme/DocPage/index.js
@@ -59,6 +59,12 @@ function DocPageContent({
     isPrereleaseBannerText: ''
   })
 
+  // Check End of Life date and show unsupported banner if deprecated version
+  const [EOLData, setEOLData] = useState({
+    showEOLBanner: false,
+    EOLBannerText: ''
+  })
+
   useEffect(() => {
     // If version is not isPrerelease, do not show banner
     if(!isPrerelease) {
@@ -69,18 +75,9 @@ function DocPageContent({
     } else {
         setPreData({
           showisPrereleaseBanner: true,
-          isPrereleaseBannerText: `This is a prerelease version. The latest stable version is ${latestStableRelease}`
+          isPrereleaseBannerText  : `This is a prerelease version. The latest stable version is ${latestStableRelease}`
         })
     }
-  })
-
-  // Check End of Life date and show unsupported banner if deprecated version
-  const [EOLData, setEOLData] = useState({
-    showEOLBanner: false,
-    EOLBannerText: ''
-  })
-
-  useEffect(() => {
     // If EOLDate not set for version, do not show banner
     if(!EOLDate) {
       setEOLData({

--- a/website/src/theme/DocPage/index.js
+++ b/website/src/theme/DocPage/index.js
@@ -50,10 +50,31 @@ function DocPageContent({
 
   // Check if page available for current version
   const { versionedPages } = usePluginData('docusaurus-build-global-data-plugin');
-  const { version: dbtVersion, EOLDate, latestStableRelease } = useContext(VersionContext)
+  const { version: dbtVersion, EOLDate, isPrerelease, latestStableRelease } = useContext(VersionContext)
   const { pageAvailable, firstAvailableVersion } = pageVersionCheck(dbtVersion, versionedPages, currentDocRoute.path)
 
-  // Check End of Life date and show unsupported banner if depricated version
+  // Check whether this version is a isPrerelease, and show banner if so
+  const [PreData, setPreData] = useState({
+    showisPrereleaseBanner: false,
+    isPrereleaseBannerText: ''
+  })
+
+  useEffect(() => {
+    // If version is not isPrerelease, do not show banner
+    if(!isPrerelease) {
+      setPreData({
+        showisPrereleaseBanner: false,
+        isPrereleaseBannerText: ''
+      })
+    } else {
+        setPreData({
+          showisPrereleaseBanner: true,
+          isPrereleaseBannerText: `This is a prerelease version. The latest stable version is ${latestStableRelease}`
+        })
+    }
+  })
+
+  // Check End of Life date and show unsupported banner if deprecated version
   const [EOLData, setEOLData] = useState({
     showEOLBanner: false,
     EOLBannerText: ''
@@ -169,6 +190,13 @@ function DocPageContent({
                 <Admonition type="caution" title={`New feature!`} icon="🎉 " >
                   <p style={{'marginTop': '5px', 'marginBottom': '0'}}>Unfortunately, this feature is not available in dbt Core version {dbtVersion}</p>
                   <p> You should upgrade to {firstAvailableVersion} or later if you want to use this feature.</p>
+                </Admonition>
+              </div>
+            )}
+            {PreData.showisPrereleaseBanner && (
+              <div className={styles.versionBanner}>
+                <Admonition type="caution" title="Warning">
+                  <div dangerouslySetInnerHTML={{__html: PreData.isPrereleaseBannerText}} />
                 </Admonition>
               </div>
             )}

--- a/website/src/theme/DocPage/index.js
+++ b/website/src/theme/DocPage/index.js
@@ -75,7 +75,7 @@ function DocPageContent({
     } else {
         setPreData({
           showisPrereleaseBanner: true,
-          isPrereleaseBannerText  : `${dbtVersion} is a prerelease version. The latest stable version is ${latestStableRelease}`
+          isPrereleaseBannerText  : `You are currently viewing v${latestStableRelease}, which is a prerelease of dbt Core. The latest stable version is v${latestStableRelease}`
         })
     }
     // If EOLDate not set for version, do not show banner

--- a/website/src/theme/DocPage/index.js
+++ b/website/src/theme/DocPage/index.js
@@ -75,7 +75,7 @@ function DocPageContent({
     } else {
         setPreData({
           showisPrereleaseBanner: true,
-          isPrereleaseBannerText  : `This is a prerelease version. The latest stable version is ${latestStableRelease}`
+          isPrereleaseBannerText  : `${dbtVersion} is a prerelease version. The latest stable version is ${latestStableRelease}`
         })
     }
     // If EOLDate not set for version, do not show banner


### PR DESCRIPTION
resolves https://github.com/dbt-labs/docs.getdbt.com/issues/1260

Let's merge this PR, before all [other v1.1 updates](https://github.com/dbt-labs/docs.getdbt.com/labels/dbt-core%20v1.1.x), since those PRs should update the migration guide.

## Description & motivation

In separate commits, should we want to split any of these off into their own PRs:
- Add v1.1 to version dropdown
- Add "isPrerelease" to VersionContext, and show a warning banner if a user has selected a prerelease version from the dropdown (@JKarlavige would love your eyes on this!)
- Add v1.1 migration guide, with one initial change
- Try using `versionedPages` to show v1.1 migration guide only when v1.1 selected in dropdown (and warn otherwise). This doesn't seem to work as I'd expect, but I'm also not sure it even makes sense for a page like this—we probably do want to show all version guides to all users, no matter which version they're using right now.
- Rename v1.0 migration guide, to follow same `Major.Minor` naming format (with sidebar update + redirect)

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [x] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

Yes! Let's change the way we do this: https://github.com/dbt-labs/docs.getdbt.com/issues/1261

## Checklist
If you added new pages (delete if not applicable):
- [x] The page has been added to `website/sidebars.js`
- [x] The new page has a unique filename

If you removed existing pages (delete if not applicable):
- [x] The page has been removed from `website/sidebars.js`
- [x] An entry has been added to `_redirects`
