### PR TITLE
fill in '<filename>' placeholder

### DIFF
--- a/website/docs/docs/build/sources.md
+++ b/website/docs/docs/build/sources.md
@@ -19,7 +19,7 @@ Sources make it possible to name and describe the data loaded into your warehous
 
 Sources are defined in `.yml` files nested under a `sources:` key.
 
-<File name='models/<filename>.yml'>
+<File name='models/schema.yml'>
 
 ```yaml
 version: 2
@@ -86,7 +86,7 @@ You can also:
 
 These should be familiar concepts if you've already added tests and descriptions to your models (if not check out the guides on [testing](/docs/build/tests) and [documentation](documentation)).
 
-<File name='models/<filename>.yml'>
+<File name='models/schema.yml'>
 
 ```yaml
 version: 2
@@ -129,7 +129,7 @@ With a couple of extra configs, dbt can optionally snapshot the "freshness" of t
 ### Declaring source freshness
 To configure sources to snapshot freshness information, add a `freshness` block to your source and `loaded_at_field` to your table declaration:
 
-<File name='models/<filename>.yml'>
+<File name='models/schema.yml'>
 
 ```yaml
 version: 2


### PR DESCRIPTION
The code examples in this doc still had `<filename>.yml` as a placeholder filename. Updated that to `schema.yml`, which I _think_ is the intended location for these snippets 😄

**Edit:** I proposed this change after coming from the Getting Started guide and not knowing exactly which file to put these snippets in. [Reading further ](https://docs.getdbt.com/blog/how-we-structure-our-dbt-projects) I see it could in fact be any yml file, and so the placeholder was probably deliberate in order to convey that.

I'll leave the PR up but maybe it is better to explicitly address what files this code could go in, from the perspective of a complete newb 🌱 