### PR TITLE
Fix method for list resources in rpc section

### DIFF
--- a/website/docs/reference/commands/rpc.md
+++ b/website/docs/reference/commands/rpc.md
@@ -370,7 +370,7 @@ Several of the following request types accept these additional parameters:
  ```json
  {
  	"jsonrpc": "2.0",
- 	"method": "build",
+ 	"method": "ls",
  	"id": "<request id>",
  	"params": {
          "select": "<str> (optional)",


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a pull request on dbt core, etc?
Fixing the method for listing project resources from `build` to `ls`

To learn more about the writing conventions used in the dbt Labs docs, see the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md).
-->

## To-do before merge
<!---
(Optional -- remove this section if not needed)
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Change the base branch
- [ ] Ensure PR #56 is merged
-->

## Prerelease docs
If this change is related to functionality in a prerelease version of dbt (delete if not applicable):
- [ ] I've added versioning components, as described in ["Versioning Docs"](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/versioningdocs.md)
- [ ] I've added a note to the prerelease version's [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/guides/migration/versions)

