### PR TITLE
Add missing semicolon in example

### DIFF
--- a/website/docs/reference/resource-configs/sql_header.md
+++ b/website/docs/reference/resource-configs/sql_header.md
@@ -102,7 +102,7 @@ This uses the config block syntax:
 
 ```sql
 {{ config(
-  sql_header="alter session set timezone = 'Australia/Sydney'"
+  sql_header="alter session set timezone = 'Australia/Sydney';"
 ) }}
 
 select * from {{ ref('other_model') }}


### PR DESCRIPTION
## Description & motivation
Missing semicolon throws an error similar to `syntax error line 3 at position 6 unexpected 'create'` since `sql_header` clause just gets prepended to `create` block.
I am not sure if there's a need to explicitly mention a note about the same in docs.


