### PR TITLE
fix formatting in [ Adapter-specific configs > Snowflake configurations ]

### DIFF
--- a/website/docs/reference/resource-configs/snowflake-configs.md
+++ b/website/docs/reference/resource-configs/snowflake-configs.md
@@ -93,12 +93,7 @@ In this example, you can set up a query tag to be applied to every query with th
 
 ```
 
-**Note:** query tags are set at the _session_ level. At the start of each model
-<Term id="materialization" />, if the model has a custom `query_tag`
-configured, dbt will run `alter session set query_tag` to set the new value.
-At the end of the materialization, dbt will run another `alter` statement to reset
-the tag to its default value. As such, build failures midway through a materialization may result in subsequent
-queries running with an incorrect tag.
+**Note:** query tags are set at the _session_ level. At the start of each model <Term id="materialization" />, if the model has a custom `query_tag` configured, dbt will run `alter session set query_tag` to set the new value. At the end of the materialization, dbt will run another `alter` statement to reset the tag to its default value. As such, build failures midway through a materialization may result in subsequent queries running with an incorrect tag.
 
 </File>
 


### PR DESCRIPTION
Line breaks were causing the page to render funny with a newline and large space before the word "materialization." I think this change should fix it.

It's a little hard for me to tell for sure if this is doing what I want it to because github isn't rendering the `<Term>` tags in the preview.

The code ticks were also rendering improperly, and this seems to fix it.

## Description & motivation

This is what I'm trying to fix (see large line break and improperly rendered code ticks):

<img width="1039" alt="Screen Shot 2022-08-01 at 5 04 46 PM" src="https://user-images.githubusercontent.com/1799931/182265111-8e5758c3-771a-4bf7-8c49-5ba1fd07beb3.png">
