### PR TITLE
correct and simplify info for Snowflake's `client_session_keep_alive` param

### DIFF
--- a/website/docs/reference/warehouse-profiles/snowflake-profile.md
+++ b/website/docs/reference/warehouse-profiles/snowflake-profile.md
@@ -171,7 +171,7 @@ The "base" configs for Snowflake targets are shown below. Note that you should a
 | warehouse | Yes | The warehouse to use when building models |
 | schema | Yes | The schema to build models into by default. Can be overridden with [custom schemas](using-custom-schemas) |
 | role | No (but recommended) | The role to assume when running queries as the specified user. |
-| client_session_keep_alive | No | If provided, issue a periodic `select` statement to keep the connection open when particularly long-running queries are executing (&gt; 4 hours). Default: False (see note below) |
+| client_session_keep_alive | No | If `True`, the snowflake client will keep connections for longer than the default 4 hours. This is helpful when particularly long-running queries are executing (&gt; 4 hours). Default: False (see [note below](#client_session_keep_alive)) |
 | threads | No | The number of concurrent models dbt should build. Set this to a higher number if using a bigger warehouse. Default=1 |
 | query_tag | No | A value with which to tag all queries, for later searching in [QUERY_HISTORY view](https://docs.snowflake.com/en/sql-reference/account-usage/query_history.html) |
 | retry_all | No | A boolean flag indicating whether to retry on all [Snowflake connector errors](https://github.com/snowflakedb/snowflake-connector-python/blob/master/src/snowflake/connector/errors.py) |


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a pull request on dbt core, etc?
-->

Someone from Snowflake told us that this was incorrect, AFAIK, they are right. Regardless, end users needn't know how the driver keeps connections alive for longer than four hours, only that it does if you set `client_session_keep_alive` to be `True`.
