### PR TITLE
Update snowflake guide to not reference databricks

### DIFF
--- a/website/docs/guides/getting-started/getting-set-up/setting-up-snowflake.md
+++ b/website/docs/guides/getting-started/getting-set-up/setting-up-snowflake.md
@@ -279,10 +279,9 @@ If you used Partner Connect, you can skip over to [initializing your dbt project
 
 Congratulations! You have successfully completed the following:
 
-- Set up a Databricks account
-- Loaded training data into your Databricks account
-- Configured a SQL endpoint in Databricks
-- Connected dbt Cloud and Databricks
+- Set up a new Snowflake instance
+- Loaded training data into your Snowflake account
+- Connected dbt Cloud and Snowflake
 
 ## Next steps
 


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a pull request on dbt core, etc?
-->
The setup guide for Snowflake was referencing databricks at the end of it when summarizing what a user had accomplished after following the guide.
