### PR TITLE
Remove link and reference to v4 since it is currently not in use

### DIFF
--- a/website/docs/docs/dbt-cloud/dbt-cloud-api/admin-cloud-api.md
+++ b/website/docs/docs/dbt-cloud/dbt-cloud-api/admin-cloud-api.md
@@ -11,5 +11,3 @@ The dbt Cloud Administrative API is enabled by default for _Team_ and _Enterpris
 - and more
 
 Reference documentation for the dbt Cloud Administrative v2 API can be found [here](/dbt-cloud/api-v2).
-
-Reference documentation for the under construction dbt Cloud Administrative v4 API can be found [here](/dbt-cloud/api-v4).


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a pull request on dbt core, etc?
-->
v4 via stratus is currently not in use, and was behind a FF in cloud thats not enabled.  This removes the reference to the v4 API docs that didnt have much content.  

I did leave in the `api-v4.js` file that actually pulls the open-api spec for v4, because it can very easily be utilized and repurposed for the v3 docs that seem to be on the way.  Though I'm not opposed to cleaning that up and adding it back later when those docs are ready.
## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged
-->

## Prerelease docs
If this change is related to functionality in a prerelease version of dbt (delete if not applicable):
- [ ] I've added versioning components, as described in ["Versioning Docs"](../contributing/versioningdocs.md)
- [ ] I've added a note to the prerelease version's [Migration Guide](../website/docs/docs/guides/migration-guide)


