### PR TITLE
Format the tidb-profile

### DIFF
--- a/website/docs/reference/warehouse-profiles/tidb-profile.md
+++ b/website/docs/reference/warehouse-profiles/tidb-profile.md
@@ -12,9 +12,9 @@ If you're interested in contributing, check out the source code repository liste
 ## Overview of dbt-tidb
 
 **Maintained by:** PingCAP      
-**Author:** Xiang Zhang, Qiang Wu, Yuhang Shi
-**dbt Slack Channel**: [#db-tidb](https://getdbt.slack.com/archives/C03CC86R1NY)
-**Source:** https://github.com/pingcap/dbt-tidb   
+**Author:** Xiang Zhang, Qiang Wu, Yuhang Shi  
+**dbt Slack Channel:** [#dbt-tidb](https://getdbt.slack.com/archives/C03CC86R1NY)   
+**Source:** [Github](https://github.com/pingcap/dbt-tidb)   
 **Core version:** v1.0.0 and newer   
 **dbt Cloud:** Not Supported
 

--- a/website/docs/reference/warehouse-profiles/tidb-profile.md
+++ b/website/docs/reference/warehouse-profiles/tidb-profile.md
@@ -13,7 +13,7 @@ If you're interested in contributing, check out the source code repository liste
 
 **Maintained by:** PingCAP      
 **Author:** Xiang Zhang, Qiang Wu, Yuhang Shi  
-**dbt Slack Channel:** [#dbt-tidb](https://getdbt.slack.com/archives/C03CC86R1NY)   
+**dbt Slack Channel:** [#db-tidb](https://getdbt.slack.com/archives/C03CC86R1NY)   
 **Source:** [Github](https://github.com/pingcap/dbt-tidb)   
 **Core version:** v1.0.0 and newer   
 **dbt Cloud:** Not Supported


### PR DESCRIPTION
## Description & motivation
The `Overview of dbt-tidb` section in the tidb-profile page looks like:
<img width="953" alt="image" src="https://user-images.githubusercontent.com/52435083/186359755-939a98f3-b503-4cf5-80ff-795481b380c1.png">

This pr will format it