### PR TITLE
Remove data build tool acronym

### DIFF
--- a/website/docs/docs/about/overview.md
+++ b/website/docs/docs/about/overview.md
@@ -5,7 +5,7 @@ id: "overview"
 
 # What is dbt?
 
-dbt (data build tool) is a productivity tool that helps analysts get more done and produce higher quality results.
+dbt is a productivity tool that helps analysts get more done and produce higher quality results.
 
 Analysts commonly spend 50-80% of their time modeling raw data—cleaning, reshaping, and applying fundamental business logic to it. dbt empowers analysts to do this work better and faster.
 


### PR DESCRIPTION
## Description & motivation
Small change to remove data build tool acronym from about page since dbt no longer stands for "data build tool".
