### PR TITLE
Remove data build tool acronym

### DIFF
--- a/website/docs/docs/about/overview.md
+++ b/website/docs/docs/about/overview.md
@@ -5,7 +5,7 @@ id: "overview"
 
 # What is dbt?
 
-dbt (data build tool) is a productivity tool that helps analysts get more done and produce higher quality results.
+dbt is a productivity tool that helps analysts get more done and produce higher quality results.
 
 Analysts commonly spend 50-80% of their time modeling raw data—cleaning, reshaping, and applying fundamental business logic to it. dbt empowers analysts to do this work better and faster.
 

--- a/website/docs/docs/available-adapters.md
+++ b/website/docs/docs/available-adapters.md
@@ -67,6 +67,7 @@ These adapter plugins are contributed and maintained by members of the community
 | Greenplum              | [Profile Setup](greenplum-profile), [Configuration](greenplum-configs)       | Greenplum 6.0+            | `pip install dbt-greenplum`  |
 | DuckDB                 | [Profile Setup](duckdb-profile)                                              | DuckDB 0.3.2              | `pip install dbt-duckdb`     |
 | SQLite                 | [Profile Setup](sqlite-profile)                                              | SQlite Version 3.0+       | `pip install dbt-sqlite`     |
+| MySQL                  | [Profile Setup](mysql-profile)                                               | MySQL 5.7 and 8.0         | `pip install dbt-mysql`      |
 
 Community-supported plugins are works in progress, and anyone is welcome to contribute by testing and writing code. If you're interested in contributing:
 - Join both the dedicated #adapter-ecosystem channel in [dbt Slack](https://community.getdbt.com/) and the channel for your adapter's data store (e.g. #db-sqlserver, #db-athena) 

--- a/website/docs/reference/warehouse-profiles/mysql-profile.md
+++ b/website/docs/reference/warehouse-profiles/mysql-profile.md
@@ -1,0 +1,99 @@
+---
+title: "MySQL Profile"
+---
+
+:::info Community plugin
+
+Some core functionality may be limited. If you're interested in contributing, check out the source code for each repository listed below.
+
+:::
+
+## Overview of dbt-mysql
+
+**Maintained by:** Community  
+**Author:** [Doug Beatty](https://github.com/dbeatty10)   
+**Source:** [GitHub](https://github.com/dbeatty10/dbt-mysql)  
+**Core version:** v1.0.8   
+**dbt Cloud:** Not Supported     
+
+![dbt-mysql stars](https://img.shields.io/github/stars/dbeatty10/dbt-mysql?style=for-the-badge)
+![latest version on PyPI](https://img.shields.io/pypi/v/dbt-mysql?style=for-the-badge)
+
+The package can be installed from PyPI with:
+
+```python
+pip install dbt-mysql
+```
+
+This is an experimental plugin:
+- It has not been tested extensively.
+- Storage engines other than the default of InnoDB are untested.
+- Only tested with [dbt-adapter-tests](https://github.com/dbt-labs/dbt-adapter-tests) with the following versions:
+  - MySQL 5.7
+  - MySQL 8.0
+  - MariaDB 10.5
+- Compatibility with other [dbt packages](https://hub.getdbt.com/) (like [dbt_utils](https://hub.getdbt.com/dbt-labs/dbt_utils/latest/)) are also untested.
+
+Please read these docs carefully and use at your own risk. [Issues](https://github.com/dbeatty10/dbt-mysql/issues/new) and [PRs](https://github.com/dbeatty10/dbt-mysql/blob/main/CONTRIBUTING.rst#contributing) welcome!
+
+
+## Connecting to MySQL with dbt-mysql
+
+MySQL targets should be set up using the following configuration in your `profiles.yml` file.
+
+Example:
+
+<File name='~/.dbt/profiles.yml'>
+
+```yaml
+your_profile_name:
+  target: dev
+  outputs:
+    dev:
+      type: mysql
+      server: localhost
+      port: 3306
+      schema: analytics
+      username: your_mysql_username
+      password: your_mysql_password
+      ssl_disabled: True
+```
+
+</File>
+
+#### Description of MySQL Profile Fields
+
+| Option          | Description                                                                         | Required?                                                          | Example                                        |
+| --------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ---------------------------------------------- |
+| type            | The specific adapter to use                                                         | Required                                                           | `mysql`, `mysql5` or `mariadb`                            |
+| server          | The server (hostname) to connect to                                                 | Required                                                           | `yourorg.mysqlhost.com`                        |
+| port            | The port to use                                                                     | Optional                                                           | `3306`                                         |
+| schema          | Specify the schema (database) to build models into                                  | Required                                                           | `analytics`                                    |
+| username        | The username to use to connect to the server                                        | Required                                                           | `dbt_admin`                                    |
+| password        | The password to use for authenticating to the server                                | Required                                                           | `correct-horse-battery-staple`                 |
+| ssl_disabled    | Set to enable or disable TLS connectivity to mysql5.x                               | Optional                                                           | `True` or `False`                              |
+
+## Supported features
+
+| MariaDB 10.5 | MySQL 5.7 | MySQL 8.0 | Feature                     |
+|:---------:|:---------:|:---:|-----------------------------|
+|     ✅     |     ✅     |  ✅  | Table materialization       |
+|     ✅     |     ✅     |  ✅  | View materialization        |
+|     ✅     |     ✅     |  ✅  | Incremental materialization |
+|     ✅     |     ❌     |  ✅  | Ephemeral materialization   |
+|     ✅     |     ✅     |  ✅  | Seeds                       |
+|     ✅     |     ✅     |  ✅  | Sources                     |
+|     ✅     |     ✅     |  ✅  | Custom data tests           |
+|     ✅     |     ✅     |  ✅  | Docs generate               |
+|     🤷     |     🤷     |  ✅  | Snapshots                   |
+
+## Notes 
+- Ephemeral materializations rely upon [Common Table Expressions](https://en.wikipedia.org/wiki/Hierarchical_and_recursive_queries_in_SQL) (CTEs), which are not supported until MySQL 8.0.
+- MySQL 5.7 has some configuration gotchas that might affect dbt snapshots to not work properly due to [automatic initialization and updating for `TIMESTAMP`](https://dev.mysql.com/doc/refman/5.7/en/timestamp-initialization.html).
+  - If the output of `SHOW VARIABLES LIKE 'sql_mode'` includes `NO_ZERO_DATE`. A solution is to include the following in a `*.cnf` file:
+  ```
+  [mysqld]
+  explicit_defaults_for_timestamp = true
+  sql_mode = "ALLOW_INVALID_DATES,{other_sql_modes}"
+  ```
+  - Where `{other_sql_modes}` is the rest of the modes from the `SHOW VARIABLES LIKE 'sql_mode'` output.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -544,6 +544,7 @@ const sidebarSettings = {
         "reference/warehouse-profiles/iomete-profile",
         "reference/warehouse-profiles/duckdb-profile",
         "reference/warehouse-profiles/sqlite-profile",
+        "reference/warehouse-profiles/mysql-profile",
       ],
     },
     {


### PR DESCRIPTION
## Description & motivation
Found out that dbt is no longer an acronym for data build tool but noticed that it still shows this in the docs. Small change to keep consistency and avoid confusion. [Link to tweet explaining dbt is no longer an acroynm](https://twitter.com/getdbt/status/1541529259096899587?s=20&t=veaidr2OpQI0CthWKyzP8A) 
