### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can use components documented in the [docusaurus library](https://v2.docusau
 
 # Writing content
 
-When writing content, you should refer to the [style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md#Callouts) and [content types](/contributing/content-types.md) to help you understand our writing standards and how we break down information in the product documentaion.
+When writing content, you should refer to the [style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [content types](/contributing/content-types.md) to help you understand our writing standards and how we break down information in the product documentation.
 
 ## Versioning content
 


### PR DESCRIPTION
## Description & motivation
Fixed typos:
- Updated URL so it doesn't include the anchor link
- Misspelling 


![Screen Shot 2022-09-16 at 12 36 35 PM](https://user-images.githubusercontent.com/107218380/190717237-dedc88ef-58d4-43ff-9056-83e5147eac8b.png)
