### PR TITLE
Update installation instructions for `dbt-tests-adapter` in "Testing a new adapter"

### DIFF
--- a/website/docs/docs/contributing/testing-a-new-adapter.md
+++ b/website/docs/docs/contributing/testing-a-new-adapter.md
@@ -216,14 +216,9 @@ In this section, we'll walk through the three steps to start running our basic t
 ### Install dependencies
 
 You should already have a virtual environment with `dbt-core` and your adapter plugin installed. You'll also need to install:
-- `pytest`
-- `dbt-tests-adapter`, the set of basic test cases
+- [`pytest`](https://pypi.org/project/pytest/)
+- [`dbt-tests-adapter`](https://pypi.org/project/dbt-tests-adapter/), the set of common test cases
 - (optional) [`pytest` plugins](https://docs.pytest.org/en/7.0.x/reference/plugin_list.html)--we'll use `pytest-dotenv` below
-
-During initial development, the `dbt-tests-adapter` package is not yet on PyPi, so please install it directly from GitHub:
-```bash
-pip install "git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter"
-```
 
 Or specify all dependencies in a requirements file like:
 <File name="dev_requirements.txt">
@@ -231,7 +226,7 @@ Or specify all dependencies in a requirements file like:
 ```txt
 pytest
 pytest-dotenv
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter
+dbt-tests-adapter
 ```
 </File>
 


### PR DESCRIPTION
These docs need another pass before final release next week. This is a quick fix because the current recommendation (`pip install git+...`) causes version issues, now that we've bumped `dbt-core`'s `main` branch to `1.2.0a1`.

See: [Slack thread](https://getdbt.slack.com/archives/C030A0UF5LM/p1650458900773539?thread_ts=1648805418.632239&cid=C030A0UF5LM)