### PR TITLE
anders's typos

### DIFF
--- a/website/docs/docs/contributing/adapter-development/1-what-are-adapters.md
+++ b/website/docs/docs/contributing/adapter-development/1-what-are-adapters.md
@@ -22,7 +22,7 @@ There's a tremendous amount of work that goes into creating a database. Here is 
 There's a lot more there than just SQL as a language. Databases (and data warehouses) are so popular because you can abstract away a great deal of the complexity from your brain to the database itself. This enables you to focus more on the data.
 
 dbt allows for further abstraction and standardization of the outermost layers of a database (SQL API, client library, connection manager) into a framework that both:
- - Opens database technology to less technical users (a large swath of a DBA's role has been automated, similar to how the vast majority of folks with websites today no longer be be "[webmasters](https://en.wikipedia.org/wiki/Webmaster)").
+ - Opens database technology to less technical users (a large swath of a DBA's role has been automated, similar to how the vast majority of folks with websites today no longer have to be "[webmasters](https://en.wikipedia.org/wiki/Webmaster)").
  - Enables more meaningful conversations about how data warehousing should be done.
 
 This is where dbt adapters become critical.

--- a/website/docs/docs/contributing/adapter-development/3-building-a-new-adapter.md
+++ b/website/docs/docs/contributing/adapter-development/3-building-a-new-adapter.md
@@ -4,7 +4,7 @@ id: "3-building-a-new-adapter"
 ---
 
 :::tip
-Before you build your adapter, we strongly encourage you to first learn dbt as an end user, learn [what an adapter is and they role they serve](1-what-are-adapters), as well as [data platform prerequisites](2-prerequisites-for-a-new-adapter)
+Before you build your adapter, we strongly encourage you to first learn dbt as an end user, learn [what an adapter is and the role they serve](1-what-are-adapters), as well as [data platform prerequisites](2-prerequisites-for-a-new-adapter)
 :::
 
 

--- a/website/docs/docs/contributing/adapter-development/3-building-a-new-adapter.md
+++ b/website/docs/docs/contributing/adapter-development/3-building-a-new-adapter.md
@@ -4,7 +4,7 @@ id: "3-building-a-new-adapter"
 ---
 
 :::tip
-Before you build your adapter, we strongly encourage you to first learn dbt as an end user, learn [what an adapter is and they role they serve]((1-what-are-adapters)), as well as [data platform prerequisites](2-prerequisites-for-a-new-adapter)
+Before you build your adapter, we strongly encourage you to first learn dbt as an end user, learn [what an adapter is and they role they serve](1-what-are-adapters), as well as [data platform prerequisites](2-prerequisites-for-a-new-adapter)
 :::
 
 


### PR DESCRIPTION
extra set of parenthesis in `1-what-are-adapters` link on tip banner causing a page not found error and replaced 'they' with 'the'.

## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a pull request on dbt core, etc?
-->

## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged
-->

## Prerelease docs
If this change is related to functionality in a prerelease version of dbt (delete if not applicable):
- [ ] I've added versioning components, as described in ["Versioning Docs"](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/versioningdocs.md)
- [ ] I've added a note to the prerelease version's [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/guides/migration/versions)

## Checklist
If you added new pages (delete if not applicable):
- [ ] The page has been added to `website/sidebars.js`
- [ ] The new page has a unique filename

If you removed existing pages (delete if not applicable):
- [ ] The page has been removed from `website/sidebars.js`
- [ ] An entry has been added to `_redirects`
