### PR TITLE
update installation method for dbt-athena

### DIFF
--- a/website/docs/docs/available-adapters.md
+++ b/website/docs/docs/available-adapters.md
@@ -62,7 +62,7 @@ These adapter plugins are contributed and maintained by members of the community
 | Azure Synapse          | [Profile Setup](azuresynapse-profile), [Configuration](azuresynapse-configs) | Azure Synapse 10+         | `pip install dbt-synapse`    |
 | Exasol Analytics       | [Profile Setup](exasol-profile)                                              | Exasol 6.x and later      | `pip install dbt-exasol`     |
 | Dremio                 | [Profile Setup](dremio-profile)                                              | Dremio 4.7+               | `pip install dbt-dremio`     |
-| Athena                 | [Profile Setup](athena-profile)                                              | Athena engine version 2   | `pip install git+https://github.com/Tomme/dbt-athena.git` |
+| Athena                 | [Profile Setup](athena-profile)                                              | Athena engine version 2   | `pip install dbt-athena-adapter` |
 | Vertica                | [Profile Setup](vertica-profile)                                             | Vertica 10.0+             | `pip install dbt-vertica`    |
 | AWS Glue               | [Profile Setup](glue-profile), [Configuration](glue-configs)                 | Glue 2.0+                 | `pip install dbt-glue`       |
 | Greenplum              | [Profile Setup](greenplum-profile), [Configuration](greenplum-configs)       | Greenplum 6.0+            | `pip install dbt-greenplum`  |

--- a/website/docs/reference/warehouse-profiles/athena-profile.md
+++ b/website/docs/reference/warehouse-profiles/athena-profile.md
@@ -12,7 +12,7 @@ title: "Athena Profile"
 
 The easiest way to install is to use pip:
 
-    pip install git+https://github.com/Tomme/dbt-athena.git
+    pip install dbt-athena-adapter
 
 ## Connecting to Athena with dbt-athena
 


### PR DESCRIPTION
## Description & motivation

The dbt Athena adapter now publishes to pypi and no longer requires pip installation from git repo

pypi: https://pypi.org/project/dbt-athena-adapter/
updated installation from dbt-athena git repo: https://github.com/Tomme/dbt-athena#installation

## To-do before merge

## Prerelease docs


## Checklist

