### PR TITLE
Fixes Jinja example in fromyaml docs page

### DIFF
--- a/website/docs/reference/dbt-jinja-functions/fromyaml.md
+++ b/website/docs/reference/dbt-jinja-functions/fromyaml.md
@@ -24,7 +24,7 @@ dogs:
 {% do log(my_dict['dogs'], info=true) %}
 -- ["good", "bad"]
 
-{% do my_dict['dogs'].pop() }
+{% do my_dict['dogs'].pop() %}
 {% do log(my_dict['dogs'], info=true) %}
 -- ["good"]
 ```


### PR DESCRIPTION
## Description & motivation
Adds missing `%` to Jinja example in the docs.

https://docs.getdbt.com/reference/dbt-jinja-functions/fromyaml#usage
