### PR TITLE
Update BigQuery credentials in Getting Started tutorial

### DIFF
--- a/website/docs/tutorial/1-setting-up.md
+++ b/website/docs/tutorial/1-setting-up.md
@@ -97,17 +97,15 @@ BigQuery has <a href="https://cloud.google.com/bigquery/pricing">a generous free
 ## Generate BigQuery credentials
 In order to let dbt connect to your warehouse, you'll need generate a keyfile. This is analogous to using a database user name and password with most other data warehouses.
 
-<LoomVideo id="2b5a8ec255bd4dce91374f6941d279e5" />
-
 1. Go to the [BigQuery credential wizard](https://console.cloud.google.com/apis/credentials/wizard). Ensure that your new project is selected in the header bar.
-2. Generate credentials with the following options:
-    * **Which API are you using?** BigQuery API
-    * **What data will you be accessing?** Application data (you'll be creating a service account)
-    * **Are you planning to use this API with App Engine or Compute Engine?** No
+2. Select the "+ Create Credentials" button. Select the "Service account" option.
+3. Create a service account with the following options:
     * **Service account name:** `dbt-user`
-    * **Role:** BigQuery Job User, BigQuery User, and BigQuery Data Editor
-    * **Key type:** JSON
-3. Download the JSON file and save it in an easy-to-remember spot, with a clear filename (e.g. `dbt-user-creds.json`)
+    * **Select a role:** BigQuery Admin
+    * **Grant users access to this service account** Leave blank
+4. Select the service account that you just created. Select the "Keys" tab.
+5. Click "Add Key" and the option "Create new key". Select "JSON" as the key type.  
+6. Download the JSON file and save it in an easy-to-remember spot, with a clear filename (e.g. `dbt-user-creds.json`).
 
 ### FAQs
 <FAQ src="database-privileges" />

--- a/website/docs/tutorial/1-setting-up.md
+++ b/website/docs/tutorial/1-setting-up.md
@@ -98,14 +98,16 @@ BigQuery has <a href="https://cloud.google.com/bigquery/pricing">a generous free
 In order to let dbt connect to your warehouse, you'll need generate a keyfile. This is analogous to using a database user name and password with most other data warehouses.
 
 1. Go to the [BigQuery credential wizard](https://console.cloud.google.com/apis/credentials/wizard). Ensure that your new project is selected in the header bar.
-2. Select the "+ Create Credentials" button. Select the "Service account" option.
-3. Create a service account with the following options:
-    * **Service account name:** `dbt-user`
-    * **Select a role:** BigQuery Admin
-    * **Grant users access to this service account** Leave blank
-4. Select the service account that you just created. Select the "Keys" tab.
-5. Click "Add Key" and the option "Create new key". Select "JSON" as the key type.  
-6. Download the JSON file and save it in an easy-to-remember spot, with a clear filename (e.g. `dbt-user-creds.json`).
+2. Select **+ Create Credentials** then select **Service account**.
+3. Type "dbt-user" in the Service account name field, then click **Create and Continue**.
+4. Type and select **BigQuery Admin** in the Role field.
+5. Click **Continue**.
+6. Leave fields blank in the "Grant users access to this service account" section and click **Done**.
+7. Click the service account that you just created.
+8. Select **Keys**.
+9. Click **Add Key** then select **Create new key**. 
+10. Select **JSON** as the key type then click **Create**.  
+11. You should be prompted to download the JSON file. Save it locally to an easy-to-remember spot, with a clear filename. For example, `dbt-user-creds.json`.
 
 ### FAQs
 <FAQ src="database-privileges" />


### PR DESCRIPTION
## Description & motivation
We are creating a technical task for Instructor candidates to join the Training team. We are piggybacking on Pro-Serve's [interview task for Analytics Engineers](https://docs.google.com/document/d/1o5fQqo1NkE77y0nv3aDNzT5AvEiLqZ-HZkB3LyFeWHQ/edit#heading=h.u9uk8vwroliv), which points to the [Getting Started tutorial](https://docs.getdbt.com/tutorial/setting-up) as a way to setup a BigQuery account and connect a dbt project to it. I realized while reviewing the "Generate BigQuery Credentials" section that it was slightly out of date.
 
1. Remove the outdated Loom video of how to get BigQuery credentials. We could re-film this video, but I think the text instructions are clear enough and Google is constantly changing their UI so it would be hard to keep this video up-to-date.
1. Update the text instructions for how to download the JSON key from BigQuery.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Testing
Validated by creating a JSON key file in my Google Cloud Platform console (using my dbtlabs Google account). Used the key to successfully connect a dbt Cloud project to BigQuery. Was able to run queries and create models with `dbt run`.