### PR TITLE
Prevent Chrome lookalike errors for docs and www

### DIFF
--- a/.well-known/assetlinks.json
+++ b/.well-known/assetlinks.json
@@ -1,0 +1,11 @@
+[
+    {
+      "relation": ["lookalikes/allowlist"],
+      "target": { "namespace": "web", "site": "https://getdbt.com" }
+    },
+    {
+      "relation": ["lookalikes/allowlist"],
+      "target": { "namespace": "web", "site": "https://docs.getdbt.com" }
+    }
+  ]
+  


### PR DESCRIPTION
# Code Task Complete ⚡️

✨ View the Asana Task [here](https://app.asana.com/0/1200099998847559/1203325932107038/f) ✨


## Description of Changes
- Adds `assetlinks.json` per [Google's specs](https://chromium.googlesource.com/chromium/src/+/master/docs/security/lookalikes/lookalike-domains.md#automated-warning-removal) to prevent lookalike warnings when viewing deploy previews.

## Additional Info
Companion PR to https://github.com/dbt-labs/www.getdbt.com/pull/1866. Both must be merged at the same time. Once both are merged, we then apply for automatic verification through Google.

I did a bit of research on this and could not find any resources regarding the lookalike warning for deploy previews. We will need to monitor this after submitting approval and may need to adjust the `assetlinks.json` file to include the deploy preview domain if we continue to see these warnings.
