### PR TITLE
Fix duplicated v1.1 in dropdown

### DIFF
--- a/website/dbt-versions.js
+++ b/website/dbt-versions.js
@@ -5,10 +5,6 @@ exports.versions = [
     isPrerelease: true
   },
   {
-    version: "1.1",
-    EOLDate: "2024-5-01"
-  },
-  {
     version: "1.0",
     EOLDate: "2023-12-03"
   },


### PR DESCRIPTION
See [slack thread](https://getdbt.slack.com/archives/C016X6ABVUK/p1649618050299469)

v1.1 is showing up twice, and once without `isPrerelease: True`. My fault when resolving the merge conflict from #1263.