### PR TITLE
Specific data warehouses - header link fix

### DIFF
--- a/website/docs/docs/build/python-models.md
+++ b/website/docs/docs/build/python-models.md
@@ -245,7 +245,7 @@ Currently, Python functions defined in one dbt model can't be imported and reuse
 
 ### Using PyPI packages
 
-You can also define functions that depend on third-party packages so long as those packages are installed and available to the Python runtime on your data platform. See notes on "Installing Packages" for [specific data warehouses](#specific-data-warehouses).
+You can also define functions that depend on third-party packages so long as those packages are installed and available to the Python runtime on your data platform. See notes on "Installing Packages" for [supported data platforms](#supported-data-platforms).
 
 In this example, we use the `holidays` package to determine if a given date is a holiday in France. The code below uses the pandas API for simplicity and consistency across platforms. The exact syntax, and the need to refactor for multi-node processing, still vary.
 


### PR DESCRIPTION
In the Using PyPI packages section, there is a link to 'specific data warehouses', but there is no header with that name. I believe the intention was to link to the 'Supported data platforms' section, so I changed the link.

## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a pull request on dbt core, etc?

To learn more about the writing conventions used in the dbt Labs docs, see the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md).
-->

## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged
-->

## Prerelease docs
If this change is related to functionality in a prerelease version of dbt (delete if not applicable):
- [ ] I've added versioning components, as described in ["Versioning Docs"](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/versioningdocs.md)
- [ ] I've added a note to the prerelease version's [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/guides/migration/versions)

## Checklist
If you added new pages (delete if not applicable):
- [ ] The page has been added to `website/sidebars.js`
- [ ] The new page has a unique filename

If you removed existing pages (delete if not applicable):
- [ ] The page has been removed from `website/sidebars.js`
- [ ] An entry has been added to `_redirects`
- [ ] [Run link testing](https://github.com/dbt-labs/docs.getdbt.com#running-the-cypress-tests-locally) to update the links that point to the deleted page
