### PR TITLE
update link to 'how we structure our dbt projects'

### DIFF
--- a/website/docs/faqs/Project/resource-yml-name.md
+++ b/website/docs/faqs/Project/resource-yml-name.md
@@ -10,4 +10,4 @@ It's up to you! Here's a few options:
 - Use the same name as your directory (assuming you're using sensible names for your directories)
 - If you test and document one model (or seed, snapshot, macro etc.) per file, you can give it the same name as the model (or seed, snapshot, macro etc.)
 
-Choose what works for your team. We have more recommendations in our guide on [structuring dbt project](https://docs.getdbt.com/guides/best-practices/how-we-structure/1-guide-overview).
+Choose what works for your team. We have more recommendations in our guide on [structuring dbt projects](https://docs.getdbt.com/guides/best-practices/how-we-structure/1-guide-overview).

--- a/website/docs/faqs/Project/resource-yml-name.md
+++ b/website/docs/faqs/Project/resource-yml-name.md
@@ -10,4 +10,4 @@ It's up to you! Here's a few options:
 - Use the same name as your directory (assuming you're using sensible names for your directories)
 - If you test and document one model (or seed, snapshot, macro etc.) per file, you can give it the same name as the model (or seed, snapshot, macro etc.)
 
-Choose what works for your team. We have more recommendations in our guide on [structuring dbt project](https://discourse.getdbt.com/t/how-we-structure-our-dbt-projects/355).
+Choose what works for your team. We have more recommendations in our guide on [structuring dbt project](https://docs.getdbt.com/guides/best-practices/how-we-structure/1-guide-overview).


### PR DESCRIPTION
Just a simple update of the url to the new project structure page.
