### PR TITLE
Update custom-generic-tests.md

### DIFF
--- a/website/docs/guides/legacy/custom-generic-tests.md
+++ b/website/docs/guides/legacy/custom-generic-tests.md
@@ -184,7 +184,7 @@ models:
 
 To change the way a built-in generic test works—whether to add additional parameters, re-write the SQL, or for any other reason—you simply add a test block named `<test_name>` to your own project. dbt will favor your version over the global implementation!
 
-<File name='tests/generic/<filename>.yml'>
+<File name='tests/generic/<filename>.sql'>
 
 ```sql
 {% test unique(model, column_name) %}


### PR DESCRIPTION
Change the example filename extension for customizing dbt's built-in tests from YAML to SQL.

## Description & motivation
This looks like it should be .sql instead of .yml:

<img width="357" alt="image" src="https://user-images.githubusercontent.com/44704949/201692142-9a0ff718-73d5-4df2-82d7-d11f889d57d4.png">

