### PR TITLE
added astrocloud init

### DIFF
--- a/website/docs/guides/orchestration/airflow-and-dbt-cloud/2-setting-up-airflow-and-dbt-cloud.md
+++ b/website/docs/guides/orchestration/airflow-and-dbt-cloud/2-setting-up-airflow-and-dbt-cloud.md
@@ -36,9 +36,10 @@ cd airflow-dbt-cloud
 
 ## 4. Start the Docker container
 
-1. Run the following command to spin up the Docker container and start your local Airflow deployment:
+1. Run the following commands to turn your directory into an Astronomer project and spin up the Docker container and start your local Airflow deployment:
 
     ```bash
+    astrocloud dev init
     astrocloud dev start
     ```
 

--- a/website/docs/guides/orchestration/airflow-and-dbt-cloud/2-setting-up-airflow-and-dbt-cloud.md
+++ b/website/docs/guides/orchestration/airflow-and-dbt-cloud/2-setting-up-airflow-and-dbt-cloud.md
@@ -38,7 +38,7 @@ cd airflow-dbt-cloud
 
 You can initialize an Astronomer project in an empty local directory using a Docker container, and then run your project locally using the `start` command.
 
-1. Run the following commands to turn your directory into an Astronomer project and spin up the Docker container and start your local Airflow deployment:
+1. Run the following commands to initialize your project and start your local Airflow deployment:
 
     ```bash
     astrocloud dev init

--- a/website/docs/guides/orchestration/airflow-and-dbt-cloud/2-setting-up-airflow-and-dbt-cloud.md
+++ b/website/docs/guides/orchestration/airflow-and-dbt-cloud/2-setting-up-airflow-and-dbt-cloud.md
@@ -36,6 +36,8 @@ cd airflow-dbt-cloud
 
 ## 4. Start the Docker container
 
+You can initialize an Astronomer project in an empty local directory using a Docker container, and then run your project locally using the `start` command.
+
 1. Run the following commands to turn your directory into an Astronomer project and spin up the Docker container and start your local Airflow deployment:
 
     ```bash


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a pull request on dbt core, etc?

To learn more about the writing conventions used in the dbt Labs docs, see the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md).
-->
I was following along the guide but I got an error message saying that my directory wasn't as Astronomer project when I tried to run `astrocloud dev start`. The terminal told me to first initialize the Astronomer project (which I did) and then I was able to successfully run the dev start command.