### PR TITLE
Update the leftbar under the Build dbt projects heading

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -97,6 +97,17 @@ const sidebarSettings = {
         },
         {
           type: "category",
+          label: "Organize your outputs",
+          collapsed: true,
+          items: [
+            "docs/build/custom-schemas",
+            "docs/build/custom-databases",
+            "docs/build/custom-aliases",
+            "docs/build/custom-target-names",
+          ],
+        },
+        {
+          type: "category",
           label: "Advanced workflows",
           collapsed: true,
           items: [
@@ -147,18 +158,6 @@ const sidebarSettings = {
             "docs/build/hooks-operations",
           ],
         },
-        {
-          type: "category",
-          label: "Organize your outputs",
-          collapsed: true,
-          items: [
-            "docs/build/custom-schemas",
-            "docs/build/custom-databases",
-            "docs/build/custom-aliases",
-            "docs/build/custom-target-names",
-          ],
-        },
-        "guides/best-practices/how-we-structure/1-guide-overview",
         //"docs/building-a-dbt-project/dont-nest-your-curlies",
         //"docs/building-a-dbt-project/archival",
 


### PR DESCRIPTION
## Description & motivation

Update the leftbar of the **Build dbt projects** heading:

- Removed link to the How to structure dbt projects guide. The leftbar for Guides looks completely different than the one for Docs. Looks like `sidebar.js` doesn't support opening links in a new tab.
- Moved "Advanced workflows" to be below "Organize your outputs" 

