### PR TITLE
Fix broken links in blogs

### DIFF
--- a/website/blog/2019-05-01-how-we-structure-dbt-projects.md
+++ b/website/blog/2019-05-01-how-we-structure-dbt-projects.md
@@ -37,8 +37,6 @@ In comparison, the (recently updated) [best practices](/guides/best-practices) r
 *   Consider the information architecture of your data warehouse
 *   Separate source-centric and business-centric transformations
 
-If you want to see what the code for one of our projects looks like, check out [this demonstration dbt project](https://github.com/dbt-labs/dbt-learn-demo/tree/day2-dbt-training/models).
-
 We also recently held (and recorded) an office hours on this topic – this article provides a high level outline, but there’s a lot more detail and discussion in the [video](https://youtu.be/xzKLh342s08).
 
 Lastly, before I dive in, a huge thank you to Jeremy Cohen for not only teaching me a lot of the material in this article, but also for doing a lot of the groundwork that went into this article – entire sections of this article are in fact lifted from his work.
@@ -69,7 +67,7 @@ In our dbt projects, this leads us to our first split in our `models/` directory
     └── models
         ├── marts
         └── staging
-    
+
 ```
 
 ## Staging raw data
@@ -119,7 +117,7 @@ Each staging directory contains at a minimum:
                 ├── stg_braintree__customers.sql
                 └── stg_braintree__payments.sql
 ```        
-    
+
 
 Some dbt users prefer to have one `.yml` file per model (e.g. `stg_braintree__customers.yml`). This is a completely reasonable choice, and we recommend implementing it if your `.yml` files start to become unwieldy.
 
@@ -133,23 +131,23 @@ That being said, in our dbt projects every source flows through exactly one mode
 
 ```
     with source as (
-        
+
         select * from {{ source('braintree', 'payments') }}
-        
+
     ),
-    
+
     renamed as (
-        
+
         select
             id as payment_id,
             order_id,
             convert_timezone('America/New_York', 'UTC', createdat) as created_at,
             ...
-        
+
         from source
-    
+
     )
-    
+
     select * from renamed
 ```    
 
@@ -175,7 +173,7 @@ In our dbt projects, we place these base models in a nested `base` subdirectory.
                 ├── stg_braintree.yml
                 ├── stg_braintree__customers.sql
                 └── stg_braintree__payments.sql
-``` 
+```
 
 In our projects, base models:
 

--- a/website/blog/2021-02-05-dbt-project-checklist.md
+++ b/website/blog/2021-02-05-dbt-project-checklist.md
@@ -2,7 +2,7 @@
 title: "Your Essential dbt Project Checklist"
 description: "A checklist created to guide our internal work, which you can use to clean up your own dbt project."
 slug: essential-dbt-project-checklist
-canonical_url: https://discourse.getdbt.com/t/your-essential-dbt-project-checklist/1377 
+canonical_url: https://discourse.getdbt.com/t/your-essential-dbt-project-checklist/1377
 
 authors: [amy_chen, dave_connors]
 
@@ -15,7 +15,7 @@ is_featured: true
 
 If you’ve been using dbt for over a year, your project is out-of-date. This is natural.  
 
-New functionalities have been released. Warehouses change. Best practices are updated. Over the last year, I and others on the Fishtown Analytics (now dbt Labs!) team have conducted seven audits for clients who have been using dbt for a minimum of 2 months. 
+New functionalities have been released. Warehouses change. Best practices are updated. Over the last year, I and others on the Fishtown Analytics (now dbt Labs!) team have conducted seven audits for clients who have been using dbt for a minimum of 2 months.
 
 <!--truncate-->
 
@@ -119,7 +119,7 @@ This post is the checklist I created to guide our internal work, and I’m shari
 *   Do you use refs and sources for everything?
     *   Make sure nothing is querying off of raw tables, etc.
         ![no querying raw tables](/img/blog/checklist-8ddc2f76de24c98690ef986dcc7974bff09adb59.png)
-        
+
 *   Do you regularly run `dbt test` as part of your workflow and production jobs?
 *   Do you use Jinja & Macros for repeated code?
     *   If you do, is the balance met where it’s not being overused to the point code is not readable?
@@ -200,7 +200,7 @@ Are you using the IDE and if so, how well?
 
 **Useful links**
 
-*   [dbt Cloud as a CI tool](/docs/dbt-cloud/using-dbt-cloud/cloud-enabling-continuous-integration-with-github)
+*   [dbt Cloud as a CI tool](/docs/deploy/cloud-ci-job)
 
 
 ## ✅ DAG Auditing
@@ -210,41 +210,41 @@ _Note: diagrams in this section show what NOT to do!_
 
 *   Does your DAG have any common modeling pitfalls?
     *   Are there any direct joins from sources into an intermediate model?
-        
+
         *   All sources should have a corresponding staging model to clean and standardize the data structure. They should not look like the image below.  
-            
+
             ![bad dag](/img/blog/checklist-28c75101367e272fbc2db2ebb1a1ec030517bb5e_2_517x250.jpeg)
-            
+
     *   Do sources join directly together?
-        
+
         *   All sources should have a corresponding staging model to clean and standardize the data structure. They should not look like the image below.  
-            
+
             ![bad dag 2](/img/blog/checklist-5d8ad45deb695eb6771003e010b242c0a3c122b9_2_517x220.jpeg)
-            
+
     *   Are there any rejoining of upstream concepts?
-        
+
         *   This may indicate:
             *   a model may need to be expanded so all the necessary data is available downstream
             *   a new intermediate model is necessary to join the concepts for use in both places  
-                
+
                 ![bad dag 2](/img/blog/checklist-acd57c0e781b1eaf75a65b5063f97ac3ddc5c493_2_517x136.jpeg)
-                
+
     *   Are there any “bending connections”?
-        
+
         *   Are models in the same layer dependent on each other?
         *   This may indicate a change in naming is necessary, or the model should reference further upstream models  
-            
+
             ![bad dag 3](/img/blog/checklist-0532fd13a7d63e3e5df71d025700c4d9c158a7ff_2_517x155.jpeg)
-            
+
     *   Are there model fan outs of intermediate/dimension/fact models?
-        
+
         *   This might indicate some transformations should move to the BI layer, or transformations should be moved upstream
         *   Your dbt project needs a defined end point!  
-            
+
             [![bad dag 4](/img/blog/checklist-33fcd7c4922233412d1364b39227c876d0cb8215_2_517x111.jpeg)
-            
+
     *   Is there repeated logic found in multiple models?
-        
+
         *   This indicates an opportunity to move logic into upstream models or create specific intermediate models to make that logic reusable
         *   One common place to look for this is complex join logic. For example, if you’re checking multiple fields for certain specific values in a join, these can likely be condensed into a single field in an upstream model to create a clean, simple join.
 

--- a/website/blog/2021-09-11-sql-dateadd.md
+++ b/website/blog/2021-09-11-sql-dateadd.md
@@ -43,7 +43,7 @@ The *functions themselves* are named slightly differently, which is common acros
 
 ```sql
 dateadd( {{ datepart }}, {{ interval }}, {{ from_date }} )
-``` 
+```
 
 *Hour, minute and second are supported!*
 
@@ -57,14 +57,14 @@ date_add( {{ startDate }}, {{ numDays }} )
 
 ```sql
 date_add( {{ from_date }}, INTERVAL {{ interval }} {{ datepart }} )
-``` 
+```
 
 *Dateparts of less than a day (hour / minute / second) are not supported.*
 
 ### The DATEADD Function in Postgres...
 
 Postgres doesn’t provide a dateadd function out of the box, so you’ve got to go it alone - but the syntax looks very similar to BigQuery’s function…
-	
+
 ```sql
 {{ from_date }} + (interval '{{ interval }} {{ datepart }}')
 ```
@@ -96,7 +96,7 @@ Adding 1 month to today would look like...
 ```
 
 > *New to dbt?  Check out [dbt introduction](https://docs.getdbt.com/docs/introduction) for more background on dbt and the analytics engineering workflow that it facilitates.*
-> 
+>
 > *TL;DR: dbt allows data practitioners to write code like software engineers, which in this case means not repeating yourself unnecessarily.*
 
 ### Compiling away your DATEADD troubles
@@ -142,6 +142,3 @@ And it’s actually quite a simple 31-line macro ([source here](https://github.c
 Enjoy! FYI I've used dateadd macro in dbt-utils on BigQuery, Postgres, Redshift and Snowflake, but it likely works across most other warehouses.
 
 *Note: While `dbt_utils` doesn't support Databricks by default, you can use other packages that [implement overrides](/reference/dbt-jinja-functions/dispatch#overriding-package-macros) as a workaround.*
-
-*This [spark_utils package](https://github.com/dbt-labs/spark-utils/blob/main/macros/dbt_utils/cross_db_utils/dateadd.sql) can help you implement the override needed to add support for Databricks dateadd*
-

--- a/website/blog/2021-09-11-sql-dateadd.md
+++ b/website/blog/2021-09-11-sql-dateadd.md
@@ -142,3 +142,5 @@ And it’s actually quite a simple 31-line macro ([source here](https://github.c
 Enjoy! FYI I've used dateadd macro in dbt-utils on BigQuery, Postgres, Redshift and Snowflake, but it likely works across most other warehouses.
 
 *Note: While `dbt_utils` doesn't support Databricks by default, you can use other packages that [implement overrides](/reference/dbt-jinja-functions/dispatch#overriding-package-macros) as a workaround.*
+
+*This [spark_utils package](https://github.com/dbt-labs/spark-utils/blob/0.3.0/macros/dbt_utils/cross_db_utils/dateadd.sql) can help you implement the override needed to add support for Databricks dateadd*

--- a/website/blog/2021-10-15-october-21-product-update-email.md
+++ b/website/blog/2021-10-15-october-21-product-update-email.md
@@ -2,7 +2,7 @@
 title: "October 2021 dbt Update: Metrics and Hat Tricks 🎩"
 description: "Also flagging that Coalesce is less than 3 weeks away! 😱"
 slug: dbt-product-update-2021-october
-authors: [lauren_craigie] 
+authors: [lauren_craigie]
 
 tags: [dbt updates]
 hide_table_of_contents: false
@@ -53,7 +53,7 @@ I've got three really exciting things to share this month!
 
 -   [Model bottlenecks beta](https://getdbt.slack.com/archives/C02GUTGK73N?utm_campaign=Monthly%20Product%20Updates&utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-_wfy8vfjMjwQ7o8TXEOVz-oXI35iVcVP1HtAvriVHfJoAd1IcsP-MCww6vJUDlvAfiuQjZ): Identify long-running models ripe for refactoring (or re-scheduling). The new model timing dashboard in the run detail page helps you quickly assess job composition, order, and duration to optimize your workflows and cut costs💰
 
- ![image-1](https://hs-8698602.f.hubspotemail.net/hub/8698602/hubfs/image-1.png?upscale=true&width=1120&upscale=true&name=image-1.png) 
+ ![image-1](https://hs-8698602.f.hubspotemail.net/hub/8698602/hubfs/image-1.png?upscale=true&width=1120&upscale=true&name=image-1.png)
 
 The Model Timing tab in dbt Cloud highlights models taking particularly long to run.
 
@@ -78,10 +78,10 @@ The Model Timing tab in dbt Cloud highlights models taking particularly long to 
     At the Future Data Conference last week Tristan noted that data workflows borrow much from software engineering, but haven't really crossed the DevOps chasm. What's missing? Spreadsheets? Actually... *maybe.* 😅 Okay you had to be there. Luckily you still can! Check out the [recording](https://futuredata.brighttalk.live/talk/19069-506932/?utm_campaign=Monthly%20Product%20Updates&utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-_wfy8vfjMjwQ7o8TXEOVz-oXI35iVcVP1HtAvriVHfJoAd1IcsP-MCww6vJUDlvAfiuQjZ).
 -   [Modeling behavioral data with Snowplow and dbt](https://get.snowplowanalytics.com/wbn/dbt-and-snowplow/data-modeling/?utm_campaign=Monthly%20Product%20Updates&utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-_wfy8vfjMjwQ7o8TXEOVz-oXI35iVcVP1HtAvriVHfJoAd1IcsP-MCww6vJUDlvAfiuQjZ) (coming up on 10/27).
     Our own Sanjana Sen joins the Snowplow team to talk modeling Snowplow event data in dbt -- including how to structure your data models, best practices to follow, and key pitfalls to avoid.
--   [How Blend Eliminated Data Silos with dbt and Hightouch](https://hightouch.io/dbt-hightouch-blend-event/?utm_campaign=Monthly%20Product%20Updates&utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-_wfy8vfjMjwQ7o8TXEOVz-oXI35iVcVP1HtAvriVHfJoAd1IcsP-MCww6vJUDlvAfiuQjZ) (coming up 10/28).
+-   ~How Blend Eliminated Data Silos with dbt and Hightouch (coming up 10/28).~
     Fin-tech behemoth, Blend, processes trillions of dollars in loans (and recently IPO'd). Join this talk with William Tsu (Customer Success Operations at Blend) to learn how adopting dbt and Hightouch has helped them overcome data silos to keep kicking a$$.
 
- 
+
 That's all for now! Thanks for reading, and as always, *let me know if there's anything else you want to see in these updates!*
 
 *Lauren Craigie*  

--- a/website/blog/2021-10-15-october-21-product-update-email.md
+++ b/website/blog/2021-10-15-october-21-product-update-email.md
@@ -78,7 +78,7 @@ The Model Timing tab in dbt Cloud highlights models taking particularly long to 
     At the Future Data Conference last week Tristan noted that data workflows borrow much from software engineering, but haven't really crossed the DevOps chasm. What's missing? Spreadsheets? Actually... *maybe.* 😅 Okay you had to be there. Luckily you still can! Check out the [recording](https://futuredata.brighttalk.live/talk/19069-506932/?utm_campaign=Monthly%20Product%20Updates&utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-_wfy8vfjMjwQ7o8TXEOVz-oXI35iVcVP1HtAvriVHfJoAd1IcsP-MCww6vJUDlvAfiuQjZ).
 -   [Modeling behavioral data with Snowplow and dbt](https://get.snowplowanalytics.com/wbn/dbt-and-snowplow/data-modeling/?utm_campaign=Monthly%20Product%20Updates&utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-_wfy8vfjMjwQ7o8TXEOVz-oXI35iVcVP1HtAvriVHfJoAd1IcsP-MCww6vJUDlvAfiuQjZ) (coming up on 10/27).
     Our own Sanjana Sen joins the Snowplow team to talk modeling Snowplow event data in dbt -- including how to structure your data models, best practices to follow, and key pitfalls to avoid.
--   ~How Blend Eliminated Data Silos with dbt and Hightouch (coming up 10/28).~
+- How Blend Eliminated Data Silos with dbt and Hightouch.
     Fin-tech behemoth, Blend, processes trillions of dollars in loans (and recently IPO'd). Join this talk with William Tsu (Customer Success Operations at Blend) to learn how adopting dbt and Hightouch has helped them overcome data silos to keep kicking a$$.
 
 

--- a/website/blog/2021-11-23-so-you-want-to-build-a-package.md
+++ b/website/blog/2021-11-23-so-you-want-to-build-a-package.md
@@ -25,7 +25,7 @@ If you’re considering making a package, you probably already know what one is 
 
 Packages are a way to share code in dbt without ever having to copy and paste (or *email* :screaming face:).
 
-Let’s break down the [dateadd macro](https://github.com/dbt-labs/dbt-utils/blob/main/macros/cross_db_utils/dateadd.sql) from the dbt_utils macro to show you the process that created this fantastic macro.
+Let’s break down the [dateadd macro](https://github.com/dbt-labs/dbt-utils/blob/0.1.20/macros/cross_db_utils/dateadd.sql) from the dbt_utils macro to show you the process that created this fantastic macro.
 
 The problem: Analysts often need to add an interval to a timestamp/date. To make this cross-database and standardized across a project, a macro is needed.
 

--- a/website/blog/2021-11-29-dbt-airflow-spiritual-alignment.md
+++ b/website/blog/2021-11-29-dbt-airflow-spiritual-alignment.md
@@ -232,7 +232,7 @@ To set up Airflow and dbt Cloud, you can:
 
 ![airflow dbt run select](/img/blog/2021-11-29-dbt-airflow-spiritual-alignment/airflow-connection-ID.png)
 
-3. ~Set up your Airflow DAG similar to this example.~
+3. ~~Set up your Airflow DAG similar to this example.~~
 
 4. You can use Airflow to call the dbt Cloud API via the new `DbtCloudRunJobOperator` to run the job and monitor it in real time through the dbt Cloud interface.
 

--- a/website/blog/2021-11-29-dbt-airflow-spiritual-alignment.md
+++ b/website/blog/2021-11-29-dbt-airflow-spiritual-alignment.md
@@ -147,7 +147,7 @@ This can be perfectly ok, in the event your data team is structured for data eng
 
 Once the data has been ingested, dbt Core can be used to model it for consumption. Most of the time, users choose to either:
 Use the dbt CLI+ [BashOperator](https://registry.astronomer.io/providers/apache-airflow/modules/bashoperator) with Airflow (If you take this route, you can use an external secrets manager to manage credentials externally), or
-Use the [KubernetesPodOperator](https://registry.astronomer.io/providers/kubernetes/modules/kubernetespodoperator) for each dbt job, as data teams have at places like [Gitlab](https://gitlab.com/gitlab-data/analytics/-/blob/master/dags/transformation/dbt_trusted_data.py#L72) and [Snowflake](https://www.snowflake.com/blog/migrating-airflow-from-amazon-ec2-to-kubernetes/). 
+Use the [KubernetesPodOperator](https://registry.astronomer.io/providers/kubernetes/modules/kubernetespodoperator) for each dbt job, as data teams have at places like [Gitlab](https://gitlab.com/gitlab-data/analytics/-/blob/master/dags/transformation/dbt_trusted_data.py#L72) and [Snowflake](https://www.snowflake.com/blog/migrating-airflow-from-amazon-ec2-to-kubernetes/).
 
 Both approaches are equally valid; the right one will depend on the team and use case at hand.
 
@@ -213,7 +213,7 @@ If the operator fails, it’s an Airflow problem. If the dbt run returns a model
 
 With the new dbt Cloud Provider, you can use Airflow to orchestrate and monitor your dbt Cloud jobs without any of the overhead of dbt Core. Out of the box, the dbt Cloud provider comes with:
 
-An operator that allows you to both [run a predefined job in dbt Cloud and download an artifact from a dbt Cloud job](https://registry.astronomer.io/dags/example-dbt-cloud).
+An operator that allows you to both run a predefined job in dbt Cloud and download an artifact from a dbt Cloud job.
 A hook that gives you a secure way to leverage Airflow’s connection manager to connect to dbt Cloud. The Operator leverages the hook, but you can also [use the hook directly in a Taskflow function or PythonOperator](https://registry.astronomer.io/dags/dbt-cloud-operational-check) if there’s custom logic you need that isn’t covered in the Operator.
 
 A sensor that allows you to poll for a job completion. You can use this [for workloads where you want to ensure your dbt job has run before continuing on with your DAG](https://registry.astronomer.io/dags/fivetran-dbt-cloud-census).
@@ -232,7 +232,7 @@ To set up Airflow and dbt Cloud, you can:
 
 ![airflow dbt run select](/img/blog/2021-11-29-dbt-airflow-spiritual-alignment/airflow-connection-ID.png)
 
-3. Set up your Airflow DAG similar to [this example](https://github.com/apache/airflow/blob/main/airflow/providers/dbt/cloud/example_dags/example_dbt_cloud.py).
+3. ~Set up your Airflow DAG similar to this example.~
 
 4. You can use Airflow to call the dbt Cloud API via the new `DbtCloudRunJobOperator` to run the job and monitor it in real time through the dbt Cloud interface.
 

--- a/website/blog/2021-11-29-the-missing-role-of-design-in-analytics.md
+++ b/website/blog/2021-11-29-the-missing-role-of-design-in-analytics.md
@@ -12,18 +12,18 @@ date: 2021-11-29
 is_featured: false
 ---
 
-If you’ve spoken to me lately, follow me on [Twitter](https://twitter.com/sethrosen), or have taken my order at [Wendy’s](https://i.ytimg.com/vi/_oMc4eD9-XM/maxresdefault.jpg), you probably know how much I hate traditional dashboards. My dad, a psychotherapist, has been working with me to get to the root of my upbringing that led to this deep-rooted feeling. 
+If you’ve spoken to me lately, follow me on [Twitter](https://twitter.com/sethrosen), or have taken my order at [Wendy’s](https://i.ytimg.com/vi/_oMc4eD9-XM/maxresdefault.jpg), you probably know how much I hate traditional dashboards. My dad, a psychotherapist, has been working with me to get to the root of my upbringing that led to this deep-rooted feeling.
 
 <!--truncate-->
 
-As it turns out, the cause of my feelings towards traditional dashboarding are actually quite obvious. Before entering the field of data, I spent my entire career as a product manager working alongside user experience designers and engineers on cross-functional product teams. 
+As it turns out, the cause of my feelings towards traditional dashboarding are actually quite obvious. Before entering the field of data, I spent my entire career as a product manager working alongside user experience designers and engineers on cross-functional product teams.
 
-When building software, getting users to actually use the product is no easy feat. The smallest amount of friction can cause a user to abandon the flow. Add enough friction to any product and users and engagement will drop dramatically.  As analysts, we know this intuitively. We are constantly measuring retention, cohorts, and engagement within our business. 
+When building software, getting users to actually use the product is no easy feat. The smallest amount of friction can cause a user to abandon the flow. Add enough friction to any product and users and engagement will drop dramatically.  As analysts, we know this intuitively. We are constantly measuring retention, cohorts, and engagement within our business.
 
-These principles also apply to analytics. The more friction there is in analytics and the less we focus on the user, the less our output will be used. So it makes me wonder why, within the field of data, is design thinking often so absent? 
+These principles also apply to analytics. The more friction there is in analytics and the less we focus on the user, the less our output will be used. So it makes me wonder why, within the field of data, is design thinking often so absent?
 
 
-## Why are we lacking design thinking in analytics? 
+## Why are we lacking design thinking in analytics?
 
 Painting with broad strokes, design is generally not something that is a top priority for data teams. There are a few primary reasons that I see off the top:
 
@@ -35,7 +35,7 @@ Painting with broad strokes, design is generally not something that is a top pri
 
 These more or less boil down to data teams running like service teams rather than [product teams](https://locallyoptimistic.com/post/run-your-data-team-like-a-product-team/)—when you always give the squeakiest wheel the grease, it’s impossible to put in the strategic effort that design thinking requires.
 
-One solution I proposed back in 2019 is hiring a [data product manager](https://www.linkedin.com/pulse/why-your-organization-may-need-data-product-manager-seth-rosen/), which seems to be picking up a bit of steam. But what would that person actually do?
+One solution I proposed back in 2019 is hiring a [data product manager](https://www.hashpath.com/2019/11/why-your-organization-may-need-a-data-product-manager/), which seems to be picking up a bit of steam. But what would that person actually do?
 
  I have attempted to sum the solutions to these complex issues into a table of overly-simplified do’s and don’ts:
 
@@ -85,9 +85,9 @@ An analyst who can gather the necessary data, transform it into the analytics-re
 If you think about the workflow for an analyst, a simple process might go something like this:
 
 1. Initial exploratory analysis and ad-hoc queries
-2. Model data in dbt 
+2. Model data in dbt
 3. Build out data visualizations
-4. Write tests/monitor performance 
+4. Write tests/monitor performance
 
 But, you might also consider adding the following to your workflow.
 
@@ -140,7 +140,7 @@ Here are a few examples:
    </td>
   </tr>
   <tr>
-   <td>Minimal software development lifecycle 
+   <td>Minimal software development lifecycle
    </td>
    <td>Strong SDLC to promote user trust
    </td>
@@ -176,17 +176,17 @@ While the data being presented in the weather app could technically be presented
 
 When it is done right, the user has everything they need to make quick decisions and take appropriate actions.
 
-It’s worth noting this simple weather app is purpose-built for everyday weather situations. There are some use cases where highly specific information may be needed by a particular subset of users. 
+It’s worth noting this simple weather app is purpose-built for everyday weather situations. There are some use cases where highly specific information may be needed by a particular subset of users.
 
 For example, surfers want different information. Ultimately, they may want an overall "Surf or don't surf" recommendation. Additionally, pilots could never simply rely on AccuWeather. These use cases warrant their own user-centered, purpose-built experiences.
 
 
 ## The missing piece of the puzzle
 
-While a design process can help you build better analytics output, there is still a missing part of the analytics stack to enable true user-centered design. 
+While a design process can help you build better analytics output, there is still a missing part of the analytics stack to enable true user-centered design.
 
-How would you, today, build out a weather-like application? 
+How would you, today, build out a weather-like application?
 
-Traditional dashboarding tools limit the user experience and prevent purpose-built applications from being created. Luckily our tools are evolving to meet the needs of the data consumer. 
+Traditional dashboarding tools limit the user experience and prevent purpose-built applications from being created. Luckily our tools are evolving to meet the needs of the data consumer.
 
 I encourage you to explore these new tools as much as possible and to work design into your analytics workflows. I’m always up for chatting, especially about this - my DMs are always open on [Twitter](https://twitter.com/sethrosen).

--- a/website/blog/2022-05-03-making-dbt-cloud-api-calls-using-dbt-cloud-cli.md
+++ b/website/blog/2022-05-03-making-dbt-cloud-api-calls-using-dbt-cloud-cli.md
@@ -12,9 +12,9 @@ date: 2022-05-03
 is_featured: true
 ---
 
-dbt Cloud is a hosted service that many organizations use for their dbt deployments. Among other things, it provides an interface for creating and managing deployment jobs. When triggered (e.g., cron schedule, API trigger), the jobs generate various artifacts that contain valuable metadata related to the dbt project and the run results. 
+dbt Cloud is a hosted service that many organizations use for their dbt deployments. Among other things, it provides an interface for creating and managing deployment jobs. When triggered (e.g., cron schedule, API trigger), the jobs generate various artifacts that contain valuable metadata related to the dbt project and the run results.
 
-dbt Cloud provides a REST API for managing jobs, run artifacts and other dbt Cloud resources. Data/analytics engineers would often write custom scripts for issuing automated calls to the API using tools [cURL](https://curl.se/) or [Python Requests](https://docs.python-requests.org/en/latest/).  In some cases, the engineers would go on and copy/rewrite them between projects that need to interact with the API. Now, they have a bunch of scripts on their hands that they need to maintain and develop further if business requirements change. If only there was a dedicated tool for interacting with the dbt Cloud API that abstracts away the complexities of the API calls behind an easy-to-use interface… Oh wait, there is: [the dbt-cloud-cli](https://github.com/data-mie/dbt-cloud-cli)!
+dbt Cloud provides a REST API for managing jobs, run artifacts and other dbt Cloud resources. Data/analytics engineers would often write custom scripts for issuing automated calls to the API using tools [cURL](https://curl.se/) or [Python Requests](https://requests.readthedocs.io/en/latest/).  In some cases, the engineers would go on and copy/rewrite them between projects that need to interact with the API. Now, they have a bunch of scripts on their hands that they need to maintain and develop further if business requirements change. If only there was a dedicated tool for interacting with the dbt Cloud API that abstracts away the complexities of the API calls behind an easy-to-use interface… Oh wait, there is: [the dbt-cloud-cli](https://github.com/data-mie/dbt-cloud-cli)!
 
 <!--truncate-->
 
@@ -78,7 +78,7 @@ Now we had exactly what we wanted and our CI workflow in GitHub actions looked s
     dbt-cloud job run --job-id $DBT_CLOUD_JOB_ID
 ```
 
-Fast forward a month or two and there was another client that needed something similar. I felt that this was an opportunity to open source the project not just to benefit me and my clients but also [the broader dbt community](https://www.getdbt.com/community/) (❤️). So, I moved the project to a public github repository with a goal of eventually covering all of the dbt Cloud API endpoints. 
+Fast forward a month or two and there was another client that needed something similar. I felt that this was an opportunity to open source the project not just to benefit me and my clients but also [the broader dbt community](https://www.getdbt.com/community/) (❤️). So, I moved the project to a public github repository with a goal of eventually covering all of the dbt Cloud API endpoints.
 
 While working with the initial 0.1.0 release that included only the `dbt-cloud job run` command I decided to have some fun and try how well pydantic (Python dataclasses on steroids!) and `click` worked together. I’m a big fan of `pydantic`, and I’ve used it in a wide variety of projects including machine learning models and automated testing software for a medical device. Even though Python has had built-in dataclasses since version 3.7, they fall short when it comes to data validation and general developer ergonomics (IMO) and that’s where `pydantic` comes in; among other things, `pydantic` implements a validator decorator that is used to define custom validations for model fields (e.g., CLI arguments).
 
@@ -87,15 +87,15 @@ I refactored the `dbt-cloud-cli` code so that the CLI commands were now implemen
 ```python
 import click
 from dbt_cloud.command import DbtCloudJobGetCommand
- 
+
 @click.group()
 def dbt_cloud():
     pass
- 
+
 @dbt_cloud.group()
 def job():
     pass
- 
+
 @job.command(help=DbtCloudJobGetCommand.get_description())
 @DbtCloudJobGetCommand.click_options
 def get(**kwargs):
@@ -121,7 +121,7 @@ Next, we use the `dbt-cloud get-artifact` command to download the `catalog.json`
 dbt-cloud run get-artifact --run-id $latest_run_id --path catalog.json -f catalog.json
 ```
 
-To explore the downloaded catalog file we’ll write a simple CLI application. The [catalog.json](https://schemas.getdbt.com/dbt/catalog/v1.json) has four top level properties: metadata, nodes, sources and errors. In this example we explore the nodes and sources only and leave the metadata and errors out. 
+To explore the downloaded catalog file we’ll write a simple CLI application. The [catalog.json](https://schemas.getdbt.com/dbt/catalog/v1.json) has four top level properties: metadata, nodes, sources and errors. In this example we explore the nodes and sources only and leave the metadata and errors out.
 
 First, we need a `Catalog` abstraction that reflects the catalog JSON schema:
 
@@ -197,7 +197,7 @@ class Catalog(BaseModel):
     errors: Optional[Dict]
 ```
 
-The four abstractions (`Stats`,`Column`, `Node `and `Catalog`) all inherit [the pydantic BaseModel](https://pydantic-docs.helpmanual.io/usage/models/) which implements various methods for parsing files and other python objects into model instances. We’ll leave the parsing to pydantic (i.e., `BaseModel.parse_file` classmethod) so that we can focus solely on the app logic. 
+The four abstractions (`Stats`,`Column`, `Node `and `Catalog`) all inherit [the pydantic BaseModel](https://pydantic-docs.helpmanual.io/usage/models/) which implements various methods for parsing files and other python objects into model instances. We’ll leave the parsing to pydantic (i.e., `BaseModel.parse_file` classmethod) so that we can focus solely on the app logic.
 
 The `CatalogExploreCommand` abstraction implements the CLI app which is then wrapped in a `click.command` that implements the CLI entry point. The `CatalogExploreCommand` class inherits `ClickBaseModel` that implements a `click_options` classmethod which we’ll use to decorate the entry point. This method is where the pydantic to click translation magic happens (i.e., pydantic model fields are translated [into click options](https://click.palletsprojects.com/en/8.0.x/options/)). Note that the app [uses inquirer](https://github.com/magmax/python-inquirer) in addition to `click` to create interactive “select option from a list” CLI prompts.
 
@@ -317,7 +317,7 @@ dbt-cloud demo data-catalog --file catalog.json
 
 ## Parting thoughts
 
-To summarize, the `dbt-cloud-cli`I implements an easy-to-use command line interface for the dbt Cloud API which abstracts away the complexities of the API calls. The CLI has interfaces to many of the API endpoints and covering all of the endpoints is on the project’s roadmap. For a list of all the covered API endpoints and implemented CLI commands, see https://github.com/data-mie/dbt-cloud-cli. 
+To summarize, the `dbt-cloud-cli`I implements an easy-to-use command line interface for the dbt Cloud API which abstracts away the complexities of the API calls. The CLI has interfaces to many of the API endpoints and covering all of the endpoints is on the project’s roadmap. For a list of all the covered API endpoints and implemented CLI commands, see https://github.com/data-mie/dbt-cloud-cli.
 
 In addition to commands that interact with a single dbt Cloud API endpoint there are composite helper commands that call one or more API endpoints and perform more complex operations (e.g., `dbt-cloud job export` and `dbt-cloud job import`).
 


### PR DESCRIPTION
## Description & motivation
<!---
Fixes broken links in /blogs pages.  Links were either updated with correct path or strikethrough text used to indicate that the link is no longer valid while leaving the general body of the blog post untouched. 
-->

## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged
-->

## Prerelease docs
If this change is related to functionality in a prerelease version of dbt (delete if not applicable):
- [ ] I've added versioning components, as described in ["Versioning Docs"](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/versioningdocs.md)
- [ ] I've added a note to the prerelease version's [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/guides/migration/versions)

## Checklist
If you added new pages (delete if not applicable):
- [ ] The page has been added to `website/sidebars.js`
- [ ] The new page has a unique filename

If you removed existing pages (delete if not applicable):
- [ ] The page has been removed from `website/sidebars.js`
- [ ] An entry has been added to `_redirects`
- [ ] [Run link testing](https://github.com/dbt-labs/docs.getdbt.com#running-the-cypress-tests-locally) to update the links that point to the deleted page
