### PR TITLE
New in v1.1: generic tests with custom names, alt format

### DIFF
--- a/website/docs/docs/guides/migration-guide/upgrading-to-v1.1.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-v1.1.md
@@ -32,6 +32,8 @@ The manifest schema version will be updated to v5. The only change is to the def
 
 _Note: If you're contributing docs for a new or updated feature in v1.1, please link those docs changes below!_
 
+- [**Generic tests**](resource-properties/tests) can define custom names. This is useful to "prettify" the synthetic name that dbt applies automatically. It's needed to disambiguate the case when the same generic test is defined multiple times with different configurations.
+
 ### Plugins
 
 - **dbt-spark** added support for a [`session` connection method](spark-profile#session), for use with a pySpark session, to support rapid iteration when developing advanced or experimental functionality. This connection method is not recommended for new users, and it is not supported in dbt Cloud.

--- a/website/docs/reference/resource-configs/alias.md
+++ b/website/docs/reference/resource-configs/alias.md
@@ -1,5 +1,5 @@
 ---
-resource_types: [models, seeds]
+resource_types: [models, seeds, snapshots, tests]
 datatype: string
 ---
 

--- a/website/docs/reference/resource-configs/database.md
+++ b/website/docs/reference/resource-configs/database.md
@@ -1,5 +1,5 @@
 ---
-resource_types: [models, seeds]
+resource_types: [models, seeds, tests]
 datatype: string
 ---
 

--- a/website/docs/reference/resource-configs/schema.md
+++ b/website/docs/reference/resource-configs/schema.md
@@ -1,5 +1,5 @@
 ---
-resource_types: [models, seeds]
+resource_types: [models, seeds, tests]
 datatype: string
 ---
 
@@ -54,6 +54,20 @@ Configure individual models using a config block:
 ```yml
 seeds:
   +schema: mappings
+```
+
+</File>
+
+### Tests
+
+Customize the name of the schema in which tests [configured to store failures](resource-configs/store_failures) will save their results:
+
+<File name='dbt_project.yml'>
+
+```yml
+tests:
+  +store_failures: true
+  +schema: the_island_of_misfit_tests
 ```
 
 </File>

--- a/website/docs/reference/resource-properties/tests.md
+++ b/website/docs/reference/resource-properties/tests.md
@@ -152,11 +152,13 @@ This feature is not implemented for analyses.
 
 ## Description
 
-The `tests` property defines assertions about a column, table, or view. The property contains a list of generic tests (referenced by name), which can include the four built-in generic tests available in dbt. It can also include any arguments or [configurations](test-configs) passed to those tests.
+The `tests` property defines assertions about a column, table, or view. The property contains a list of [generic tests](building-a-dbt-project/tests#generic-tests), referenced by name, which can include the four built-in generic tests available in dbt. Any arguments or [configurations](test-configs) passed to those tests should be nested below the test name.
 
 Once these tests are defined, you can validate their correctness by running `dbt test`.
 
 ## test_name
+
+There are four generic tests that are available out of the box, for everyone using dbt.
 
 ### `not_null`
 
@@ -270,7 +272,7 @@ models:
 
 ### Define and use a custom generic test
 
-If you define your own custom generic ("schema") test, you can use that as the `test_name`:
+If you've defined your own custom generic test, you can use that as the `test_name`:
 
 <File name='models/<filename>.yml'>
 
@@ -282,10 +284,195 @@ models:
     columns:
       - name: order_id
         tests:
-          - primary_key
+          - primary_key  # name of my custom generic test
 
 ```
 
 </File>
 
 Check out the guide on writing a [custom generic test](custom-generic-tests) for more information.
+
+### Define a custom name for one test
+
+<VersionBlock firstVersion="1.1">
+
+By default, dbt will synthesize a name for your generic test by concatenating:
+- test name (`not_null`, `unique`, etc)
+- model name (or source/seed/snapshot)
+- column name (if relevant)
+- arguments (if relevant, e.g. `values` for `accepted_values`)
+
+It does not include any configurations for the test. If the concatenated name is too long, dbt will use a truncated and hashed version instead. The goal is to preserve unique identifiers for all resources in your project, including tests.
+
+You may also define your own name for a specific test, via the `name` property.
+
+**When might you want this?** dbt's default approach can result in some wonky (and ugly) test names. By defining a custom name, you get full control over how the test will appear in log messages and metadata artifacts. You'll also be able to select the test by that name.
+
+<File name='models/<filename>.yml'>
+
+```yaml
+version: 2
+
+models:
+  - name: orders
+    columns:
+      - name: status
+        tests:
+          - accepted_values:
+              name: unexpected_order_status_today
+              values: ['placed', 'shipped', 'completed', 'returned']
+              config:
+                where: "order_date = current_date"
+```
+
+</File>
+
+```sh
+$ dbt test --select unexpected_order_status_today
+12:43:41  Running with dbt=1.1.0
+12:43:41  Found 1 model, 1 test, 0 snapshots, 0 analyses, 167 macros, 0 operations, 1 seed file, 0 sources, 0 exposures, 0 metrics
+12:43:41
+12:43:41  Concurrency: 5 threads (target='dev')
+12:43:41
+12:43:41  1 of 1 START test unexpected_order_status_today ................................ [RUN]
+12:43:41  1 of 1 PASS unexpected_order_status_today ...................................... [PASS in 0.03s]
+12:43:41
+12:43:41  Finished running 1 test in 0.13s.
+12:43:41
+12:43:41  Completed successfully
+12:43:41
+12:43:41  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
+```
+
+A test's name must be unique for all tests defined on a given model-column combination. If you give the same name to tests defined on several different columns, or across several different models, then `dbt test --select <repeated_custom_name>` will select them all.
+
+**When might you need this?** In cases where you have defined the same test twice, with only a difference in configuration, dbt will consider these tests to be duplicates:
+
+<File name='models/<filename>.yml'>
+
+```yaml
+version: 2
+
+models:
+  - name: orders
+    columns:
+      - name: status
+        tests:
+          - accepted_values:
+              values: ['placed', 'shipped', 'completed', 'returned']
+              config:
+                where: "order_date = current_date"
+          - accepted_values:
+              values: ['placed', 'shipped', 'completed', 'returned']
+              config:
+                # only difference is in the 'where' config
+                where: "order_date = (current_date - interval '1 day')" # PostgreSQL syntax
+```
+
+</File>
+
+```sh
+Compilation Error
+  dbt found two tests with the name "accepted_values_orders_status__placed__shipped__completed__returned" defined on column "status" in "models.orders".
+
+  Since these resources have the same name, dbt will be unable to find the correct resource
+  when running tests.
+
+  To fix this, change the name of one of these resources:
+  - test.testy.accepted_values_orders_status__placed__shipped__completed__returned.69dce9e5d5 (models/one_file.yml)
+  - test.testy.accepted_values_orders_status__placed__shipped__completed__returned.69dce9e5d5 (models/one_file.yml)
+```
+
+By providing a custom name, you enable dbt to disambiguate them:
+
+<File name='models/<filename>.yml'>
+
+```yaml
+version: 2
+
+models:
+  - name: orders
+    columns:
+      - name: status
+        tests:
+          - accepted_values:
+              name: unexpected_order_status_today
+              values: ['placed', 'shipped', 'completed', 'returned']
+              config:
+                where: "order_date = current_date"
+          - accepted_values:
+              name: unexpected_order_status_yesterday
+              values: ['placed', 'shipped', 'completed', 'returned']
+              config:
+                where: "order_date = (current_date - interval '1 day')" # PostgreSQL
+```
+
+</File>
+
+```sh
+$ dbt test
+12:48:03  Running with dbt=1.1.0-b1
+12:48:04  Found 1 model, 2 tests, 0 snapshots, 0 analyses, 167 macros, 0 operations, 1 seed file, 0 sources, 0 exposures, 0 metrics
+12:48:04
+12:48:04  Concurrency: 5 threads (target='dev')
+12:48:04
+12:48:04  1 of 2 START test unexpected_order_status_today ................................ [RUN]
+12:48:04  2 of 2 START test unexpected_order_status_yesterday ............................ [RUN]
+12:48:04  1 of 2 PASS unexpected_order_status_today ...................................... [PASS in 0.04s]
+12:48:04  2 of 2 PASS unexpected_order_status_yesterday .................................. [PASS in 0.04s]
+12:48:04
+12:48:04  Finished running 2 tests in 0.21s.
+12:48:04
+12:48:04  Completed successfully
+12:48:04
+12:48:04  Done. PASS=2 WARN=0 ERROR=0 SKIP=0 TOTAL=2
+```
+
+**If using [`store_failures`](resource-configs/store_failures):** dbt uses each test's name as the name of the table in which to store any failing records. If you have defined a custom name for one test, that custom name will also be used for its table of failures. You may optionally configure an [`alias`](resource-configs/alias) for the test, in order to separately control both the name of the test (for metadata) and the name of its database table (for storing failures).
+
+</VersionBlock>
+
+<VersionBlock lastVersion="1.0">
+
+Only supported by v1.1 or newer.
+
+</VersionBlock>
+
+### Alternative format for defining tests
+
+<VersionBlock firstVersion="1.1">
+
+When defining a generic test with a number of arguments and configurations, the YAML can look and feel unwieldy. If you find it easier easier, you can define the same test properties as top-level keys of a single dictionary, by providing the test name as `test_name` instead. It's totally up to you.
+
+This example is identical to the one above:
+
+<File name='models/<filename>.yml'>
+
+```yaml
+version: 2
+
+models:
+  - name: orders
+    columns:
+      - name: status
+        tests:
+          - name: unexpected_order_status_today
+            test_name: accepted_values  # name of the generic test to apply
+            values:
+              - placed
+              - shipped
+              - completed
+              - returned
+            config:
+              where: "order_date = current_date"
+```
+
+</File>
+
+</VersionBlock>
+
+<VersionBlock lastVersion="1.0">
+
+Only supported by v1.1 or newer.
+
+</VersionBlock>

--- a/website/docs/reference/resource-properties/tests.md
+++ b/website/docs/reference/resource-properties/tests.md
@@ -152,11 +152,11 @@ This feature is not implemented for analyses.
 
 ## Description
 
-The `tests` property defines assertions about a column, table, or view. The property contains a list of [generic tests](building-a-dbt-project/tests#generic-tests), referenced by name, which can include the four built-in generic tests available in dbt. Any arguments or [configurations](test-configs) passed to those tests should be nested below the test name.
+The `tests` property defines assertions about a column, table, or view. The property contains a list of [generic tests](building-a-dbt-project/tests#generic-tests), referenced by name, which can include the four built-in generic tests available in dbt. For example, you can add tests that ensure a column contains no duplicates and zero null values. Any arguments or [configurations](test-configs) passed to those tests should be nested below the test name.
 
 Once these tests are defined, you can validate their correctness by running `dbt test`.
 
-## test_name
+## Out-of-the-box tests
 
 There are four generic tests that are available out of the box, for everyone using dbt.
 

--- a/website/docs/reference/test-configs.md
+++ b/website/docs/reference/test-configs.md
@@ -140,6 +140,10 @@ tests:
     [+](plus-prefix)[enabled](enabled): true | false
     [+](plus-prefix)[tags](resource-configs/tags): <string> | [<string>]
     [+](plus-prefix)[meta](resource-configs/meta): {dictionary}
+    # relevant for [store_failures](resource-configs/store_failures) only
+    [+](plus-prefix)[database](resource-configs/database): <string>
+    [+](plus-prefix)[schema](resource-configs/schema): <string>
+    [+](plus-prefix)[alias](resource-configs/alias): <string>
 ```
 </File>
 
@@ -153,7 +157,10 @@ tests:
 {{ config(
     [enabled](enabled)=true | false,
     [tags](resource-configs/tags)="<string>" | ["<string>"]
-    [meta](resource-configs/meta)={dictionary}
+    [meta](resource-configs/meta)={dictionary},
+    [database](resource-configs/database)="<string>",
+    [schema](resource-configs/schema)="<string>",
+    [alias](resource-configs/alias)="<string>",
 ) }}
 
 ```
@@ -174,6 +181,10 @@ version: 2
             [enabled](enabled): true | false
             [tags](resource-configs/tags): <string> | [<string>]
             [meta](resource-configs/meta): {dictionary}
+            # relevant for [store_failures](resource-configs/store_failures) only
+            [database](resource-configs/database): <string>
+            [schema](resource-configs/schema): <string>
+            [alias](resource-configs/alias): <string>
 
     [columns](columns):
       - name: <column_name>
@@ -184,6 +195,10 @@ version: 2
                 [enabled](enabled): true | false
                 [tags](resource-configs/tags): <string> | [<string>]
                 [meta](resource-configs/meta): {dictionary}
+                # relevant for [store_failures](resource-configs/store_failures) only
+                [database](resource-configs/database): <string>
+                [schema](resource-configs/schema): <string>
+                [alias](resource-configs/alias): <string>
 ```
 
 This configuration mechanism is supported for specific instances of generic tests only. To configure a specific singular test, you should use the `config()` macro in its SQL definition.


### PR DESCRIPTION
resolves #1269

## Description & motivation
Adds two new versioned sections to "Tests" resource property page:
- Defining a custom name for one test — this is pretty long right now, lots of examples and motivation
- Alternative format for defining tests

Both are new in v1.1. I'm observed that version blocks don't prevent headers from appearing on the right-hand sidebar. So if the user has selected an earlier version from the dropdown, I have those same sections appear and display the test `Only supported by v1.1 or newer.`. This feels similar to our approach for [versioning entire pages](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/versioningdocs.md#versioning-entire-pages).

While here, I found that `database`/`schema`/`alias` are missing from available test configs. They're only relevant if you're using `--store-failures`, but still, worth documenting.

Updates to the migration guide across all these PRs are going to cause such merge conflicts, but I don't think it's a huge deal (worthy of `changie`-like approach). It's important that we show all relevant info to end users, in a way that's approachable and easy to digest.

## Pre-release docs
Is this change related to an unreleased version of dbt? _Yes, following new paradigm!_
