### PR TITLE
Update: Core versions, v1.1 migration guide, adapter guide

### DIFF
--- a/website/docs/docs/contributing/building-a-new-adapter.md
+++ b/website/docs/docs/contributing/building-a-new-adapter.md
@@ -391,3 +391,15 @@ Many community members maintain their adapter plugins under open source licenses
 - Hosting on a public git provider (e.g. GitHub, GitLab)
 - Publishing to [PyPi](https://pypi.org/)
 - Adding to the list of ["Available Adapters"](available-adapters#community-supported)
+
+### Maintaining your new adapter
+
+If your adapter catches on, and people start using it, you may find yourself as the maintainer of an increasingly popular open source project. It's best to communicate your intentions early and often: Is this experimental work that people should use at their own risk? Or is this production-grade code that you're committed to maintaining into the future?
+
+Be aware that new minor version releases of `dbt-core` may include changes to the Python interface for adapter plugins, as well as new or updated test cases. The maintainers of `dbt-core` will clearly communicate these changes in documentation and release notes, and they will aim for backwards compatibility whenever possible. Patch releases of `dbt-core` will _not_ include breaking changes to adapter-facing code. (For more details, see ["About dbt Core versions"](core-versions).)
+
+We strongly encourage you to adopt the following approach when versioning and releasing your plugin:
+- The minor version of your plugin should match the minor version in `dbt-core` (e.g. 1.1.x).
+- Aim to release a new version of your plugin for each new minor version of `dbt-core` (once every three months).
+- While your plugin is new, and you're iterating on features, aim to offer backwards compatibility and deprecation notices for at least one minor version. As your plugin matures, aim to leave backwards compatibility and deprecation notices in place until the next major version (dbt Core v2).
+- Release patch versions of your plugins whenever needed. These patch releases should contain fixes _only_.

--- a/website/docs/docs/contributing/building-a-new-adapter.md
+++ b/website/docs/docs/contributing/building-a-new-adapter.md
@@ -394,9 +394,15 @@ Many community members maintain their adapter plugins under open source licenses
 
 ### Maintaining your new adapter
 
-If your adapter catches on, and people start using it, you may find yourself as the maintainer of an increasingly popular open source project. It's best to communicate your intentions early and often: Is this experimental work that people should use at their own risk? Or is this production-grade code that you're committed to maintaining into the future?
+When your adapter becomes more popular, and people start using it, you may quickly become the maintainer of an increasingly popular open source project. With this new role, comes some unexpected responsibilities that not only include code maintenance, but also working with a community of users and contributors. To help people understand what to expect of your project, you should communicate your intentions early and often in your adapter documentation or README. Answer questions like, Is this experimental work that people should use at their own risk? Or is this production-grade code that you're committed to maintaining into the future?
 
-Be aware that new minor version releases of `dbt-core` may include changes to the Python interface for adapter plugins, as well as new or updated test cases. The maintainers of `dbt-core` will clearly communicate these changes in documentation and release notes, and they will aim for backwards compatibility whenever possible. Patch releases of `dbt-core` will _not_ include breaking changes to adapter-facing code. (For more details, see ["About dbt Core versions"](core-versions).)
+#### Keeping the code compatible with dbt Core
+
+New minor version releases of `dbt-core` may include changes to the Python interface for adapter plugins, as well as new or updated test cases. The maintainers of `dbt-core` will clearly communicate these changes in documentation and release notes, and they will aim for backwards compatibility whenever possible.
+
+Patch releases of `dbt-core` will _not_ include breaking changes to adapter-facing code. For more details, see ["About dbt Core versions"](core-versions).
+
+#### Versioning and releasing your adapter
 
 We strongly encourage you to adopt the following approach when versioning and releasing your plugin:
 - The minor version of your plugin should match the minor version in `dbt-core` (e.g. 1.1.x).

--- a/website/docs/docs/core-versions.md
+++ b/website/docs/docs/core-versions.md
@@ -72,6 +72,10 @@ Like many software projects, dbt Core releases follow [semantic versioning](http
 - **Minor versions**, also called "feature" releases, include a mix of new features, behind-the-scenes improvements, and changes to existing capabilities that are **backwards compatible** with previous minor versions. They will not break code in your project that relies on documented functionality.
 - **Patch versions**, also called "bugfix" or "security" releases, include **fixes _only_**. These fixes could be needed to restore previous (documented) behavior, fix obvious shortcomings of new features, or offer critical fixes for security or installation issues. We are judicious about which fixes are included in patch releases, to minimize the surface area of changes.
 
+We are committed to avoiding breaking changes in minor versions for end users of dbt. There are two types of breaking changes that may be included in minor versions:
+- Changes to the [Python interface for adapter plugins](building-a-new-adapter). These changes are relevant _only_ to adapter maintainers, and they will be clearly communicated in documentation and release notes.
+- Changes to metadata interfaces, including [artifacts](dbt-artifacts) and [logging](events-logging), signalled by a version bump. Those version upgrades may require you to update external code that depends on these interfaces, or to coordinate upgrades between dbt orchestrations that share metadata, such as [state-powered selection](understanding-state).
+
 ### How we version adapter plugins
 
 When you use dbt, you're using `dbt-core` together with an adapter plugin specific to your database. You can see the current list in ["Available adapters"](available-adapters). Both `dbt-core` and dbt adapter plugins follow semantic versioning.

--- a/website/docs/guides/migration/versions/05-upgrading-to-v1.3.md
+++ b/website/docs/guides/migration/versions/05-upgrading-to-v1.3.md
@@ -9,7 +9,7 @@ title: "Trying out v1.3 (beta)"
 
 ## Breaking changes
 
-There are no breaking changes for end users of dbt. We are committed to providing backwards compatibility for all versions 1.x. If you encounter an error upon upgrading, please let us know by [opening an issue](https://github.com/dbt-labs/dbt-core/issues/new).
+There are no breaking changes for code in dbt projects and packages. We are committed to providing backwards compatibility for all versions 1.x. If you encounter an error upon upgrading, please let us know by [opening an issue](https://github.com/dbt-labs/dbt-core/issues/new).
 
 ### For consumers of dbt artifacts (metadata)
 

--- a/website/docs/guides/migration/versions/06-upgrading-to-v1.2.md
+++ b/website/docs/guides/migration/versions/06-upgrading-to-v1.2.md
@@ -9,7 +9,7 @@ title: "Upgrading to v1.2 (latest)"
 
 ## Breaking changes
 
-There are no breaking changes for end users of dbt. We are committed to providing backwards compatibility for all versions 1.x. If you encounter an error upon upgrading, please let us know by [opening an issue](https://github.com/dbt-labs/dbt-core/issues/new).
+There are no breaking changes for code in dbt projects and packages. We are committed to providing backwards compatibility for all versions 1.x. If you encounter an error upon upgrading, please let us know by [opening an issue](https://github.com/dbt-labs/dbt-core/issues/new).
 
 ### For consumers of dbt artifacts (metadata)
 

--- a/website/docs/guides/migration/versions/07-upgrading-to-v1.1.md
+++ b/website/docs/guides/migration/versions/07-upgrading-to-v1.1.md
@@ -9,7 +9,7 @@ title: "Upgrading to v1.1"
 
 ## Breaking changes
 
-There are no breaking changes for end users of dbt. We are committed to providing backwards compatibility for all versions 1.x. If you encounter an error upon upgrading, please let us know by [opening an issue](https://github.com/dbt-labs/dbt-core/issues/new).
+There are no breaking changes for code in dbt projects and packages. We are committed to providing backwards compatibility for all versions 1.x. If you encounter an error upon upgrading, please let us know by [opening an issue](https://github.com/dbt-labs/dbt-core/issues/new).
 
 ### For maintainers of adapter plugins
 
@@ -20,6 +20,16 @@ The abstract methods `get_response` and `execute` now only return `connection.Ad
 ### For consumers of dbt artifacts (metadata)
 
 The manifest schema version will be updated to v5. The only change is to the default value of `config` for parsed nodes.
+
+For users of [state-based functionality](understanding-state), such as the `state:modified` selector, recall that:
+
+> The `--state` artifacts must be of schema versions that are compatible with the currently running dbt version.
+
+If you have two jobs, whereby one job compares or defers to artifacts produced by the other, you'll need to upgrade both at the same time. If there's a mismatch, dbt will alert you with this error message:
+
+```
+Expected a schema version of "https://schemas.getdbt.com/dbt/manifest/v5.json" in <state-path>/manifest.json, but found "https://schemas.getdbt.com/dbt/manifest/v4.json". Are you running with a different version of dbt?
+```
 
 ## New and changed documentation
 


### PR DESCRIPTION
There are two kinds of "breaking" changes that are allowed in dbt minor versions:
1. Python interface for adapter plugin maintainers. This is said implicitly in a couple places, but I think it's worth calling out explicitly in both "About dbt Core versions" and "Building a new adapter" (our dedicated guide). The language here is an imperfect placeholder — @dataders I'd appreciate your help in how we might set/communicate this expectation.
2. Metadata interfaces, which are versioned independently, and will always bump their versions to reflect an underlying change. This is a good thing—no surprises!—but it does require some coordination during upgrades if using external tools that parse metdata, or an advanced metadata-powered feature _within dbt_ such as `--state`-powered node selection. A user just ran into this, and perceived it as a breaking change: https://github.com/dbt-labs/dbt-core/issues/5213