### PR TITLE
Add redirect pointing next to docs.getdbt.com

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,3 +1,6 @@
+# redirect next
+https://next.docs.getdbt.com/*     https://docs.getdbt.com/:splat 301!
+
 /img/docs/dbt-cloud/dbt-cloud-enterprise/icon.png	https://www.getdbt.com/ui/img/dbt-icon.png	301!
 /dbt-cli/installation-guides/centos		/dbt-cli/install/overview	302
 /dbt-cli/installation-guides/centos	/dbt-cli/install/overview	302


### PR DESCRIPTION
## Description & motivation
We are shutting down next.docs.getdbt.com (#1340). This adds a redirect to point all traffic to docs.getdbt.com

## Pre-release docs
Is this change related to an unreleased version of dbt?
- [ ] Yes: please
    - update the base branch to `next`
    - add Changelog components: `<Changelog>[New/Changed] in v0.x.0</Changelog>`
    - add links to the "New and changed documentation" section of the latest [Migration Guide](../website/docs/docs/guides/migration-guide)
- [x] No: please ensure the base branch is `current`
- [ ] Unsure: we'll let you know!