### PR TITLE
dbtignore and migration note

### DIFF
--- a/website/docs/guides/migration/versions/05-upgrading-to-v1.3.md
+++ b/website/docs/guides/migration/versions/05-upgrading-to-v1.3.md
@@ -9,7 +9,11 @@ title: "Upgrading to v1.3 (latest)"
 
 ## Breaking changes
 
-There are no breaking changes for code in dbt projects and packages. We are committed to providing backward compatibility for all versions 1.x. If you encounter an error upon upgrading, please let us know by [opening an issue](https://github.com/dbt-labs/dbt-core/issues/new).
+There is one notable change that may be considered breaking: with the introduction of Python models in v1.3, dbt will parse and attempt to execute `.py` files in the `models/` directory (or other directories for models per `dbt_project.yml`), likely causing an error.
+
+Use a [`.dbtignore` file](/reference/dbtignore) to have dbt ignore non-model `.py` files or move them out of the model directories.
+
+We are committed to providing backward compatibility for all versions 1.x. If you encounter an error upon upgrading, please let us know by [opening an issue](https://github.com/dbt-labs/dbt-core/issues/new).
 
 **Note:** If you have custom code accessing the `raw_sql` property of models (with the [model](dbt-jinja-functions/model) or [graph](/reference/dbt-jinja-functions/graph) objects), it has been renamed to `raw_code`. This is a change to the manifest contract, described in more detail below.
 

--- a/website/docs/guides/migration/versions/05-upgrading-to-v1.3.md
+++ b/website/docs/guides/migration/versions/05-upgrading-to-v1.3.md
@@ -9,13 +9,12 @@ title: "Upgrading to v1.3 (latest)"
 
 ## Breaking changes
 
-There is one notable change that may be considered breaking: with the introduction of Python models in v1.3, dbt will parse and attempt to execute `.py` files in the `models/` directory (or other directories for models per `dbt_project.yml`), likely causing an error.
-
-Use a [`.dbtignore` file](/reference/dbtignore) to have dbt ignore non-model `.py` files or move them out of the model directories.
-
 We are committed to providing backward compatibility for all versions 1.x. If you encounter an error upon upgrading, please let us know by [opening an issue](https://github.com/dbt-labs/dbt-core/issues/new).
 
-**Note:** If you have custom code accessing the `raw_sql` property of models (with the [model](dbt-jinja-functions/model) or [graph](/reference/dbt-jinja-functions/graph) objects), it has been renamed to `raw_code`. This is a change to the manifest contract, described in more detail below.
+There are three changes in dbt Core v1.3 that may require action from some users:
+1. If you have a `profiles.yml` file located in the root directory where you run dbt, dbt will start preferring that profiles file over the default location on your machine. [More details](connection-profiles/advanced-customizing-a-profile-directory) 
+2. If you already have `.py` files defined in the `model-paths` of your dbt project, dbt will start trying to read them as Python models. You can use [the new `.dbtignore` file](dbtignore) to tell dbt to ignore those files.
+3. If you have custom code accessing the `raw_sql` property of models (with the [model](dbt-jinja-functions/model) or [graph](/reference/dbt-jinja-functions/graph) objects), it has been renamed to `raw_code`. This is a change to the manifest contract, described in more detail below.
 
 ### For users of dbt Metrics
 
@@ -48,7 +47,7 @@ _GitHub discussion forthcoming_
 - Updates made to **[Metrics](building-a-dbt-project/metrics)** reflect their new syntax for definition, as well as additional properties that are now available.
 - Plus, a few related updates to **[exposure properties](exposure-properties)**: `config`, `label`, and `name` validation.
 - **[Custom `node_color`](/docs/reference/resource-configs/docs.md)** in `dbt-docs`. For the first time, you can control the colors displayed in dbt's DAG. Want bronze, silver, and gold layers? It's at your fingertips.
-- Search for **[`Profiles.yml`](/docs/dbt-cli/configure-your-profile#advanced-customizing-a-profile-directory)** in the current working directory before `~/.dbt`
+- **[`Profiles.yml`](connection-profiles/advanced-customizing-a-profile-directory)** search order now looks in the current working directory before `~/.dbt`.
 
 ### Quick hits
 - **["Full refresh"](full_refresh)** flag supports a short name, `-f`.

--- a/website/docs/reference/dbtignore.md
+++ b/website/docs/reference/dbtignore.md
@@ -1,10 +1,12 @@
-:::info New in v1.3
-Added with the introduction of Python models to allow ignoring non-model `.py` files from being parsed by dbt.
-:::
+---
+title: .dbtignore
+---
 
-You can create a `.dbtignore` file in the root of your [dbt project](projects) to specify files that dbt should ignored by dbt. The file behaves like a [`.gitignore` file, using the same syntax](https://git-scm.com/docs/gitignore).
+You can create a `.dbtignore` file in the root of your [dbt project](projects) to specify files that should be **entirely** ignored by dbt. The file behaves like a [`.gitignore` file, using the same syntax](https://git-scm.com/docs/gitignore). Files and subdirectories matching the pattern will not be read, parsed, or otherwise detected by dbt—as if they didn't exist.
 
-For instance:
+**Examples**
+
+<File name=".dbtignore">
 
 ```md
 # .dbtignore
@@ -19,3 +21,5 @@ another-non-dbt-model.py
 # ignore all .py files with "codegen" in the filename
 *codegen*.py
 ```
+
+</File>

--- a/website/docs/reference/dbtignore.md
+++ b/website/docs/reference/dbtignore.md
@@ -1,0 +1,21 @@
+:::info New in v1.3
+Added with the introduction of Python models to allow ignoring non-model `.py` files from being parsed by dbt.
+:::
+
+You can create a `.dbtignore` file in the root of your [dbt project](projects) to specify files that dbt should ignored by dbt. The file behaves like a [`.gitignore` file, using the same syntax](https://git-scm.com/docs/gitignore).
+
+For instance:
+
+```md
+# .dbtignore
+
+# ignore individual .py files
+not-a-dbt-model.py
+another-non-dbt-model.py
+
+# ignore all .py files
+**.py
+
+# ignore all .py files with "codegen" in the filename
+*codegen*.py
+```

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -379,6 +379,7 @@ const sidebarSettings = {
       label: "Project configs",
       items: [
         "reference/dbt_project.yml",
+        "reference/dbtignore",
         "reference/project-configs/analysis-paths",
         "reference/project-configs/asset-paths",
         "reference/project-configs/clean-targets",


### PR DESCRIPTION
## Description & motivation

There is a significant change in v1.3 that could be considered a breaking change -- non-model `.py` files are now parsed and likely to cause errors if they exist in model directories.

This was first reported in the community Slack, and since has been seen a few times. To address it, we added a `.dbtignore` file in v1.3 that can be used to ignore non-model `.py` files (or anything) from being parsed by dbt.

## To-do before merge

I could not figure out how to make the actual filename/sidebar show as ".dbtignore" -- if that's possible, we should do that.

Any cleanup desired by docs team.

Do we call this a breaking change? I'd say it technically is one.

## Prerelease docs
N/A

## Checklist
If you added new pages (delete if not applicable):
- [x] The page has been added to `website/sidebars.js`
- [x] The new page has a unique filename
