### PR TITLE
Release v1.2

### DIFF
--- a/website/dbt-versions.js
+++ b/website/dbt-versions.js
@@ -1,8 +1,7 @@
 exports.versions = [
   {
     version: "1.2",
-    EOLDate: "2023-07-15",  // TODO estimated for now
-    isPrerelease: true,
+    EOLDate: "2023-07-26",
   },
   {
     version: "1.1",

--- a/website/docs/guides/migration/versions/06-upgrading-to-v1.2.md
+++ b/website/docs/guides/migration/versions/06-upgrading-to-v1.2.md
@@ -1,20 +1,11 @@
 ---
-title: "Upgrading to v1.2 (prerelease)"
+title: "Upgrading to v1.2 (latest)"
 ---
 ### Resources
 
 - [Changelog](https://github.com/dbt-labs/dbt-core/blob/main/CHANGELOG.md)
 - [CLI Installation guide](/dbt-cli/install/overview)
 - [Cloud upgrade guide](/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-choosing-a-dbt-version)
-
-<Snippet src="available-prerelease-banner" />
-
-## Installation
-
-Using `pip`, install `dbt-core` and your `<adapter>` (for example, `dbt-postgres`):
-```sh
-python -m pip install --upgrade dbt-<adapter>~=1.2.0rc1
-```
 
 ## Breaking changes
 

--- a/website/docs/guides/migration/versions/07-upgrading-to-v1.1.md
+++ b/website/docs/guides/migration/versions/07-upgrading-to-v1.1.md
@@ -1,5 +1,5 @@
 ---
-title: "Upgrading to v1.1 (latest)"
+title: "Upgrading to v1.1"
 ---
 ### Resources
 

--- a/website/docs/reference/resource-configs/grants.md
+++ b/website/docs/reference/resource-configs/grants.md
@@ -5,8 +5,6 @@ default_value: {}
 id: "grants"
 ---
 
-<Snippet src="available-prerelease-banner" />
-
 You can manage access to the datasets you're producing with dbt by using grants. To implement these permissions, define grants as resource configs on each model, seed, or snapshot. Define the default grants that apply to the entire project in your `dbt_project.yml`, and define model-specific grants within each model's SQL or YAML file.
 
 The grant resource configs enable you to apply permissions at build time to a specific set of recipients and model, seed, or snapshot. When your model, seed, or snapshot finishes building, dbt ensures that the grants on its view or table match exactly the grants you have configured.

--- a/website/snippets/core-versions-table.md
+++ b/website/snippets/core-versions-table.md
@@ -1,9 +1,9 @@
 | dbt Core                        | Initial Release | Active Support Until | Critical Support Until  | dbt Cloud Until | Final Patch |
 |---------------------------------|-----------------|----------------------|-------------------------|-----------------|-------------|
-| **v0.X**                        | (various dates) | v1.0.0 release       | Dec 3, 2021             | See below ⚠️  | v0.21.1     |
-| [**v1.0**](upgrading-to-v1.0)   | Dec 3, 2021     | v1.1.0 release       | Dec 3, 2022             | Dec 2022     |             |
-| [**v1.1**](upgrading-to-v1.1)   | Apr 28, 2022    | v1.2.0 release       | Apr 28, 2023            | Apr 2023    |             |
-| _**v1.2**_                      | _Jul 2022_      | _v1.3.0 release_     | _Jul 2023_              | _Jul 2023_      |             |
+| **v0.X**                        | (various dates) | v1.0.0 release       | Dec 3, 2021             | See below ⚠️     | v0.21.1     |
+| [**v1.0**](upgrading-to-v1.0)   | Dec 3, 2021     | v1.1.0 release       | Dec 3, 2022             | Dec 2022        |             |
+| [**v1.1**](upgrading-to-v1.1)   | Apr 28, 2022    | v1.2.0 release       | Apr 28, 2023            | Apr 2023        |             |
+| [**v1.2**](upgrading-to-v1.2)   | Jul 26, 2022    | v1.3.0 release       | Jul 26, 2022            | Jul 2023        |             |
 | _**v1.3**_                      | _Oct 2022_      | _v1.4.0 release_     | _Oct 2023_              | _Oct 2023_      |             |
 
 _Italics: Future releases, NOT definite commitments. Shown for indication only._


### PR DESCRIPTION
resolves #1718

## Description & motivation
- Update v1.2 migration guide
- Remove "latest" from v1.1 migration guide
- Update `dbt-versions` entry
- Remove "prerelease" banner from `grants` page

## TODO before merge
- [x] Update version table snippet with final release date
- [x] Wait for actual `dbt-core` v1.2 final release (today)