### PR TITLE
update h2 header within version block

### DIFF
--- a/website/docs/reference/project-configs/target-path.md
+++ b/website/docs/reference/project-configs/target-path.md
@@ -14,12 +14,14 @@ target-path: [directorypath]
 Optionally specify a custom directory where compiled files (e.g. compiled models and tests) will be written when you run the `dbt run`, `dbt compile`, or `dbt test` command.
 
 
+
 ## Default
 By default, dbt will write compiled files to the `target` directory, i.e. `target-path: target`
 
-<VersionBlock firstVersion="1.2">
-## Configuration
+<VersionBlock firstVersion="1.2"> 
 
+<h2>Configuration</h2>
+  
 In the manner of a ["global" config](global-configs), the target path can be set in three places:
 1. `--target-path` CLI flag
 2. `DBT_TARGET_PATH` environment variable


### PR DESCRIPTION
fixed configuration header as it was appearing as ## Configuration on docs site. i think it's mean to be an H2 and the ## wasn't captured because it was within the version block
![Screenshot 2022-11-24 at 14 37 15](https://user-images.githubusercontent.com/89008547/203809975-28e9d7be-43aa-4611-a213-39e8886ee27d.png)

## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a pull request on dbt core, etc?

To learn more about the writing conventions used in the dbt Labs docs, see the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md).
-->

## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged
-->

## Prerelease docs
If this change is related to functionality in a prerelease version of dbt (delete if not applicable):
- [ ] I've added versioning components, as described in ["Versioning Docs"](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/versioningdocs.md)
- [ ] I've added a note to the prerelease version's [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/guides/migration/versions)

## Checklist
If you added new pages (delete if not applicable):
- [ ] The page has been added to `website/sidebars.js`
- [ ] The new page has a unique filename

If you removed existing pages (delete if not applicable):
- [ ] The page has been removed from `website/sidebars.js`
- [ ] An entry has been added to `_redirects`
- [ ] [Run link testing](https://github.com/dbt-labs/docs.getdbt.com#running-the-cypress-tests-locally) to update the links that point to the deleted page
