### PR TITLE
One FAQ entry not showing on the Sources page

### DIFF
--- a/website/docs/docs/building-a-dbt-project/using-sources.md
+++ b/website/docs/docs/building-a-dbt-project/using-sources.md
@@ -121,7 +121,7 @@ You can find more details on the available properties for sources in the [refere
 <FAQ src="Project/source-in-different-database" />
 <FAQ src="Models/source-quotes" />
 <FAQ src="Tests/testing-sources" />
-<FAQ src="Runs/running-model-downstream-of-source" />
+<FAQ src="Runs/running-models-downstream-of-source" />
 
 ## Snapshotting source data freshness
 With a couple of extra configs, dbt can optionally snapshot the "freshness" of the data in your source tables. This is useful for understanding if your data pipelines are in a healthy state, and is a critical component of defining SLAs for your warehouse.


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a pull request on dbt core, etc?

To learn more about the writing conventions used in the dbt Labs docs, see the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md).
-->
The name of the FAQ file misses an `s`.
Would there be a way to do those checks automatically?
