### PR TITLE
fix typing for partial_parse setting

### DIFF
--- a/website/docs/reference/profiles.yml.md
+++ b/website/docs/reference/profiles.yml.md
@@ -14,7 +14,7 @@ This article lists the parts of your `profiles.yml` which are _not_ database spe
 [config](global-configs):
   [send_anonymous_usage_stats](global-configs#send_anonymous_usage_stats): <true | false>
   [use_colors](global-configs#use_colors): <true | false>
-  [partial_parse](global-configs#partial_parse): <integer>
+  [partial_parse](global-configs#partial_parse): <bool>
   [printer_width](global-configs#printer_width): <true | false>
   [write_json](global-configs#write_json): <true | false>
   [warn_error](global-configs#warn_error): <true | false>


### PR DESCRIPTION
this:
```yaml
config:
  partial_parse: 0
```

results in an error:

```
❯ dbt compile
23:35:32  Encountered an error:
0 is not valid under any of the given schemas

Failed validating 'oneOf' in schema['properties']['partial_parse']:
    {'oneOf': [{'type': 'boolean'}, {'type': 'null'}]}

On instance['partial_parse']:
    0
```


