### PR TITLE
minor fix to reverse ETL glossary

### DIFF
--- a/website/docs/terms/reverse-etl.md
+++ b/website/docs/terms/reverse-etl.md
@@ -72,7 +72,7 @@ Reverse ETL tools typically establish the connection between your data warehouse
 |:---:|:---:|:---:|
 | Hightouch | A platform to sync data models and create custom audiences for downstream business platforms. | :x: |
 | Census | Another reverse ETL tool that can sync data from your data warehouse to your go-to-market tools. | :x: |
-| Rudderstack | Also a CDP (customer data platform), Rudderstack additionally supports pushing down data and audience to external tools, such as ad platforms and email CRMs. | :x: |
+| Rudderstack | Also a CDP (customer data platform), Rudderstack additionally supports pushing down data and audience to external tools, such as ad platforms and email CRMs. | :white_check_mark: |
 | Grouparoo | Grouparoo, part of Airbyte, is an open source framework to move data from data warehouses to different cloud-based tools. | :white_check_mark: |
 
 ## Conclusion
@@ -83,6 +83,6 @@ Reverse ETL enables you to sync your transformed data stored in your data wareho
 
 If you’re interested learning more about reverse ETL and the impact it could have on your team, check out the following:
 
-- [How dbt Labs’s Data Team Approaches Reverse ETL](https://getdbt.com/open-source-data-culture/reverse-etl-playbook/)
-- [The Operational Data Warehouse in Action: Reverse ETL, CDPs, and the Future of Data Activation](https://www.getdbt.com/coalesce-2021/operational-data-warehouse-reverse-etl-cdp-data-activation/)
-- [The Analytics Engineering Guide: Operational Analytics](https://www.getdbt.com/analytics-engineering/use-cases/operational-analytics/)
+- [How dbt Labs’s data team approaches reverse ETL](https://getdbt.com/open-source-data-culture/reverse-etl-playbook/)
+- [The operational data warehouse in action: Reverse ETL, CDPs, and the future of data activation](https://www.getdbt.com/coalesce-2021/operational-data-warehouse-reverse-etl-cdp-data-activation/)
+- [The analytics engineering guide: Operational analytics](https://www.getdbt.com/analytics-engineering/use-cases/operational-analytics/)

--- a/website/docs/terms/surrogate-key.md
+++ b/website/docs/terms/surrogate-key.md
@@ -30,17 +30,17 @@ Let’s take this to an example. Below, there is a table you pull from an ad pla
 
 <table>
   <tr>
-   <td>calendar_date
+   <td><b>calendar_date</b>
    </td>
-   <td>ad_id
+   <td><b>ad_id</b>
    </td>
-   <td>impressions
+   <td><b>impressions</b>
    </td>
-   <td>spend
+   <td><b>spend</b>
    </td>
-   <td>clicks
+   <td><b>clicks</b>
    </td>
-   <td>conversions
+   <td><b>conversions</b>
    </td>
   </tr>
   <tr>
@@ -103,19 +103,19 @@ After executing this, the table would now have the `unique_id` field now uniquel
 
 <table>
   <tr>
-   <td>unique_id
+   <td><b>unique_id</b>
    </td>
-   <td>calendar_date
+   <td><b>calendar_date</b>
    </td>
-   <td>ad_id
+   <td><b>ad_id</b>
    </td>
-   <td>impressions
+   <td><b>impressions</b>
    </td>
-   <td>spend
+   <td><b>spend</b>
    </td>
-   <td>clicks
+   <td><b>clicks</b>
    </td>
-   <td>conversions
+   <td><b>conversions</b>
    </td>
   </tr>
   <tr>

--- a/website/docs/terms/view.md
+++ b/website/docs/terms/view.md
@@ -2,13 +2,13 @@
 id: view
 title: View
 displayText: view  
-hoverSnippet: A view (as opposed to a table) is a defined passthrough SQL query that can be run against a database (or <Term id="data-warehouse" />).
+hoverSnippet: A view (as opposed to a table) is a defined passthrough SQL query that can be run against a database (or data warehouse).
 ---
 :::important This page could use some love
 This term would benefit from additional depth and examples. Have knowledge to contribute? [Create a discussion in the docs.getdbt.com GitHub repository](https://github.com/dbt-labs/docs.getdbt.com/discussions) to begin the process of becoming a glossary contributor!
 :::
 
-A view (as opposed to a <Term id="table" />) is a defined passthrough SQL query that can be run against a database (or data warehouse). A view doesn’t store data, like a table does, but it defines the logic that you need to fetch the underlying data.
+A view (as opposed to a <Term id="table" />) is a defined passthrough SQL query that can be run against a database (or <Term id="data-warehouse" />). A view doesn’t store data, like a table does, but it defines the logic that you need to fetch the underlying data.
 
 For example, you might define a SQL view to count new users in a day:
 

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -20620,6 +20620,19 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/ua-parser-js": {
       "version": "0.7.31",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
@@ -37556,6 +37569,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "peer": true
     },
     "ua-parser-js": {
       "version": "0.7.31",


### PR DESCRIPTION
Fixing the open source flag + capitalization in Further Reading

## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a pull request on dbt core, etc?
-->
Noticed that Rudderstack's rows in Reverse ETL glossary page didn't have the correct open source flag set.

