### PR TITLE
Remove gitlab published docs from example list

### DIFF
--- a/website/docs/faqs/example-projects.md
+++ b/website/docs/faqs/example-projects.md
@@ -7,6 +7,6 @@ Yes!
 * **Jaffle Shop:** A demonstration project (closely related to the tutorial) for a fictional ecommerce store ([source code](https://github.com/fishtown-analytics/jaffle_shop))
 * **MRR Playbook:** A demonstration project that models subscription revenue ([source code](https://github.com/fishtown-analytics/mrr-playbook), [docs](https://www.getdbt.com/mrr-playbook/#!/overview))
 * **Attribution Playbook:** A demonstration project that models marketing attribution  ([source code](https://github.com/fishtown-analytics/attribution-playbook), [docs](https://www.getdbt.com/attribution-playbook/#!/overview))
-* **GitLab:** Gitlab's internal dbt project is open source and is a great example of how to use dbt at scale ([source code](https://gitlab.com/gitlab-data/analytics/-/tree/master/transform/snowflake-dbt), [docs](https://dbt.gitlabdata.com/))
+* **GitLab:** Gitlab's internal dbt project is open source and is a great example of how to use dbt at scale ([source code](https://gitlab.com/gitlab-data/analytics/-/tree/master/transform/snowflake-dbt))
 
 If you have an example project to add to this list, suggest an [edit](https://github.com/fishtown-analytics/docs.getdbt.com/edit/master/website/docs/faqs/example-projects.md).


### PR DESCRIPTION

## Description & motivation
Previously, Gitlab had a very nice, elaborate dbt docs website. Unfortunately, it's now secured and not publicly available without authentication.

