### PR TITLE
Fix typo in hooks-operations.md doc

### DIFF
--- a/website/docs/docs/build/hooks-operations.md
+++ b/website/docs/docs/build/hooks-operations.md
@@ -196,10 +196,10 @@ You can also use a [macro](jinja-macros#macros) to bundle up hook logic. Check o
 
 ## About operations
 
-Operations are [macros](jinja-macros#macros) that you can run using the [`run-operation` command](run-operation) command. As such, operations aren't actually a separate resource in your dbt project — they are just a convenient way to invoke a macro without needing to run a model.
+Operations are [macros](jinja-macros#macros) that you can run using the [`run-operation`](run-operation) command. As such, operations aren't actually a separate resource in your dbt project — they are just a convenient way to invoke a macro without needing to run a model.
 
 :::info Explicitly execute the SQL in an operation
-Unlike hooks, you need to explicitly execute a query within a macro, by using either a [statement block](statement-blocks) or a helper macro like the [run_query macro](run_query) macro. Otherwise, dbt will return the query as a string without executing it.
+Unlike hooks, you need to explicitly execute a query within a macro, by using either a [statement block](statement-blocks) or a helper macro like the [run_query](run_query) macro. Otherwise, dbt will return the query as a string without executing it.
 :::
 
 This macro performs a similar action as the above hooks:


### PR DESCRIPTION
## Description & motivation
Noticed a repetition in the `command` and `macro` links
Removed the redundant words