### PR TITLE
remove "on disk" from table glossary definition

### DIFF
--- a/website/docs/terms/table.md
+++ b/website/docs/terms/table.md
@@ -2,13 +2,13 @@
 id: table
 title: Table
 displayText:  table 
-hoverSnippet: In simplest terms, a table is the direct storage of data on disk in rows and columns.  Think excel sheet with raw values in each of the cells.  
+hoverSnippet: In simplest terms, a table is the direct storage of data in rows and columns.  Think excel sheet with raw values in each of the cells.  
 ---
 :::important This page could use some love
 This term would benefit from additional depth and examples. Have knowledge to contribute? [Create a discussion in the docs.getdbt.com GitHub repository](https://github.com/dbt-labs/docs.getdbt.com/discussions) to begin the process of becoming a glossary contributor!
 :::
 
-In simplest terms, a table is the direct storage of data on disk in rows and columns.  Think excel sheet with raw values in each of the cells.  
+In simplest terms, a table is the direct storage of data in rows and columns.  Think excel sheet with raw values in each of the cells.  
 
 Here is an example of a table:
 


### PR DESCRIPTION
As discussed exhaustively here https://github.com/dbt-labs/docs.getdbt.com/discussions/1815, to quote @jasnonaz : "on disk is on net more confusing than helpful at this stage"

## Description & motivation
Making the simple, high-level definition of "table" simpler and higher level.

