### PR TITLE
Changing Version for Metrics Package

### DIFF
--- a/website/docs/docs/building-a-dbt-project/metrics.md
+++ b/website/docs/docs/building-a-dbt-project/metrics.md
@@ -318,7 +318,7 @@ Use the following [metrics package](https://hub.getdbt.com/dbt-labs/metrics/late
 ```yml
 packages:
   - package: dbt-labs/metrics
-    version: [">=0.4.0", "<0.5.0"]
+    version: [">=1.3.0", "<1.4.0"]
 ```
 
 </VersionBlock>


### PR DESCRIPTION
## Description & motivation
We decided to go with a different version number for the metrics package to better reflect its 1:1 tie with the dbt-core version. 