### PR TITLE
Update Using Airflow section with dbt Cloud provider

### DIFF
--- a/website/docs/docs/running-a-dbt-project/running-dbt-in-production.md
+++ b/website/docs/docs/running-a-dbt-project/running-dbt-in-production.md
@@ -34,8 +34,10 @@ If you're interested in giving dbt Cloud a spin, you can sign up for a *forever 
 
 ### Using Airflow
 If your organization is using [Airflow](https://airflow.apache.org/), there are a number of ways you can run your dbt jobs, including:
-* Invoking dbt through the [BashOperator](https://airflow.apache.org/howto/operator/bash.html). In this case, be sure to install dbt into a virtual environment to avoid issues with conflicting dependencies between Airflow and dbt.
-* Installing the [airflow-dbt](https://pypi.org/project/airflow-dbt/) python package. This package uses Airflow's operator and hook concept — the source code can be found on [github](https://github.com/gocardless/airflow-dbt).
+* Invoking dbt Core jobs through the [BashOperator](https://registry.astronomer.io/providers/apache-airflow/modules/bashoperator). In this case, be sure to install dbt into a virtual environment to avoid issues with conflicting dependencies between Airflow and dbt.
+* Installing the [dbt Cloud Provider](https://registry.astronomer.io/providers/dbt-cloud) to orchestrate dbt Cloud jobs. This package contains multiple Hooks, Operators, and Sensors to complete various actions within dbt Cloud.
+
+For more details on both of these methods, including example implementations, check out [this guide](https://www.astronomer.io/guides/airflow-dbt).
 
 ### Using Prefect
 If your organization is using [Prefect](https://www.prefect.io), use the [DbtShellTask](https://docs.prefect.io/api/latest/tasks/dbt.html#dbtshelltask) to schedule, execute and monitor your dbt runs.


### PR DESCRIPTION
## Description & motivation
Replaces the `airflow-dbt` Python package bullet with a reference to the new dbt Cloud Provider, which is the preferred way of orchestrating dbt Cloud jobs from Airflow. Also update a few links and add link out to guide with detailed instructions.
