### PR TITLE
manually trigger preference center

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -172,7 +172,7 @@ var siteSettings = {
             <a href='https://www.getdbt.com/cloud/privacy-policy/'>Privacy Policy</a>
             <a href='https://www.getdbt.com/security/'>Security</a>
             <a href='https://www.getdbt.com/cloud/terms/'>Terms of Service</a>
-            <button id=\"ot-sdk-btn\" class=\"ot-sdk-show-settings\">Cookie Settings</button>
+            <button id=\"ot-sdk-btn\" onclick="openPreferenceCenter()">Cookie Settings</button>
           </div>
 
           <div class='footer__items--right'>
@@ -239,6 +239,7 @@ var siteSettings = {
       defer: true,
     },
     "/js/gtm.js",
+    "/js/onetrust.js",
     "https://kit.fontawesome.com/7110474d41.js",
   ],
   stylesheets: [

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -1522,7 +1522,7 @@ html[data-theme="dark"] .breadcrumbs__item--active .breadcrumbs__link {
 }
 
 /* OneTrust Cookies Settings Btn in Footer */
-footer #ot-sdk-btn.ot-sdk-show-settings,
+footer #ot-sdk-btn,
 footer #ot-sdk-btn.optanon-show-settings {
   background: none;
   border: none;
@@ -1536,7 +1536,7 @@ footer #ot-sdk-btn.optanon-show-settings {
   font-weight: 400;
   cursor: pointer;
 }
-footer #ot-sdk-btn.ot-sdk-show-settings:hover,
+footer #ot-sdk-btn:hover,
 footer #ot-sdk-btn.optanon-show-settings:hover {
   background: none;
   border: none;

--- a/website/static/js/onetrust.js
+++ b/website/static/js/onetrust.js
@@ -1,0 +1,6 @@
+function openPreferenceCenter() {
+  if(window?.OneTrust?.ToggleInfoDisplay) {
+    console.log('opening center')
+    window.OneTrust.ToggleInfoDisplay()
+  }
+}


### PR DESCRIPTION
## Description & motivation
This adjusts how the OneTrust Preference Center is triggered, fixing a bug where it only opens on the first page loaded.

To test:
- Click the 'Cookie Settings' link in the footer and verify OneTrust preference center opens
- Navigate to a different page, click the Cookie Settings link and verify the preference center opens again.

## Preview
https://deploy-preview-2213--docs-getdbt-com.netlify.app/