### PR TITLE
Add itertools module

### DIFF
--- a/website/docs/guides/migration/versions/upgrading-to-v1.2.md
+++ b/website/docs/guides/migration/versions/upgrading-to-v1.2.md
@@ -24,3 +24,5 @@ We added a collection of ["cross-database macros"](cross-database-macros) to dbt
 _Under construction_
 
 https://github.com/dbt-labs/docs.getdbt.com/labels/dbt-core%20v1.2
+
+- [Modules](modules): The `itertools` Python module is available in dbt's Jinja templating context.

--- a/website/docs/reference/dbt-jinja-functions/modules.md
+++ b/website/docs/reference/dbt-jinja-functions/modules.md
@@ -48,3 +48,46 @@ This variable is a pointer to the Python [re](https://docs.python.org/3/library/
     ) -%}
 {% endif %}
 ```
+
+<VersionBlock firstVersion="1.2">
+
+## itertools
+This variable is a pointer to the Python [itertools](https://docs.python.org/3/library/itertools.html) module, which includes useful functions for working with iterators (loops, lists, and the like).
+
+The supported functions are:
+- `count`
+- `cycle`
+- `repeat`
+- `accumulate`
+- `chain`
+- `compress`
+- `islice`
+- `starmap`
+- `tee`
+- `zip_longest`
+- `product`
+- `permutations`
+- `combinations`
+- `combinations_with_replacement`
+
+**Usage**
+
+```
+{%- set A = [1, 2] -%}
+{%- set B = ['x', 'y', 'z'] -%}
+{%- set AB_cartesian = modules.itertools.product(A, B) -%}
+
+{%- for item in AB_cartesian %}
+  {{ item }}
+{%- endfor -%}
+```
+```
+  (1, 'x')
+  (1, 'y')
+  (1, 'z')
+  (2, 'x')
+  (2, 'y')
+  (2, 'z')
+```
+
+</VersionBlock>


### PR DESCRIPTION
Resolves #1368

Add `itertools` to `modules` documentation, with an example. The Python docs are much more thorough, so clearly linking to those is really our best bet: https://docs.python.org/3/library/itertools.html

## Prerelease docs
If this change is related to functionality in a prerelease version of dbt (delete if not applicable):
- [x] I've added versioning components, as described in ["Versioning Docs"](../contributing/versioningdocs.md)
- [x] I've added a note to the prerelease version's [Migration Guide](../website/docs/docs/guides/migration-guide)
