### PR TITLE
anders owns more, Amy owns less

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,8 +14,9 @@
 
 
 # Adapter & Package Development Docs
-/website/docs/docs/available-adapters.md/                       @runleonarun @amychen1776 @dataders
-/website/docs/reference/warehouse-profiles/                     @runleonarun @amychen1776 @dataders
+/website/docs/docs/available-adapters.md/                       @runleonarun @dataders
+/website/docs/reference/warehouse-profiles/                     @runleonarun @dataders
+/website/docs/reference/resource-configs/                       @runleonarun @dataders
 /website/docs/guides/building-packages                          @runleonarun @amychen1776 @dataders @dbeatty10 
 /website/docs/contributing/building-a-new-adapter               @runleonarun @dataders @dbeatty10
 /website/docs/contributing/testing-a-new-adapter                @runleonarun @dataders @dbeatty10


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a pull request on dbt core, etc?
-->

It's time @dataders fully owns the "Available Adapters" section of the docs site. Also time for @amychen1776 to have fewer GitHub notifications