### PR TITLE
update docs with correct port number

### DIFF
--- a/website/docs/reference/commands/cmd-docs.md
+++ b/website/docs/reference/commands/cmd-docs.md
@@ -26,7 +26,7 @@ dbt docs generate --no-compile
 ```
 
 ### dbt docs serve
-This command starts a webserver on port 8000 to serve your documentation locally. The webserver is rooted in your `target/` directory. Be sure to run `dbt docs generate` before `dbt docs serve` because the  `generate` command produces a [catalog metadata artifact](/reference/artifacts/catalog-json) that the `serve` command depends upon. You will see an error message if the catalog is missing.  
+This command starts a webserver on port 8080 to serve your documentation locally. The webserver is rooted in your `target/` directory. Be sure to run `dbt docs generate` before `dbt docs serve` because the  `generate` command produces a [catalog metadata artifact](/reference/artifacts/catalog-json) that the `serve` command depends upon. You will see an error message if the catalog is missing.  
 
 **Usage:**
 ```


### PR DESCRIPTION
docs are served on 8080 by default, not 8000

## Description & motivation
docs edit for port number
