### PR TITLE
fix typo in zip.md

### DIFF
--- a/website/docs/reference/dbt-jinja-functions/zip.md
+++ b/website/docs/reference/dbt-jinja-functions/zip.md
@@ -5,7 +5,7 @@ id: "zip"
 
 ### zip
 
-The `zip` context method can be used to used to return an iterator of tuples, where the i-th tuple contains the i-th element from each of the argument iterables. ([Python docs](https://docs.python.org/3/library/functions.html#zip))
+The `zip` context method can be used to return an iterator of tuples, where the i-th tuple contains the i-th element from each of the argument iterables. ([Python docs](https://docs.python.org/3/library/functions.html#zip))
         :param 
         :param 
         


### PR DESCRIPTION
## Description & motivation
This PR removes duplicate text ("used to") in `zip.md`.
