### PR TITLE
Add info for status of model with warning

### DIFF
--- a/website/docs/reference/dbt-jinja-functions/exceptions.md
+++ b/website/docs/reference/dbt-jinja-functions/exceptions.md
@@ -23,7 +23,7 @@ __Example usage__:
 
 ## warn
 
-The `exceptions.warn` method will raise a compiler warning with the provided message. If the `--warn-error`  flag is provided to dbt, then this warning will be elevated to an exception, which is raised.
+The `exceptions.warn` method will raise a compiler warning with the provided message, but any model will still be successful and be treated as a PASS. If the `--warn-error`  flag is provided to dbt, then this warning will be elevated to an exception, which is raised.
 
 __Example usage__:
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
Currently it is not entirely clear that when a warning is raised within a model that that model should still go on to have a PASS status, this will help reduce confusion and make clear that models cannot have a WARN status.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [x] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."

