### PR TITLE
Add splat redirect for legacy guides

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -309,3 +309,4 @@ https://tutorial.getdbt.com/*	https://docs.getdbt.com/:splat	301!
 /docs/guides/migration-guide/upgrading-to-1-0-0	    /guides/migration/versions/upgrading-to-v1.0	302
 /docs/guides/getting-help	/guides/legacy/getting-help 302
 /docs/guides/migration-guide/*  /guides/migration/versions/:splat 301!
+/docs/guides/* /guides/legacy/:splat 301

--- a/_redirects
+++ b/_redirects
@@ -309,4 +309,4 @@ https://tutorial.getdbt.com/*	https://docs.getdbt.com/:splat	301!
 /docs/guides/migration-guide/upgrading-to-1-0-0	    /guides/migration/versions/upgrading-to-v1.0	302
 /docs/guides/getting-help	/guides/legacy/getting-help 302
 /docs/guides/migration-guide/*  /guides/migration/versions/:splat 301!
-/docs/guides/* /guides/legacy/:splat 301
+/docs/guides/* /guides/legacy/:splat 301!

--- a/_redirects
+++ b/_redirects
@@ -309,4 +309,5 @@ https://tutorial.getdbt.com/*	https://docs.getdbt.com/:splat	301!
 /docs/guides/migration-guide/upgrading-to-1-0-0	    /guides/migration/versions/upgrading-to-v1.0	302
 /docs/guides/getting-help	/guides/legacy/getting-help 302
 /docs/guides/migration-guide/*  /guides/migration/versions/:splat 301!
+/docs/guides/best-practices  /guides/best-practices
 /docs/guides/* /guides/legacy/:splat 301!

--- a/_redirects
+++ b/_redirects
@@ -15,7 +15,7 @@ https://next.docs.getdbt.com/*     https://docs.getdbt.com/:splat 301!
 /docs/api-variable	/docs/writing-code-in-dbt/api-variable	302
 /docs/archival	/docs/building-a-dbt-project/archival	302
 /docs/artifacts	/docs/dbt-cloud/using-dbt-cloud/artifacts	302
-/docs/best-practices	/docs/guides/best-practices	302
+/docs/best-practices	/guides/best-practices	302
 /docs/bigquery-configs	/reference/resource-configs/bigquery-configs	302
 /docs/building-a-dbt-project/building-models/bigquery-configs	/reference/resource-configs/bigquery-configs	302
 /docs/building-a-dbt-project/building-models/configuring-models	/reference/model-configs

--- a/website/docs/docs/building-a-dbt-project/snapshots.md
+++ b/website/docs/docs/building-a-dbt-project/snapshots.md
@@ -72,6 +72,7 @@ When you run the [`dbt snapshot` command](snapshot):
 Snapshots can be referenced in downstream models the same way as referencing models — by using the [ref](ref) function.
 
 ## Example
+
 To add a snapshot to your project:
 
 1. Create a file in your `snapshots` directory with a `.sql` file extension, e.g. `snapshots/orders.sql`

--- a/website/docs/docs/building-a-dbt-project/tests.md
+++ b/website/docs/docs/building-a-dbt-project/tests.md
@@ -236,7 +236,6 @@ where {{ column_name }} is null
   </TabItem>
 </Tabs>
 
-
 ## Storing test failures
 
 <Changelog>

--- a/website/docs/docs/building-a-dbt-project/tests.md
+++ b/website/docs/docs/building-a-dbt-project/tests.md
@@ -257,7 +257,6 @@ Note that, if you elect to store test failures:
 
 ## FAQs
 
-
 <FAQ src="Tests/test-one-model" />
 <FAQ src="Runs/failed-tests" />
 <FAQ src="Tests/recommended-tests" />


### PR DESCRIPTION
## Description & motivation
Somehow splat redirect for all the legacy guides got lost in the redirect kerfuffle, adding back.
