### PR TITLE
Lightbox component adjustment

### DIFF
--- a/website/src/components/lightbox/index.js
+++ b/website/src/components/lightbox/index.js
@@ -40,7 +40,7 @@ function Lightbox({
           </a>
         </span>
         {title && (
-          <p className={styles.title}>{ title }</p>
+          <span className={styles.title}>{ title }</span>
         )}
       </div>
     </>

--- a/website/src/components/lightbox/index.js
+++ b/website/src/components/lightbox/index.js
@@ -21,7 +21,7 @@ function Lightbox({
   return (
     <>
       <link href="/css/featherlight-styles.css" type="text/css" rel="stylesheet" />
-      <div 
+      <span 
         className={`
           ${styles.docImage} 
           ${collapsed ? styles.collapsed : ''}
@@ -42,7 +42,7 @@ function Lightbox({
         {title && (
           <span className={styles.title}>{ title }</span>
         )}
-      </div>
+      </span>
     </>
   );
 }

--- a/website/src/components/lightbox/styles.module.css
+++ b/website/src/components/lightbox/styles.module.css
@@ -2,6 +2,7 @@
   text-align: center;
   font-size: small;
   width: 100%;
+  display: block;
 }
 
 :local(.docImage) {


### PR DESCRIPTION
Currently on docs pages where the `Lightbox` component is used, such as [this page](https://docs.getdbt.com/docs/get-started/getting-started/getting-set-up/setting-up-snowflake#option-2-connect-dbt-cloud-and-snowflake-manually), sections below the Lightbox are being wrapped in a Lightbox class.

The behavior seems like it's an issue with html tags. In the Lightbox component, the `title` prop is wrapped with a `<p>` tag. On certain pages such as [this page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/website/docs/docs/get-started/getting-started/getting-set-up/setting-up-snowflake.md), the Lightbox component is wrapped with `p` tags. 

I don't believe a `p` tag can wrap another `p` tag, which makes me think that's the issue

Update - I believe it's tied to the `Lightbox` component being a `div`. Paragraphs cannot wrap `div` tags.

https://deploy-preview-2735--docs-getdbt-com.netlify.app/docs/get-started/getting-started/getting-set-up/setting-up-snowflake#initialize-your-repository-and-start-development