### PR TITLE
Update - Clarify we don't track raw model contents

### DIFF
--- a/website/docs/reference/global-configs.md
+++ b/website/docs/reference/global-configs.md
@@ -298,7 +298,7 @@ Unlike the other global configs documented on this page, which can be set in `pr
 
 We want to build the best version of dbt possible, and a crucial part of that is understanding how users work with dbt. To this end, we've added some simple event tracking to dbt (using Snowplow). We do not track credentials, raw model contents or model names (we consider these private, and frankly none of our business).
 
-Usage statistics are fired when dbt is invoked and when models are run. These events contain basic platform information (OS + python version). You can see all the event definitions in [`tracking.py`](https://github.com/dbt-labs/dbt-core/blob/HEAD/core/dbt/tracking.py).
+Usage statistics are fired when dbt is invoked and when models are run. These events contain basic platform information (OS + python version) and metadata such as whether the invocation succeeded, how long it took, an anonymized hash key representing the raw model content, and number of nodes that were run. You can see all the event definitions in [`tracking.py`](https://github.com/dbt-labs/dbt-core/blob/HEAD/core/dbt/tracking.py).
 
 By default this is turned on – you can opt out of event tracking at any time by adding the following to your `profiles.yml` file:
 

--- a/website/docs/reference/global-configs.md
+++ b/website/docs/reference/global-configs.md
@@ -296,7 +296,7 @@ Unlike the other global configs documented on this page, which can be set in `pr
 
 ### Send anonymous usage stats
 
-We want to build the best version of dbt possible, and a crucial part of that is understanding how users work with dbt. To this end, we've added some simple event tracking to dbt (using Snowplow). We do not track credentials, model contents or model names (we consider these private, and frankly none of our business).
+We want to build the best version of dbt possible, and a crucial part of that is understanding how users work with dbt. To this end, we've added some simple event tracking to dbt (using Snowplow). We do not track credentials, raw model contents or model names (we consider these private, and frankly none of our business).
 
 Usage statistics are fired when dbt is invoked and when models are run. These events contain basic platform information (OS + python version). You can see all the event definitions in [`tracking.py`](https://github.com/dbt-labs/dbt-core/blob/HEAD/core/dbt/tracking.py).
 


### PR DESCRIPTION
## Description & motivation
This is a very minor change to clarify that we don't track `raw` model contents. Our current tracking does track hashed contents as you can see in the `hashed_content` key of the schema:

http://iglu.sinter-collect.com/schemas/com.dbt/run_model/jsonschema/1-0-2
