### PR TITLE
fix broken non-breaking space character

### DIFF
--- a/website/src/components/faqs/index.js
+++ b/website/src/components/faqs/index.js
@@ -48,7 +48,7 @@ function FAQ({ children, src, alt_header = null }) {
           style={{
             transform: isOn ? null : 'rotateX(180deg)'
           }}>
-        </span >& nbsp;
+        </span >&nbsp;
         <span>{alt_header || fileContent?.meta && fileContent.meta.title}</span>
       </span >
       <div style={{ display: (isOn ? 'block' : 'none') }} className={styles.body}>


### PR DESCRIPTION
## Description & motivation
An extra space in an HTML entity was causing it to render incorrectly. We should remove that space so that dropdown titles render correctly.

I noticed it in the faq section of this page: https://docs.getdbt.com/docs/building-a-dbt-project/projects

Let me know if you need anything else for this PR!
