### PR TITLE
update pagination_next and pagination_prev

### DIFF
--- a/website/docs/guides/getting-started/getting-set-up/setting-up-bigquery.md
+++ b/website/docs/guides/getting-started/getting-set-up/setting-up-bigquery.md
@@ -3,6 +3,7 @@ title: "Set up and connect BigQuery"
 id: setting-up-bigquery
 description: "Set up BigQuery with sample data and connect to dbt Cloud."
 sidebar_label: "Set up and connect BigQuery"
+pagination_next: guides/getting-started/building-your-first-project/build-your-first-models
 ---
 
 ## Introduction

--- a/website/docs/guides/getting-started/getting-set-up/setting-up-databricks.md
+++ b/website/docs/guides/getting-started/getting-set-up/setting-up-databricks.md
@@ -3,6 +3,8 @@ title: "Set up and connect Databricks"
 id: setting-up-databricks
 description: "Set up Databricks with sample data and connect to dbt Cloud."
 sidebar_label: "Set up and connect Databricks"
+pagination_prev: guides/getting-started/getting-set-up
+pagination_next: guides/getting-started/building-your-first-project/build-your-first-models
 ---
 
 ## Introduction

--- a/website/docs/guides/getting-started/getting-set-up/setting-up-redshift.md
+++ b/website/docs/guides/getting-started/getting-set-up/setting-up-redshift.md
@@ -3,6 +3,8 @@ title: "Set up and connect Redshift"
 id: setting-up-redshift
 description: "Set up Redshift with sample data and connect to dbt Cloud."
 sidebar_label: "Set up and connect Redshift"
+pagination_prev: guides/getting-started/getting-set-up
+pagination_next: guides/getting-started/building-your-first-project/build-your-first-models
 ---
 
 ## Introduction

--- a/website/docs/guides/getting-started/getting-set-up/setting-up-snowflake.md
+++ b/website/docs/guides/getting-started/getting-set-up/setting-up-snowflake.md
@@ -3,6 +3,8 @@ title: "Set up and connect Snowflake"
 id: setting-up-snowflake
 description: "Set up Snowflake with sample data and connect to dbt Cloud."
 sidebar_label: "Set up and connect Snowflake"
+pagination_prev: guides/getting-started/getting-set-up
+pagination_next: guides/getting-started/building-your-first-project/build-your-first-models
 ---
 
 ## Introduction


### PR DESCRIPTION
Make the pagination match the steps in the tutorial rather than the order of docs by referencing id

## Description & motivation
Updating the pagination links to follow the order of the getting-started guide rather than follow the integration order.

