### PR TITLE
Fix the `Getting Started Tutorial` link

### DIFF
--- a/website/docs/faqs/Project/example-projects.md
+++ b/website/docs/faqs/Project/example-projects.md
@@ -8,7 +8,7 @@ id: example-projects
 
 Yes!
 
-* **Getting Started Tutorial:** You can build your own example dbt project in the [Getting Started Tutorial](tutorial/getting-started.md)
+* **Getting Started Tutorial:** You can build your own example dbt project in the [Getting Started Tutorial](/guides/getting-started)
 * **Jaffle Shop:** A demonstration project (closely related to the tutorial) for a fictional ecommerce store ([source code](https://github.com/dbt-labs/jaffle_shop))
 * **MRR Playbook:** A demonstration project that models subscription revenue ([source code](https://github.com/dbt-labs/mrr-playbook), [docs](https://www.getdbt.com/mrr-playbook/#!/overview))
 * **Attribution Playbook:** A demonstration project that models marketing attribution  ([source code](https://github.com/dbt-labs/attribution-playbook), [docs](https://www.getdbt.com/attribution-playbook/#!/overview))


### PR DESCRIPTION
## Description & motivation
* Fix the `Getting Started Tutorial` link in the [example-projects](https://docs.getdbt.com/faqs/project/example-projects) page 