### PR TITLE
Adds inline math equation for docs and dev blog

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,6 +1,9 @@
 const path = require('path');
+const math = require('remark-math');
+const katex = require('rehype-katex');
 const { versions, versionedPages } = require('./dbt-versions');
 require('dotenv').config()
+
 
 /* Debugging */
 var SITE_URL;
@@ -173,6 +176,8 @@ var siteSettings = {
           path: 'docs',
           routeBasePath: '/',
           sidebarPath: require.resolve('./sidebars.js'),
+          remarkPlugins: [math],
+          rehypePlugins: [katex],
 
           editUrl: 'https://github.com/dbt-labs/docs.getdbt.com/edit/' + GIT_BRANCH + '/website/',
           showLastUpdateTime: false,
@@ -186,6 +191,8 @@ var siteSettings = {
           postsPerPage: 20,
           blogSidebarTitle: 'Recent posts',
           blogSidebarCount: 5,
+          remarkPlugins: [math],
+          rehypePlugins: [katex],
         },
 
       },
@@ -222,7 +229,14 @@ var siteSettings = {
     '/css/search.css',
     '/css/api.css',
     'https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;500;600;700&display=swap',
-    'https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;500;600;700&display=swap'
+    'https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;500;600;700&display=swap',
+    {
+      href: 'https://cdn.jsdelivr.net/npm/katex@0.13.24/dist/katex.min.css',
+      type: 'text/css',
+      integrity:
+        'sha384-odtC+0UGzzFL/6PNoE8rX/SPcQDXBJ+uRepguP4QkPCm2LBxH3FA3y+fKSiJ+AmM',
+      crossorigin: 'anonymous',
+    },
   ],
 }
 

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -20,6 +20,7 @@
         "file-loader": "^6.2.0",
         "fs": "0.0.2",
         "gray-matter": "^4.0.3",
+        "hast-util-is-element": "^1.1.0",
         "js-yaml": "^4.1.0",
         "mobx": "^6.3.7",
         "node-polyfill-webpack-plugin": "^1.1.4",
@@ -29,6 +30,8 @@
         "react-is": "^18.1.0",
         "react-tooltip": "^4.2.21",
         "redoc": "^2.0.0-rc.57",
+        "rehype-katex": "^5.0.0",
+        "remark-math": "^3.0.1",
         "slugify": "^1.6.1",
         "styled-components": "5.3.3",
         "url-loader": "^4.1.1"
@@ -4884,6 +4887,11 @@
       "version": "7.0.11",
       "license": "MIT"
     },
+    "node_modules/@types/katex": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.11.1.tgz",
+      "integrity": "sha512-DUlIj2nk0YnJdlWgsFuVKcX27MLW0KbKmGVoUHmFr+74FYYNUDAaj9ZqTADvsbE8rfxuVmSFc7KczYn5Y09ozg=="
+    },
     "node_modules/@types/lodash": {
       "version": "4.14.182",
       "license": "MIT"
@@ -9446,6 +9454,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-is-element": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.1.0.tgz",
+      "integrity": "sha512-oUmNua0bFbdrD/ELDSSEadRVtWZOf3iF6Lbv81naqsIV99RnSCieTbWuWCY8BAeEfKJTKl0gRdokv+dELutHGQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-parse-selector": {
       "version": "2.2.5",
       "license": "MIT",
@@ -9483,6 +9500,20 @@
         "web-namespaces": "^1.0.0",
         "xtend": "^4.0.0",
         "zwitch": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-2.0.1.tgz",
+      "integrity": "sha512-8nsgCARfs6VkwH2jJU9b8LNTuR4700na+0h3PqCaEk4MAnMDeu5P0tP8mjk9LLNGxIeQRLbiDbZVw6rku+pYsQ==",
+      "dependencies": {
+        "hast-util-is-element": "^1.0.0",
+        "repeat-string": "^1.0.0",
+        "unist-util-find-after": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -12243,6 +12274,29 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.13.24",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.13.24.tgz",
+      "integrity": "sha512-jZxYuKCma3VS5UuxOx/rFV1QyGSl3Uy/i0kTJF3HgQ5xMinCQVF8Zd4bMY/9aI9b9A2pjIBOsjSSm68ykTAr8w==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "dependencies": {
+        "commander": "^8.0.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/keyv": {
@@ -15389,6 +15443,36 @@
         "jsesc": "bin/jsesc"
       }
     },
+    "node_modules/rehype-katex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-katex/-/rehype-katex-5.0.0.tgz",
+      "integrity": "sha512-ksSuEKCql/IiIadOHiKRMjypva9BLhuwQNascMqaoGLDVd0k2NlE2wMvgZ3rpItzRKCd6vs8s7MFbb8pcR0AEg==",
+      "dependencies": {
+        "@types/katex": "^0.11.0",
+        "hast-util-to-text": "^2.0.0",
+        "katex": "^0.13.0",
+        "rehype-parse": "^7.0.0",
+        "unified": "^9.0.0",
+        "unist-util-visit": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-katex/node_modules/rehype-parse": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-7.0.1.tgz",
+      "integrity": "sha512-fOiR9a9xH+Le19i4fGzIEowAbwG7idy2Jzs4mOrFWBSJ0sNUgy0ev871dwWnbOo371SjgjG4pwzrbgSVrKxecw==",
+      "dependencies": {
+        "hast-util-from-parse5": "^6.0.0",
+        "parse5": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-parse": {
       "version": "6.0.2",
       "license": "MIT",
@@ -15478,6 +15562,15 @@
     "node_modules/remark-footnotes": {
       "version": "2.0.0",
       "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-3.0.1.tgz",
+      "integrity": "sha512-epT77R/HK0x7NqrWHdSV75uNLwn8g9qTyMqCRCDujL0vj/6T6+yhdrR7mjELWtkse+Fw02kijAaBuVcHBor1+Q==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -17507,6 +17600,18 @@
     "node_modules/unist-builder": {
       "version": "2.0.3",
       "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-3.0.0.tgz",
+      "integrity": "sha512-ojlBqfsBftYXExNu3+hHLfJQ/X1jYY/9vdm4yZWjIbf0VuWF6CRufci1ZyoD/wV2TYMKxXUoNuoqwy+CkgzAiQ==",
+      "dependencies": {
+        "unist-util-is": "^4.0.0"
+      },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -21867,6 +21972,11 @@
     "@types/json-schema": {
       "version": "7.0.11"
     },
+    "@types/katex": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.11.1.tgz",
+      "integrity": "sha512-DUlIj2nk0YnJdlWgsFuVKcX27MLW0KbKmGVoUHmFr+74FYYNUDAaj9ZqTADvsbE8rfxuVmSFc7KczYn5Y09ozg=="
+    },
     "@types/lodash": {
       "version": "4.14.182"
     },
@@ -24769,6 +24879,11 @@
         "web-namespaces": "^1.0.0"
       }
     },
+    "hast-util-is-element": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.1.0.tgz",
+      "integrity": "sha512-oUmNua0bFbdrD/ELDSSEadRVtWZOf3iF6Lbv81naqsIV99RnSCieTbWuWCY8BAeEfKJTKl0gRdokv+dELutHGQ=="
+    },
     "hast-util-parse-selector": {
       "version": "2.2.5"
     },
@@ -24795,6 +24910,16 @@
         "web-namespaces": "^1.0.0",
         "xtend": "^4.0.0",
         "zwitch": "^1.0.0"
+      }
+    },
+    "hast-util-to-text": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-2.0.1.tgz",
+      "integrity": "sha512-8nsgCARfs6VkwH2jJU9b8LNTuR4700na+0h3PqCaEk4MAnMDeu5P0tP8mjk9LLNGxIeQRLbiDbZVw6rku+pYsQ==",
+      "requires": {
+        "hast-util-is-element": "^1.0.0",
+        "repeat-string": "^1.0.0",
+        "unist-util-find-after": "^3.0.0"
       }
     },
     "hastscript": {
@@ -26489,6 +26614,21 @@
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
+      }
+    },
+    "katex": {
+      "version": "0.13.24",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.13.24.tgz",
+      "integrity": "sha512-jZxYuKCma3VS5UuxOx/rFV1QyGSl3Uy/i0kTJF3HgQ5xMinCQVF8Zd4bMY/9aI9b9A2pjIBOsjSSm68ykTAr8w==",
+      "requires": {
+        "commander": "^8.0.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+          "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
+        }
       }
     },
     "keyv": {
@@ -28394,6 +28534,30 @@
         }
       }
     },
+    "rehype-katex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-katex/-/rehype-katex-5.0.0.tgz",
+      "integrity": "sha512-ksSuEKCql/IiIadOHiKRMjypva9BLhuwQNascMqaoGLDVd0k2NlE2wMvgZ3rpItzRKCd6vs8s7MFbb8pcR0AEg==",
+      "requires": {
+        "@types/katex": "^0.11.0",
+        "hast-util-to-text": "^2.0.0",
+        "katex": "^0.13.0",
+        "rehype-parse": "^7.0.0",
+        "unified": "^9.0.0",
+        "unist-util-visit": "^2.0.0"
+      },
+      "dependencies": {
+        "rehype-parse": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-7.0.1.tgz",
+          "integrity": "sha512-fOiR9a9xH+Le19i4fGzIEowAbwG7idy2Jzs4mOrFWBSJ0sNUgy0ev871dwWnbOo371SjgjG4pwzrbgSVrKxecw==",
+          "requires": {
+            "hast-util-from-parse5": "^6.0.0",
+            "parse5": "^6.0.0"
+          }
+        }
+      }
+    },
     "rehype-parse": {
       "version": "6.0.2",
       "requires": {
@@ -28459,6 +28623,11 @@
     },
     "remark-footnotes": {
       "version": "2.0.0"
+    },
+    "remark-math": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-3.0.1.tgz",
+      "integrity": "sha512-epT77R/HK0x7NqrWHdSV75uNLwn8g9qTyMqCRCDujL0vj/6T6+yhdrR7mjELWtkse+Fw02kijAaBuVcHBor1+Q=="
     },
     "remark-mdx": {
       "version": "1.6.22",
@@ -29731,6 +29900,14 @@
     },
     "unist-builder": {
       "version": "2.0.3"
+    },
+    "unist-util-find-after": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-3.0.0.tgz",
+      "integrity": "sha512-ojlBqfsBftYXExNu3+hHLfJQ/X1jYY/9vdm4yZWjIbf0VuWF6CRufci1ZyoD/wV2TYMKxXUoNuoqwy+CkgzAiQ==",
+      "requires": {
+        "unist-util-is": "^4.0.0"
+      }
     },
     "unist-util-generated": {
       "version": "1.1.6"

--- a/website/package.json
+++ b/website/package.json
@@ -19,6 +19,7 @@
     "file-loader": "^6.2.0",
     "fs": "0.0.2",
     "gray-matter": "^4.0.3",
+    "hast-util-is-element": "^1.1.0",
     "js-yaml": "^4.1.0",
     "mobx": "^6.3.7",
     "node-polyfill-webpack-plugin": "^1.1.4",
@@ -28,6 +29,8 @@
     "react-is": "^18.1.0",
     "react-tooltip": "^4.2.21",
     "redoc": "^2.0.0-rc.57",
+    "rehype-katex": "^5.0.0",
+    "remark-math": "^3.0.1",
     "slugify": "^1.6.1",
     "styled-components": "5.3.3",
     "url-loader": "^4.1.1"


### PR DESCRIPTION
[Asana Task](https://app.asana.com/0/1200099998847559/1202340450297116/f)

## Description & motivation
In Lauren's latest blog post, she is attempting to use formulaic variables to explain a concept in her article. She is using `$` to wrap text, but it doesn't seem to render. Jason found a plugin to enable this functionality. 

This PR adds ability to use inline math equations by wrapping math in `$`.
Example: `$x*y = n$`

Math blocks can also be used by wrapping them in `$$`.
Example:
```
$$
I = \int_0^{2\pi} \sin(x)\,dx
$$
```

## Other Notes
This plugin is built using KaTeX. Please review [documentation](https://docusaurus.io/docs/markdown-features/math-equations#inline) for examples of usage.

## Screenshot
![image](https://user-images.githubusercontent.com/46692803/172193197-215af0e2-b6e5-4754-8d91-6f37f6992587.png)
