### PR TITLE
Add `build` to commands that generate artifacts

### DIFF
--- a/website/docs/reference/artifacts/dbt-artifacts.md
+++ b/website/docs/reference/artifacts/dbt-artifacts.md
@@ -18,8 +18,8 @@ dbt has produced artifacts since the release of dbt-docs in v0.11.0. Starting in
 ## When are artifacts produced?
 
 Most dbt commands (and corresponding RPC methods) produce artifacts:
-- [manifest](manifest-json): produced by `compile`, `run`, `test`, `docs generate`, `ls`
-- [run results](run-results-json): produced by `run`, `test`, `seed`, `snapshot`, `docs generate`
+- [manifest](manifest-json): produced by `build`, `compile`, `run`, `test`, `docs generate`, `ls`
+- [run results](run-results-json): produced by `build`, `run`, `test`, `seed`, `snapshot`, `docs generate`
 - [catalog](catalog-json): produced by `docs generate`
 - [sources](sources-json): produced by `source freshness`
 


### PR DESCRIPTION
## Description & motivation
Add `build` to the list of commands that generates `run_results` and `catalog`. This seems to have been missed when `build` reached full release.