### PR TITLE
remove unneeded space

### DIFF
--- a/website/docs/reference/advanced-config-usage.md
+++ b/website/docs/reference/advanced-config-usage.md
@@ -17,7 +17,7 @@ select ...
 
 While dbt provides an alias for any core configurations (e.g. you should use `pre_hook` instead of `pre-hook` in a config block), your dbt project may contain custom configurations without aliases.
 
-If you want to specify these configurations in side of a model, use the altenative config block syntax:
+If you want to specify these configurations inside of a model, use the altenative config block syntax:
 
 
 <File name='models/events/base/base_events.sql'>


### PR DESCRIPTION
## Description & motivation
Discovered an extra space between "in" and "side" when reading through documentation. This PR removes the space!