### PR TITLE
combine-state-result-selector-description

### DIFF
--- a/website/docs/docs/deploy/about-state.md
+++ b/website/docs/docs/deploy/about-state.md
@@ -64,7 +64,7 @@ The available options depend on the node type:
 
 ### Combining `state` and `result` selectors
 
-The state and result selectors can also be combined in a single invocation of dbt to capture errors from a previous run AND any new or modified models.
+The state and result selectors can also be combined in a single invocation of dbt to capture errors from a previous run OR any new or modified models.
 
 ```bash
 $ dbt run --select result:<status>+ state:modified+ --defer --state ./<dbt-artifact-path>


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a pull request on dbt core, etc?

To learn more about the writing conventions used in the dbt Labs docs, see the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md).
-->

@bethanyhipple-dbtlabs and I discovered that the description of the command should be `OR` not `AND` because the set operator used is a ` ` and not a `,`