### PR TITLE
Update core versions table: v1.0 EOL, into 2023

### DIFF
--- a/website/snippets/core-versions-table.md
+++ b/website/snippets/core-versions-table.md
@@ -1,10 +1,13 @@
 | dbt Core                        | Initial Release | Active Support Until | Critical Support Until  | dbt Cloud Until | Final Patch |
 |---------------------------------|-----------------|----------------------|-------------------------|-----------------|-------------|
 | **v0.X**                        | (various dates) | v1.0.0 release       | Dec 3, 2021             | See below ⚠️     | v0.21.1     |
-| [**v1.0**](upgrading-to-v1.0)   | Dec 3, 2021     | v1.1.0 release       | Dec 3, 2022             | Dec 2022        |             |
+| [**v1.0**](upgrading-to-v1.0)   | Dec 3, 2021     | v1.1.0 release       | Dec 3, 2022             | Dec 2022        | v1.0.8      |
 | [**v1.1**](upgrading-to-v1.1)   | Apr 28, 2022    | v1.2.0 release       | Apr 28, 2023            | Apr 2023        |             |
 | [**v1.2**](upgrading-to-v1.2)   | Jul 26, 2022    | v1.3.0 release       | Jul 26, 2023            | Jul 2023        |             |
 | [**v1.3**](upgrading-to-v1.3)   | Oct 12, 2022    | v1.4.0 release       | Oct 12, 2023            | Oct 2023        |             |
 | _**v1.4**_                      | _Jan 2023_      | _v1.5.0 release_     | _Jan 2024_              | _Jan 2024_      |             |
+| _**v1.5**_                      | _Apr 2023_      | _v1.6.0 release_     | _Apr 2024_              | _Apr 2024_      |             |
+| _**v1.6**_                      | _Jul 2023_      | _v1.7.0 release_     | _Jul 2024_              | _Jul 2024_      |             |
+| _**v1.7**_                      | _Oct 2023_      | _v1.8.0 release_     | _Oct 2024_              | _Oct 2024_      |             |
 
 _Italics: Future releases, NOT definite commitments. Shown for indication only._


### PR DESCRIPTION
Apparently we're going to keep building `dbt-core`, and releasing some more versions next year!

Also, v1.0 reached End Of Life on Dec 3 (https://github.com/dbt-labs/docs.getdbt.com/pull/2449). It's no longer under "official support," meaning that v1.0.8 was its final patch release; there won't be any others.

**Questions:**
- Should we split up into multiple tables: currently supported versions, future versions, no-longer-supported versions?
- **Support in dbt Cloud:** We're still doing "soft" drawdowns of old versions; we aren't yet in a place of forcefully upgrading accounts, or removing old versions. How should we reflect that on the docs site? [Here's the answer](https://getdbt.slack.com/archives/C37J8BQEL/p1669030531253179?thread_ts=1666014898.024699&cid=C37J8BQEL) I gave a community member:
> After Dec 3, we won't be releasing any new patches of v1.0.x, we won't be providing the same level of ongoing support in Cloud, and we'll strongly encourage you to upgrade to a newer version. I'm hoping it's a relatively painless upgrade — there should be minimal friction, and zero breaking changes.