### PR TITLE
CLI typo

### DIFF
--- a/website/docs/docs/get-started/about-the-cli.md
+++ b/website/docs/docs/get-started/about-the-cli.md
@@ -3,7 +3,7 @@ title: "About the CLI"
 id: "about-the-cli"
 ---
 
-dbt ships with a Command Line Interface (CLI) for running your dbt project. This way of running dbt a dbt project is free and open source.
+dbt ships with a command line interface (CLI) for running your dbt project. This way of running dbt a dbt project is free and open source.
 
 To use the CLI, your workflow generally looks like:
 * **Build your dbt project in a code editor:** popular choices include VSCode and Atom.


### PR DESCRIPTION
## Description & motivation

Fixed "Command Line Interface" to "command line interface" 

from convo in https://github.com/dbt-labs/docs.getdbt.com/pull/2454#discussion_r1037952990 

