### PR TITLE
distinguish URLs for app and user token approaches in Github private …

### DIFF
--- a/website/docs/docs/build/packages.md
+++ b/website/docs/docs/build/packages.md
@@ -177,7 +177,11 @@ In GitHub:
 
 ```yaml
 packages:
+  # use this format when accessing your repository via a github application token
   - git: "https://{{env_var('DBT_ENV_SECRET_GIT_CREDENTIAL')}}@github.com/dbt-labs/awesome_repo.git" # git HTTPS URL
+
+  # use this format when accessing your repository via a personal access token
+  - git: "https://{{env_var('DBT_ENV_SECRET_GITHUB_USERNAME')}}:{{env_var('DBT_ENV_SECRET_GIT_CREDENTIAL')}}@github.com/dbt-labs/awesome_repo.git" # git HTTPS URL
 ```
 
 </File>


### PR DESCRIPTION
…packages

## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a pull request on dbt core, etc?

To learn more about the writing conventions used in the dbt Labs docs, see the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md).
-->

The current documentation is incorrect when using a personal access token to clone private packages. With this approach, *both* the username and token need to be included in the URL. This adds examples for both the app token and personal token methods with comments to clarify.
