### PR TITLE
Add meta title and meta description field to the docs site for glossary pages

### DIFF
--- a/website/docs/terms/cte.md
+++ b/website/docs/terms/cte.md
@@ -1,9 +1,14 @@
 ---
 id: cte
 title: CTE in SQL
+description: Testing custom meta descriptions
 displayText: CTE  
 hoverSnippet: A Common Table Expression (CTE) is a temporary result set that can be used in a SQL query. You can use CTEs to break up complex queries into simpler blocks of code that can connect and build on each other.
 ---
+
+<head>
+	<title>This is a custom title</title>
+</head>
 
 In a formal sense, a Common Table Expression (CTE), is a temporary result set that can be used in a SQL query. You can use CTEs to break up complex queries into simpler blocks of code that can connect and build on each other. In a less formal, more human-sense, you can think of a CTE as a separate, smaller query within the larger query you’re building up. Creating a CTE is essentially like making a temporary <Term id="view" /> that you can access throughout the rest of the query you are writing.
 


### PR DESCRIPTION
## Description & motivation
Now that the glossary pages have been live and indexed for a while, we would like to optimize the meta title and meta description to see if that has a positive impact on SEO performance.

Currently, the glossary pages use the `title` field to populate the H1 and metatitle. Ideally, we would like to be able to populate unique text for the H1, metatitle, and meta description.
