### PR TITLE
v1.1: support for inline source config (`enabled`)

### DIFF
--- a/website/docs/docs/guides/migration-guide/upgrading-to-v1.1.md
+++ b/website/docs/docs/guides/migration-guide/upgrading-to-v1.1.md
@@ -36,6 +36,7 @@ _Note: If you're contributing docs for a new or updated feature in v1.1, please 
 
 - [**Incremental models**](configuring-incremental-models) can now accept a list of multiple columns as their `unique_key`, for models that need a combination of columns to uniquely identify each row. This is supported by the most common data warehouses, for incremental strategies that make use of the `unique_key` config (`merge` and `delete+insert`).
 - [**Generic tests**](resource-properties/tests) can define custom names. This is useful to "prettify" the synthetic name that dbt applies automatically. It's needed to disambiguate the case when the same generic test is defined multiple times with different configurations.
+- [**Sources**](resource-properties/sources) can define configuration inline with other `.yml` properties, just like other resource types. The only supported config is `enabled`; you can use this to dynamically enable/disable sources based on environment or package variables.
 - [Python compatibility](install-python-compatibility): dbt Core officially supports Python 3.10
 
 ### For users of specific adapter plugins

--- a/website/docs/reference/source-configs.md
+++ b/website/docs/reference/source-configs.md
@@ -4,14 +4,85 @@ id: source-configs
 ---
 
 ## Available configurations
-### Source-specific configurations
-* None
+
+Sources only support one configuration, [`enabled`](enabled).
 
 ### General configurations
-* [enabled](resource-configs/enabled.md): true | false
+
+<Tabs
+  groupId="config-languages"
+  defaultValue="project-yaml"
+  values={[
+    { label: 'Project file', value: 'project-yaml', },
+    { label: 'Property file', value: 'property-yaml', },
+  ]
+}>
+
+<TabItem value="project-yaml">
+
+<File name='dbt_project.yml'>
+
+```yaml
+sources:
+  [<resource-path>](resource-path):
+    [+](plus-prefix)[enabled](enabled): true | false
+
+```
+
+</File>
+
+</TabItem>
+
+
+<TabItem value="property-yaml">
+
+<VersionBlock firstVersion="1.1">
+
+<File name='models/properties.yml'>
+
+```yaml
+version: 2
+
+sources:
+  - name: [<source-name>]
+    [config](resource-properties/config):
+      [enabled](enabled): true | false
+    tables:
+      - name: [<source-table-name>]
+        [config](resource-properties/config):
+          [enabled](enabled): true | false
+
+```
+
+</File>
+
+</VersionBlock>
+
+<VersionBlock lastVersion="1.0">
+
+Configuring sources within their yaml file definitions is only supported by v1.1 and newer.
+
+</VersionBlock>
+
+</TabItem>
+
+</Tabs>
 
 ## Configuring sources
+
+<VersionBlock firstVersion="1.1">
+
 Sources can be configured via a `config:` block within their `.yml` definitions, or from the `dbt_project.yml` file under the `sources:` key. This configuration is most useful for configuring sources imported from [a package](package-management). You can disable sources imported from a package to prevent them from rendering in the documentation, or to prevent [source freshness checks](using-sources#snapshotting-source-data-freshness) from running on source tables imported from packages.
+
+</VersionBlock>
+
+<VersionBlock lastVersion="1.0">
+
+Sources can be configured from the `dbt_project.yml` file under the `sources:` key. This configuration is most useful for configuring sources imported from [a package](package-management). You can disable sources imported from a package to prevent them from rendering in the documentation, or to prevent [source freshness checks](using-sources#snapshotting-source-data-freshness) from running on source tables imported from packages.
+
+Unlike other resource types, sources do not yet support a `config` property. It is not possible to (re)define source configs hierarchically across multiple yaml files.
+
+</VersionBlock>
 
 ### Examples
 #### Disable all sources imported from a package
@@ -71,6 +142,12 @@ sources:
 ```
 
 </File>
+
+</VersionBlock>
+
+<VersionBlock lastVersion="1.0">
+
+Configuring sources within their yaml file definitions is only supported by v1.1 and newer.
 
 </VersionBlock>
 

--- a/website/docs/reference/source-configs.md
+++ b/website/docs/reference/source-configs.md
@@ -11,15 +11,7 @@ id: source-configs
 * [enabled](resource-configs/enabled.md): true | false
 
 ## Configuring sources
-Sources can be configured from the `dbt_project.yml` file under the `sources:`
-key. This configuration is most useful for configuring sources imported from
-[a package](package-management). You can disable sources imported from a package
-to prevent them from rendering in the documentation, or to prevent
-[source freshness checks](using-sources#snapshotting-source-data-freshness)
-from running on source tables imported from packages.
-
-Unlike other resource types, sources do not yet support a `config` property. It
-is not possible to (re)define source configs hierarchically across multiple yaml files.
+Sources can be configured via a `config:` block within their `.yml` definitions, or from the `dbt_project.yml` file under the `sources:` key. This configuration is most useful for configuring sources imported from [a package](package-management). You can disable sources imported from a package to prevent them from rendering in the documentation, or to prevent [source freshness checks](using-sources#snapshotting-source-data-freshness) from running on source tables imported from packages.
 
 ### Examples
 #### Disable all sources imported from a package
@@ -31,7 +23,6 @@ state your configuration under the [project name](project-configs/name.md) in th
 <File name='dbt_project.yml'>
 
 ```yml
-
 sources:
   events:
     +enabled: false
@@ -40,16 +31,56 @@ sources:
 </File>
 
 
-#### Disable a specific source
+#### Conditionally enable a single source
 
-To disable a specific source, qualify the resource path for your configuration
-with both a package name and a source name.
+<VersionBlock firstVersion="1.1">
 
+When defining a source, you can disable the entire source, or specific source tables, using the inline `config` property:
+
+<File name='models/sources.yml'>
+
+```yml
+version: 2
+
+sources:
+  - name: my_source
+    config:
+      enabled: true
+    tables:
+      - name: my_source_table  # enabled
+      - name: ignore_this_one  # not enabled
+        config:
+          enabled: false
+```
+
+</File>
+
+You can configure specific source tables, and use [variables](dbt-jinja-functions/var) as the input to that configuration:
+ 
+<File name='models/sources.yml'>
+
+```yml
+version: 2
+
+sources:
+  - name: my_source
+    tables:
+      - name: my_source_table
+        config:
+          enabled: "{{ var('my_source_table_enabled', false) }}"
+```
+
+</File>
+
+</VersionBlock>
+
+#### Disable a single source from a package
+
+To disable a specific source from another package, qualify the resource path for your configuration with both a package name and a source name. In this case, we're disabling the `clickstream` source from the `events` package.
 
 <File name='dbt_project.yml'>
 
 ```yml
-
 sources:
   events:
     clickstream:
@@ -58,8 +89,7 @@ sources:
 
 </File>
 
-Similarly, you can disable a specific table from a source by qualifying the
-resource path with a package name, source name, and table name:
+Similarly, you can disable a specific table from a source by qualifying the resource path with a package name, source name, and table name:
 
 <File name='dbt_project.yml'>
 

--- a/website/docs/reference/source-properties.md
+++ b/website/docs/reference/source-properties.md
@@ -25,6 +25,10 @@ sources:
     [loaded_at_field](resource-properties/freshness#loaded_at_field): <column_name>
     [meta](meta): {<dictionary>}
     [tags](resource-configs/tags): [<string>]
+    
+    # requires v1.1+
+    [config](resource-properties/config):
+      [<source_config>](source-configs): <config_value>
 
     [overrides](resource-properties/overrides): <string>
 


### PR DESCRIPTION
resolves https://github.com/dbt-labs/docs.getdbt.com/issues/1331

## Description & motivation
- In v1.1, it's possible to define inline `config` property for sources
- Why does this matter? It's now possible to (conditionally) enable/disable a single source or source table, which is very useful for people who maintain or use packages

## Pre-release docs
Is this change related to an unreleased version of dbt?

Yes! New prerelease flow