### PR TITLE
Fix typo in tags.md

### DIFF
--- a/website/docs/reference/resource-configs/tags.md
+++ b/website/docs/reference/resource-configs/tags.md
@@ -84,7 +84,7 @@ These tags can be used as part of the [resource selection syntax](node-selection
 - `dbt run --select tag:my_tag`
 - `dbt seed --select tag:my_tag`
 - `dbt snapshot --select tag:my_tag`
-- `dbt test --select tag:my_tag` (indirectly runs all tests accociated with the models that are tagged)
+- `dbt test --select tag:my_tag` (indirectly runs all tests associated with the models that are tagged)
 
 ## Examples
 ### Use tags to run parts of your project


### PR DESCRIPTION
## Description & motivation
Noticed a typo when I was reading through the documentation
Replaced `accociated` with `associated`

