### PR TITLE
Add Dremio to supported platforms

### DIFF
--- a/website/docs/docs/supported-data-platforms.md
+++ b/website/docs/docs/supported-data-platforms.md
@@ -43,6 +43,7 @@ Who made and maintains and adapter is certainly relevant, but we recommend using
 | Snowflake ([setup](snowflake-setup))     | 1.2.0                    |
 | Apache Spark ([setup](spark-setup))      | 1.2.0                    |
 | Starburst & Trino ([setup](trino-setup)) | 1.2.0 :construction:     |
+| Dremio ([setup](dremio-setup))           | 1.3.0 :construction:     |
 
 ### Community Adapters
 

--- a/website/docs/docs/supported-data-platforms.md
+++ b/website/docs/docs/supported-data-platforms.md
@@ -38,12 +38,12 @@ Who made and maintains and adapter is certainly relevant, but we recommend using
 | AlloyDB  ([setup](alloydb-setup))        | (same as `dbt-postgres`) |
 | BigQuery ([setup](bigquery-setup))       | 1.2.0                    |
 | Databricks ([setup](databricks-setup))   | 1.2.0 :construction:     |
+| Dremio ([setup](dremio-setup))           | 1.3.0 :construction:     |
 | Postgres ([setup](postgres-setup))       | 1.2.0                    |
 | Redshift ([setup](redshift-setup))       | 1.2.0                    |
 | Snowflake ([setup](snowflake-setup))     | 1.2.0                    |
 | Apache Spark ([setup](spark-setup))      | 1.2.0                    |
 | Starburst & Trino ([setup](trino-setup)) | 1.2.0 :construction:     |
-| Dremio ([setup](dremio-setup))           | 1.3.0 :construction:     |
 
 ### Community Adapters
 


### PR DESCRIPTION
Adding Dremio to the list of verified adapters. 
Construction sign has been added to indicate that verification is in progress. Identified that dbt-dremio GA will be against 1.3.0.

## Description & motivation
Identify that Dremio is submitting an adapter for verification, against dbt-core 1.3 (hot off the presses!).

