### PR TITLE
Add support for dbt Cloud by Dagster

### DIFF
--- a/website/docs/docs/running-a-dbt-project/running-dbt-in-production.md
+++ b/website/docs/docs/running-a-dbt-project/running-dbt-in-production.md
@@ -52,7 +52,7 @@ Alternatively, you can use the supported [ShellTask](https://docs.prefect.io/api
 You can also trigger dbt Cloud jobs with the [DbtCloudRunJob](https://docs.prefect.io/api/latest/tasks/dbt.html#dbtcloudrunjob) task. Running this task will generate a markdown artifact viewable in the Prefect UI. The artifact will contain links to the dbt artifacts generate as a result of the job run.
 
 ### Using Dagster
-If your organization is using [Dagster](https://dagster.io/), you can use the [dagster_dbt](https://docs.dagster.io/_apidocs/libraries/dagster-dbt) library to integrate dbt commands into your pipelines. Execution through both the dbt CLI and the dbt RPC server is supported, and metadata from dbt runs is automatically aggregated. Check out the [example pipeline](https://dagster.io/blog/dagster-dbt) for details.
+If your organization is using [Dagster](https://dagster.io/), you can use the [dagster_dbt](https://docs.dagster.io/_apidocs/libraries/dagster-dbt) library to integrate dbt commands into your pipelines. This library supports the execution of dbt through dbt Cloud, dbt CLI and the dbt RPC server. Running dbt from Dagster automatically aggregates metadata about your dbt runs. Check out the [example pipeline](https://dagster.io/blog/dagster-dbt) for details.
 
 ### Using an automation server
 Automation servers, like CodeDeploy, GitLab CI/CD ([video](https://youtu.be/-XBIIY2pFpc?t=1301)), Bamboo and Jenkins, can be used to schedule bash commands for dbt. They also provide a UI to view logging to the command line, and integrate with your git repository.


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a pull request on dbt core, etc?
-->
Dagster also supports triggering [dbt Cloud jobs](https://docs.dagster.io/_apidocs/libraries/dagster-dbt#dbt-cloud-ops) (in addition to CLI and RPC)
I have updated the page to reflect it.
