### PR TITLE
Clarify where using an expression in a test might fail

### DIFF
--- a/website/docs/docs/faqs/uniqueness-two-columns.md
+++ b/website/docs/docs/faqs/uniqueness-two-columns.md
@@ -52,6 +52,8 @@ models:
 
 #### 2. Test an expression
 
+Note that this method will likely fail if you try to [store failures](https://docs.getdbt.com/docs/building-a-dbt-project/tests#storing-test-failures) for this test, due to not having a valid column name for the table.
+
 <File name='models/orders.yml'>
 
 ```yml


### PR DESCRIPTION
## Description & motivation
We noticed that using the `--store-failures` flag would cause uniqueness tests that relied on the trick described in option 2 to fail, so I added a line to note this behavior. Hopefully somebody else finds it useful.