### PR TITLE
fix typo in tojson.md

### DIFF
--- a/website/docs/reference/dbt-jinja-functions/tojson.md
+++ b/website/docs/reference/dbt-jinja-functions/tojson.md
@@ -6,7 +6,7 @@ id: "tojson"
 The `tojson` context method can be used to serialize a Python object primitive, eg. a `dict` or `list` to a JSON string.
 
 __Args__:
- * `value`: The value serialize to json (required)
+ * `value`: The value to serialize to json (required)
  * `default`: A default value to return if the `value` argument cannot be serialized (optional)
 
 ### Usage:


### PR DESCRIPTION
## Description & motivation
This PR adds "to" in order to fix a typo in the `tojson.md` file.
