### PR TITLE
fix two broken links to jinja functions doc

### DIFF
--- a/website/docs/faqs/dbt-specific-jinja.md
+++ b/website/docs/faqs/dbt-specific-jinja.md
@@ -2,4 +2,4 @@
 title: What parts of Jinja are dbt-specific?
 ---
 
-There are certain expressions that are specific to dbt — these are documented in the [Jinja function reference](dbt-jinja-functions) section of these docs. Further, docs blocks, snapshots, and <Term id="materialization">materializations</Term> are custom Jinja _blocks_ that exist only in dbt.
+There are certain expressions that are specific to dbt — these are documented in the [Jinja function reference](dbt-jinja-functions/adapter) section of these docs. Further, docs blocks, snapshots, and <Term id="materialization">materializations</Term> are custom Jinja _blocks_ that exist only in dbt.

--- a/website/docs/faqs/which-jinja-docs.md
+++ b/website/docs/faqs/which-jinja-docs.md
@@ -5,5 +5,5 @@ title: Which docs should I use when writing Jinja or creating a macro?
 If you are stuck with a Jinja issue, it can get confusing where to check for more information. We recommend you check (in order):
 
 1. [Jinja's Template Designer Docs](https://jinja.palletsprojects.com/page/templates/): This is the best reference for most of the Jinja you'll use
-2. [Our Jinja function reference](dbt-jinja-functions): This documents any additional functionality we've added to Jinja in dbt.
+2. [Our Jinja function reference](dbt-jinja-functions/adapter): This documents any additional functionality we've added to Jinja in dbt.
 3. [Agate's table docs](https://agate.readthedocs.io/page/api/table.html): If you're operating on the result of a query, dbt will pass it back to you as an agate table. This means that the methods you call on the <Term id="table" /> belong to the Agate library rather than Jinja or dbt.


### PR DESCRIPTION
## Description & motivation
A user reached out pointing out that a link referenced in the FAQS section of the [Jinja and Macros](http://localhost:3000/docs/building-a-dbt-project/jinja-macros) doc returned a 404 error. Specifically, the link is found under the following two FAQS:

What parts of Jinja are dbt-specific?
Which docs should I use when writing Jinja or creating a macro?

While you can navigate to https://docs.getdbt.com/reference/dbt-jinja-functions by directly pasting it into your web browser URL, this link cannot be referenced in the above docs, as it's not an actual web page. To fix this, I updated the link to point specifically to https://docs.getdbt.com/reference/dbt-jinja-functions/adapter