### PR TITLE
Update v1.0 EOL date

### DIFF
--- a/website/dbt-versions.js
+++ b/website/dbt-versions.js
@@ -13,7 +13,7 @@ exports.versions = [
   },
   {
     version: "1.0",
-    EOLDate: "2023-12-03"
+    EOLDate: "2022-12-03"
   },
   {
     version: "0.21",


### PR DESCRIPTION
## Description & motivation

v1.0 is actually reaching End of Life on Dec 3 — in just over a week! That means it was almost one full year ago that we released v1.0 :')

(It looks like this was just a simple off-by-one error from a few months ago: https://github.com/dbt-labs/docs.getdbt.com/commit/74ba0ef7d5a3e148cbfed8a8ce61e2801c95ad14)

By updating this field, in `dbt-versions.js`, we will start showing top-of-page banners about v1.0's EOL coming soon / having passed, and encouraging users to upgrade.

What does this mean, in practice? Here's the answer I recently gave a community member [in Slack](https://getdbt.slack.com/archives/C37J8BQEL/p1669030531253179?thread_ts=1666014898.024699&cid=C37J8BQEL):

> After Dec 3, we won't be releasing any new patches of v1.0.x, we won't be providing the same level of ongoing support in Cloud, and we'll strongly encourage you to upgrade to a newer version. I'm hoping it's a relatively painless upgrade — there should be minimal friction, and zero breaking changes.