### PR TITLE
Clarify usage of secret env vars

### DIFF
--- a/website/docs/reference/dbt-jinja-functions/env_var.md
+++ b/website/docs/reference/dbt-jinja-functions/env_var.md
@@ -64,6 +64,8 @@ For certain configurations, you can use "secret" env vars. Any env var named wit
 
 The primary use case of secret env vars is git access tokens for [private packages](package-management#private-packages).
 
+**Note:** When dbt is loading profile credentials and package configuration, secret env vars will be replaced with the string value of the environment variable. You cannot modify secrets using Jinja filters, including type-casting filters such as [`as_number`](as_number) or [`as_bool`](as_bool), or pass them as arguments into other Jinja macros.
+
 ### Custom metadata
 
 <Changelog>


### PR DESCRIPTION
Per a security fix included in v1.0.8 + v1.1.1, we've further locked down "secret" env vars to only ever return their string values. They cannot be passed into other Jinja filters/macros to manipulate the returned value.