### PR TITLE
fix doris-setup id

### DIFF
--- a/website/docs/reference/warehouse-setups/doris-setup.md
+++ b/website/docs/reference/warehouse-setups/doris-setup.md
@@ -1,6 +1,6 @@
 ---
 title: "Doris setup"
-id: "Doris-setup"
+id: "doris-setup"
 meta:
   maintained_by: SelectDB
   authors: long2ice,catpineapple


### PR DESCRIPTION
## Description & motivation
Fixing `current` which is now broken due to an incorrect syntax