### PR TITLE
Update packages.md: bump dbt-utils version

### DIFF
--- a/website/docs/docs/build/packages.md
+++ b/website/docs/docs/build/packages.md
@@ -35,7 +35,7 @@ packages:
     version: 0.7.0
 
   - git: "https://github.com/dbt-labs/dbt-utils.git"
-    revision: 0.1.21
+    revision: 0.9.2
 
   - local: /opt/dbt/redshift
 ```
@@ -119,7 +119,7 @@ Packages stored on a Git server can be installed using the `git` syntax, like so
 ```yaml
 packages:
   - git: "https://github.com/dbt-labs/dbt-utils.git" # git URL
-    revision: 0.1.21 # tag or branch name
+    revision: 0.9.2 # tag or branch name
 ```
 
 </File>


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a pull request on dbt core, etc?

To learn more about the writing conventions used in the dbt Labs docs, see the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md).
-->

Currently the example dbt-utils package is set to `revision: 0.1.21` in the packages documentation. If a user interested in testing out packages were to copy and paste the example directly (as I did!), they are met with an opaque error from the latest major version of dbt:

```
❯ dbt deps
16:26:38  Running with dbt=1.3.0
16:26:40  Encountered an error:
Runtime Error
  Invalid config version: 1, expected 2
```

This error is resolved with an more up-to-date version of dbt-utils in the example. 

## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged
-->

## Prerelease docs
If this change is related to functionality in a prerelease version of dbt - N/A

## Checklist
If you added new pages - N/A

If you removed existing pages - N/A
