### PR TITLE
add redirect and fix links for getting help guide

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@ Include any notes about things that need to happen before this PR is merged, e.g
 
 ## Prerelease docs
 If this change is related to functionality in a prerelease version of dbt (delete if not applicable):
-- [ ] I've added versioning components, as described in ["Versioning Docs"](../contributing/versioningdocs.md)
+- [ ] I've added versioning components, as described in ["Versioning Docs"](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/versioningdocs.md)
 - [ ] I've added a note to the prerelease version's [Migration Guide](../website/docs/docs/guides/migration-guide)
 
 ## Checklist

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@ Include any notes about things that need to happen before this PR is merged, e.g
 ## Prerelease docs
 If this change is related to functionality in a prerelease version of dbt (delete if not applicable):
 - [ ] I've added versioning components, as described in ["Versioning Docs"](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/versioningdocs.md)
-- [ ] I've added a note to the prerelease version's [Migration Guide](../website/docs/docs/guides/migration-guide)
+- [ ] I've added a note to the prerelease version's [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/guides/migration/versions)
 
 ## Checklist
 If you added new pages (delete if not applicable):

--- a/_redirects
+++ b/_redirects
@@ -253,7 +253,7 @@ https://next.docs.getdbt.com/*     https://docs.getdbt.com/:splat 301!
 /docs/writing-code-in-dbt/jinja-context/var	/reference/dbt-jinja-functions/var	302
 /docs/writing-code-in-dbt/macros	/docs/building-a-dbt-project/jinja-macros	302
 /docs/writing-code-in-dbt/using-jinja	/guides/getting-started/learning-more/using-jinja	302
-/faqs/getting-help/	/docs/guides/getting-help/	302
+/faqs/getting-help/	/guides/legacy/getting-help	302
 /reference/accounts	/dbt-cloud/api	302
 /reference/api	/dbt-cloud/api	302
 /reference/connections	/dbt-cloud/api	302
@@ -307,4 +307,5 @@ https://tutorial.getdbt.com/*	https://docs.getdbt.com/:splat	301!
 /docs/guides/migration-guide/upgrading-to-0-20-0	/guides/migration/versions/upgrading-to-v0.20	302
 /docs/guides/migration-guide/upgrading-to-0-21-0	/guides/migration/versions/upgrading-to-v0.21	302
 /docs/guides/migration-guide/upgrading-to-1-0-0	    /guides/migration/versions/upgrading-to-v1.0	302
+/docs/guides/getting-help	/guides/legacy/getting-help 302
 /docs/guides/migration-guide/*  /guides/migration/versions/:splat 301!

--- a/website/docs/docs/dbt-cloud/cloud-dbt-cloud-support.md
+++ b/website/docs/docs/dbt-cloud/cloud-dbt-cloud-support.md
@@ -6,7 +6,7 @@ id: "cloud-dbt-cloud-support"
 Welcome to dbt Cloud Support!
 
 Our purpose is to assist dbt Cloud users as they work through implementing and utilizing dbt Cloud at their organizations. Have a question you can't find an answer to in [our docs](https://docs.getdbt.com/), [dbt discourse](https://discourse.getdbt.com/), or [Stack Overflow](https://stackoverflow.com/questions/tagged/dbt)? dbt Support is here to `dbt help` you!
-Check out our guide on [getting help](https://docs.getdbt.com/docs/guides/getting-help) - half of the problem is often knowing where to look... and how to ask good questions!
+Check out our guide on [getting help](https://docs.getdbt.com/guides/legacy/getting-help) - half of the problem is often knowing where to look... and how to ask good questions!
 Types of questions dbt Support will assist you with:
 - **How do I...**
     - set up a dbt Cloud project?

--- a/website/docs/docs/dbt-cloud/cloud-dbt-cloud-support.md
+++ b/website/docs/docs/dbt-cloud/cloud-dbt-cloud-support.md
@@ -6,7 +6,7 @@ id: "cloud-dbt-cloud-support"
 Welcome to dbt Cloud Support!
 
 Our purpose is to assist dbt Cloud users as they work through implementing and utilizing dbt Cloud at their organizations. Have a question you can't find an answer to in [our docs](https://docs.getdbt.com/), [dbt discourse](https://discourse.getdbt.com/), or [Stack Overflow](https://stackoverflow.com/questions/tagged/dbt)? dbt Support is here to `dbt help` you!
-Check out our guide on [getting help](https://docs.getdbt.com/guides/legacy/getting-help) - half of the problem is often knowing where to look... and how to ask good questions!
+Check out our guide on [getting help](/guides/legacy/getting-help) - half of the problem is often knowing where to look... and how to ask good questions!
 Types of questions dbt Support will assist you with:
 - **How do I...**
     - set up a dbt Cloud project?

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -273,7 +273,7 @@ function Home() {
           <div className="row" style={{ "maxWidth": "var(--ifm-container-width)", "margin": "calc(2vh) auto" }}>
             <div className="col">
               <h1>Having trouble?</h1>
-              <p>If you&#39;re having trouble, check out our guide on <a href="/docs/guides/getting-help" >Getting Help</a> for information on getting support and asking questions in the community.</p>
+              <p>If you&#39;re having trouble, check out our guide on <a href="/guides/legacy/getting-help" >Getting Help</a> for information on getting support and asking questions in the community.</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a pull request on dbt core, etc?
-->
The getting help link on the homepage and in various other places results in the user getting a 404.  This adds a redirect to get it going to the correct place.

I also squeezed in 1 tiny other fix for the versioning docs link in the PR template.  Not sure what the migration guide is supposed to link to otherwise I'd take care of that as well.
## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged
-->

## Prerelease docs
If this change is related to functionality in a prerelease version of dbt (delete if not applicable):
- [ ] I've added versioning components, as described in ["Versioning Docs"](../contributing/versioningdocs.md)
- [ ] I've added a note to the prerelease version's [Migration Guide](../website/docs/docs/guides/migration-guide)

## Checklist

- [x] getting help link on the homepage is fixed and takes you to the getting help guide
- [x] getting help link on the dbt cloud support page is fixed and takes you to the getting help guide
- [x] getting help link on the debugging error page still links to the getting help guide
- [x] getting help link on the slack rules of the road page still links to the getting help guide
- [x] sidebar link still takes you to the getting help guide