### PR TITLE
add git action to merge current branch into next

### DIFF
--- a/.github/workflows/create_next_pr.yml
+++ b/.github/workflows/create_next_pr.yml
@@ -1,0 +1,18 @@
+on:
+  push:
+    branches:
+    - "current"
+
+jobs:
+  pull-request:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: pull-request
+      uses: repo-sync/pull-request@v2
+      with:
+        source_branch: "current"
+        destination_branch: "next"
+        pr_title: "Merge current branch into next"
+        pr_body: "*An automated PR to keep the next branch up to date with current*"
+        github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description & motivation
When changes are merged into `current`, a github action will automatically generate a new PR to merge those changes into `next`, to keep `next` up to date with `current`.