### PR TITLE
Initialize documentation for v1.2

### DIFF
--- a/website/dbt-versions.js
+++ b/website/dbt-versions.js
@@ -28,7 +28,7 @@ exports.versionedPages = [
     "firstVersion": "1.2",
   },
   {
-    "page": "docs/guides/migration-guide/upgrading-to-v1.2",
+    "page": "guides/migration/versions/upgrading-to-v1.2",
     "firstVersion": "1.2",
   },
   {
@@ -36,7 +36,7 @@ exports.versionedPages = [
     "firstVersion": "1.1",
   },
   {
-    "page": "docs/guides/migration-guide/upgrading-to-v1.1",
+    "page": "guides/migration/versions/upgrading-to-v1.1",
     "firstVersion": "1.1",
   },
   {

--- a/website/dbt-versions.js
+++ b/website/dbt-versions.js
@@ -2,7 +2,7 @@ exports.versions = [
   {
     version: "1.2",
     EOLDate: "2023-07-15",  // TODO estimated for now
-    isPrerelease: True,
+    isPrerelease: true,
   },
   {
     version: "1.1",

--- a/website/dbt-versions.js
+++ b/website/dbt-versions.js
@@ -1,7 +1,12 @@
 exports.versions = [
   {
+    version: "1.2",
+    EOLDate: "2023-07-15",  // TODO estimated for now
+    isPrerelease: True,
+  },
+  {
     version: "1.1",
-    EOLDate: "2023-04-28",  // TODO estimated for now
+    EOLDate: "2023-04-28",
   },
   {
     version: "1.0",
@@ -18,6 +23,10 @@ exports.versions = [
 ]
 
 exports.versionedPages = [
+  {
+    "page": "docs/guides/migration-guide/upgrading-to-v1.2",
+    "firstVersion": "1.2",
+  },
   {
     "page": "docs/contributing/testing-a-new-adapter",
     "firstVersion": "1.1",

--- a/website/dbt-versions.js
+++ b/website/dbt-versions.js
@@ -24,6 +24,10 @@ exports.versions = [
 
 exports.versionedPages = [
   {
+    "page": "docs/reference/dbt-jinja-functions/cross-database-macros",
+    "firstVersion": "1.2",
+  },
+  {
     "page": "docs/guides/migration-guide/upgrading-to-v1.2",
     "firstVersion": "1.2",
   },

--- a/website/dbt-versions.js
+++ b/website/dbt-versions.js
@@ -28,7 +28,7 @@ exports.versionedPages = [
     "firstVersion": "1.2",
   },
   {
-    "page": "docs/guides/migration-guide/upgrading-to-v1.2",
+    "page": "guides/migration/versions/upgrading-to-v1.2",
     "firstVersion": "1.2",
   },
   {

--- a/website/docs/guides/migration/versions/upgrading-to-v1.2.md
+++ b/website/docs/guides/migration/versions/upgrading-to-v1.2.md
@@ -1,5 +1,5 @@
 ---
-title: "Upgrading to v1.2 (latest)"
+title: "Upgrading to v1.2 (prerelease)"
 ---
 ### Resources
 
@@ -14,6 +14,10 @@ dbt Core v1.2 will soon be available as a **beta prerelease.** Join the #dbt-pre
 ## Breaking changes
 
 There are no breaking changes for end users of dbt. We are committed to providing backwards compatibility for all versions 1.x. If you encounter an error upon upgrading, please let us know by [opening an issue](https://github.com/dbt-labs/dbt-core/issues/new).
+
+### For maintainers of adapter plugins
+
+We added a collection of ["cross-database macros"](cross-database-macros) to dbt Core v1.2. Default implementations are automatically inherited by adapters and included in the testing suite. Adapter maintainers may need to override the implementation of one or more macros to align with database-specific syntax or optimize performance. For details on the testing suite, see: ["Testing a new adapter"](testing-a-new-adapter).
 
 ## New and changed documentation
 

--- a/website/docs/guides/migration/versions/upgrading-to-v1.2.md
+++ b/website/docs/guides/migration/versions/upgrading-to-v1.2.md
@@ -1,0 +1,22 @@
+---
+title: "Upgrading to v1.2 (latest)"
+---
+### Resources
+
+- [Changelog](https://github.com/dbt-labs/dbt-core/blob/main/CHANGELOG.md)
+- [CLI Installation guide](/dbt-cli/install/overview)
+- [Cloud upgrade guide](/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-choosing-a-dbt-version)
+
+:::info Beta
+dbt Core v1.2 will soon be available as a **beta prerelease.** Join the #dbt-prereleases channel in the Community Slack so that you're the first to know!
+:::
+
+## Breaking changes
+
+There are no breaking changes for end users of dbt. We are committed to providing backwards compatibility for all versions 1.x. If you encounter an error upon upgrading, please let us know by [opening an issue](https://github.com/dbt-labs/dbt-core/issues/new).
+
+## New and changed documentation
+
+_Under construction_
+
+https://github.com/dbt-labs/docs.getdbt.com/labels/dbt-core%20v1.2

--- a/website/docs/reference/dbt-jinja-functions/cross-database-macros.md
+++ b/website/docs/reference/dbt-jinja-functions/cross-database-macros.md
@@ -1,6 +1,6 @@
 ---
-title: "dbt"
-id: "dbt"
+title: "cross-database macros"
+id: "cross-database-macros"
 ---
 
 # Overview
@@ -68,7 +68,6 @@ compatibility. In general, you should not need these macros in your own dbt proj
 - [dbt.date_trunc](#date_trunc)
 - [dbt.last_day](#last_day)
 
-
 # Set functions
 
 ## except
@@ -110,7 +109,7 @@ __Args__:
 ## concat
 __Args__:
 
- * `fields`: Jinja array of [attribute names or expressions](#sql_expressions).
+ * `fields`: Jinja array of [attribute names or expressions](#sql-expressions).
 
 This macro combines a list of strings together.
 
@@ -130,9 +129,9 @@ This macro combines a list of strings together.
 ## hash
 __Args__:
 
- * `field`: [attribute name or expression](#sql_expressions).
+ * `field`: [attribute name or expression](#sql-expressions).
 
-This macro provides a hash (such as [MD5](https://en.wikipedia.org/wiki/MD5)) of an [expression](#sql_expressions) cast as a string.
+This macro provides a hash (such as [MD5](https://en.wikipedia.org/wiki/MD5)) of an [expression](#sql-expressions) cast as a string.
 
 **Usage**:
 
@@ -148,7 +147,7 @@ This macro provides a hash (such as [MD5](https://en.wikipedia.org/wiki/MD5)) of
 ## length
 __Args__:
 
- * `expression`: string [expression](#sql_expressions).
+ * `expression`: string [expression](#sql-expressions).
 
 
 This macro calculates the number of characters in a string.
@@ -166,8 +165,8 @@ This macro calculates the number of characters in a string.
 ## position
 __Args__:
 
- * `substring_text`: [attribute name or expression](#sql_expressions).
- * `string_text`: [attribute name or expression](#sql_expressions).
+ * `substring_text`: [attribute name or expression](#sql-expressions).
+ * `string_text`: [attribute name or expression](#sql-expressions).
 
 This macro searches for the first occurrence of `substring_text` within `string_text` and returns the 1-based position if found.
 
@@ -185,9 +184,9 @@ This macro searches for the first occurrence of `substring_text` within `string_
 ## replace
 __Args__:
 
- * `field`: [attribute name or expression](#sql_expressions).
- * `old_chars`: [attribute name or expression](#sql_expressions).
- * `new_chars`: [attribute name or expression](#sql_expressions).
+ * `field`: [attribute name or expression](#sql-expressions).
+ * `old_chars`: [attribute name or expression](#sql-expressions).
+ * `new_chars`: [attribute name or expression](#sql-expressions).
 
 This macro updates a string and replaces all occurrences of one substring with another. The precise behavior may vary slightly from one adapter to another.
 
@@ -205,8 +204,8 @@ This macro updates a string and replaces all occurrences of one substring with a
 ## right
 __Args__:
 
- * `string_text`: [attribute name or expression](#sql_expressions).
- * `length_expression`: numeric [expression](#sql_expressions).
+ * `string_text`: [attribute name or expression](#sql-expressions).
+ * `length_expression`: numeric [expression](#sql-expressions).
 
 This macro returns the N rightmost characters from a string.
 
@@ -221,13 +220,12 @@ This macro returns the N rightmost characters from a string.
 
 </File>
 
-
 # Aggregate and window functions
 
 ## any_value
 __Args__:
 
- * `expression`: an [expression](#sql_expressions).
+ * `expression`: an [expression](#sql-expressions).
 
 This macro returns some value of the expression from the group. The selected value is non-deterministic (rather than random).
 
@@ -244,7 +242,7 @@ This macro returns some value of the expression from the group. The selected val
 ## bool_or
 __Args__:
 
- * `expression`: [attribute name or expression](#sql_expressions).
+ * `expression`: [attribute name or expression](#sql-expressions).
 
 This macro returns the logical `OR` of all non-`NULL` expressions -- `true` if at least one record in the group evaluates to `true`.
 
@@ -264,7 +262,7 @@ This macro returns the logical `OR` of all non-`NULL` expressions -- `true` if a
 ## listagg
 __Args__:
 
- * `measure` (required): The [attribute name or expression](#sql_expressions) that determines the values to be concatenated. To only include distinct values add keyword `DISTINCT` to beginning of expression (example: 'DISTINCT column_to_agg').
+ * `measure` (required): The [attribute name or expression](#sql-expressions) that determines the values to be concatenated. To only include distinct values add keyword `DISTINCT` to beginning of expression (example: 'DISTINCT column_to_agg').
  * `delimiter_text` (required): Text representing the delimiter to separate concatenated values by.
  * `order_by_clause` (optional): An expression (typically one or more column names separated by commas) that determines the order of the concatenated values.
  * `limit_num` (optional): Specifies the maximum number of values to be concatenated.
@@ -283,13 +281,12 @@ Note: If there are instances of `delimiter_text` within your `measure`, you cann
 
 </File>
 
-
 # Cast functions
 
 ## cast_bool_to_text
 __Args__:
 
- * `field`: boolean [attribute name or expression](#sql_expressions).
+ * `field`: boolean [attribute name or expression](#sql-expressions).
 
 This macro casts a boolean value to a string.
 
@@ -311,7 +308,7 @@ This macro casts a boolean value to a string.
 ## safe_cast
 __Args__:
 
- * `field`: [attribute name or expression](#sql_expressions).
+ * `field`: [attribute name or expression](#sql-expressions).
  * `type`: data type to convert to
 
 For databases that support it, this macro will return `NULL` when the cast fails (instead of raising an error).
@@ -327,7 +324,6 @@ For databases that support it, this macro will return `NULL` when the cast fails
 ```
 
 </File>
-
 
 # Non-SQL Jinja functions
 
@@ -370,7 +366,6 @@ select {{ dbt.string_literal("Pennsylvania") }}
 
 </File>
 
-
 # Timestamp functions
 
 ## current_timestamp
@@ -407,15 +402,14 @@ This macro returns the current timestamp expressed in [Coordinated Universal Tim
 
 </File>
 
-
 # Date and time functions
 
 ## dateadd
 __Args__:
 
- * `datepart`: [date or time part](#date_and_time_parts).
+ * `datepart`: [date or time part](#date-and-time-parts).
  * `interval`: integer count of the `datepart` to add (can be positive or negative)
- * `from_date_or_timestamp`: date/time [expression](#sql_expressions).
+ * `from_date_or_timestamp`: date/time [expression](#sql-expressions).
 
 This macro adds a time/day interval to the supplied date/timestamp. Note: The `datepart` argument is database-specific.
 
@@ -433,9 +427,9 @@ This macro adds a time/day interval to the supplied date/timestamp. Note: The `d
 ## datediff
 __Args__:
 
- * `first_date`: date/time [expression](#sql_expressions).
- * `second_date`: date/time [expression](#sql_expressions).
- * `datepart`: [date or time part](#date_and_time_parts).
+ * `first_date`: date/time [expression](#sql-expressions).
+ * `second_date`: date/time [expression](#sql-expressions).
+ * `datepart`: [date or time part](#date-and-time-parts).
 
 This macro calculates the difference between two dates.
 
@@ -454,10 +448,10 @@ This macro calculates the difference between two dates.
 ## date_trunc
 __Args__:
 
- * `datepart`: [date or time part](#date_and_time_parts).
- * `date`: date/time [expression](#sql_expressions).
+ * `datepart`: [date or time part](#date-and-time-parts).
+ * `date`: date/time [expression](#sql-expressions).
 
-This macro truncates / rounds a timestamp to the first instant for the given [date or time part](#date_and_time_parts).
+This macro truncates / rounds a timestamp to the first instant for the given [date or time part](#date-and-time-parts).
 
 **Usage**:
 
@@ -474,8 +468,8 @@ This macro truncates / rounds a timestamp to the first instant for the given [da
 ## last_day
 __Args__:
 
- * `date`: date/time [expression](#sql_expressions).
- * `datepart`: [date or time part](#date_and_time_parts).
+ * `date`: date/time [expression](#sql-expressions).
+ * `datepart`: [date or time part](#date-and-time-parts).
 
 This macro gets the last day for a given date and datepart.
 
@@ -492,7 +486,7 @@ This macro gets the last day for a given date and datepart.
 
 </File>
 
-# Date and time parts
+## Date and time parts
 
 Often supported date and time parts (case insensitive):
 * `year`
@@ -510,14 +504,14 @@ Often supported date and time parts (case insensitive):
 This listing is not meant to be exhaustive, and some of these date and time parts may not be supported for particular adapters.
 Some macros may not support all date and time parts. Some adapters may support more or less precision.
 
-# SQL expressions
+## SQL expressions
 
 A SQL expression may take forms like the following:
 - function
 - column name
 - date literal
 - string literal
-- <other data type> literal (number, etc)
+- &lt;other data type&gt; literal (number, etc)
 - `NULL`
 
 Example:

--- a/website/docs/reference/dbt-jinja-functions/cross-database-macros.md
+++ b/website/docs/reference/dbt-jinja-functions/cross-database-macros.md
@@ -75,13 +75,9 @@ __Args__:
 
 **Usage**:
 
-<File>
-
 ```sql
 {{ except() }}
 ```
-
-</File>
 
 **Default Output**:
 
@@ -98,13 +94,9 @@ __Args__:
 
 **Usage**:
 
-<File>
-
 ```sql
 {{ intersect() }}
 ```
-
-</File>
 
 **Default Output**:
 
@@ -124,16 +116,12 @@ This macro combines a list of strings together.
 
 **Usage**:
 
-<File>
-
 ```sql
 {{ concat(["column_1", "column_2"]) }}
 {{ concat(["year_column", "'-'" , "month_column", "'-'" , "day_column"]) }}
 {{ concat(["first_part_column", "'.'" , "second_part_column"]) }}
 {{ concat(["first_part_column", "','" , "second_part_column"]) }}
 ```
-
-</File>
 
 **Default Output**:
 
@@ -152,8 +140,6 @@ __Args__:
 This macro provides a hash (such as [MD5](https://en.wikipedia.org/wiki/MD5)) of an [expression](#sql-expressions) cast as a string.
 
 **Usage**:
-
-<File>
 
 ```sql
 {{ hash("column") }}
@@ -181,13 +167,9 @@ This macro calculates the number of characters in a string.
 
 **Usage**:
 
-<File>
-
 ```sql
 {{ length("column") }}
 ```
-
-</File>
 
 **Default Output**:
 
@@ -207,14 +189,10 @@ This macro searches for the first occurrence of `substring_text` within `string_
 
 **Usage**:
 
-<File>
-
 ```sql
 {{ position("substring_column", "text_column") }}
 {{ position("'-'", "text_column") }}
 ```
-
-</File>
 
 **Default Output**:
 
@@ -240,14 +218,10 @@ This macro updates a string and replaces all occurrences of one substring with a
 
 **Usage**:
 
-<File>
-
 ```sql
 {{ replace("string_text_column", "old_chars_column", "new_chars_column") }}
 {{ replace("string_text_column", "'-'", "'_'") }}
 ```
-
-</File>
 
 **Default Output**:
 
@@ -279,14 +253,10 @@ This macro returns the N rightmost characters from a string.
 
 **Usage**:
 
-<File>
-
 ```sql
 {{ right("string_text_column", "length_column") }}
 {{ right("string_text_column", "3") }}
 ```
-
-</File>
 
 **Default Output**:
 
@@ -316,14 +286,10 @@ To escape quotes for column values, consider a macro like [replace](#replace) or
 
 **Usage**:
 
-<File>
-
 ```sql
 {{ escape_single_quotes("they're") }}
 {{ escape_single_quotes("ain't ain't a word") }}
 ```
-
-</File>
 
 **Default Output**:
 
@@ -343,13 +309,9 @@ To cast column values to a string, consider a macro like [safe_cast](#safe_cast)
 
 **Usage**:
 
-<File>
-
 ```sql
 select {{ string_literal("Pennsylvania") }}
 ```
-
-</File>
 
 **Default Output**:
 
@@ -368,13 +330,9 @@ This macro returns some value of the expression from the group. The selected val
 
 **Usage**:
 
-<File>
-
 ```sql
 {{ any_value("column_name") }}
 ```
-
-</File>
 
 **Default Output**:
 
@@ -391,16 +349,12 @@ This macro returns the logical `OR` of all non-`NULL` expressions -- `true` if a
 
 **Usage**:
 
-<File>
-
 ```sql
 {{ bool_or("boolean_column") }}
 {{ bool_or("integer_column = 3") }}
 {{ bool_or("string_column = 'Pennsylvania'") }}
 {{ bool_or("column1 = column2") }}
 ```
-
-</File>
 
 **Default Output**:
 
@@ -425,13 +379,9 @@ This macro returns the concatenated input values from a group of rows separated 
 
 Note: If there are instances of `delimiter_text` within your `measure`, you cannot include a `limit_num`.
 
-<File>
-
 ```sql
 {{ listagg(measure="column_to_agg", delimiter_text="','", order_by_clause="order by order_by_column", limit_num=10) }}
 ```
-
-</File>
 
 **Default Output**:
 
@@ -456,8 +406,6 @@ This macro casts a boolean value to a string.
 
 **Usage**:
 
-<File>
-
 ```sql
 {{ cast_bool_to_text("boolean_column_name") }}
 {{ cast_bool_to_text("false") }}
@@ -466,8 +414,6 @@ This macro casts a boolean value to a string.
 {{ cast_bool_to_text("1 = 1") }}
 {{ cast_bool_to_text("null") }}
 ```
-
-</File>
 
 **Default Output**:
 
@@ -524,15 +470,11 @@ For databases that support it, this macro will return `NULL` when the cast fails
 
 **Usage**:
 
-<File>
-
 ```sql
 {{ safe_cast("column_1", api.Column.translate_type("string")) }}
 {{ safe_cast("column_2", api.Column.translate_type("integer")) }}
 {{ safe_cast("'2016-03-09'", api.Column.translate_type("date")) }}
 ```
-
-</File>
 
 **Default Output**:
 
@@ -561,14 +503,10 @@ This macro adds a time/day interval to the supplied date/timestamp. Note: The `d
 
 **Usage**:
 
-<File>
-
 ```sql
 {{ dateadd(datepart="day", interval=1, from_date_or_timestamp="'2016-03-09'") }}
 {{ dateadd(datepart="month", interval=-2, from_date_or_timestamp="'2016-03-09'") }}
 ```
-
-</File>
 
 **Default Output**:
 
@@ -592,15 +530,11 @@ This macro calculates the difference between two dates.
 
 **Usage**:
 
-<File>
-
 ```sql
 {{ datediff("column_1", "column_2", "day") }}
 {{ datediff("column", "'2016-03-09'", "month") }}
 {{ datediff("'2016-03-09'", "column", "year") }}
 ```
-
-</File>
 
 **Default Output**:
 
@@ -627,15 +561,11 @@ This macro truncates / rounds a timestamp to the first instant for the given [da
 
 **Usage**:
 
-<File>
-
 ```sql
 {{ date_trunc("day", "updated_at") }}
 {{ date_trunc("month", "updated_at") }}
 {{ date_trunc("year", "'2016-03-09'") }}
 ```
-
-</File>
 
 **Default Output**:
 
@@ -657,14 +587,10 @@ This macro gets the last day for a given date and datepart.
 - The `datepart` argument is database-specific.
 - This macro currently only supports dateparts of `month` and `quarter`.
 
-<File>
-
 ```sql
 {{ last_day("created_at", "month") }}
 {{ last_day("'2016-03-09'", "year") }}
 ```
-
-</File>
 
 **Default Output**:
 

--- a/website/docs/reference/dbt-jinja-functions/cross-database-macros.md
+++ b/website/docs/reference/dbt-jinja-functions/cross-database-macros.md
@@ -79,7 +79,7 @@ __Args__:
 {{ except() }}
 ```
 
-**Default Output**:
+**Sample Output (PostgreSQL)**:
 
 ```sql
 except
@@ -98,7 +98,7 @@ __Args__:
 {{ intersect() }}
 ```
 
-**Default Output**:
+**Sample Output (PostgreSQL)**:
 
 ```sql
 intersect
@@ -123,7 +123,7 @@ This macro combines a list of strings together.
 {{ concat(["first_part_column", "','" , "second_part_column"]) }}
 ```
 
-**Default Output**:
+**Sample Output (PostgreSQL)**:
 
 ```sql
 column_1 || column_2
@@ -146,7 +146,7 @@ This macro provides a hash (such as [MD5](https://en.wikipedia.org/wiki/MD5)) of
 {{ hash("'Pennsylvania'") }}
 ```
 
-**Default Output**:
+**Sample Output (PostgreSQL)**:
 
 ```sql
 md5(cast(column as 
@@ -171,7 +171,7 @@ This macro calculates the number of characters in a string.
 {{ length("column") }}
 ```
 
-**Default Output**:
+**Sample Output (PostgreSQL)**:
 
 ```sql
     length(
@@ -194,7 +194,7 @@ This macro searches for the first occurrence of `substring_text` within `string_
 {{ position("'-'", "text_column") }}
 ```
 
-**Default Output**:
+**Sample Output (PostgreSQL)**:
 
 ```sql
     position(
@@ -223,7 +223,7 @@ This macro updates a string and replaces all occurrences of one substring with a
 {{ replace("string_text_column", "'-'", "'_'") }}
 ```
 
-**Default Output**:
+**Sample Output (PostgreSQL)**:
 
 ```sql
     replace(
@@ -258,7 +258,7 @@ This macro returns the N rightmost characters from a string.
 {{ right("string_text_column", "3") }}
 ```
 
-**Default Output**:
+**Sample Output (PostgreSQL)**:
 
 ```sql
     right(
@@ -291,7 +291,7 @@ To escape quotes for column values, consider a macro like [replace](#replace) or
 {{ escape_single_quotes("ain't ain't a word") }}
 ```
 
-**Default Output**:
+**Sample Output (PostgreSQL)**:
 
 ```sql
 they''re
@@ -313,7 +313,7 @@ To cast column values to a string, consider a macro like [safe_cast](#safe_cast)
 select {{ string_literal("Pennsylvania") }}
 ```
 
-**Default Output**:
+**Sample Output (PostgreSQL)**:
 
 ```sql
 select 'Pennsylvania'
@@ -334,7 +334,7 @@ This macro returns some value of the expression from the group. The selected val
 {{ any_value("column_name") }}
 ```
 
-**Default Output**:
+**Sample Output (PostgreSQL)**:
 
 ```sql
 any(column_name)
@@ -356,7 +356,7 @@ This macro returns the logical `OR` of all non-`NULL` expressions -- `true` if a
 {{ bool_or("column1 = column2") }}
 ```
 
-**Default Output**:
+**Sample Output (PostgreSQL)**:
 
 ```sql
 bool_or(boolean_column)
@@ -383,7 +383,7 @@ Note: If there are instances of `delimiter_text` within your `measure`, you cann
 {{ listagg(measure="column_to_agg", delimiter_text="','", order_by_clause="order by order_by_column", limit_num=10) }}
 ```
 
-**Default Output**:
+**Sample Output (PostgreSQL)**:
 
 ```sql
 array_to_string(
@@ -415,7 +415,7 @@ This macro casts a boolean value to a string.
 {{ cast_bool_to_text("null") }}
 ```
 
-**Default Output**:
+**Sample Output (PostgreSQL)**:
 
 ```sql
     cast(boolean_column_name as 
@@ -476,7 +476,7 @@ For databases that support it, this macro will return `NULL` when the cast fails
 {{ safe_cast("'2016-03-09'", api.Column.translate_type("date")) }}
 ```
 
-**Default Output**:
+**Sample Output (PostgreSQL)**:
 
 ```sql
     cast(column_1 as TEXT)
@@ -508,7 +508,7 @@ This macro adds a time/day interval to the supplied date/timestamp. Note: The `d
 {{ dateadd(datepart="month", interval=-2, from_date_or_timestamp="'2016-03-09'") }}
 ```
 
-**Default Output**:
+**Sample Output (PostgreSQL)**:
 
 ```sql
     '2016-03-09' + ((interval '10 day') * (1))
@@ -536,7 +536,7 @@ This macro calculates the difference between two dates.
 {{ datediff("'2016-03-09'", "column", "year") }}
 ```
 
-**Default Output**:
+**Sample Output (PostgreSQL)**:
 
 ```sql
         ((column_2)::date - (column_1)::date)
@@ -567,7 +567,7 @@ This macro truncates / rounds a timestamp to the first instant for the given [da
 {{ date_trunc("year", "'2016-03-09'") }}
 ```
 
-**Default Output**:
+**Sample Output (PostgreSQL)**:
 
 ```sql
 date_trunc('day', updated_at)
@@ -592,7 +592,7 @@ This macro gets the last day for a given date and datepart.
 {{ last_day("'2016-03-09'", "year") }}
 ```
 
-**Default Output**:
+**Sample Output (PostgreSQL)**:
 
 ```sql
 cast(

--- a/website/docs/reference/dbt-jinja-functions/cross-database-macros.md
+++ b/website/docs/reference/dbt-jinja-functions/cross-database-macros.md
@@ -104,7 +104,6 @@ __Args__:
 intersect
 ```
 
-
 # String functions
 
 ## concat
@@ -201,7 +200,6 @@ This macro searches for the first occurrence of `substring_text` within `string_
         substring_column in text_column
     )
 
-
     position(
         '-' in text_column
     )
@@ -231,10 +229,6 @@ This macro updates a string and replaces all occurrences of one substring with a
         old_chars_column,
         new_chars_column
     )
-    
-
-
-
 
     replace(
         string_text_column,
@@ -265,7 +259,6 @@ This macro returns the N rightmost characters from a string.
         string_text_column,
         length_column
     )
-
 
     right(
         string_text_column,
@@ -422,42 +415,25 @@ This macro casts a boolean value to a string.
     varchar
 )
 
-
-
-  
     cast(false as 
     varchar
 )
 
-
-
-  
     cast(true as 
     varchar
 )
 
-
-
-  
     cast(0 = 1 as 
     varchar
 )
 
-
-
-  
     cast(1 = 1 as 
     varchar
 )
 
-
-
-  
     cast(null as 
     varchar
 )
-
-
 ```
 
 ## safe_cast
@@ -480,13 +456,7 @@ For databases that support it, this macro will return `NULL` when the cast fails
 
 ```sql
     cast(column_1 as TEXT)
-
-
-    
     cast(column_2 as INT)
-
-
-    
     cast('2016-03-09' as date)
 ```
 
@@ -512,10 +482,6 @@ This macro adds a time/day interval to the supplied date/timestamp. Note: The `d
 
 ```sql
     '2016-03-09' + ((interval '10 day') * (1))
-
-
-
-
     '2016-03-09' + ((interval '10 month') * (-2))
 ```
 
@@ -540,15 +506,11 @@ This macro calculates the difference between two dates.
 
 ```sql
         ((column_2)::date - (column_1)::date)
-    
 
-        (
-        (date_part('year', ('2016-03-09')::date) - date_part('year', (column)::date))
+        ((date_part('year', ('2016-03-09')::date) - date_part('year', (column)::date))
      * 12 + date_part('month', ('2016-03-09')::date) - date_part('month', (column)::date))
-    
 
         (date_part('year', (column)::date) - date_part('year', ('2016-03-09')::date))
-
 ```
 
 ## date_trunc
@@ -596,26 +558,13 @@ This macro gets the last day for a given date and datepart.
 
 ```sql
 cast(
-        
-
-    
-
     date_trunc('month', created_at) + ((interval '10 month') * (1))
-
  + ((interval '10 day') * (-1))
-
-
         as date)
+
 cast(
-        
-
-    
-
     date_trunc('year', '2016-03-09') + ((interval '10 year') * (1))
-
  + ((interval '10 day') * (-1))
-
-
         as date)
 ```
 

--- a/website/docs/reference/dbt-jinja-functions/cross-database-macros.md
+++ b/website/docs/reference/dbt-jinja-functions/cross-database-macros.md
@@ -75,7 +75,7 @@ __Args__:
 
 **Usage**:
 
-<File name='models/example.sql'>
+<File>
 
 ```sql
 {{ except() }}
@@ -98,7 +98,7 @@ __Args__:
 
 **Usage**:
 
-<File name='models/example.sql'>
+<File>
 
 ```sql
 {{ intersect() }}
@@ -124,7 +124,7 @@ This macro combines a list of strings together.
 
 **Usage**:
 
-<File name='models/example.sql'>
+<File>
 
 ```sql
 {{ concat(["column_1", "column_2"]) }}
@@ -153,7 +153,7 @@ This macro provides a hash (such as [MD5](https://en.wikipedia.org/wiki/MD5)) of
 
 **Usage**:
 
-<File name='models/example.sql'>
+<File>
 
 ```sql
 {{ hash("column") }}
@@ -181,7 +181,7 @@ This macro calculates the number of characters in a string.
 
 **Usage**:
 
-<File name='models/example.sql'>
+<File>
 
 ```sql
 {{ length("column") }}
@@ -207,7 +207,7 @@ This macro searches for the first occurrence of `substring_text` within `string_
 
 **Usage**:
 
-<File name='models/example.sql'>
+<File>
 
 ```sql
 {{ position("substring_column", "text_column") }}
@@ -240,7 +240,7 @@ This macro updates a string and replaces all occurrences of one substring with a
 
 **Usage**:
 
-<File name='models/example.sql'>
+<File>
 
 ```sql
 {{ replace("string_text_column", "old_chars_column", "new_chars_column") }}
@@ -279,7 +279,7 @@ This macro returns the N rightmost characters from a string.
 
 **Usage**:
 
-<File name='models/example.sql'>
+<File>
 
 ```sql
 {{ right("string_text_column", "length_column") }}
@@ -316,7 +316,7 @@ To escape quotes for column values, consider a macro like [replace](#replace) or
 
 **Usage**:
 
-<File name='models/example.sql'>
+<File>
 
 ```sql
 {{ escape_single_quotes("they're") }}
@@ -343,7 +343,7 @@ To cast column values to a string, consider a macro like [safe_cast](#safe_cast)
 
 **Usage**:
 
-<File name='models/example.sql'>
+<File>
 
 ```sql
 select {{ string_literal("Pennsylvania") }}
@@ -368,7 +368,7 @@ This macro returns some value of the expression from the group. The selected val
 
 **Usage**:
 
-<File name='models/example.sql'>
+<File>
 
 ```sql
 {{ any_value("column_name") }}
@@ -391,7 +391,7 @@ This macro returns the logical `OR` of all non-`NULL` expressions -- `true` if a
 
 **Usage**:
 
-<File name='models/example.sql'>
+<File>
 
 ```sql
 {{ bool_or("boolean_column") }}
@@ -425,7 +425,7 @@ This macro returns the concatenated input values from a group of rows separated 
 
 Note: If there are instances of `delimiter_text` within your `measure`, you cannot include a `limit_num`.
 
-<File name='models/example.sql'>
+<File>
 
 ```sql
 {{ listagg(measure="column_to_agg", delimiter_text="','", order_by_clause="order by order_by_column", limit_num=10) }}
@@ -456,7 +456,7 @@ This macro casts a boolean value to a string.
 
 **Usage**:
 
-<File name='models/example.sql'>
+<File>
 
 ```sql
 {{ cast_bool_to_text("boolean_column_name") }}
@@ -524,7 +524,7 @@ For databases that support it, this macro will return `NULL` when the cast fails
 
 **Usage**:
 
-<File name='models/example.sql'>
+<File>
 
 ```sql
 {{ safe_cast("column_1", api.Column.translate_type("string")) }}
@@ -561,7 +561,7 @@ This macro adds a time/day interval to the supplied date/timestamp. Note: The `d
 
 **Usage**:
 
-<File name='models/example.sql'>
+<File>
 
 ```sql
 {{ dateadd(datepart="day", interval=1, from_date_or_timestamp="'2016-03-09'") }}
@@ -592,7 +592,7 @@ This macro calculates the difference between two dates.
 
 **Usage**:
 
-<File name='models/example.sql'>
+<File>
 
 ```sql
 {{ datediff("column_1", "column_2", "day") }}
@@ -627,7 +627,7 @@ This macro truncates / rounds a timestamp to the first instant for the given [da
 
 **Usage**:
 
-<File name='models/example.sql'>
+<File>
 
 ```sql
 {{ date_trunc("day", "updated_at") }}
@@ -657,7 +657,7 @@ This macro gets the last day for a given date and datepart.
 - The `datepart` argument is database-specific.
 - This macro currently only supports dateparts of `month` and `quarter`.
 
-<File name='models/example.sql'>
+<File>
 
 ```sql
 {{ last_day("created_at", "month") }}

--- a/website/docs/reference/dbt-jinja-functions/cross-database-macros.md
+++ b/website/docs/reference/dbt-jinja-functions/cross-database-macros.md
@@ -13,8 +13,6 @@ compatibility. In general, you should not need these macros in your own dbt proj
 - [dbt.bool_or](#bool_or)
 - [dbt.cast_bool_to_text](#cast_bool_to_text)
 - [dbt.concat](#concat)
-- [dbt.current_timestamp](#current_timestamp)
-- [dbt.current_timestamp_in_utc](#current_timestamp_in_utc)
 - [dbt.dateadd](#dateadd)
 - [dbt.datediff](#datediff)
 - [dbt.date_trunc](#date_trunc)
@@ -57,10 +55,6 @@ compatibility. In general, you should not need these macros in your own dbt proj
 [**Cast functions**](#cast-functions)
 - [dbt.cast_bool_to_text](#cast_bool_to_text)
 - [dbt.safe_cast](#safe_cast)
-
-[**Timestamp functions**](#timestamp-functions)
-- [dbt.current_timestamp](#current_timestamp)
-- [dbt.current_timestamp_in_utc](#current_timestamp_in_utc)
 
 [**Date and time functions**](#date-and-time-functions)
 - [dbt.dateadd](#dateadd)
@@ -362,42 +356,6 @@ For databases that support it, this macro will return `NULL` when the cast fails
 {{ dbt.safe_cast("column_1", api.Column.translate_type("string")) }}
 {{ dbt.safe_cast("column_2", api.Column.translate_type("integer")) }}
 {{ dbt.safe_cast("'2016-03-09'", api.Column.translate_type("date")) }}
-```
-
-</File>
-
-# Timestamp functions
-
-## current_timestamp
-__Args__:
-
- * None
-
-This macro returns the current timestamp.
-
-**Usage**:
-
-<File name='models/example.sql'>
-
-```sql
-{{ dbt.current_timestamp() }}
-```
-
-</File>
-
-## current_timestamp_in_utc
-__Args__:
-
- * None
-
-This macro returns the current timestamp expressed in [Coordinated Universal Time (UTC)](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).
-
-**Usage**:
-
-<File name='models/example.sql'>
-
-```sql
-{{ dbt.current_timestamp_in_utc() }}
 ```
 
 </File>

--- a/website/docs/reference/dbt-jinja-functions/cross-database-macros.md
+++ b/website/docs/reference/dbt-jinja-functions/cross-database-macros.md
@@ -5,62 +5,64 @@ id: "cross-database-macros"
 
 # Overview
 
-These macros make it easier for package authors (especially those writing modeling packages) to implement cross-database
-compatibility. In general, you should not need these macros in your own dbt project (unless it is a package or you otherwise desire cross-database compatibility).
+These macros benefit three different user groups:
+- If you maintain a package, your package is more likely to work on other adapters by using these macros (rather than a specific database's SQL syntax)
+- If you maintain an adapter, your adapter is more likely to support more packages by implementing (and testing) these macros.
+- If you're an end user, more packages and adapters are likely to "just work" for you (without you having to do anything).
 
 ## All functions (alphabetical)
-- [dbt.any_value](#any_value)
-- [dbt.bool_or](#bool_or)
-- [dbt.cast_bool_to_text](#cast_bool_to_text)
-- [dbt.concat](#concat)
-- [dbt.dateadd](#dateadd)
-- [dbt.datediff](#datediff)
-- [dbt.date_trunc](#date_trunc)
-- [dbt.escape_single_quotes](#escape_single_quotes)
-- [dbt.except](#except)
-- [dbt.hash](#hash)
-- [dbt.intersect](#intersect)
-- [dbt.last_day](#last_day)
-- [dbt.length](#length)
-- [dbt.listagg](#listagg)
-- [dbt.position](#position)
-- [dbt.replace](#replace)
-- [dbt.right](#right)
-- [dbt.safe_cast](#safe_cast)
-- [dbt.split_part](#split_part)
-- [dbt.string_literal](#string_literal)
+- [any_value](#any_value)
+- [bool_or](#bool_or)
+- [cast_bool_to_text](#cast_bool_to_text)
+- [concat](#concat)
+- [dateadd](#dateadd)
+- [datediff](#datediff)
+- [date_trunc](#date_trunc)
+- [escape_single_quotes](#escape_single_quotes)
+- [except](#except)
+- [hash](#hash)
+- [intersect](#intersect)
+- [last_day](#last_day)
+- [length](#length)
+- [listagg](#listagg)
+- [position](#position)
+- [replace](#replace)
+- [right](#right)
+- [safe_cast](#safe_cast)
+- [split_part](#split_part)
+- [string_literal](#string_literal)
 
 [**Set functions**](#set-functions)
-- [dbt.except](#except)
-- [dbt.intersect](#intersect)
+- [except](#except)
+- [intersect](#intersect)
 
 [**String functions**](#string-functions)
-- [dbt.concat](#concat)
-- [dbt.hash](#hash)
-- [dbt.length](#length)
-- [dbt.position](#position)
-- [dbt.replace](#replace)
-- [dbt.right](#right)
-- [dbt.split_part](#split_part)
+- [concat](#concat)
+- [hash](#hash)
+- [length](#length)
+- [position](#position)
+- [replace](#replace)
+- [right](#right)
+- [split_part](#split_part)
 
 [**String literal functions**](#string-literal-functions)
-- [dbt.escape_single_quotes](#escape_single_quotes)
-- [dbt.string_literal](#string_literal)
+- [escape_single_quotes](#escape_single_quotes)
+- [string_literal](#string_literal)
 
 [**Aggregate and window functions**](#aggregate-and-window-functions)
-- [dbt.any_value](#any_value)
-- [dbt.bool_or](#bool_or)
-- [dbt.listagg](#listagg)
+- [any_value](#any_value)
+- [bool_or](#bool_or)
+- [listagg](#listagg)
 
 [**Cast functions**](#cast-functions)
-- [dbt.cast_bool_to_text](#cast_bool_to_text)
-- [dbt.safe_cast](#safe_cast)
+- [cast_bool_to_text](#cast_bool_to_text)
+- [safe_cast](#safe_cast)
 
 [**Date and time functions**](#date-and-time-functions)
-- [dbt.dateadd](#dateadd)
-- [dbt.datediff](#datediff)
-- [dbt.date_trunc](#date_trunc)
-- [dbt.last_day](#last_day)
+- [dateadd](#dateadd)
+- [datediff](#datediff)
+- [date_trunc](#date_trunc)
+- [last_day](#last_day)
 
 # Set functions
 
@@ -76,7 +78,7 @@ __Args__:
 <File name='models/example.sql'>
 
 ```sql
-{{ dbt.except() }}
+{{ except() }}
 ```
 
 </File>
@@ -93,7 +95,7 @@ __Args__:
 <File name='models/example.sql'>
 
 ```sql
-{{ dbt.intersect() }}
+{{ intersect() }}
 ```
 
 </File>
@@ -112,10 +114,10 @@ This macro combines a list of strings together.
 <File name='models/example.sql'>
 
 ```sql
-{{ dbt.concat(["column_1", "column_2"]) }}
-{{ dbt.concat(["year_column", "'-'" , "month_column", "'-'" , "day_column"]) }}
-{{ dbt.concat(["first_part_column", "'.'" , "second_part_column"]) }}
-{{ dbt.concat(["first_part_column", "','" , "second_part_column"]) }}
+{{ concat(["column_1", "column_2"]) }}
+{{ concat(["year_column", "'-'" , "month_column", "'-'" , "day_column"]) }}
+{{ concat(["first_part_column", "'.'" , "second_part_column"]) }}
+{{ concat(["first_part_column", "','" , "second_part_column"]) }}
 ```
 
 </File>
@@ -132,8 +134,8 @@ This macro provides a hash (such as [MD5](https://en.wikipedia.org/wiki/MD5)) of
 <File name='models/example.sql'>
 
 ```sql
-{{ dbt.hash("column") }}
-{{ dbt.hash("'Pennsylvania'") }}
+{{ hash("column") }}
+{{ hash("'Pennsylvania'") }}
 ```
 
 </File>
@@ -151,7 +153,7 @@ This macro calculates the number of characters in a string.
 <File name='models/example.sql'>
 
 ```sql
-{{ dbt.length("column") }}
+{{ length("column") }}
 ```
 
 </File>
@@ -169,8 +171,8 @@ This macro searches for the first occurrence of `substring_text` within `string_
 <File name='models/example.sql'>
 
 ```sql
-{{ dbt.position("substring_column", "text_column") }}
-{{ dbt.position("'-'", "text_column") }}
+{{ position("substring_column", "text_column") }}
+{{ position("'-'", "text_column") }}
 ```
 
 </File>
@@ -189,8 +191,8 @@ This macro updates a string and replaces all occurrences of one substring with a
 <File name='models/example.sql'>
 
 ```sql
-{{ dbt.replace("string_text_column", "old_chars_column", "new_chars_column") }}
-{{ dbt.replace("string_text_column", "'-'", "'_'") }}
+{{ replace("string_text_column", "old_chars_column", "new_chars_column") }}
+{{ replace("string_text_column", "'-'", "'_'") }}
 ```
 
 </File>
@@ -208,8 +210,8 @@ This macro returns the N rightmost characters from a string.
 <File name='models/example.sql'>
 
 ```sql
-{{ dbt.right("string_text_column", "length_column") }}
-{{ dbt.right("string_text_column", "3") }}
+{{ right("string_text_column", "length_column") }}
+{{ right("string_text_column", "3") }}
 ```
 
 </File>
@@ -230,8 +232,8 @@ To escape quotes for column values, consider a macro like [replace](#replace) or
 <File name='models/example.sql'>
 
 ```sql
-{{ dbt.escape_single_quotes("they're") }}
-{{ dbt.escape_single_quotes("ain't ain't a word") }}
+{{ escape_single_quotes("they're") }}
+{{ escape_single_quotes("ain't ain't a word") }}
 ```
 
 </File>
@@ -250,7 +252,7 @@ To cast column values to a string, consider a macro like [safe_cast](#safe_cast)
 <File name='models/example.sql'>
 
 ```sql
-select {{ dbt.string_literal("Pennsylvania") }}
+select {{ string_literal("Pennsylvania") }}
 ```
 
 </File>
@@ -269,7 +271,7 @@ This macro returns some value of the expression from the group. The selected val
 <File name='models/example.sql'>
 
 ```sql
-{{ dbt.any_value("column_name") }}
+{{ any_value("column_name") }}
 ```
 
 </File>
@@ -286,10 +288,10 @@ This macro returns the logical `OR` of all non-`NULL` expressions -- `true` if a
 <File name='models/example.sql'>
 
 ```sql
-{{ dbt.bool_or("boolean_column") }}
-{{ dbt.bool_or("integer_column = 3") }}
-{{ dbt.bool_or("string_column = 'Pennsylvania'") }}
-{{ dbt.bool_or("column1 = column2") }}
+{{ bool_or("boolean_column") }}
+{{ bool_or("integer_column = 3") }}
+{{ bool_or("string_column = 'Pennsylvania'") }}
+{{ bool_or("column1 = column2") }}
 ```
 
 </File>
@@ -311,7 +313,7 @@ Note: If there are instances of `delimiter_text` within your `measure`, you cann
 <File name='models/example.sql'>
 
 ```sql
-{{ dbt.listagg(measure="column_to_agg", delimiter_text="','", order_by_clause="order by order_by_column", limit_num=10) }}
+{{ listagg(measure="column_to_agg", delimiter_text="','", order_by_clause="order by order_by_column", limit_num=10) }}
 ```
 
 </File>
@@ -330,12 +332,12 @@ This macro casts a boolean value to a string.
 <File name='models/example.sql'>
 
 ```sql
-{{ dbt.cast_bool_to_text("boolean_column_name") }}
-{{ dbt.cast_bool_to_text("false") }}
-{{ dbt.cast_bool_to_text("true") }}
-{{ dbt.cast_bool_to_text("0 = 1") }}
-{{ dbt.cast_bool_to_text("1 = 1") }}
-{{ dbt.cast_bool_to_text("null") }}
+{{ cast_bool_to_text("boolean_column_name") }}
+{{ cast_bool_to_text("false") }}
+{{ cast_bool_to_text("true") }}
+{{ cast_bool_to_text("0 = 1") }}
+{{ cast_bool_to_text("1 = 1") }}
+{{ cast_bool_to_text("null") }}
 ```
 
 </File>
@@ -353,9 +355,9 @@ For databases that support it, this macro will return `NULL` when the cast fails
 <File name='models/example.sql'>
 
 ```sql
-{{ dbt.safe_cast("column_1", api.Column.translate_type("string")) }}
-{{ dbt.safe_cast("column_2", api.Column.translate_type("integer")) }}
-{{ dbt.safe_cast("'2016-03-09'", api.Column.translate_type("date")) }}
+{{ safe_cast("column_1", api.Column.translate_type("string")) }}
+{{ safe_cast("column_2", api.Column.translate_type("integer")) }}
+{{ safe_cast("'2016-03-09'", api.Column.translate_type("date")) }}
 ```
 
 </File>
@@ -376,8 +378,8 @@ This macro adds a time/day interval to the supplied date/timestamp. Note: The `d
 <File name='models/example.sql'>
 
 ```sql
-{{ dbt.dateadd(datepart="day", interval=1, from_date_or_timestamp="'2016-03-09'") }}
-{{ dbt.dateadd(datepart="month", interval=-2, from_date_or_timestamp="'2016-03-09'") }}
+{{ dateadd(datepart="day", interval=1, from_date_or_timestamp="'2016-03-09'") }}
+{{ dateadd(datepart="month", interval=-2, from_date_or_timestamp="'2016-03-09'") }}
 ```
 
 </File>
@@ -396,9 +398,9 @@ This macro calculates the difference between two dates.
 <File name='models/example.sql'>
 
 ```sql
-{{ dbt.datediff("column_1", "column_2", "day") }}
-{{ dbt.datediff("column", "'2016-03-09'", "month") }}
-{{ dbt.datediff("'2016-03-09'", "column", "year") }}
+{{ datediff("column_1", "column_2", "day") }}
+{{ datediff("column", "'2016-03-09'", "month") }}
+{{ datediff("'2016-03-09'", "column", "year") }}
 ```
 
 </File>
@@ -416,9 +418,9 @@ This macro truncates / rounds a timestamp to the first instant for the given [da
 <File name='models/example.sql'>
 
 ```sql
-{{ dbt.date_trunc("day", "updated_at") }}
-{{ dbt.date_trunc("month", "updated_at") }}
-{{ dbt.date_trunc("year", "'2016-03-09'") }}
+{{ date_trunc("day", "updated_at") }}
+{{ date_trunc("month", "updated_at") }}
+{{ date_trunc("year", "'2016-03-09'") }}
 ```
 
 </File>
@@ -438,8 +440,8 @@ This macro gets the last day for a given date and datepart.
 <File name='models/example.sql'>
 
 ```sql
-{{ dbt.last_day("created_at", "month") }}
-{{ dbt.last_day("'2016-03-09'", "year") }}
+{{ last_day("created_at", "month") }}
+{{ last_day("'2016-03-09'", "year") }}
 ```
 
 </File>

--- a/website/docs/reference/dbt-jinja-functions/cross-database-macros.md
+++ b/website/docs/reference/dbt-jinja-functions/cross-database-macros.md
@@ -45,6 +45,10 @@ compatibility. In general, you should not need these macros in your own dbt proj
 - [dbt.right](#right)
 - [dbt.split_part](#split_part)
 
+[**String literal functions**](#string-literal-functions)
+- [dbt.escape_single_quotes](#escape_single_quotes)
+- [dbt.string_literal](#string_literal)
+
 [**Aggregate and window functions**](#aggregate-and-window-functions)
 - [dbt.any_value](#any_value)
 - [dbt.bool_or](#bool_or)
@@ -53,10 +57,6 @@ compatibility. In general, you should not need these macros in your own dbt proj
 [**Cast functions**](#cast-functions)
 - [dbt.cast_bool_to_text](#cast_bool_to_text)
 - [dbt.safe_cast](#safe_cast)
-
-[**String literal functions**](#string-literal-functions)
-- [dbt.escape_single_quotes](#escape_single_quotes)
-- [dbt.string_literal](#string_literal)
 
 [**Timestamp functions**](#timestamp-functions)
 - [dbt.current_timestamp](#current_timestamp)
@@ -220,6 +220,47 @@ This macro returns the N rightmost characters from a string.
 
 </File>
 
+# String literal functions
+
+## escape_single_quotes
+__Args__:
+
+ * `value`: Jinja string literal value
+
+This macro adds escape characters for any single quotes within the provided string literal. Note: if given a column, it will only operate on the column _name_, not the values within the column.
+
+To escape quotes for column values, consider a macro like [replace](#replace) or a regular expression replace.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+{{ dbt.escape_single_quotes("they're") }}
+{{ dbt.escape_single_quotes("ain't ain't a word") }}
+```
+
+</File>
+
+## string_literal
+__Args__:
+
+ * `value`: Jinja string value
+
+This macro converts a Jinja string into a SQL string literal.
+
+To cast column values to a string, consider a macro like [safe_cast](#safe_cast) or an ordinary cast.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+select {{ dbt.string_literal("Pennsylvania") }}
+```
+
+</File>
+
 # Aggregate and window functions
 
 ## any_value
@@ -321,47 +362,6 @@ For databases that support it, this macro will return `NULL` when the cast fails
 {{ dbt.safe_cast("column_1", api.Column.translate_type("string")) }}
 {{ dbt.safe_cast("column_2", api.Column.translate_type("integer")) }}
 {{ dbt.safe_cast("'2016-03-09'", api.Column.translate_type("date")) }}
-```
-
-</File>
-
-# String literal functions
-
-## escape_single_quotes
-__Args__:
-
- * `value`: Jinja string literal value
-
-This macro adds escape characters for any single quotes within the provided string literal. Note: if given a column, it will only operate on the column _name_, not the values within the column.
-
-To escape quotes for column values, consider a macro like [replace](#replace) or a regular expression replace.
-
-**Usage**:
-
-<File name='models/example.sql'>
-
-```sql
-{{ dbt.escape_single_quotes("they're") }}
-{{ dbt.escape_single_quotes("ain't ain't a word") }}
-```
-
-</File>
-
-## string_literal
-__Args__:
-
- * `value`: Jinja string value
-
-This macro converts a Jinja string into a SQL string literal.
-
-To cast column values to a string, consider a macro like [safe_cast](#safe_cast) or an ordinary cast.
-
-**Usage**:
-
-<File name='models/example.sql'>
-
-```sql
-select {{ dbt.string_literal("Pennsylvania") }}
 ```
 
 </File>

--- a/website/docs/reference/dbt-jinja-functions/cross-database-macros.md
+++ b/website/docs/reference/dbt-jinja-functions/cross-database-macros.md
@@ -54,7 +54,7 @@ compatibility. In general, you should not need these macros in your own dbt proj
 - [dbt.cast_bool_to_text](#cast_bool_to_text)
 - [dbt.safe_cast](#safe_cast)
 
-[**Non-SQL Jinja functions**](#non-sql-jinja-functions)
+[**String literal functions**](#string-literal-functions)
 - [dbt.escape_single_quotes](#escape_single_quotes)
 - [dbt.string_literal](#string_literal)
 
@@ -325,7 +325,7 @@ For databases that support it, this macro will return `NULL` when the cast fails
 
 </File>
 
-# Non-SQL Jinja functions
+# String literal functions
 
 ## escape_single_quotes
 __Args__:

--- a/website/docs/reference/dbt-jinja-functions/cross-database-macros.md
+++ b/website/docs/reference/dbt-jinja-functions/cross-database-macros.md
@@ -83,6 +83,12 @@ __Args__:
 
 </File>
 
+**Default Output**:
+
+```sql
+except
+```
+
 ## intersect
 __Args__:
 
@@ -99,6 +105,13 @@ __Args__:
 ```
 
 </File>
+
+**Default Output**:
+
+```sql
+intersect
+```
+
 
 # String functions
 
@@ -122,6 +135,15 @@ This macro combines a list of strings together.
 
 </File>
 
+**Default Output**:
+
+```sql
+column_1 || column_2
+year_column || '-' || month_column || '-' || day_column
+first_part_column || '.' || second_part_column
+first_part_column || ',' || second_part_column
+```
+
 ## hash
 __Args__:
 
@@ -138,7 +160,16 @@ This macro provides a hash (such as [MD5](https://en.wikipedia.org/wiki/MD5)) of
 {{ hash("'Pennsylvania'") }}
 ```
 
-</File>
+**Default Output**:
+
+```sql
+md5(cast(column as 
+    varchar
+))
+md5(cast('Pennsylvania' as 
+    varchar
+))
+```
 
 ## length
 __Args__:
@@ -158,6 +189,14 @@ This macro calculates the number of characters in a string.
 
 </File>
 
+**Default Output**:
+
+```sql
+    length(
+        column
+    )
+```
+
 ## position
 __Args__:
 
@@ -176,6 +215,19 @@ This macro searches for the first occurrence of `substring_text` within `string_
 ```
 
 </File>
+
+**Default Output**:
+
+```sql
+    position(
+        substring_column in text_column
+    )
+
+
+    position(
+        '-' in text_column
+    )
+```
 
 ## replace
 __Args__:
@@ -197,6 +249,26 @@ This macro updates a string and replaces all occurrences of one substring with a
 
 </File>
 
+**Default Output**:
+
+```sql
+    replace(
+        string_text_column,
+        old_chars_column,
+        new_chars_column
+    )
+    
+
+
+
+
+    replace(
+        string_text_column,
+        '-',
+        '_'
+    )
+```
+
 ## right
 __Args__:
 
@@ -215,6 +287,21 @@ This macro returns the N rightmost characters from a string.
 ```
 
 </File>
+
+**Default Output**:
+
+```sql
+    right(
+        string_text_column,
+        length_column
+    )
+
+
+    right(
+        string_text_column,
+        3
+    )
+```
 
 # String literal functions
 
@@ -238,6 +325,13 @@ To escape quotes for column values, consider a macro like [replace](#replace) or
 
 </File>
 
+**Default Output**:
+
+```sql
+they''re
+ain''t ain''t a word
+```
+
 ## string_literal
 __Args__:
 
@@ -256,6 +350,12 @@ select {{ string_literal("Pennsylvania") }}
 ```
 
 </File>
+
+**Default Output**:
+
+```sql
+select 'Pennsylvania'
+```
 
 # Aggregate and window functions
 
@@ -276,6 +376,12 @@ This macro returns some value of the expression from the group. The selected val
 
 </File>
 
+**Default Output**:
+
+```sql
+any(column_name)
+```
+
 ## bool_or
 __Args__:
 
@@ -295,6 +401,15 @@ This macro returns the logical `OR` of all non-`NULL` expressions -- `true` if a
 ```
 
 </File>
+
+**Default Output**:
+
+```sql
+bool_or(boolean_column)
+bool_or(integer_column = 3)
+bool_or(string_column = 'Pennsylvania')
+bool_or(column1 = column2)
+```
 
 ## listagg
 __Args__:
@@ -317,6 +432,18 @@ Note: If there are instances of `delimiter_text` within your `measure`, you cann
 ```
 
 </File>
+
+**Default Output**:
+
+```sql
+array_to_string(
+        (array_agg(
+            column_to_agg
+            order by order_by_column
+        ))[1:10],
+        ','
+        )
+```
 
 # Cast functions
 
@@ -342,6 +469,51 @@ This macro casts a boolean value to a string.
 
 </File>
 
+**Default Output**:
+
+```sql
+    cast(boolean_column_name as 
+    varchar
+)
+
+
+
+  
+    cast(false as 
+    varchar
+)
+
+
+
+  
+    cast(true as 
+    varchar
+)
+
+
+
+  
+    cast(0 = 1 as 
+    varchar
+)
+
+
+
+  
+    cast(1 = 1 as 
+    varchar
+)
+
+
+
+  
+    cast(null as 
+    varchar
+)
+
+
+```
+
 ## safe_cast
 __Args__:
 
@@ -361,6 +533,20 @@ For databases that support it, this macro will return `NULL` when the cast fails
 ```
 
 </File>
+
+**Default Output**:
+
+```sql
+    cast(column_1 as TEXT)
+
+
+    
+    cast(column_2 as INT)
+
+
+    
+    cast('2016-03-09' as date)
+```
 
 # Date and time functions
 
@@ -384,6 +570,17 @@ This macro adds a time/day interval to the supplied date/timestamp. Note: The `d
 
 </File>
 
+**Default Output**:
+
+```sql
+    '2016-03-09' + ((interval '10 day') * (1))
+
+
+
+
+    '2016-03-09' + ((interval '10 month') * (-2))
+```
+
 ## datediff
 __Args__:
 
@@ -405,6 +602,21 @@ This macro calculates the difference between two dates.
 
 </File>
 
+**Default Output**:
+
+```sql
+        ((column_2)::date - (column_1)::date)
+    
+
+        (
+        (date_part('year', ('2016-03-09')::date) - date_part('year', (column)::date))
+     * 12 + date_part('month', ('2016-03-09')::date) - date_part('month', (column)::date))
+    
+
+        (date_part('year', (column)::date) - date_part('year', ('2016-03-09')::date))
+
+```
+
 ## date_trunc
 __Args__:
 
@@ -424,6 +636,14 @@ This macro truncates / rounds a timestamp to the first instant for the given [da
 ```
 
 </File>
+
+**Default Output**:
+
+```sql
+date_trunc('day', updated_at)
+date_trunc('month', updated_at)
+date_trunc('year', '2016-03-09')
+```
 
 ## last_day
 __Args__:
@@ -445,6 +665,33 @@ This macro gets the last day for a given date and datepart.
 ```
 
 </File>
+
+**Default Output**:
+
+```sql
+cast(
+        
+
+    
+
+    date_trunc('month', created_at) + ((interval '10 month') * (1))
+
+ + ((interval '10 day') * (-1))
+
+
+        as date)
+cast(
+        
+
+    
+
+    date_trunc('year', '2016-03-09') + ((interval '10 year') * (1))
+
+ + ((interval '10 day') * (-1))
+
+
+        as date)
+```
 
 ## Date and time parts
 

--- a/website/docs/reference/dbt-jinja-functions/cross-database-macros.md
+++ b/website/docs/reference/dbt-jinja-functions/cross-database-macros.md
@@ -32,11 +32,11 @@ compatibility. In general, you should not need these macros in your own dbt proj
 - [dbt.split_part](#split_part)
 - [dbt.string_literal](#string_literal)
 
-## Set functions
+[**Set functions**](#set-functions)
 - [dbt.except](#except)
 - [dbt.intersect](#intersect)
 
-## String functions
+[**String functions**](#string-functions)
 - [dbt.concat](#concat)
 - [dbt.hash](#hash)
 - [dbt.length](#length)
@@ -45,24 +45,24 @@ compatibility. In general, you should not need these macros in your own dbt proj
 - [dbt.right](#right)
 - [dbt.split_part](#split_part)
 
-## Aggregate and window functions
+[**Aggregate and window functions**](#aggregate-and-window-functions)
 - [dbt.any_value](#any_value)
 - [dbt.bool_or](#bool_or)
 - [dbt.listagg](#listagg)
 
-## Cast functions
+[**Cast functions**](#cast-functions)
 - [dbt.cast_bool_to_text](#cast_bool_to_text)
 - [dbt.safe_cast](#safe_cast)
 
-## Non-SQL Jinja functions
+[**Non-SQL Jinja functions**](#non-sql-jinja-functions)
 - [dbt.escape_single_quotes](#escape_single_quotes)
 - [dbt.string_literal](#string_literal)
 
-## Timestamp functions
+[**Timestamp functions**](#timestamp-functions)
 - [dbt.current_timestamp](#current_timestamp)
 - [dbt.current_timestamp_in_utc](#current_timestamp_in_utc)
 
-## Date and time functions
+[**Date and time functions**](#date-and-time-functions)
 - [dbt.dateadd](#dateadd)
 - [dbt.datediff](#datediff)
 - [dbt.date_trunc](#date_trunc)

--- a/website/docs/reference/dbt-jinja-functions/dbt.md
+++ b/website/docs/reference/dbt-jinja-functions/dbt.md
@@ -7,13 +7,17 @@ id: "dbt"
 
 `dbt` TODO rest of paragraph here.
 
+These macros make it easier for package authors (especially those writing modeling packages) to implement cross-database
+compatibility. In general, you should not use these macros in your own dbt project (unless it is a package).
+
+
 The following functions are available:
 - [dbt.any_value](#any_value)
 - [dbt.bool_or](#bool_or)
 - [dbt.cast_bool_to_text](#cast_bool_to_text)
 - [dbt.concat](#concat)
-- [dbt.current_timestamp_in_utc](#current_timestamp_in_utc)
 - [dbt.current_timestamp](#current_timestamp)
+- [dbt.current_timestamp_in_utc](#current_timestamp_in_utc)
 - [dbt.date_trunc](#date_trunc)
 - [dbt.dateadd](#dateadd)
 - [dbt.datediff](#datediff)
@@ -34,8 +38,8 @@ The following functions are available:
 ## any_value
 __Args__:
 
- * `arg1`: desc1
- * `arg1`: desc2
+ * `TODO`: TODO
+ * `TODO`: TODO
 
 Paragraph_description.
 
@@ -52,8 +56,8 @@ Paragraph_description.
 ## bool_or
 __Args__:
 
- * `arg1`: desc1
- * `arg1`: desc2
+ * `TODO`: TODO
+ * `TODO`: TODO
 
 Paragraph_description.
 
@@ -70,8 +74,8 @@ Paragraph_description.
 ## cast_bool_to_text
 __Args__:
 
- * `arg1`: desc1
- * `arg1`: desc2
+ * `TODO`: TODO
+ * `TODO`: TODO
 
 Paragraph_description.
 
@@ -88,8 +92,8 @@ Paragraph_description.
 ## concat
 __Args__:
 
- * `arg1`: desc1
- * `arg1`: desc2
+ * `TODO`: TODO
+ * `TODO`: TODO
 
 Paragraph_description.
 
@@ -106,17 +110,16 @@ Paragraph_description.
 ## current_timestamp
 __Args__:
 
- * `arg1`: desc1
- * `arg1`: desc2
+ * None
 
-Paragraph_description.
+This macro returns the current timestamp.
 
 **Usage**:
 
 <File name='models/example.sql'>
 
 ```sql
--- TODO
+{{ dbt_utils.current_timestamp() }}
 ```
 
 </File>
@@ -124,8 +127,8 @@ Paragraph_description.
 ## current_timestamp_in_utc
 __Args__:
 
- * `arg1`: desc1
- * `arg1`: desc2
+ * `TODO`: TODO
+ * `TODO`: TODO
 
 Paragraph_description.
 
@@ -142,8 +145,8 @@ Paragraph_description.
 ## date_trunc
 __Args__:
 
- * `arg1`: desc1
- * `arg1`: desc2
+ * `TODO`: TODO
+ * `TODO`: TODO
 
 Paragraph_description.
 
@@ -160,17 +163,18 @@ Paragraph_description.
 ## dateadd
 __Args__:
 
- * `arg1`: desc1
- * `arg1`: desc2
+ * `datepart`: TODO
+ * `interval`: TODO
+ * `from_date_or_timestamp`: TODO
 
-Paragraph_description.
+This macro adds a time/day interval to the supplied date/timestamp. Note: The `datepart` argument is database-specific.
 
 **Usage**:
 
 <File name='models/example.sql'>
 
 ```sql
--- TODO
+{{ dbt_utils.dateadd(datepart='day', interval=1, from_date_or_timestamp="'2017-01-01'") }}
 ```
 
 </File>
@@ -178,17 +182,18 @@ Paragraph_description.
 ## datediff
 __Args__:
 
- * `arg1`: desc1
- * `arg1`: desc2
+ * `TODO`: TODO
+ * `TODO`: TODO
+ * `datepart`: TODO
 
-Paragraph_description.
+This macro calculates the difference between two dates.
 
 **Usage**:
 
 <File name='models/example.sql'>
 
 ```sql
--- TODO
+{{ dbt_utils.datediff("'2018-01-01'", "'2018-01-20'", 'day') }}
 ```
 
 </File>
@@ -196,8 +201,8 @@ Paragraph_description.
 ## escape_single_quotes
 __Args__:
 
- * `arg1`: desc1
- * `arg1`: desc2
+ * `TODO`: TODO
+ * `TODO`: TODO
 
 Paragraph_description.
 
@@ -214,8 +219,8 @@ Paragraph_description.
 ## except
 __Args__:
 
- * `arg1`: desc1
- * `arg1`: desc2
+ * `TODO`: TODO
+ * `TODO`: TODO
 
 Paragraph_description.
 
@@ -232,8 +237,8 @@ Paragraph_description.
 ## hash
 __Args__:
 
- * `arg1`: desc1
- * `arg1`: desc2
+ * `TODO`: TODO
+ * `TODO`: TODO
 
 Paragraph_description.
 
@@ -250,8 +255,8 @@ Paragraph_description.
 ## intersect
 __Args__:
 
- * `arg1`: desc1
- * `arg1`: desc2
+ * `TODO`: TODO
+ * `TODO`: TODO
 
 Paragraph_description.
 
@@ -268,17 +273,19 @@ Paragraph_description.
 ## last_day
 __Args__:
 
- * `arg1`: desc1
- * `arg1`: desc2
+ * `date`: TODO
+ * `datepart`: TODO
 
-Paragraph_description.
+Gets the last day for a given date and datepart.
 
 **Usage**:
+- The `datepart` argument is database-specific.
+- This macro currently only supports dateparts of `month` and `quarter`.
 
 <File name='models/example.sql'>
 
 ```sql
--- TODO
+{{ dbt_utils.last_day(date, datepart) }}
 ```
 
 </File>
@@ -286,8 +293,8 @@ Paragraph_description.
 ## length
 __Args__:
 
- * `arg1`: desc1
- * `arg1`: desc2
+ * `TODO`: TODO
+ * `TODO`: TODO
 
 Paragraph_description.
 
@@ -304,17 +311,21 @@ Paragraph_description.
 ## listagg
 __Args__:
 
- * `arg1`: desc1
- * `arg1`: desc2
+ * `measure` (required): The expression (typically a column name) that determines the values to be concatenated. To only include distinct values add keyword `DISTINCT` to beginning of expression (example: 'DISTINCT column_to_agg').
+ * `delimiter_text` (required): Text representing the delimiter to separate concatenated values by.
+ * `order_by_clause` (optional): An expression (typically a column name) that determines the order of the concatenated values.
+ * `limit_num` (optional): Specifies the maximum number of values to be concatenated.
 
-Paragraph_description.
+This macro returns the concatenated input values from a group of rows separated by a specified delimiter.
 
 **Usage**:
+
+Note: If there are instances of `delimiter_text` within your `measure`, you cannot include a `limit_num`.
 
 <File name='models/example.sql'>
 
 ```sql
--- TODO
+{{ dbt_utils.listagg(measure='column_to_agg', delimiter_text="','", order_by_clause="order by order_by_column", limit_num=10) }}
 ```
 
 </File>
@@ -322,8 +333,8 @@ Paragraph_description.
 ## position
 __Args__:
 
- * `arg1`: desc1
- * `arg1`: desc2
+ * `TODO`: TODO
+ * `TODO`: TODO
 
 Paragraph_description.
 
@@ -340,8 +351,8 @@ Paragraph_description.
 ## replace
 __Args__:
 
- * `arg1`: desc1
- * `arg1`: desc2
+ * `TODO`: TODO
+ * `TODO`: TODO
 
 Paragraph_description.
 
@@ -358,8 +369,8 @@ Paragraph_description.
 ## right
 __Args__:
 
- * `arg1`: desc1
- * `arg1`: desc2
+ * `TODO`: TODO
+ * `TODO`: TODO
 
 Paragraph_description.
 
@@ -376,8 +387,8 @@ Paragraph_description.
 ## safe_cast
 __Args__:
 
- * `arg1`: desc1
- * `arg1`: desc2
+ * `TODO`: TODO
+ * `TODO`: TODO
 
 Paragraph_description.
 
@@ -394,17 +405,20 @@ Paragraph_description.
 ## split_part
 __Args__:
 
- * `arg1`: desc1
- * `arg1`: desc2
+ * `string_text` (required): Text to be split into parts.
+ * `delimiter_text` (required): Text representing the delimiter to split by.
+ * `part_number` (required): Requested part of the split (1-based). If the value is negative, the parts are counted backward from the end of the string.
 
-Paragraph_description.
+This macro splits a string of text using the supplied delimiter and returns the supplied part number (1-indexed).
 
 **Usage**:
+When referencing a column, use one pair of quotes. When referencing a string, use single quotes enclosed in double quotes.
 
 <File name='models/example.sql'>
 
 ```sql
--- TODO
+{{ dbt_utils.split_part(string_text='column_to_split', delimiter_text='delimiter_column', part_number=1) }}
+{{ dbt_utils.split_part(string_text="'1|2|3'", delimiter_text="'|'", part_number=1) }}
 ```
 
 </File>
@@ -412,8 +426,8 @@ Paragraph_description.
 ## string_literal
 __Args__:
 
- * `arg1`: desc1
- * `arg1`: desc2
+ * `TODO`: TODO
+ * `TODO`: TODO
 
 Paragraph_description.
 

--- a/website/docs/reference/dbt-jinja-functions/dbt.md
+++ b/website/docs/reference/dbt-jinja-functions/dbt.md
@@ -3,24 +3,21 @@ title: "dbt"
 id: "dbt"
 ---
 
-## Overview
-
-`dbt` TODO rest of paragraph here.
+# Overview
 
 These macros make it easier for package authors (especially those writing modeling packages) to implement cross-database
-compatibility. In general, you should not use these macros in your own dbt project (unless it is a package).
+compatibility. In general, you should not need these macros in your own dbt project (unless it is a package or you otherwise desire cross-database compatibility).
 
-
-The following functions are available:
+## All functions (alphabetical)
 - [dbt.any_value](#any_value)
 - [dbt.bool_or](#bool_or)
 - [dbt.cast_bool_to_text](#cast_bool_to_text)
 - [dbt.concat](#concat)
 - [dbt.current_timestamp](#current_timestamp)
 - [dbt.current_timestamp_in_utc](#current_timestamp_in_utc)
-- [dbt.date_trunc](#date_trunc)
 - [dbt.dateadd](#dateadd)
 - [dbt.datediff](#datediff)
+- [dbt.date_trunc](#date_trunc)
 - [dbt.escape_single_quotes](#escape_single_quotes)
 - [dbt.except](#except)
 - [dbt.hash](#hash)
@@ -35,20 +32,211 @@ The following functions are available:
 - [dbt.split_part](#split_part)
 - [dbt.string_literal](#string_literal)
 
-## any_value
+## Set functions
+- [dbt.except](#except)
+- [dbt.intersect](#intersect)
+
+## String functions
+- [dbt.concat](#concat)
+- [dbt.hash](#hash)
+- [dbt.length](#length)
+- [dbt.position](#position)
+- [dbt.replace](#replace)
+- [dbt.right](#right)
+- [dbt.split_part](#split_part)
+
+## Aggregate and window functions
+- [dbt.any_value](#any_value)
+- [dbt.bool_or](#bool_or)
+- [dbt.listagg](#listagg)
+
+## Cast functions
+- [dbt.cast_bool_to_text](#cast_bool_to_text)
+- [dbt.safe_cast](#safe_cast)
+
+## Non-SQL Jinja functions
+- [dbt.escape_single_quotes](#escape_single_quotes)
+- [dbt.string_literal](#string_literal)
+
+## Timestamp functions
+- [dbt.current_timestamp](#current_timestamp)
+- [dbt.current_timestamp_in_utc](#current_timestamp_in_utc)
+
+## Date and time functions
+- [dbt.dateadd](#dateadd)
+- [dbt.datediff](#datediff)
+- [dbt.date_trunc](#date_trunc)
+- [dbt.last_day](#last_day)
+
+
+# Set functions
+
+## except
 __Args__:
 
- * `TODO`: TODO
- * `TODO`: TODO
+ * None
 
-Paragraph_description.
+`except` is one of the set operators specified ANSI SQL-92 (along with `union` and `intersect`) and is akin to [set difference](https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement).
 
 **Usage**:
 
 <File name='models/example.sql'>
 
 ```sql
--- TODO
+{{ dbt.except() }}
+```
+
+</File>
+
+## intersect
+__Args__:
+
+ * None
+
+`intersect` is one of the set operators specified ANSI SQL-92 (along with `union` and `except`) and is akin to [set intersection](https://en.wikipedia.org/wiki/Intersection_(set_theory)).
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+{{ dbt.intersect() }}
+```
+
+</File>
+
+# String functions
+
+## concat
+__Args__:
+
+ * `fields`: Jinja array of [attribute names or expressions](#sql_expressions).
+
+This macro combines a list of strings together.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+{{ dbt.concat(["column_1", "column_2"]) }}
+{{ dbt.concat(["year_column", "'-'" , "month_column", "'-'" , "day_column"]) }}
+{{ dbt.concat(["first_part_column", "'.'" , "second_part_column"]) }}
+{{ dbt.concat(["first_part_column", "','" , "second_part_column"]) }}
+```
+
+</File>
+
+## hash
+__Args__:
+
+ * `field`: [attribute name or expression](#sql_expressions).
+
+This macro provides a hash (such as [MD5](https://en.wikipedia.org/wiki/MD5)) of an [expression](#sql_expressions) cast as a string.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+{{ dbt.hash("column") }}
+{{ dbt.hash("'Pennsylvania'") }}
+```
+
+</File>
+
+## length
+__Args__:
+
+ * `expression`: string [expression](#sql_expressions).
+
+
+This macro calculates the number of characters in a string.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+{{ dbt.length("column") }}
+```
+
+</File>
+
+## position
+__Args__:
+
+ * `substring_text`: [attribute name or expression](#sql_expressions).
+ * `string_text`: [attribute name or expression](#sql_expressions).
+
+This macro searches for the first occurrence of `substring_text` within `string_text` and returns the 1-based position if found.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+{{ dbt.position("substring_column", "text_column") }}
+{{ dbt.position("'-'", "text_column") }}
+```
+
+</File>
+
+## replace
+__Args__:
+
+ * `field`: [attribute name or expression](#sql_expressions).
+ * `old_chars`: [attribute name or expression](#sql_expressions).
+ * `new_chars`: [attribute name or expression](#sql_expressions).
+
+This macro updates a string and replaces all occurrences of one substring with another. The precise behavior may vary slightly from one adapter to another.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+{{ dbt.replace("string_text_column", "old_chars_column", "new_chars_column") }}
+{{ dbt.replace("string_text_column", "'-'", "'_'") }}
+```
+
+</File>
+
+## right
+__Args__:
+
+ * `string_text`: [attribute name or expression](#sql_expressions).
+ * `length_expression`: numeric [expression](#sql_expressions).
+
+This macro returns the N rightmost characters from a string.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+{{ dbt.right("string_text_column", "length_column") }}
+{{ dbt.right("string_text_column", "3") }}
+```
+
+</File>
+
+
+# Aggregate and window functions
+
+## any_value
+__Args__:
+
+ * `expression`: an [expression](#sql_expressions).
+
+This macro returns some value of the expression from the group. The selected value is non-deterministic (rather than random).
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+{{ dbt.any_value("column_name") }}
 ```
 
 </File>
@@ -56,56 +244,134 @@ Paragraph_description.
 ## bool_or
 __Args__:
 
- * `TODO`: TODO
- * `TODO`: TODO
+ * `expression`: [attribute name or expression](#sql_expressions).
 
-Paragraph_description.
+This macro returns the logical `OR` of all non-`NULL` expressions -- `true` if at least one record in the group evaluates to `true`.
 
 **Usage**:
 
 <File name='models/example.sql'>
 
 ```sql
--- TODO
+{{ dbt.bool_or("boolean_column") }}
+{{ dbt.bool_or("integer_column = 3") }}
+{{ dbt.bool_or("string_column = 'Pennsylvania'") }}
+{{ dbt.bool_or("column1 = column2") }}
 ```
 
 </File>
+
+## listagg
+__Args__:
+
+ * `measure` (required): The [attribute name or expression](#sql_expressions) that determines the values to be concatenated. To only include distinct values add keyword `DISTINCT` to beginning of expression (example: 'DISTINCT column_to_agg').
+ * `delimiter_text` (required): Text representing the delimiter to separate concatenated values by.
+ * `order_by_clause` (optional): An expression (typically one or more column names separated by commas) that determines the order of the concatenated values.
+ * `limit_num` (optional): Specifies the maximum number of values to be concatenated.
+
+This macro returns the concatenated input values from a group of rows separated by a specified delimiter.
+
+**Usage**:
+
+Note: If there are instances of `delimiter_text` within your `measure`, you cannot include a `limit_num`.
+
+<File name='models/example.sql'>
+
+```sql
+{{ dbt.listagg(measure="column_to_agg", delimiter_text="','", order_by_clause="order by order_by_column", limit_num=10) }}
+```
+
+</File>
+
+
+# Cast functions
 
 ## cast_bool_to_text
 __Args__:
 
- * `TODO`: TODO
- * `TODO`: TODO
+ * `field`: boolean [attribute name or expression](#sql_expressions).
 
-Paragraph_description.
+This macro casts a boolean value to a string.
 
 **Usage**:
 
 <File name='models/example.sql'>
 
 ```sql
--- TODO
+{{ dbt.cast_bool_to_text("boolean_column_name") }}
+{{ dbt.cast_bool_to_text("false") }}
+{{ dbt.cast_bool_to_text("true") }}
+{{ dbt.cast_bool_to_text("0 = 1") }}
+{{ dbt.cast_bool_to_text("1 = 1") }}
+{{ dbt.cast_bool_to_text("null") }}
 ```
 
 </File>
 
-## concat
+## safe_cast
 __Args__:
 
- * `TODO`: TODO
- * `TODO`: TODO
+ * `field`: [attribute name or expression](#sql_expressions).
+ * `type`: data type to convert to
 
-Paragraph_description.
+For databases that support it, this macro will return `NULL` when the cast fails (instead of raising an error).
 
 **Usage**:
 
 <File name='models/example.sql'>
 
 ```sql
--- TODO
+{{ dbt.safe_cast("column_1", api.Column.translate_type("string")) }}
+{{ dbt.safe_cast("column_2", api.Column.translate_type("integer")) }}
+{{ dbt.safe_cast("'2016-03-09'", api.Column.translate_type("date")) }}
 ```
 
 </File>
+
+
+# Non-SQL Jinja functions
+
+## escape_single_quotes
+__Args__:
+
+ * `value`: Jinja string literal value
+
+This macro adds escape characters for any single quotes within the provided string literal. Note: if given a column, it will only operate on the column _name_, not the values within the column.
+
+To escape quotes for column values, consider a macro like [replace](#replace) or a regular expression replace.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+{{ dbt.escape_single_quotes("they're") }}
+{{ dbt.escape_single_quotes("ain't ain't a word") }}
+```
+
+</File>
+
+## string_literal
+__Args__:
+
+ * `value`: Jinja string value
+
+This macro converts a Jinja string into a SQL string literal.
+
+To cast column values to a string, consider a macro like [safe_cast](#safe_cast) or an ordinary cast.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+select {{ dbt.string_literal("Pennsylvania") }}
+```
+
+</File>
+
+
+# Timestamp functions
 
 ## current_timestamp
 __Args__:
@@ -119,7 +385,7 @@ This macro returns the current timestamp.
 <File name='models/example.sql'>
 
 ```sql
-{{ dbt_utils.current_timestamp() }}
+{{ dbt.current_timestamp() }}
 ```
 
 </File>
@@ -127,45 +393,29 @@ This macro returns the current timestamp.
 ## current_timestamp_in_utc
 __Args__:
 
- * `TODO`: TODO
- * `TODO`: TODO
+ * None
 
-Paragraph_description.
-
-**Usage**:
-
-<File name='models/example.sql'>
-
-```sql
--- TODO
-```
-
-</File>
-
-## date_trunc
-__Args__:
-
- * `TODO`: TODO
- * `TODO`: TODO
-
-Paragraph_description.
+This macro returns the current timestamp expressed in [Coordinated Universal Time (UTC)](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).
 
 **Usage**:
 
 <File name='models/example.sql'>
 
 ```sql
--- TODO
+{{ dbt.current_timestamp_in_utc() }}
 ```
 
 </File>
+
+
+# Date and time functions
 
 ## dateadd
 __Args__:
 
- * `datepart`: TODO
- * `interval`: TODO
- * `from_date_or_timestamp`: TODO
+ * `datepart`: [date or time part](#date_and_time_parts).
+ * `interval`: integer count of the `datepart` to add (can be positive or negative)
+ * `from_date_or_timestamp`: date/time [expression](#sql_expressions).
 
 This macro adds a time/day interval to the supplied date/timestamp. Note: The `datepart` argument is database-specific.
 
@@ -174,7 +424,8 @@ This macro adds a time/day interval to the supplied date/timestamp. Note: The `d
 <File name='models/example.sql'>
 
 ```sql
-{{ dbt_utils.dateadd(datepart='day', interval=1, from_date_or_timestamp="'2017-01-01'") }}
+{{ dbt.dateadd(datepart="day", interval=1, from_date_or_timestamp="'2016-03-09'") }}
+{{ dbt.dateadd(datepart="month", interval=-2, from_date_or_timestamp="'2016-03-09'") }}
 ```
 
 </File>
@@ -182,9 +433,9 @@ This macro adds a time/day interval to the supplied date/timestamp. Note: The `d
 ## datediff
 __Args__:
 
- * `TODO`: TODO
- * `TODO`: TODO
- * `datepart`: TODO
+ * `first_date`: date/time [expression](#sql_expressions).
+ * `second_date`: date/time [expression](#sql_expressions).
+ * `datepart`: [date or time part](#date_and_time_parts).
 
 This macro calculates the difference between two dates.
 
@@ -193,79 +444,29 @@ This macro calculates the difference between two dates.
 <File name='models/example.sql'>
 
 ```sql
-{{ dbt_utils.datediff("'2018-01-01'", "'2018-01-20'", 'day') }}
+{{ dbt.datediff("column_1", "column_2", "day") }}
+{{ dbt.datediff("column", "'2016-03-09'", "month") }}
+{{ dbt.datediff("'2016-03-09'", "column", "year") }}
 ```
 
 </File>
 
-## escape_single_quotes
+## date_trunc
 __Args__:
 
- * `TODO`: TODO
- * `TODO`: TODO
+ * `datepart`: [date or time part](#date_and_time_parts).
+ * `date`: date/time [expression](#sql_expressions).
 
-Paragraph_description.
+This macro truncates / rounds a timestamp to the first instant for the given [date or time part](#date_and_time_parts).
 
 **Usage**:
 
 <File name='models/example.sql'>
 
 ```sql
--- TODO
-```
-
-</File>
-
-## except
-__Args__:
-
- * `TODO`: TODO
- * `TODO`: TODO
-
-Paragraph_description.
-
-**Usage**:
-
-<File name='models/example.sql'>
-
-```sql
--- TODO
-```
-
-</File>
-
-## hash
-__Args__:
-
- * `TODO`: TODO
- * `TODO`: TODO
-
-Paragraph_description.
-
-**Usage**:
-
-<File name='models/example.sql'>
-
-```sql
--- TODO
-```
-
-</File>
-
-## intersect
-__Args__:
-
- * `TODO`: TODO
- * `TODO`: TODO
-
-Paragraph_description.
-
-**Usage**:
-
-<File name='models/example.sql'>
-
-```sql
--- TODO
+{{ dbt.date_trunc("day", "updated_at") }}
+{{ dbt.date_trunc("month", "updated_at") }}
+{{ dbt.date_trunc("year", "'2016-03-09'") }}
 ```
 
 </File>
@@ -273,10 +474,10 @@ Paragraph_description.
 ## last_day
 __Args__:
 
- * `date`: TODO
- * `datepart`: TODO
+ * `date`: date/time [expression](#sql_expressions).
+ * `datepart`: [date or time part](#date_and_time_parts).
 
-Gets the last day for a given date and datepart.
+This macro gets the last day for a given date and datepart.
 
 **Usage**:
 - The `datepart` argument is database-specific.
@@ -285,158 +486,58 @@ Gets the last day for a given date and datepart.
 <File name='models/example.sql'>
 
 ```sql
-{{ dbt_utils.last_day(date, datepart) }}
+{{ dbt.last_day("created_at", "month") }}
+{{ dbt.last_day("'2016-03-09'", "year") }}
 ```
 
 </File>
 
-## length
-__Args__:
+# Date and time parts
 
- * `TODO`: TODO
- * `TODO`: TODO
+Often supported date and time parts (case insensitive):
+* `year`
+* `quarter`
+* `month`
+* `week`
+* `day`
+* `hour`
+* `minute`
+* `second`
+* `millisecond`
+* `microsecond`
+* `nanosecond`
 
-Paragraph_description.
+This listing is not meant to be exhaustive, and some of these date and time parts may not be supported for particular adapters.
+Some macros may not support all date and time parts. Some adapters may support more or less precision.
 
-**Usage**:
+# SQL expressions
 
-<File name='models/example.sql'>
+A SQL expression may take forms like the following:
+- function
+- column name
+- date literal
+- string literal
+- <other data type> literal (number, etc)
+- `NULL`
 
+Example:
+Suppose there is an `orders` table with a column named `order_date`. The following shows 3 different types of expressions:
 ```sql
--- TODO
+select
+    date_trunc(month, order_date) as expression_function,
+    order_date as expression_column_name,
+    '2016-03-09' as expression_date_literal,
+    'Pennsylvania' as expression_string_literal,
+    3 as expression_number_literal,
+    NULL as expression_null,
+from orders
 ```
 
-</File>
+Note that the string literal example includes single quotes. (Note: the string literal character may vary per database. For this example, we suppose a single quote.) To refer to a SQL string literal in Jinja, surrounding double quotes are required.
 
-## listagg
-__Args__:
-
- * `measure` (required): The expression (typically a column name) that determines the values to be concatenated. To only include distinct values add keyword `DISTINCT` to beginning of expression (example: 'DISTINCT column_to_agg').
- * `delimiter_text` (required): Text representing the delimiter to separate concatenated values by.
- * `order_by_clause` (optional): An expression (typically a column name) that determines the order of the concatenated values.
- * `limit_num` (optional): Specifies the maximum number of values to be concatenated.
-
-This macro returns the concatenated input values from a group of rows separated by a specified delimiter.
-
-**Usage**:
-
-Note: If there are instances of `delimiter_text` within your `measure`, you cannot include a `limit_num`.
-
-<File name='models/example.sql'>
-
-```sql
-{{ dbt_utils.listagg(measure='column_to_agg', delimiter_text="','", order_by_clause="order by order_by_column", limit_num=10) }}
-```
-
-</File>
-
-## position
-__Args__:
-
- * `TODO`: TODO
- * `TODO`: TODO
-
-Paragraph_description.
-
-**Usage**:
-
-<File name='models/example.sql'>
-
-```sql
--- TODO
-```
-
-</File>
-
-## replace
-__Args__:
-
- * `TODO`: TODO
- * `TODO`: TODO
-
-Paragraph_description.
-
-**Usage**:
-
-<File name='models/example.sql'>
-
-```sql
--- TODO
-```
-
-</File>
-
-## right
-__Args__:
-
- * `TODO`: TODO
- * `TODO`: TODO
-
-Paragraph_description.
-
-**Usage**:
-
-<File name='models/example.sql'>
-
-```sql
--- TODO
-```
-
-</File>
-
-## safe_cast
-__Args__:
-
- * `TODO`: TODO
- * `TODO`: TODO
-
-Paragraph_description.
-
-**Usage**:
-
-<File name='models/example.sql'>
-
-```sql
--- TODO
-```
-
-</File>
-
-## split_part
-__Args__:
-
- * `string_text` (required): Text to be split into parts.
- * `delimiter_text` (required): Text representing the delimiter to split by.
- * `part_number` (required): Requested part of the split (1-based). If the value is negative, the parts are counted backward from the end of the string.
-
-This macro splits a string of text using the supplied delimiter and returns the supplied part number (1-indexed).
-
-**Usage**:
-When referencing a column, use one pair of quotes. When referencing a string, use single quotes enclosed in double quotes.
-
-<File name='models/example.sql'>
-
-```sql
-{{ dbt_utils.split_part(string_text='column_to_split', delimiter_text='delimiter_column', part_number=1) }}
-{{ dbt_utils.split_part(string_text="'1|2|3'", delimiter_text="'|'", part_number=1) }}
-```
-
-</File>
-
-## string_literal
-__Args__:
-
- * `TODO`: TODO
- * `TODO`: TODO
-
-Paragraph_description.
-
-**Usage**:
-
-<File name='models/example.sql'>
-
-```sql
--- TODO
-```
-
-</File>
+So within Jinja, the string values would be:
+- `"date_trunc(month, order_date)"`
+- `"order_date"`
+- `"'2016-03-09'"`
+- `"'Pennsylvania'"`
+- `"NULL"`

--- a/website/docs/reference/dbt-jinja-functions/dbt.md
+++ b/website/docs/reference/dbt-jinja-functions/dbt.md
@@ -44,6 +44,7 @@ Paragraph_description.
 <File name='models/example.sql'>
 
 ```sql
+-- TODO
 ```
 
 </File>
@@ -61,6 +62,7 @@ Paragraph_description.
 <File name='models/example.sql'>
 
 ```sql
+-- TODO
 ```
 
 </File>
@@ -78,6 +80,7 @@ Paragraph_description.
 <File name='models/example.sql'>
 
 ```sql
+-- TODO
 ```
 
 </File>
@@ -95,6 +98,7 @@ Paragraph_description.
 <File name='models/example.sql'>
 
 ```sql
+-- TODO
 ```
 
 </File>
@@ -112,6 +116,7 @@ Paragraph_description.
 <File name='models/example.sql'>
 
 ```sql
+-- TODO
 ```
 
 </File>
@@ -129,6 +134,7 @@ Paragraph_description.
 <File name='models/example.sql'>
 
 ```sql
+-- TODO
 ```
 
 </File>
@@ -146,6 +152,7 @@ Paragraph_description.
 <File name='models/example.sql'>
 
 ```sql
+-- TODO
 ```
 
 </File>
@@ -163,6 +170,7 @@ Paragraph_description.
 <File name='models/example.sql'>
 
 ```sql
+-- TODO
 ```
 
 </File>
@@ -180,6 +188,7 @@ Paragraph_description.
 <File name='models/example.sql'>
 
 ```sql
+-- TODO
 ```
 
 </File>
@@ -197,6 +206,7 @@ Paragraph_description.
 <File name='models/example.sql'>
 
 ```sql
+-- TODO
 ```
 
 </File>
@@ -214,6 +224,7 @@ Paragraph_description.
 <File name='models/example.sql'>
 
 ```sql
+-- TODO
 ```
 
 </File>
@@ -231,6 +242,7 @@ Paragraph_description.
 <File name='models/example.sql'>
 
 ```sql
+-- TODO
 ```
 
 </File>
@@ -248,6 +260,7 @@ Paragraph_description.
 <File name='models/example.sql'>
 
 ```sql
+-- TODO
 ```
 
 </File>
@@ -265,6 +278,7 @@ Paragraph_description.
 <File name='models/example.sql'>
 
 ```sql
+-- TODO
 ```
 
 </File>
@@ -282,6 +296,7 @@ Paragraph_description.
 <File name='models/example.sql'>
 
 ```sql
+-- TODO
 ```
 
 </File>
@@ -299,6 +314,7 @@ Paragraph_description.
 <File name='models/example.sql'>
 
 ```sql
+-- TODO
 ```
 
 </File>
@@ -316,6 +332,7 @@ Paragraph_description.
 <File name='models/example.sql'>
 
 ```sql
+-- TODO
 ```
 
 </File>
@@ -333,6 +350,7 @@ Paragraph_description.
 <File name='models/example.sql'>
 
 ```sql
+-- TODO
 ```
 
 </File>
@@ -350,6 +368,7 @@ Paragraph_description.
 <File name='models/example.sql'>
 
 ```sql
+-- TODO
 ```
 
 </File>
@@ -367,6 +386,7 @@ Paragraph_description.
 <File name='models/example.sql'>
 
 ```sql
+-- TODO
 ```
 
 </File>
@@ -384,6 +404,7 @@ Paragraph_description.
 <File name='models/example.sql'>
 
 ```sql
+-- TODO
 ```
 
 </File>
@@ -401,6 +422,7 @@ Paragraph_description.
 <File name='models/example.sql'>
 
 ```sql
+-- TODO
 ```
 
 </File>

--- a/website/docs/reference/dbt-jinja-functions/dbt.md
+++ b/website/docs/reference/dbt-jinja-functions/dbt.md
@@ -30,3 +30,377 @@ The following functions are available:
 - [dbt.safe_cast](#safe_cast)
 - [dbt.split_part](#split_part)
 - [dbt.string_literal](#string_literal)
+
+## any_value
+__Args__:
+
+ * `arg1`: desc1
+ * `arg1`: desc2
+
+Paragraph_description.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+```
+
+</File>
+
+## bool_or
+__Args__:
+
+ * `arg1`: desc1
+ * `arg1`: desc2
+
+Paragraph_description.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+```
+
+</File>
+
+## cast_bool_to_text
+__Args__:
+
+ * `arg1`: desc1
+ * `arg1`: desc2
+
+Paragraph_description.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+```
+
+</File>
+
+## concat
+__Args__:
+
+ * `arg1`: desc1
+ * `arg1`: desc2
+
+Paragraph_description.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+```
+
+</File>
+
+## current_timestamp
+__Args__:
+
+ * `arg1`: desc1
+ * `arg1`: desc2
+
+Paragraph_description.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+```
+
+</File>
+
+## current_timestamp_in_utc
+__Args__:
+
+ * `arg1`: desc1
+ * `arg1`: desc2
+
+Paragraph_description.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+```
+
+</File>
+
+## date_trunc
+__Args__:
+
+ * `arg1`: desc1
+ * `arg1`: desc2
+
+Paragraph_description.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+```
+
+</File>
+
+## dateadd
+__Args__:
+
+ * `arg1`: desc1
+ * `arg1`: desc2
+
+Paragraph_description.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+```
+
+</File>
+
+## datediff
+__Args__:
+
+ * `arg1`: desc1
+ * `arg1`: desc2
+
+Paragraph_description.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+```
+
+</File>
+
+## escape_single_quotes
+__Args__:
+
+ * `arg1`: desc1
+ * `arg1`: desc2
+
+Paragraph_description.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+```
+
+</File>
+
+## except
+__Args__:
+
+ * `arg1`: desc1
+ * `arg1`: desc2
+
+Paragraph_description.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+```
+
+</File>
+
+## hash
+__Args__:
+
+ * `arg1`: desc1
+ * `arg1`: desc2
+
+Paragraph_description.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+```
+
+</File>
+
+## intersect
+__Args__:
+
+ * `arg1`: desc1
+ * `arg1`: desc2
+
+Paragraph_description.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+```
+
+</File>
+
+## last_day
+__Args__:
+
+ * `arg1`: desc1
+ * `arg1`: desc2
+
+Paragraph_description.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+```
+
+</File>
+
+## length
+__Args__:
+
+ * `arg1`: desc1
+ * `arg1`: desc2
+
+Paragraph_description.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+```
+
+</File>
+
+## listagg
+__Args__:
+
+ * `arg1`: desc1
+ * `arg1`: desc2
+
+Paragraph_description.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+```
+
+</File>
+
+## position
+__Args__:
+
+ * `arg1`: desc1
+ * `arg1`: desc2
+
+Paragraph_description.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+```
+
+</File>
+
+## replace
+__Args__:
+
+ * `arg1`: desc1
+ * `arg1`: desc2
+
+Paragraph_description.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+```
+
+</File>
+
+## right
+__Args__:
+
+ * `arg1`: desc1
+ * `arg1`: desc2
+
+Paragraph_description.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+```
+
+</File>
+
+## safe_cast
+__Args__:
+
+ * `arg1`: desc1
+ * `arg1`: desc2
+
+Paragraph_description.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+```
+
+</File>
+
+## split_part
+__Args__:
+
+ * `arg1`: desc1
+ * `arg1`: desc2
+
+Paragraph_description.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+```
+
+</File>
+
+## string_literal
+__Args__:
+
+ * `arg1`: desc1
+ * `arg1`: desc2
+
+Paragraph_description.
+
+**Usage**:
+
+<File name='models/example.sql'>
+
+```sql
+```
+
+</File>

--- a/website/docs/reference/dbt-jinja-functions/dbt.md
+++ b/website/docs/reference/dbt-jinja-functions/dbt.md
@@ -1,0 +1,32 @@
+---
+title: "dbt"
+id: "dbt"
+---
+
+## Overview
+
+`dbt` TODO rest of paragraph here.
+
+The following functions are available:
+- [dbt.any_value](#any_value)
+- [dbt.bool_or](#bool_or)
+- [dbt.cast_bool_to_text](#cast_bool_to_text)
+- [dbt.concat](#concat)
+- [dbt.current_timestamp_in_utc](#current_timestamp_in_utc)
+- [dbt.current_timestamp](#current_timestamp)
+- [dbt.date_trunc](#date_trunc)
+- [dbt.dateadd](#dateadd)
+- [dbt.datediff](#datediff)
+- [dbt.escape_single_quotes](#escape_single_quotes)
+- [dbt.except](#except)
+- [dbt.hash](#hash)
+- [dbt.intersect](#intersect)
+- [dbt.last_day](#last_day)
+- [dbt.length](#length)
+- [dbt.listagg](#listagg)
+- [dbt.position](#position)
+- [dbt.replace](#replace)
+- [dbt.right](#right)
+- [dbt.safe_cast](#safe_cast)
+- [dbt.split_part](#split_part)
+- [dbt.string_literal](#string_literal)

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -654,6 +654,7 @@ const sidebarSettings = {
             slug: '/guides/migration/versions',
           },
           items: [
+            "guides/migration/versions/upgrading-to-v1.2",
             "guides/migration/versions/upgrading-to-v1.1",
             "guides/migration/versions/upgrading-to-v1.0",
             "guides/migration/versions/upgrading-to-v0.21",


### PR DESCRIPTION
Continues #1609
## Things to review

[Link to Netlify Preview](https://deploy-preview-1619--docs-getdbt-com.netlify.app/reference/dbt-jinja-functions/cross-database-macros)

<details>
  <summary>Location within navigation</summary>

  ### Questions
  - The content is currently within Jinja Reference > dbt Jinja functions > cross-database macros. Is this where we want it? Or somewhere else?

### Screenshot

<img width="226" alt="image" src="https://user-images.githubusercontent.com/44704949/175778428-3bec0462-532a-4561-ae53-c16b8ec3e518.png">

</details>


<details>
  <summary>Group by category or alphabetical listing (or both)</summary>

  ### Questions
  - The first draft contains both an alphabetical listing and grouped into categories. Do we favor one over the other?
      - I prefer retaining a grouping by functional category as it makes it easier for me understand the usage of each macro when it is surrounded by more context.
      - Snowflake includes both types of listings: by category ([here](https://docs.snowflake.com/en/sql-reference/functions.html) and [here](https://docs.snowflake.com/en/sql-reference/functions-date-time.html#list-of-functions)) and [alphabetical](https://docs.snowflake.com/en/sql-reference/functions-all.html).
  - Single page listing all macros? Or separate pages based on functional category?
      - My only preference is that the detailed entires are grouped into categories rather than alphabetical. An alphabetical listing of links feels desirable too.

### Screenshots

Alphabetical:

<img width="308" alt="image" src="https://user-images.githubusercontent.com/44704949/175777338-bf83ca99-b8f7-4d20-95e2-e3fe5852ec12.png">


Functional grouping:

<img width="392" alt="image" src="https://user-images.githubusercontent.com/44704949/175777360-e36b9ee4-347b-49f5-8ccd-e3401837fa26.png">

</details>


<details>
  <summary>Format of examples</summary>

### Questions
  - Include `dbt.` prefix for macros? Or drop?
      - The result feels more readable without the prefix to me.
  - Convert to a SQL query that can actually execute?
      - It could be hard to create examples that will work cross-database without making them a bit complicated with common table expressions (CTE) and usage of other macros 
  - Include the filename wrappers (i.e., `models/example.sql`)?
      - this feels a bit inaccurate unless we supply SQL examples that are fully executable
 - Multiple variations per example? Or just a single variation per example?
     - I strongly prefer multiple variations to make it easier to see how to express column names vs. SQL string literals vs. an expression containing a function.

### Screenshot
<img width="845" alt="image" src="https://user-images.githubusercontent.com/44704949/175778388-956c3254-a79b-4e21-9ae3-b39b926d5bfa.png">

</details>

<details>
  <summary>Versioning this page</summary>

  ### Questions
  - I added an entry to `dbt-versions.js`, but it doesn't appear to be taking effect. Versioning didn't appear to take effect for [this page](https://docs.getdbt.com/guides/migration/versions/upgrading-to-v1.1) either (even though it is listed within `dbt-versions.js`).
      - Do we know how to get this to work?

### Screenshots

[Versioning working](https://docs.getdbt.com/reference/dbt-jinja-functions/selected_resources):

- <img width="338" alt="image" src="https://user-images.githubusercontent.com/44704949/175778880-28df835f-96c1-4229-96d6-f390616f08e1.png">

[Versioning not working](https://docs.getdbt.com/guides/migration/versions/upgrading-to-v1.1):

- <img width="340" alt="image" src="https://user-images.githubusercontent.com/44704949/175778834-2fb4f523-a8a9-49c7-9f91-901e0e048183.png">

</details>

## Description & motivation
We want to document the macros introduced [here](https://github.com/dbt-labs/dbt-core/pull/5298) so that:
- package maintainers (and other users) know what they do and how to use them
- adapter maintainers know how to implement them

These macros came from [dbt_utils](https://github.com/dbt-labs/dbt-utils/tree/0.8.6#cross-database-macros), but few of them had pre-existing documentation. Existing documentation was lifted-and-shifted when available, but but most of this content is net new.

The most novel feature is organization into functional groups (similar to the [groupings within Snowflake docs](https://docs.snowflake.com/en/sql-reference-functions.html)).

## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR dbt-labs/dbt-utils#56 is merged
-->
- [x] Determine if `current_timestamp*` macros should be included or not.
- [x] Determine if data type macros should be included or not (i.e., whatever abstraction on top of `api.Column.translate_type()` that we go with).

## Prerelease docs
If this change is related to functionality in a prerelease version of dbt (delete if not applicable):
- [x] I've added versioning components, as described in ["Versioning Docs"](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/versioningdocs.md)
- [x] I've added a note to the prerelease version's [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/guides/migration/versions)

## Checklist
If you added new pages (delete if not applicable):
- [x] The page ~has been added to `website/sidebars.js`~ is within a category listed within `website/sidebars.js`
- [x] The new page has a unique filename