### PR TITLE
Fix capitalization of PyPI

### DIFF
--- a/website/docs/dbt-cli/install/pip.md
+++ b/website/docs/dbt-cli/install/pip.md
@@ -5,7 +5,7 @@ description: "You can use pip to install dbt Core and adapter plugins from the c
 
 You need to use `pip` to install dbt Core on Windows or Linux operating systems. You should use [Homebrew](install/homebrew) for installing dbt Core on a MacOS. 
 
-You can install dbt Core and plugins using `pip` because they are Python modules distributed on [PyPi](https://pypi.org/project/dbt/).  We recommend using virtual environments when installing with `pip`.
+You can install dbt Core and plugins using `pip` because they are Python modules distributed on [PyPI](https://pypi.org/project/dbt/). We recommend using virtual environments when installing with `pip`.
 
 <FAQ src="Core/install-pip-os-prereqs" />
 <FAQ src="Core/install-python-compatibility" />
@@ -50,7 +50,7 @@ pip install dbt-core
 
 ### `pip install dbt`
 
-Note that, as of v1.0.0, `pip install dbt` is no longer supported and will raise an explicit error. Since v0.13, the PyPi package named `dbt` was a simple "pass-through" of `dbt-core` and the four original database adapter plugins. For v1, we formalized that split.
+Note that, as of v1.0.0, `pip install dbt` is no longer supported and will raise an explicit error. Since v0.13, the PyPI package named `dbt` was a simple "pass-through" of `dbt-core` and the four original database adapter plugins. For v1, we formalized that split.
 
 If you have workflows or integrations that relied on installing the package named `dbt`, you can achieve the same behavior going forward by installing the same five packages that it used:
 

--- a/website/docs/docs/contributing/adapter-development/5-documenting-a-new-adapter.md
+++ b/website/docs/docs/contributing/adapter-development/5-documenting-a-new-adapter.md
@@ -9,7 +9,7 @@ If you've already [built](3-building-a-new-adapter), and [tested](4-testing-a-ne
 
 Many community members maintain their adapter plugins under open source licenses. If you're interested in doing this, we recommend:
 - Hosting on a public git provider (for example, GitHub or Gitlab)
-- Publishing to [PyPi](https://pypi.org/)
+- Publishing to [PyPI](https://pypi.org/)
 - Adding to the list of ["Supported Data Platforms"](supported-data-platforms#community-supported) (more info below)
 
 ## General Guidelines


### PR DESCRIPTION
Resolves #2150

## Description & motivation

Replace "PyPi" with "PyPI" to match the capitalization used at https://pypi.org/

## Before

https://docs.getdbt.com/dbt-cli/install/pip

<img width="600" alt="image" src="https://user-images.githubusercontent.com/44704949/194314040-17bef23f-da34-423c-839c-32454353c65f.png">

<img width="600" alt="image" src="https://user-images.githubusercontent.com/44704949/194314080-fc2fb931-e7b7-4673-a79f-c7543c84ac0e.png">

https://docs.getdbt.com/docs/contributing/adapter-development/5-documenting-a-new-adapter

<img width="600" alt="image" src="https://user-images.githubusercontent.com/44704949/194314155-a1899f9c-65d9-4b72-96fc-d47d0a2c23f3.png">
