### PR TITLE
Removing vestigial content and adding example

### DIFF
--- a/website/docs/docs/building-a-dbt-project/metrics.md
+++ b/website/docs/docs/building-a-dbt-project/metrics.md
@@ -62,7 +62,7 @@ metrics:
     [description](description): "The 14 day rolling count of paying customers using the product"
 
     calculation_method: count_distinct
-    expression: user_id # superfluous here, but shown as an example
+    expression: user_id 
 
     timestamp: signup_date
     time_grains: [day, week, month, quarter, year]
@@ -116,7 +116,7 @@ metrics:
     description: "The 14 day rolling count of paying customers using the product"
 
     type: count_distinct
-    sql: user_id # superfluous here, but shown as an example
+    sql: user_id 
 
     timestamp: signup_date
     time_grains: [day, week, month, quarter, year]
@@ -164,7 +164,7 @@ Metrics can have many declared **properties**, which define aspects of your metr
 | label       | A short for name / label for the metric                     | New Customers                   | no        |
 | description | Long form, human-readable description for the metric        | The number of customers who.... | no        |
 | calculation_method | The method of calculation (aggregation or derived) that is applied to the expression  | count_distinct | yes       |
-| expression  | The expression to aggregate/calculate over | user_id | yes       |
+| expression  | The expression to aggregate/calculate over | user_id, cast(user_id as int) | yes       |
 | timestamp   | The time-based component of the metric                      | signup_date                     | yes       |
 | time_grains | One or more "grains" at which the metric can be evaluated. For more information, see the "Custom Calendar" section.   | [day, week, month, quarter, year]              | yes       |
 | dimensions  | A list of dimensions to group or filter the metric by       | [plan, country]                 | no        |

--- a/website/docs/docs/building-a-dbt-project/metrics.md
+++ b/website/docs/docs/building-a-dbt-project/metrics.md
@@ -184,7 +184,7 @@ Metrics can have many declared **properties**, which define aspects of your metr
 | label       | A short for name / label for the metric                     | New Customers                   | no        |
 | description | Long form, human-readable description for the metric        | The number of customers who.... | no        |
 | type | The method of calculation (aggregation or derived) that is applied to the expression  | count_distinct | yes       |
-| sql | The expression to aggregate/calculate over | user_id | yes       |
+| sql | The expression to aggregate/calculate over | user_id, cast(user_id as int) | yes       |
 | timestamp   | The time-based component of the metric                      | signup_date                     | yes       |
 | time_grains | One or more "grains" at which the metric can be evaluated   | [day, week, month, quarter, year]              | yes       |
 | dimensions  | A list of dimensions to group or filter the metric by       | [plan, country]                 | no        |


### PR DESCRIPTION
## Description & motivation
Removing a holdover from old metric documentation that was confusing to some users AND adding a new example for the `expression` field to show users they can use non-aggregating sql functions