### PR TITLE
Rotating blog CTA to April 19th's staging event

### DIFF
--- a/website/blog/ctas.yml
+++ b/website/blog/ctas.yml
@@ -8,6 +8,6 @@
 - name: staging
   header: "Staging: dbt Demo Day"
   subheader: Is back April 19th! Learn what's new and coming soon to dbt.
-  button_text: Register Here
+  button_text: Register
   url: https://www.getdbt.com/resources/staging-dbt-demo-days-april-2022/?utm_medium=internal&utm_source=blog&utm_campaign=q1-2023_staging-demo-days_awareness&utm_content=connect
 

--- a/website/blog/ctas.yml
+++ b/website/blog/ctas.yml
@@ -5,3 +5,9 @@
   subheader: The annual conference dedicated to the advancement of analytics engineering wrapped up on December 10th.
   button_text: Watch the talks
   url: https://getdbt.com/coalesce-2021/
+- name: staging
+  header: "Staging: dbt Demo Day"
+  subheader: Is back April 19th! Learn what's new and coming soon to dbt.
+  button_text: Register Here
+  url: https://www.getdbt.com/resources/staging-dbt-demo-days-april-2022/?utm_medium=internal&utm_source=blog&utm_campaign=q1-2023_staging-demo-days_awareness&utm_content=connect
+

--- a/website/blog/metadata.yml
+++ b/website/blog/metadata.yml
@@ -2,7 +2,7 @@
 featured_image: ""
 
 # This CTA lives in right sidebar on blog index
-featured_cta: "coalesce"
+featured_cta: "staging"
 
 # How many featured posts to show on blog index
 featured_posts_count: 4


### PR DESCRIPTION
## Description & motivation
The next Staging is coming up on April 19th - let's let people know in the dev blog CTA section.

[Asana ticket here](https://app.asana.com/0/1199544066268568/1201974603233509/f).

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ x ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!
