### PR TITLE
Add useful link to config docs

### DIFF
--- a/website/docs/reference/dbt-jinja-functions/config.md
+++ b/website/docs/reference/dbt-jinja-functions/config.md
@@ -24,7 +24,7 @@ is responsible for handling model code that looks like this:
 }}
 ```
 
-For more information about valid arguments to use, see:
+Review [Model configurations](/reference/model-configs) for examples and more information on valid arguments.
 https://docs.getdbt.com/reference/model-configs
 
 

--- a/website/docs/reference/dbt-jinja-functions/config.md
+++ b/website/docs/reference/dbt-jinja-functions/config.md
@@ -24,6 +24,10 @@ is responsible for handling model code that looks like this:
 }}
 ```
 
+For more information about valid arguments to use, see:
+https://docs.getdbt.com/reference/model-configs
+
+
 ## config.get
 __Args__:
 


### PR DESCRIPTION
## Description & motivation
The documentation for the config function isn't that useful when it comes to describing the valid arguments. I have to hunt for the model configuration page each time to find the valid arguments. This issue is compounded by the fact that there will be no error if an *invalid* argument is supplied.

## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged
-->

## Prerelease docs
If this change is related to functionality in a prerelease version of dbt (delete if not applicable):
- [ ] I've added versioning components, as described in ["Versioning Docs"](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/versioningdocs.md)
- [ ] I've added a note to the prerelease version's [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/guides/migration/versions)

## Checklist
If you added new pages (delete if not applicable):
- [ ] The page has been added to `website/sidebars.js`
- [ ] The new page has a unique filename

If you removed existing pages (delete if not applicable):
- [ ] The page has been removed from `website/sidebars.js`
- [ ] An entry has been added to `_redirects`
- [ ] [Run link testing](https://github.com/dbt-labs/docs.getdbt.com#running-the-cypress-tests-locally) to update the links that point to the deleted page
