### PR TITLE
add redirect

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -519,3 +519,6 @@ docs/contributing/documenting-a-new-adapter /docs/contributing/adapter-developme
 /community/maintaining-a-channel /community/resources/maintaining-a-channel 301
 /docs/contributing/oss-expectations /community/resources/oss-expectations 301
 /docs/contributing/slack-rules-of-the-road /community/resources/slack-rules-of-the-road 301
+
+/blog/getting-started-with-the-dbt-semantic-layer /blog/understanding-the-components-of-the-dbt-semantic-layer 301!
+

--- a/website/src/components/discourse/index.js
+++ b/website/src/components/discourse/index.js
@@ -210,6 +210,7 @@ function TopicWrapper({ topic, children }) {
   }
 }
 
+// Format date by YYYY-MM-DD
 function formatDate(date) {
   return `${date.getFullYear()}-${('0'+ (date.getMonth()+1)).slice(-2)}-${('0'+ date.getDate()).slice(-2)}`
 }


### PR DESCRIPTION
Adds a redirect for Semantic Layer blog post.

## Preview

https://deploy-preview-2278--docs-getdbt-com.netlify.app/blog/getting-started-with-the-dbt-semantic-layer

This should redirect to: https://deploy-preview-2278--docs-getdbt-com.netlify.app/blog/understanding-the-components-of-the-dbt-semantic-layer
