### PR TITLE
Updating typo for table name in Redshift

### DIFF
--- a/website/snippets/tutorial-initiate-project.md
+++ b/website/snippets/tutorial-initiate-project.md
@@ -27,7 +27,7 @@ select * from default.jaffle_shop_customers
 <div warehouse="Redshift">
 
 ```sql
-select * from jaffle_shop_customers
+select * from jaffle_shop.customers
 ```
 
 </div>


### PR DESCRIPTION
## Description & motivation
Per internal discussion, there's a typo in the Redshift table name found above "[Next steps](https://docs.getdbt.com/docs/get-started/getting-started/getting-set-up/setting-up-redshift#next-steps)" 

## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged
-->

## Prerelease docs
If this change is related to functionality in a prerelease version of dbt (delete if not applicable):
- [ ] I've added versioning components, as described in ["Versioning Docs"](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/versioningdocs.md)
- [ ] I've added a note to the prerelease version's [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/guides/migration/versions)

## Checklist
