### PR TITLE
missing import for BaseAdapterMethod

### DIFF
--- a/website/docs/docs/contributing/testing-a-new-adapter.md
+++ b/website/docs/docs/contributing/testing-a-new-adapter.md
@@ -301,6 +301,7 @@ from dbt.tests.adapter.basic.test_incremental import BaseIncremental
 from dbt.tests.adapter.basic.test_generic_tests import BaseGenericTests
 from dbt.tests.adapter.basic.test_snapshot_check_cols import BaseSnapshotCheckCols
 from dbt.tests.adapter.basic.test_snapshot_timestamp import BaseSnapshotTimestamp
+from dbt.tests.adapter.basic.test_adapter_methods import BaseAdapterMethod
 
 class TestSimpleMaterializationsMyAdapter(BaseSimpleMaterializations):
     pass


### PR DESCRIPTION
code sample for test_basic.py is missing the import for BaseAdapterMethod

## Description & motivation

The import is needed for the code sample to work.
