### PR TITLE
Remove references to data build tool

### DIFF
--- a/website/docs/docs/introduction.md
+++ b/website/docs/docs/introduction.md
@@ -3,7 +3,7 @@ title: "What is dbt?"
 id: "introduction"
 ---
 
-dbt (data build tool) enables analytics engineers to transform data in their warehouses by simply writing select statements. dbt handles turning these select statements into <Term id="table">tables</Term> and <Term id="view">views</Term>.
+dbt enables analytics engineers to transform data in their warehouses by simply writing select statements. dbt handles turning these select statements into <Term id="table">tables</Term> and <Term id="view">views</Term>.
 
 dbt does the `T` in <Term id="elt" /> (Extract, Load, Transform) processes – it doesn’t extract or load data, but it’s extremely good at transforming data that’s already loaded into your warehouse.
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -44,7 +44,7 @@ console.log("DEBUG: metatags = ", metatags);
 var siteSettings = {
   baseUrl: '/',
   favicon: '/img/favicon.ico',
-  tagline: 'End user documentation, guides and technical reference for dbt (data build tool)',
+  tagline: 'End user documentation, guides and technical reference for dbt',
   title: 'dbt Docs',
   url: SITE_URL,
   onBrokenLinks: 'warn',


### PR DESCRIPTION
## Description & motivation
A community member pointed out that we still called out dbt standing for data build tool in some docs. 