### PR TITLE
fix typo in toyaml.md

### DIFF
--- a/website/docs/reference/dbt-jinja-functions/toyaml.md
+++ b/website/docs/reference/dbt-jinja-functions/toyaml.md
@@ -6,7 +6,7 @@ id: "toyaml"
 The `toyaml` context method can be used to serialize a Python object primitive, eg. a `dict` or `list` to a yaml string.
 
 __Args__:
- * `value`: The value serialize to yaml (required)
+ * `value`: The value to serialize to yaml (required)
  * `default`: A default value to return if the `value` argument cannot be serialized (optional)
 
 ### Usage:


### PR DESCRIPTION
## Description & motivation
This PR adds "to" in order to fix a typo in the `toyaml.md` file.
