### PR TITLE
Throw error for broken Mark Down links

### DIFF
--- a/website/docs/guides/migration/versions/05-upgrading-to-v1.3.md
+++ b/website/docs/guides/migration/versions/05-upgrading-to-v1.3.md
@@ -46,7 +46,7 @@ _GitHub discussion forthcoming_
 - **[Python models](building-models/python-models)** are natively supported in `dbt-core` for the first time, on data warehouses that support Python runtimes.
 - Updates made to **[Metrics](build/metrics)** reflect their new syntax for definition, as well as additional properties that are now available.
 - Plus, a few related updates to **[exposure properties](exposure-properties)**: `config`, `label`, and `name` validation.
-- **[Custom `node_color`](/docs/reference/resource-configs/docs.md)** in `dbt-docs`. For the first time, you can control the colors displayed in dbt's DAG. Want bronze, silver, and gold layers? It's at your fingertips.
+- **[Custom `node_color`](/reference/resource-configs/docs)** in `dbt-docs`. For the first time, you can control the colors displayed in dbt's DAG. Want bronze, silver, and gold layers? It's at your fingertips.
 - **[`Profiles.yml`](connection-profiles/advanced-customizing-a-profile-directory)** search order now looks in the current working directory before `~/.dbt`.
 
 ### Quick hits

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -45,6 +45,7 @@ var siteSettings = {
   title: "dbt Developer Hub",
   url: SITE_URL,
   onBrokenLinks: "warn",
+  onBrokenMarkdownLinks" "throw",
   trailingSlash: false,
   themeConfig: {
     image: "/img/avatar.png",

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -45,7 +45,7 @@ var siteSettings = {
   title: "dbt Developer Hub",
   url: SITE_URL,
   onBrokenLinks: "warn",
-  onBrokenMarkdownLinks" "throw",
+  onBrokenMarkdownLinks: "throw",
   trailingSlash: false,
   themeConfig: {
     image: "/img/avatar.png",

--- a/website/src/pages/styles.js
+++ b/website/src/pages/styles.js
@@ -38,11 +38,11 @@ function Styles() {
                 <h1>Linked Markdown Code Blocks</h1>
 <pre>{`
 \`\`\`
-[view the intro](introduction)
+[view the intro](docs/introduction)
 \`\`\`
 `}</pre>
             <CodeBlock>
-[view the intro](introduction)
+[view the intro](docs/introduction)
             </CodeBlock>
             <br/>
             <p>Use a backslash to escape linking:</p>

--- a/website/src/pages/styles.js
+++ b/website/src/pages/styles.js
@@ -38,11 +38,11 @@ function Styles() {
                 <h1>Linked Markdown Code Blocks</h1>
 <pre>{`
 \`\`\`
-[view the license](license)
+[view the intro](introduction)
 \`\`\`
 `}</pre>
             <CodeBlock>
-[view the license](license)
+[view the intro](introduction)
             </CodeBlock>
             <br/>
             <p>Use a backslash to escape linking:</p>

--- a/website/src/pages/styles.js
+++ b/website/src/pages/styles.js
@@ -135,34 +135,8 @@ password: hunter2
             </div>
 
             <div className='section' style={{marginTop: '40px'}}>
-                <h1>Markdown Link</h1>
-Links to pages can be specified using:
-<li>Just the <code>id</code>¹ of the document, if the <code>id</code> is unique. Note: the <code>id</code> may be specified in the YAML front-matter of a document. If not, then it defaults to the filename.</li>
-<li>A relative <code>id</code> of the document. Note: this is required when two documents have the same <code>id</code>.</li>
-<li>Or, a path to the document (with <code>.md</code> file extension), relative to the <code>website/docs/</code> directory. Note: this is <em>required</em> for pages where the <code>id</code> looks like a filename (e.g. <code>profiles.yml</code>)</li>
-<br/>
-Bad links will appear with red underlines when building locally, and will cause an error in a deploy preview.
-<br/>
-<pre>{`[Supported Data Platforms](supported-data-platforms)
-[disambiguated link to duplicate id](docs/about/overview)
-[second disambiguated link to duplicate id](dbt-cli/install/overview)
-[file paths work too](docs/about/overview.md)
-[link to document where id looks like a filename](reference/profiles.yml.md)
-[a bad link](bad-link)
-`}</pre>
-
-                <Link href="supported-data-platforms">link to unique id</Link>
-                <br />
-                <Link href="docs/about/overview">disambiguated link to duplicate id</Link>
-                <br />
-                <Link href="dbt-cli/install/overview">second disambiguated link to duplicate id</Link>
-                <br />
-                <Link href="docs/about/overview.md">file paths work too</Link>
-                <br />
-                <Link href="docs/reference/profiles.yml.md">link to document where id looks like a file</Link>
-                <br />
-                <Link href="bad-link" ignoreInvalid={true}>a bad link</Link>
-
+                <h1>Markdown Links</h1>
+                  Refer to the <Link href="https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md#Links">Links section</Link> of the Content Style Guide to read about how you can use links in the dbt product documentation.
             </div>
 
             <div className='section' style={{marginTop: '40px'}}>


### PR DESCRIPTION
## Description & motivation

Per this [internal discussion](https://dbt-labs.slack.com/archives/C02NCQ9483C/p1665582637728089), I think it's important to throw an error when a PR introduces a broken Markdown link. I would also like to see the GitHub tests fails and the PR unmergeable, but I'm not sure this configuration will do that. 

