### PR TITLE
add link to databricks GCP guide

### DIFF
--- a/website/docs/docs/building-a-dbt-project/hooks-operations.md
+++ b/website/docs/docs/building-a-dbt-project/hooks-operations.md
@@ -196,7 +196,7 @@ You can also use a [macro](jinja-macros#macros) to bundle up hook logic. Check o
 
 ## About operations
 
-Operations are [macros](jinja-macros#macros) that you can run using the [`run-operation` command](run-operation) command. As such, operations aren't actually a separate resource in your dbt project — they are just a convenient way to invoke a macro without needing to run a model.
+Operations are [macros](jinja-macros#macros) that you can run using the [`run-operation` command](run-operation). As such, operations aren't actually a separate resource in your dbt project — they are just a convenient way to invoke a macro without needing to run a model.
 
 :::info Explicitly execute the SQL in an operation
 Unlike hooks, you need to explicitly execute a query within a macro, by using either a [statement block](statement-blocks) or a helper macro like the [run_query macro](run_query) macro. Otherwise, dbt will return the query as a string without executing it.

--- a/website/docs/guides/getting-started/getting-set-up/setting-up-databricks.md
+++ b/website/docs/guides/getting-started/getting-set-up/setting-up-databricks.md
@@ -31,7 +31,7 @@ Before starting this tutorial, you will need the following:
     <Lightbox src="/img/databricks_tutorial/images/signup_form.png" title="Sign up for Databricks" />
     </div>
 
-2. For the purpose of this tutorial, you will be selecting AWS as our cloud provider but if you use Azure or GCP internally, please choose one of them. The setup process will be similar.
+2. For the purpose of this tutorial, you will be selecting AWS as our cloud provider but if you use Azure or GCP ([five steps to get started](https://databricks.com/blog/2021/10/08/5-steps-to-get-started-with-databricks-on-google-cloud.html)) internally, please choose one of them. The setup process will be similar.
 3. Check your email to complete the verification process.
 4. After setting up your password, you will be guided to choose a subscription plan. You will need to select either the `Premium` or `Enterprise` plan to access the SQL Compute functionality, required for using the SQL Endpoint for dbt. We have chosen `Premium` for this tutorial. Click `Continue` after selecting your plan.
     

--- a/website/docs/guides/getting-started/getting-set-up/setting-up-databricks.md
+++ b/website/docs/guides/getting-started/getting-set-up/setting-up-databricks.md
@@ -148,7 +148,7 @@ Our next step is to load some data to transform. Luckily for us, Databricks make
     ```sql
     select * from default.jaffle_shop_customers
     select * from default.jaffle_shop_orders
-    select * from default.stripe.payments
+    select * from default.stripe_payments
     ```
 
     <div style={{maxWidth: '400px'}}>


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a pull request on dbt core, etc?
-->

Going through the dbt fundamentals course I was asked to setup a data platform to connect to.
I chose Databricks on GCP and saw our docs focus on the respective AWS setup. 
I added a link to a databricks 5 steps guide that helps you get started on GCP.

I also ran into a small issue in the `select` statement presented

## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged
-->

## Prerelease docs
If this change is related to functionality in a prerelease version of dbt (delete if not applicable):
- [ ] I've added versioning components, as described in ["Versioning Docs"](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/versioningdocs.md)
- [ ] I've added a note to the prerelease version's [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/guides/migration/versions)

## Checklist
If you added new pages (delete if not applicable):
- [ ] The page has been added to `website/sidebars.js`
- [ ] The new page has a unique filename

If you removed existing pages (delete if not applicable):
- [ ] The page has been removed from `website/sidebars.js`
- [ ] An entry has been added to `_redirects`
