### PR TITLE
Update exposures.md - missing version in example

### DIFF
--- a/website/docs/docs/building-a-dbt-project/exposures.md
+++ b/website/docs/docs/building-a-dbt-project/exposures.md
@@ -27,6 +27,8 @@ Exposures are defined in `.yml` files nested under an `exposures:` key.
 <File name='models/<filename>.yml'>
 
 ```yaml
+version: 2
+
 exposures:
   
   - name: weekly_jaffle_metrics


### PR DESCRIPTION
Example exposure YAML file is the missing version. The existing sample on this page results in an error. Adding the `version: 2` line fixes it.

## Description & motivation
<!---
Existing sample code results in an error due to missing version.
-->

## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged
-->

## Prerelease docs
If this change is related to functionality in a prerelease version of dbt (delete if not applicable):
- [ ] I've added versioning components, as described in ["Versioning Docs"](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/versioningdocs.md)
- [ ] I've added a note to the prerelease version's [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/guides/migration/versions)

## Checklist
If you added new pages (delete if not applicable):
- [ ] The page has been added to `website/sidebars.js`
- [ ] The new page has a unique filename

If you removed existing pages (delete if not applicable):
- [ ] The page has been removed from `website/sidebars.js`
- [ ] An entry has been added to `_redirects`
