### PR TITLE
feat: add multi line yaml string to vars doc

### DIFF
--- a/website/docs/docs/building-a-dbt-project/building-models/using-variables.md
+++ b/website/docs/docs/building-a-dbt-project/building-models/using-variables.md
@@ -82,6 +82,14 @@ If only one variable is being set, the brackets are optional, eg:
 $ dbt run --vars 'key: value'
 ```
 
+The following is valid too (can increase readability if many variables are used):
+```
+$ dbt run --vars '
+  key: value
+  date: 20180101
+'
+```
+
 You can find more information on defining dictionaries with YAML [here](https://github.com/Animosity/CraftIRC/wiki/Complete-idiot%27s-introduction-to-yaml).
 
 ### Variable precedence


### PR DESCRIPTION
## Description & motivation

We are internally using dbt run or dbt run-operations commands that have many vars / args, which can make them hard to read in a readme or an Airflow DAG, if the command is a one liner. So we are usually using the proposed way of inputting vars, but realized that not everyone in the team was aware that this is a valid YAML string as well. So we added it to our internal documentation, but I thought this might be relevant for other dbt users as well. If not, feel free to reject the PR.