### PR TITLE
Adjust VersionBlock component wrapper

### DIFF
--- a/website/src/components/versionBlock/index.js
+++ b/website/src/components/versionBlock/index.js
@@ -33,5 +33,5 @@ export default function VersionBlock({ firstVersion = 0, lastVersion = undefined
 
   return loading
     ?  null
-    : <div>{children}</div>
+    : <>{children}</>
 }


### PR DESCRIPTION
## Description & motivation
Currently, the VersionBlock component wraps it's children with a div, which adds an extra html element to the page and complicates trying to use it inline with other text. This should be changed to a react fragment to avoid adding an additional div to the page.

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!