### PR TITLE
Wistia videos overlapping H1 in docs

### DIFF
--- a/website/docs/guides/orchestration/airflow-and-dbt-cloud/2-setting-up-airflow-and-dbt-cloud.md
+++ b/website/docs/guides/orchestration/airflow-and-dbt-cloud/2-setting-up-airflow-and-dbt-cloud.md
@@ -13,7 +13,7 @@ In this example, we’re using Homebrew to install Astro CLI. Follow the instruc
 brew install astronomer/cloud/astrocloud
 ```
 
-<WistiaVideo id="uosszw1qul" />
+<WistiaVideo id="uosszw1qul" paddingTweak="62.25%" />
 
 ## 2. Install and start Docker Desktop
 
@@ -21,7 +21,7 @@ Docker allows us to spin up an environment with all the apps and dependencies we
 
 Follow the instructions [here](https://docs.docker.com/desktop/) to install Docker desktop for your own operating system. Once Docker is installed, ensure you have it up and running for the next steps.
 
-<WistiaVideo id="qr84pa8k9f" />
+<WistiaVideo id="qr84pa8k9f" paddingTweak="62.25%" />
 
 ## 3. Clone the airflow-dbt-cloud repository
 
@@ -32,7 +32,7 @@ git clone https://github.com/sungchun12/airflow-dbt-cloud.git
 cd airflow-dbt-cloud
 ```
 
-<WistiaVideo id="oo1yel115i" />
+<WistiaVideo id="oo1yel115i" paddingTweak="62.25%" />
 
 ## 4. Start the Docker container
 
@@ -64,13 +64,13 @@ cd airflow-dbt-cloud
 
     ![Airflow login screen](/img/guides/orchestration/airflow-and-dbt-cloud/airflow-login.png)
 
-<WistiaVideo id="2rzsjo0uml" />
+<WistiaVideo id="2rzsjo0uml" paddingTweak="62.25%" />
 
 ## 5. Create a dbt Cloud service token
 
 Create a service token from within dbt Cloud using the instructions [found here](https://docs.getdbt.com/docs/dbt-cloud-apis/service-tokens). Ensure that you save a copy of the token, as you won’t be able to access this later. In this example we use `Account Admin`, but you can also use `Job Admin` instead for token permissions.
 
-<WistiaVideo id="amubh6qmwq" />
+<WistiaVideo id="amubh6qmwq" paddingTweak="62.25%" />
 
 ## 6. Create a dbt Cloud job
 
@@ -84,4 +84,4 @@ In your dbt Cloud account create a job, paying special attention to the informat
 https://cloud.getdbt.com/#/accounts/{account_id}/projects/{project_id}/jobs/{job_id}/
 ```
 
-<WistiaVideo id="qiife5rzlp" />
+<WistiaVideo id="qiife5rzlp" paddingTweak="62.25%" />

--- a/website/src/components/wistia/index.js
+++ b/website/src/components/wistia/index.js
@@ -1,26 +1,30 @@
 import React from 'react';
 
-
-
 function WistiaVideo({id, paddingTweak = "56.25%"}) {
   return (
-
-  	 <React.Fragment>
-		 <div className="wistia_responsive_padding" style={{padding:`${paddingTweak} 0 0 0`,position:"relative",marginBottom:"30px"}}>
-			<div className="wistia_responsive_wrapper" style={{height:"100%",left:0,position:"absolute",top:0,width:"100%"}}>
-				<iframe 
-					src={`https://fast.wistia.net/embed/iframe/${id}?seo=false&videoFoam=true`} 
-					allow="autoplay; fullscreen" 
-					allowtransparency="true" 
-					frameBorder="0" 
-					scrolling="no" 
-					className="wistia_embed" 
-					name="wistia_embed" allowFullScreen msallowfullscreen="true" width="100%" height="100%">
-				</iframe>
-			</div>
-		</div>
-		<script src="https://fast.wistia.net/assets/external/E-v1.js" async></script>
-  	 </React.Fragment>
+    <React.Fragment>
+      <div className="wistia_responsive_padding" style={{padding:`${paddingTweak} 0 0 0`,position:"relative",marginBottom:"30px"}}>
+        <div className="wistia_responsive_wrapper" style={{height:"100%",left:0,position:"absolute",top:0,width:"100%"}}>
+          <iframe 
+            src={`https://fast.wistia.net/embed/iframe/${id}?seo=false&videoFoam=true`} 
+            allow="autoplay; fullscreen" 
+            allowtransparency="true" 
+            frameBorder="0" 
+            scrolling="no" 
+            className="wistia_embed" 
+            name="wistia_embed" 
+            allowfullscreen 
+            mozallowfullscreen 
+            webkitallowfullscreen 
+            oallowfullscreen 
+            msallowfullscreen 
+            width="100%" 
+            height="100%">
+          </iframe>
+        </div>
+      </div>
+		  <script src="https://fast.wistia.net/assets/external/E-v1.js" async></script>
+    </React.Fragment>
 	);
 }
 


### PR DESCRIPTION
## Description & motivation

Wistia videos are overlapping the docs h1 in the airflow set up guide. It looks like these specific videos have an aspect ratio which isn't 16:9, causing the default padding to not push the rest of the content down far enough on this page.

It looks like there is an existing optional `paddingTweak` prop setup on the `WistiaVideo` component, likely to fix videos that experience this specific issue. I added the `paddingTweak` prop for videos on this page which have the issue. 

## Preview
https://deploy-preview-2389--docs-getdbt-com.netlify.app/guides/orchestration/airflow-and-dbt-cloud/2-setting-up-airflow-and-dbt-cloud

Example page where issue is not occurring.
https://deploy-preview-2389--docs-getdbt-com.netlify.app/docs/get-started/learning-more/refactoring-legacy-sql