### PR TITLE
Adding BigQuery label length req

### DIFF
--- a/website/docs/reference/resource-configs/bigquery-configs.md
+++ b/website/docs/reference/resource-configs/bigquery-configs.md
@@ -294,6 +294,8 @@ models:
 dbt supports the specification of BigQuery labels for the tables and <Term id="view">views</Term> that it creates. These labels can be specified using the `labels` model config.
 
 The `labels` config can be provided in a model config, or in the `dbt_project.yml` file, as shown below.
+  
+**Note:** Per BigQuery requirements, both key-value pair entries for labels have a maximum length of 63 characters.
 
 **Configuring labels in a model file**
 

--- a/website/docs/reference/resource-configs/bigquery-configs.md
+++ b/website/docs/reference/resource-configs/bigquery-configs.md
@@ -295,7 +295,9 @@ dbt supports the specification of BigQuery labels for the tables and <Term id="v
 
 The `labels` config can be provided in a model config, or in the `dbt_project.yml` file, as shown below.
   
-**Note:** Per BigQuery requirements, both key-value pair entries for labels have a maximum length of 63 characters.
+:::note
+BigQuery requires that both key-value pair entries for labels have a maximum length of 63 characters.
+:::
 
 **Configuring labels in a model file**
 

--- a/website/docs/reference/resource-configs/bigquery-configs.md
+++ b/website/docs/reference/resource-configs/bigquery-configs.md
@@ -295,7 +295,7 @@ dbt supports the specification of BigQuery labels for the tables and <Term id="v
 
 The `labels` config can be provided in a model config, or in the `dbt_project.yml` file, as shown below.
   
-:::note
+:::info Note
 BigQuery requires that both key-value pair entries for labels have a maximum length of 63 characters.
 :::
 


### PR DESCRIPTION
## Description & motivation
Adding in a note about BigQuery enforcing a max length on labels. This has been a new error shown in dbt that people have hit. It would be ideal if they knew the limitation beforehand though so they can avoid the issue all together. 

Example issue: https://github.com/dbt-labs/dbt-bigquery/issues/202
Code where error message was added: https://github.com/dbt-labs/dbt-core/pull/3703