### PR TITLE
Change doc to show dbt Cloud is supported

### DIFF
--- a/website/docs/reference/warehouse-profiles/databricks-profile.md
+++ b/website/docs/reference/warehouse-profiles/databricks-profile.md
@@ -8,7 +8,7 @@ id: "databricks-profile"
 **Maintained by:** some dbt loving Bricksters  
 **Author:** Databricks  
 **Source:** [Github](https://github.com/databricks/dbt-databricks)  
-**dbt Cloud:** Coming Soon  
+**dbt Cloud:** Supported  
 **dbt Slack channel** [Link to channel](https://getdbt.slack.com/archives/CNGCW8HKL)  
 
 ![dbt-databricks stars](https://img.shields.io/github/stars/databricks/dbt-databricks?style=for-the-badge)


### PR DESCRIPTION
## Description & motivation
Docs should reflect that Databricks does [in fact](https://docs.getdbt.com/docs/dbt-cloud/cloud-configuring-dbt-cloud/connecting-your-database#connecting-to-databricks) (now) support dbt Cloud.