### PR TITLE
call out support for AlloyDB via dbt-postgres

### DIFF
--- a/website/docs/docs/available-adapters.md
+++ b/website/docs/docs/available-adapters.md
@@ -36,6 +36,7 @@ These adapter plugins are built and maintained by the same people who build and 
 
 | Adapter for                                                                                                   | Documentation                                                                               | Install from PyPi |
 |---------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------| ----------------- |
+| AlloyDB (via [dbt-postgres](https://github.com/dbt-labs/dbt-postgres))                                        | [Profile Setup](alloydb-profile)                                                           | `pip install dbt-postgres` |
 | ClickHouse ([dbt-clickhouse](https://github.com/ClickHouse/dbt-clickhouse))                                   | [Profile Setup](clickhouse-profile), [Configuration](clickhouse-configs)                    | `pip install dbt-clickhouse` |
 | Databricks ([dbt-databricks](https://github.com/databricks/dbt-databricks))                                   | [Profile Setup](databricks-profile), [Configuration](spark-configs#databricks-configurations) | `pip install dbt-databricks` |
 | Firebolt ([dbt-firebolt](https://github.com/firebolt-db/dbt-firebolt))                                        | [Profile Setup](firebolt-profile), [Configuration](firebolt-configs)                        | `pip install dbt-firebolt` |

--- a/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/connecting-your-database.md
+++ b/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/connecting-your-database.md
@@ -25,13 +25,13 @@ any database grants.
 Allowing these IP addresses only enables the connection to your <Term id="data-warehouse" />. However, you might want to send API requests from your restricted network to the dbt Cloud API.  For example, you could use the API to send a POST request that [triggers a job to run](https://docs.getdbt.com/dbt-cloud/api-v2#operation/triggerRun). Using the dbt Cloud API requires that you allow the `cloud.getdbt.com` subdomain. For more on the dbt Cloud architecture, see "[Deployment architecture](deployment-architecture)."
 
 
-## Connecting to Redshift and Postgres
+## Connecting to Postgres, Redshift, and AlloyDB
 
-The following fields are required when creating a Redshift connection:
+The following fields are required when creating a Postgres, Redshift, or AlloyDB connection:
 
 | Field | Description | Examples |
 | ----- | ----------- | -------- |
-| Host Name | The hostname of the Postgres or Redshift database to connect to. This can either be a hostname or an IP address. | `xxx.us-east-1.amazonaws.com` |
+| Host Name | The hostname of the Postgres, Redshift, or AlloyDB database to connect to. This can either be a hostname or an IP address. | `xxx.us-east-1.amazonaws.com` |
 | Port | Usually 5432 (Postgres) or 5439 (Redshift) | `5439` |
 | Database | The logical database to connect to and run queries against. | `analytics` |
 
@@ -41,7 +41,7 @@ The following fields are required when creating a Redshift connection:
 
 ### Connecting via an SSH Tunnel
 
-To connect to a Postgres or Redshift instance via an SSH tunnel, check the "Use SSH Tunnel" option when creating your connection. When configuring the tunnel, you'll need to supply the hostname, username, and port for the bastion server.
+To connect to a Postgres, Redshift, or AlloyDB instance via an SSH tunnel, check the "Use SSH Tunnel" option when creating your connection. When configuring the tunnel, you'll need to supply the hostname, username, and port for the bastion server.
 
 Once the connection is saved, a public key will be generated and displayed for the Connection. You can copy this public key to the bastion server to authorize dbt Cloud to connect to your database via the bastion server.
 

--- a/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/connecting-your-database.md
+++ b/website/docs/docs/dbt-cloud/cloud-configuring-dbt-cloud/connecting-your-database.md
@@ -41,7 +41,7 @@ The following fields are required when creating a Postgres, Redshift, or AlloyDB
 
 ### Connecting via an SSH Tunnel
 
-To connect to a Postgres, Redshift, or AlloyDB instance via an SSH tunnel, check the "Use SSH Tunnel" option when creating your connection. When configuring the tunnel, you'll need to supply the hostname, username, and port for the bastion server.
+To connect to a Postgres, Redshift, or AlloyDB instance via an SSH tunnel, select the **Use SSH Tunnel** option when creating your connection. When configuring the tunnel, you must supply the hostname, username, and port for the bastion server.
 
 Once the connection is saved, a public key will be generated and displayed for the Connection. You can copy this public key to the bastion server to authorize dbt Cloud to connect to your database via the bastion server.
 

--- a/website/docs/reference/warehouse-profiles/alloydb-profile.md
+++ b/website/docs/reference/warehouse-profiles/alloydb-profile.md
@@ -1,0 +1,13 @@
+---
+title: "AlloyDB Profile"
+---
+
+## Overview of AlloyDB support
+**Maintained by:** N/A
+**Author:** N/A    
+**dbt Cloud:** Supported       
+**dbt Slack channel** [Link to channel](https://getdbt.slack.com/archives/C0172G2E273)      
+
+## Profile Configuration
+
+AlloyDB targets are configured exactly the same as [Postgres targets](postgres-profile.md#profile-configuration).

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -550,6 +550,7 @@ const sidebarSettings = {
         "reference/warehouse-profiles/sqlite-profile",
         "reference/warehouse-profiles/mysql-profile",
         "reference/warehouse-profiles/ibmdb2-profile",
+        "reference/warehouse-profiles/alloydb-profile",
       ],
     },
     {


### PR DESCRIPTION
## Description & motivation

dbt Core and dbt Cloud both work using AlloyDB, this should be documented here.

[Link to preview of entire docs site](https://deploy-preview-1926--docs-getdbt-com.netlify.app/)

## Changes
This PR adds:
### 1. An entry for AlloyDB to our list of vendor-supported adapters on [Available Adapters](https://deploy-preview-1926--docs-getdbt-com.netlify.app/docs/available-adapters#vendor-supported) 
![image](https://user-images.githubusercontent.com/8158673/187531393-c007e5f1-06f1-4418-a78a-bdde6063b7af.png)
    
### 2. a [profile page for AlloyDB](https://deploy-preview-1926--docs-getdbt-com.netlify.app/reference/warehouse-profiles/alloydb-profile) that redirects users to existing docs for dbt-postgres
![image](https://user-images.githubusercontent.com/8158673/187531082-ce421bb4-5df2-459f-af15-878bbb18f7fd.png)
    
### 3. references to AlloyDB on the [dbt Cloud doc: Connecting to your Database](https://deploy-preview-1926--docs-getdbt-com.netlify.app/docs/dbt-cloud/cloud-configuring-dbt-cloud/connecting-your-database#connecting-to-postgres-redshift-and-alloydb)
![image](https://user-images.githubusercontent.com/8158673/187531043-5017e1f3-1a7e-45cd-95e3-1c81cd566411.png)



## To-do before merge
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Ensure https://github.com/dbt-labs/www.getdbt.com/pull/1355/ (repo private to dbt Labs)is merged, which adds AlloyDB to the [dbt Cloud integrations page](https://www.getdbt.com/product/integrations/) (screenshot below)
    
    ![image](https://user-images.githubusercontent.com/8158673/187529149-b093d60b-657a-4695-9b35-4769e9a181dd.png)



## Checklist
If you added new pages (delete if not applicable):
- [x] The page has been added to `website/sidebars.js`
- [x] The new page has a unique filename

