### PR TITLE
Fix `firstVersion` typo

### DIFF
--- a/website/docs/docs/build/incremental-models.md
+++ b/website/docs/docs/build/incremental-models.md
@@ -303,7 +303,7 @@ select ...
 
 </File>
 
-<VersionBlock firstVersiont="1.4">
+<VersionBlock firstVersion="1.4">
 
 ### About incremental_predicates
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
Should this line contain `firstVersion` instead of `firstVersiont` (which looks like a typo)?

## Checklist
No checklist items were applicable.