### PR TITLE
Adjust FAQs on Docs site to use `id` instead of filename

### DIFF
--- a/website/docs/faqs/install-pip-os-prereqs.md
+++ b/website/docs/faqs/install-pip-os-prereqs.md
@@ -1,5 +1,4 @@
 ---
-id: install-pip-os-prereqs
 title: "Does my operating system have prerequisites?"
 Description: "You can check whether your operating system has prerequisites for installing dbt Core."
 

--- a/website/docs/faqs/test/install-pip-os-prereqs.md
+++ b/website/docs/faqs/test/install-pip-os-prereqs.md
@@ -1,5 +1,5 @@
 ---
-
+id: install-pip-os-prereqs
 title: "Does my operating system have prerequisites?"
 Description: "You can check whether your operating system has prerequisites for installing dbt Core."
 

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -7801,7 +7801,8 @@
     },
     "node_modules/gray-matter": {
       "version": "4.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
       "dependencies": {
         "js-yaml": "^3.13.1",
         "kind-of": "^6.0.2",
@@ -20093,6 +20094,8 @@
     },
     "gray-matter": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
       "requires": {
         "js-yaml": "^3.13.1",
         "kind-of": "^6.0.2",

--- a/website/plugins/buildGlobalData/get-directory-files.js
+++ b/website/plugins/buildGlobalData/get-directory-files.js
@@ -1,0 +1,41 @@
+/**
+ * Get an array of all files in a directory
+ * and the ID from each file's frontmatter
+ * @param {string} dir Directory path 
+ * @param {Array.<Object>} [directoryArr=[]] - Subdirectory found in readdirSync
+ * @returns {Array} - Array of file paths and file IDs
+ */
+
+const fs = require('fs')
+const matter = require('gray-matter')
+
+const getDirectoryFiles = (dir, directoryArr = []) => {
+  const files = fs.readdirSync(dir)
+  files.map(file => {
+    const filePath = `${dir}/${file}`
+    if(fs.statSync(filePath).isDirectory()) {
+      // If current item is directory, self-invoke getDirectoryFiles function
+      getDirectoryFiles(filePath, directoryArr)
+    } else {
+      // If a file, get markdown content
+      const fileData = fs.readFileSync(filePath, { encoding: 'utf8' })
+      if(!fileData)
+        return null
+      
+      // convert frontmatter to json
+      const fileJson = matter(fileData)
+      if(!fileJson)
+        return null
+      
+      // add file contents to array
+      const { data } = fileJson
+      directoryArr.push({
+        filePath,
+        id: data?.id || null
+      })
+    }
+  })
+  return directoryArr
+}
+
+module.exports = { getDirectoryFiles }

--- a/website/plugins/buildGlobalData/index.js
+++ b/website/plugins/buildGlobalData/index.js
@@ -1,6 +1,7 @@
 const fs = require('fs')
 const yaml = require('js-yaml')
 const slugify = require('slugify')
+const { getDirectoryFiles } = require('./get-directory-files')
 
 // Pass custom data to blog
 module.exports = function buildGlobalDataPlugin(context, options) {
@@ -25,11 +26,16 @@ module.exports = function buildGlobalDataPlugin(context, options) {
       // This controls versioning for sidebar
       const { versionedPages } = options
       
+      // Get all FAQ doc ids
+      // FAQ component uses these to pull file
+      const faqFiles = getDirectoryFiles(`docs/faqs`)
+
       return {
         tagData,
         blogMeta,
         CTAData,
-        versionedPages
+        versionedPages,
+        faqFiles
       }
     },
     async contentLoaded({content, actions}) {


### PR DESCRIPTION
[Asana task](https://app.asana.com/0/1200099998847559/1202220638270389/f)

Original issue: #1404 

Since the faqs are moved into subdirectories, the path above is no longer accurate for these FAQs withing the FAQs component, causing the build to fail as it is unable to find those files. This updates the FAQ component to resolve this.

Adjusted the FAQ component to support getting the content by both the faq frontmatter id and filename. This will allow it to work with the current production code which gets FAQ items by filename, and by frontmatter IDs once they are set.

To test this PR, I set an id for the `/docs/faqs/test/install-pip-os-prereqs.md` faq file, and moved it into a subdirectory: `/test`.

Once this is live, #1404 should merge `current` to include these updates. The FAQs in subdirectories should begin working as expected and the build should pass.
 
## Before Merge

- [x] Remove ID in `/docs/faqs/test/install-pip-os-prereqs.md` file.
- [x] Move `/docs/faqs/test/install-pip-os-prereqs.md` into original faqs directory.

## Preview Link
https://deploy-preview-1419--docs-getdbt-com.netlify.app/dbt-cli/install/from-source

The first FAQ at the bottom of this page `Does my operating system have prerequisites?` is pulling the faq by id, while the other two are still pulling the faq by filename.