### PR TITLE
change "should" to "can"

### DIFF
--- a/website/docs/dbt-cli/install/pip.md
+++ b/website/docs/dbt-cli/install/pip.md
@@ -3,7 +3,7 @@ title: "Use pip to install dbt"
 description: "You can use pip to install dbt Core and adapter plugins from the command line."
 ---
 
-You need to use `pip` to install dbt Core on Windows or Linux operating systems. You should use [Homebrew](install/homebrew) for installing dbt Core on a MacOS. 
+You need to use `pip` to install dbt Core on Windows or Linux operating systems. You can use `pip` or [Homebrew](install/homebrew) for installing dbt Core on a MacOS. 
 
 You can install dbt Core and plugins using `pip` because they are Python modules distributed on [PyPI](https://pypi.org/project/dbt/). We recommend using virtual environments when installing with `pip`.
 


### PR DESCRIPTION
Change the wording to make it more clear that a mac user can use either `pip` or `homebrew` to install dbt core.