### PR TITLE
Update permissions for Python models on GCP

### DIFF
--- a/website/docs/docs/build/python-models.md
+++ b/website/docs/docs/build/python-models.md
@@ -674,10 +674,12 @@ models:
 
 Any user or service account that runs dbt Python models will need the following permissions(in addition to the required BigQuery permissions) ([docs](https://cloud.google.com/dataproc/docs/concepts/iam/iam)):
 ```
+dataproc.batches.create
 dataproc.clusters.use
 dataproc.jobs.create
 dataproc.jobs.get
 dataproc.operations.get
+dataproc.operations.list
 storage.buckets.get
 storage.objects.create
 storage.objects.delete


### PR DESCRIPTION
resolves #2308 (I think)

## Description & motivation

Missing two permissions needed for Dataproc Serverless. See [this dbt Community Slack thread](https://getdbt.slack.com/archives/C03QUA7DWCW/p1666735982763349?thread_ts=1666735910.433449&cid=C03QUA7DWCW)