### PR TITLE
Note raw_sql -> raw_code for user-space code

### DIFF
--- a/website/docs/guides/migration/versions/05-upgrading-to-v1.3.md
+++ b/website/docs/guides/migration/versions/05-upgrading-to-v1.3.md
@@ -11,6 +11,8 @@ title: "Trying out v1.3 (prerelease)"
 
 There are no breaking changes for code in dbt projects and packages. We are committed to providing backward compatibility for all versions 1.x. If you encounter an error upon upgrading, please let us know by [opening an issue](https://github.com/dbt-labs/dbt-core/issues/new).
 
+**Note:** If you have custom code accessing the `raw_sql` property of models (via the [`model`](dbt-jinja-functions/model) or [`graph`](https://docs.getdbt.com/reference/dbt-jinja-functions/graph) objects), it has been renamed to `raw_code`. This is a change to the manifest contract, described in more detail below.
+
 ### For users of dbt Metrics
 
 The names of metric properties have changed, with backward compatibility. Those changes are:


### PR DESCRIPTION
## Description & motivation

Motivated by [this internal Slack thread](https://dbt-labs.slack.com/archives/C01JNSRKTC3/p1665077529503009?thread_ts=1664897197.882049&cid=C01JNSRKTC3)

Call out what might be a surprising change for a small subset of users in v1.3, if (and only if) they have custom code accessing semi-documented functionality (contracted within `manifest.json`):

```sql
-- models/some_model.sql
-- {{ model.raw_sql }}
```
Needs to become:
```sql
-- models/some_model.sql
-- {{ model.raw_code }}
```