### PR TITLE
fix internal link

### DIFF
--- a/website/docs/reference/dbt-classes.md
+++ b/website/docs/reference/dbt-classes.md
@@ -8,7 +8,7 @@ These classes are often useful when building advanced dbt models and macros.
 
 ## Relation
 
-The `Relation` object is used to interpolate schema and <Term id="table" /> names into SQL code with appropriate quoting. This object should _always_ be used instead of interpolating values with `{{ schema }}.{{ table }}` directly. Quoting of the Relation object can be configured using the [`quoting` config][quoting].
+The `Relation` object is used to interpolate schema and <Term id="table" /> names into SQL code with appropriate quoting. This object should _always_ be used instead of interpolating values with `{{ schema }}.{{ table }}` directly. Quoting of the Relation object can be configured using the [`quoting` config](/reference/project-configs/quoting).
 
 ### Creating Relations
 


### PR DESCRIPTION
## Description & motivation
This PR updates a broken link by converting square brackets to parentheses in `dbt-classes.md`. It was previously displaying as "[quoting config][quoting]" on the website.

This PR also adds the full path (in keeping with PR #2526). I tested it by pasting `/reference/project-configs/quoting` after `https://docs.getdbt.com` in my browser, and it took me to the quoting config page as expected. I'd be glad for feedback if there are other ways to test and/or best practices regarding this!

