### PR TITLE
Add Spark `session` connection method

### DIFF
--- a/website/docs/docs/guides/migration-guide/upgrading-to-v1.1.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-v1.1.md
@@ -31,3 +31,7 @@ The manifest schema version will be updated to v5. The only change is to the def
 ## New and changed documentation
 
 _Note: If you're contributing docs for a new or updated feature in v1.1, please link those docs changes below!_
+
+### Plugins
+
+- **dbt-spark** added support for a [`session` connection method](spark-profile#session), for use with a pySpark session, to support rapid iteration when developing advanced or experimental functionality. This connection method is not recommended for new users, and it is not supported in dbt Cloud.

--- a/website/docs/reference/warehouse-profiles/spark-profile.md
+++ b/website/docs/reference/warehouse-profiles/spark-profile.md
@@ -18,14 +18,19 @@ id: "spark-profile"
 
 dbt-spark can connect to Spark clusters by three different methods:
 
-- `odbc` is the preferred method when connecting to Databricks. It supports connecting to a SQL Endpoint or an all-purpose interactive cluster.
-- `http` is a more generic method for connecting to a managed service that provides an HTTP endpoint. Currently, this includes connections to a Databricks interactive cluster.
-- `thrift` connects directly to the lead node of a cluster, either locally hosted / on premise or in the cloud (e.g. Amazon EMR).
-- `session` *FOR ADVANCED USERS* use a pySpark session.
+- [`odbc`](#odbc) is the preferred method when connecting to Databricks. It supports connecting to a SQL Endpoint or an all-purpose interactive cluster.
+- [`thrift`](#thrift) connects directly to the lead node of a cluster, either locally hosted / on premise or in the cloud (e.g. Amazon EMR).
+- [`http`](#http) is a more generic method for connecting to a managed service that provides an HTTP endpoint. Currently, this includes connections to a Databricks interactive cluster.
 
-:::info session
-The `session` connection method is intended for advanced users. This connection method is not supported by dbt cloud.
+<VersionBlock firstVersion="1.1">
+
+- [`session`](#session) connects to a pySpark session, running locally or on a remote machine.
+
+:::info Advanced functionality
+The `session` connection method is intended for advanced users and experimental dbt development. This connection method is not supported by dbt Cloud.
 :::
+
+</VersionBlock>
 
 ### ODBC
 
@@ -117,6 +122,8 @@ Databricks interactive clusters can take several minutes to start up. You may
 include the optional profile configs `connect_timeout` and `connect_retries`,
 and dbt will periodically retry the connection.
 
+<VersionBlock firstVersion="1.1">
+
 ### Session
 
 Use the `session` method if you want to run `dbt` against a pySpark session. 
@@ -136,6 +143,8 @@ your_profile_name:
 
 </File>
 
+</VersionBlock>
+
 ## Installation and Distribution
 
 dbt's adapter for Apache Spark and Databricks is managed in its own repository, [dbt-spark](https://github.com/dbt-labs/dbt-spark). To use it, 
@@ -151,13 +160,20 @@ If connecting to a Spark cluster via the generic thrift or http methods, it requ
 ```
 # odbc connections
 $ pip install "dbt-spark[ODBC]"
-
+```
+```
 # thrift or http connections
 $ pip install "dbt-spark[PyHive]"
+```
 
+<VersionBlock firstVersion="1.1">
+
+```
 # session connections
 $ pip install "dbt-spark[session]"
 ```
+
+</VersionBlock>
 
 ## Caveats
 

--- a/website/docs/reference/warehouse-profiles/spark-profile.md
+++ b/website/docs/reference/warehouse-profiles/spark-profile.md
@@ -21,6 +21,11 @@ dbt-spark can connect to Spark clusters by three different methods:
 - `odbc` is the preferred method when connecting to Databricks. It supports connecting to a SQL Endpoint or an all-purpose interactive cluster.
 - `http` is a more generic method for connecting to a managed service that provides an HTTP endpoint. Currently, this includes connections to a Databricks interactive cluster.
 - `thrift` connects directly to the lead node of a cluster, either locally hosted / on premise or in the cloud (e.g. Amazon EMR).
+- `session` *FOR ADVANCED USERS* use a pySpark session.
+
+:::info session
+The `session` connection method is intended for advanced users. This connection method is not supported by dbt cloud.
+:::
 
 ### ODBC
 
@@ -112,6 +117,25 @@ Databricks interactive clusters can take several minutes to start up. You may
 include the optional profile configs `connect_timeout` and `connect_retries`,
 and dbt will periodically retry the connection.
 
+### Session
+
+Use the `session` method if you want to run `dbt` against a pySpark session. 
+
+<File name='~/.dbt/profiles.yml'>
+
+```yaml
+your_profile_name:
+  target: dev
+  outputs:
+    dev:
+      type: spark
+      method: session
+      schema: [database/schema name]
+      host: NA                           # not used, but required by `dbt-core`
+```
+
+</File>
+
 ## Installation and Distribution
 
 dbt's adapter for Apache Spark and Databricks is managed in its own repository, [dbt-spark](https://github.com/dbt-labs/dbt-spark). To use it, 
@@ -130,6 +154,9 @@ $ pip install "dbt-spark[ODBC]"
 
 # thrift or http connections
 $ pip install "dbt-spark[PyHive]"
+
+# session connections
+$ pip install "dbt-spark[session]"
 ```
 
 ## Caveats


### PR DESCRIPTION
- Picks up from https://github.com/dbt-labs/docs.getdbt.com/pull/1101
- Adds `VersionBlock` for v1.1
- Adds note to v1.1 migration guide