### PR TITLE
Updating to correct Python version

### DIFF
--- a/website/docs/faqs/install-pip-os-prereqs.md
+++ b/website/docs/faqs/install-pip-os-prereqs.md
@@ -54,4 +54,4 @@ pip install cryptography~=3.4
 
 Windows requires Python and git to successfully install and run dbt Core.
 
-Install [Git for Windows](https://git-scm.com/downloads) and [Python version 3.6 or higher for Windows](https://www.python.org/downloads/windows/).
+Install [Git for Windows](https://git-scm.com/downloads) and [Python version 3.7 or higher for Windows](https://www.python.org/downloads/windows/).

--- a/website/docs/faqs/install-pip-os-prereqs.md
+++ b/website/docs/faqs/install-pip-os-prereqs.md
@@ -55,3 +55,5 @@ pip install cryptography~=3.4
 Windows requires Python and git to successfully install and run dbt Core.
 
 Install [Git for Windows](https://git-scm.com/downloads) and [Python version 3.7 or higher for Windows](https://www.python.org/downloads/windows/).
+
+For further questions, please see the [Python compatibility FAQ](/docs/faqs/install-python-compatibility.md)

--- a/website/docs/faqs/install-pip-os-prereqs.md
+++ b/website/docs/faqs/install-pip-os-prereqs.md
@@ -56,4 +56,4 @@ Windows requires Python and git to successfully install and run dbt Core.
 
 Install [Git for Windows](https://git-scm.com/downloads) and [Python version 3.7 or higher for Windows](https://www.python.org/downloads/windows/).
 
-For further questions, please see the [Python compatibility FAQ](/docs/faqs/install-python-compatibility.md)
+For further questions, please see the [Python compatibility FAQ](/docs/faqs/install-python-compatibility)


### PR DESCRIPTION
## Description & motivation
Just noticed that the Python version here still said Python 3.6 when we are now only supporting 3.7 and above.

## Prerelease docs
If this change is related to functionality in a prerelease version of dbt (delete if not applicable):
- [ ] I've added versioning components, as described in ["Versioning Docs"](../contributing/versioningdocs.md)
- [ ] I've added a note to the prerelease version's [Migration Guide](../website/docs/docs/guides/migration-guide)

## Checklist
n/a