### PR TITLE
Release dbt Core v1.3

### DIFF
--- a/website/dbt-versions.js
+++ b/website/dbt-versions.js
@@ -1,8 +1,7 @@
 exports.versions = [
   {
     version: "1.3",
-    EOLDate: "2023-10-07",  // TODO estimated for now
-    isPrerelease: true,
+    EOLDate: "2023-10-12",
   },
   {
     version: "1.2",

--- a/website/docs/guides/migration/versions/05-upgrading-to-v1.3.md
+++ b/website/docs/guides/migration/versions/05-upgrading-to-v1.3.md
@@ -1,9 +1,9 @@
 ---
-title: "Trying out v1.3 (prerelease)"
+title: "Upgrading to v1.3 (latest)"
 ---
 ### Resources
 
-- [Changelog](https://github.com/dbt-labs/dbt-core/blob/main/CHANGELOG.md)
+- [Changelog](https://github.com/dbt-labs/dbt-core/blob/1.3.latest/CHANGELOG.md)
 - [CLI Installation guide](/dbt-cli/install/overview)
 - [Cloud upgrade guide](/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-choosing-a-dbt-version)
 

--- a/website/docs/guides/migration/versions/06-upgrading-to-v1.2.md
+++ b/website/docs/guides/migration/versions/06-upgrading-to-v1.2.md
@@ -1,5 +1,5 @@
 ---
-title: "Upgrading to v1.2 (latest)"
+title: "Upgrading to v1.2"
 ---
 ### Resources
 

--- a/website/docs/reference/artifacts/manifest-json.md
+++ b/website/docs/reference/artifacts/manifest-json.md
@@ -2,7 +2,7 @@
 title: Manifest
 ---
 
-_Current schema_: [`v6`](https://schemas.getdbt.com/dbt/manifest/v6/index.html)
+_Current schema_: [`v7`](https://schemas.getdbt.com/dbt/manifest/v7/index.html)
 
 _Produced by:_
 - `dbt compile`


### PR DESCRIPTION
## Description & motivation

- Update migration guide title
- Remove `isPrerelease: true` from v1.3 version dropdown
- Update latest version of manifest artifact (accounting for https://github.com/dbt-labs/schemas.getdbt.com/pull/15)