### PR TITLE
Update BigQuery timeout + retry configs for v1.1

### DIFF
--- a/website/docs/docs/guides/migration-guide/upgrading-to-v1.0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-v1.0.md
@@ -46,6 +46,7 @@ Global project macros have been reorganized, and some old unused macros have bee
 ### For users of adapter plugins
 
 - **BigQuery:** Support for [ingestion-time-partitioned tables](creating-date-partitioned-tables) has been officially deprecated in favor of modern approaches. Use `partition_by` and incremental modeling strategies instead.
+- **BigQuery:** Support fine-grained control of the BigQuery query timeout and retry [bigquery-profile](bigquery-profile).
 
 ### For maintainers of plugins + other integrations
 

--- a/website/docs/docs/guides/migration-guide/upgrading-to-v1.0.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-v1.0.md
@@ -46,7 +46,6 @@ Global project macros have been reorganized, and some old unused macros have bee
 ### For users of adapter plugins
 
 - **BigQuery:** Support for [ingestion-time-partitioned tables](creating-date-partitioned-tables) has been officially deprecated in favor of modern approaches. Use `partition_by` and incremental modeling strategies instead.
-- **BigQuery:** Support fine-grained control of the BigQuery query timeout and retry [bigquery-profile](bigquery-profile).
 
 ### For maintainers of plugins + other integrations
 

--- a/website/docs/docs/guides/migration-guide/upgrading-to-v1.1.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-v1.1.md
@@ -36,4 +36,5 @@ _Note: If you're contributing docs for a new or updated feature in v1.1, please 
 
 ### Plugins
 
+- **dbt-bigquery:** Support for finer-grained configuration of query timeout and retry when defining your [connection profile](bigquery-profile).
 - **dbt-spark** added support for a [`session` connection method](spark-profile#session), for use with a pySpark session, to support rapid iteration when developing advanced or experimental functionality. This connection method is not recommended for new users, and it is not supported in dbt Cloud.


### PR DESCRIPTION
- Picks up from https://github.com/dbt-labs/docs.getdbt.com/pull/962
- Edit structure, tweak language
- Add versioning logic (i.e. put back old content, wrapped in `lastVersion="1.0"`)
- Move migration guide note from v1.0 &rarr; v1.1

**Note:** If headers are repeated between versioned blocks, or they differ between versioned sections, _all_ headers show up in the right-hand sidebar. In this case, I updated both sections to use a common `### Timeouts and Retries` section.

## Pre-release docs
Yes, following new paradigm