### PR TITLE
Updates for v1.1 RC release

### DIFF
--- a/website/docs/docs/guides/migration-guide/upgrading-to-v1.1.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-v1.1.md
@@ -3,10 +3,10 @@ title: "Upgrading to v1.1 (prerelease)"
 
 ---
 
-:::info Beta
-v1.1 is currently available as a beta prerelease. Install it from PyPi [for your adapter](available-adapters), if available:
+:::info Release candidate
+v1.1 is currently available as a release candidate. Install it from PyPi [for your adapter](available-adapters), if available:
 ```
-pip install "dbt-<adapter>~=1.1.0b1"
+pip install "dbt-<adapter>~=1.1.0rc1"
 ```
 :::
 


### PR DESCRIPTION
## Description & motivation
Let's get the docs ready for RC!

- [x] Update banner text? Jeremy and I looked at the banner text and it seems appropriate for both beta and RC:
> You are currently viewing v1.1, which is a prerelease of dbt Core. The latest stable version is v1.0
- [x] Change the install path to the correct version
- [x] Update the page note to change form `beta` to `rc`. 
- [ ] Add blurb about changes to the migration guide about v1.1-specific content/changes
- [ ] Merge once the RC has released.

## To-do before merge
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged


## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [ ] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!

## Checklist
If you added new pages (delete if not applicable):
- [ ] The page has been added to `website/sidebars.js`
- [ ] The new page has a unique filename

If you removed existing pages (delete if not applicable):
- [ ] The page has been removed from `website/sidebars.js`
- [ ] An entry has been added to `_redirects`
