### PR TITLE
Fix glossary link

### DIFF
--- a/website/docs/reference/model-configs.md
+++ b/website/docs/reference/model-configs.md
@@ -108,7 +108,7 @@ models:
     [+](plus-prefix)[persist_docs](persist_docs): <dict>
     [+](plus-prefix)[full_refresh](full_refresh): <boolean>
     [+](plus-prefix)[meta](meta): {<dictionary>}
-    [+](plus-prefix)[grant](grant): {<dictionary>}
+    [+](plus-prefix)[grants](grants): {<dictionary>}
 
 ```
 


### PR DESCRIPTION
## Description & motivation
Fix broken link to the `grants` glossary term in this code example: https://docs.getdbt.com/reference/model-configs#general-configurations 

![Screen Shot 2022-09-21 at 2 38 55 PM](https://user-images.githubusercontent.com/107218380/191615335-59f0fb76-3b98-4a67-a77c-34f24d061a29.png)
