### PR TITLE
Shorten Descriptions on Devhub Homepage Blog Posts

### DIFF
--- a/website/functions/post-preview.js
+++ b/website/functions/post-preview.js
@@ -1,0 +1,7 @@
+export default function createPostPreview(description, charCount) {
+  if (description.length <= charCount) { return description }; 
+  const clippedDesc = description.slice(0, charCount-1);
+  // return the version of the description clipped to the last instance of a space
+  // this is so there are no cut-off words.
+  return clippedDesc.slice(0, clippedDesc.lastIndexOf(" ")) + '...';
+}

--- a/website/src/components/blogPostCard/index.js
+++ b/website/src/components/blogPostCard/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import styles from './styles.module.css';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import Link from '@docusaurus/Link';
+import createPostPreview from '@site/functions/post-preview';
 
 
 function BlogPostCard({ postMetaData }) {
@@ -10,13 +11,13 @@ function BlogPostCard({ postMetaData }) {
     <div className={styles.cardWrapper}>
       <article className={`${image ? styles.imageCard : styles.card}`}>
         {image && <div className={styles.imageContainer} style={{ "background": `no-repeat center/100% url(${image})` }}></div>}
-        <div className={`${image ? styles.contentContainer : null}`}>
+        <div className={`${styles.contentContainer} ${image && styles.imageContentContainer}`}>
           <Link to={useBaseUrl(link)}><h3>{title}</h3></Link>
           {readingTime && <span>{date} · {readingTime} minute read</span>}
           <p>
-            {description}
+            {createPostPreview(description, 140)}
           </p>
-          <Link to={useBaseUrl(link)}><a className={styles.ctaLink}>Read more</a></Link>
+          <Link className={styles.ctaLink} to={useBaseUrl(link)}>Read more</Link>
         </div>
       </article>
     </div>

--- a/website/src/components/blogPostCard/index.js
+++ b/website/src/components/blogPostCard/index.js
@@ -10,8 +10,8 @@ function BlogPostCard({ postMetaData }) {
   return (
     <div className={styles.cardWrapper}>
       <article className={`${image ? styles.imageCard : styles.card}`}>
-        {image && <div className={styles.imageContainer} style={{ "background": `no-repeat center/100% url(${image})` }}></div>}
-        <div className={`${styles.contentContainer} ${image && styles.imageContentContainer}`}>
+        {image && <div className={styles.imageContentContainer} style={{ "background": `no-repeat center/100% url(${image})` }}></div>}
+        <div className={`${styles.contentContainer} ${image ? styles.imageContentContainer : null}`}>
           <Link to={useBaseUrl(link)}><h3>{title}</h3></Link>
           {readingTime && <span>{date} · {readingTime} minute read</span>}
           <p>

--- a/website/src/components/blogPostCard/styles.module.css
+++ b/website/src/components/blogPostCard/styles.module.css
@@ -18,8 +18,9 @@
   padding: 0;
 }
 
-.imageContentContainer {
+.contentContainer.imageContentContainer {
   padding: 2.5rem 2.5rem 1.5rem 2.5rem;
+  display: block;
 }
 
 .contentContainer {

--- a/website/src/components/blogPostCard/styles.module.css
+++ b/website/src/components/blogPostCard/styles.module.css
@@ -18,15 +18,23 @@
   padding: 0;
 }
 
-.contentContainer {
+.imageContentContainer {
   padding: 2.5rem 2.5rem 1.5rem 2.5rem;
 }
 
-.imageContainer {
+.contentContainer {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  flex-flow: wrap;
+}
+
+.imageContentContainer {
   width: 100%;
   border-radius: var(--border-radius) var(--border-radius) 0px 0px;
   min-height: 200px;
 }
+
 
 .cardWrapper, .cardWrapper article {
   height: 100%;
@@ -47,9 +55,11 @@
 a.ctaLink {
   color: #009999;
   font-weight: 600;
+  margin-top: auto;
 }
 a.ctaLink:after {
   content: ' →';
+  margin-left: 5px;
 }
 
 .icon {


### PR DESCRIPTION
## Description & motivation
This PR:
- Shortens the blog post descriptions on the home page to make sure the cards are all a fixed height
- Aligns the 'read more' link to the bottom of the card, so they're all aligned
- Adds in a new util function `createPostPreview`