### PR TITLE
Revert addition of `VersionBlock`s to Manifest page

### DIFF
--- a/website/docs/reference/artifacts/manifest-json.md
+++ b/website/docs/reference/artifacts/manifest-json.md
@@ -1,25 +1,7 @@
 ---
 title: Manifest
 ---
-<VersionBlock firstVersion="1.4">
-**dbt Core v1.4 produces schema**: [`v8`](https://schemas.getdbt.com/dbt/manifest/v8/index.html)
-</VersionBlock>
-
-<VersionBlock lastVersion="1.3">
-**dbt Core v1.3 produces schema**: [`v7`](https://schemas.getdbt.com/dbt/manifest/v7/index.html)
-</VersionBlock>
-
-<VersionBlock lastVersion="1.2">
-**dbt Core v1.2 produces schema**: [`v6`](https://schemas.getdbt.com/dbt/manifest/v6/index.html)
-</VersionBlock>
-
-<VersionBlock lastVersion="1.1">
-**dbt Core v1.1 produces schema**: [`v5`](https://schemas.getdbt.com/dbt/manifest/v5/index.html)
-</VersionBlock>
-
-<VersionBlock lastVersion="1.0">
-**dbt Core v1.0 produces schema**: [`v4`](https://schemas.getdbt.com/dbt/manifest/v4/index.html)
-</VersionBlock>
+**Current schema**: [`v8`](https://schemas.getdbt.com/dbt/manifest/v8/index.html)
 
 **Produced by:** [`build`](commands/build) [`compile`](commands/compile) [`docs generate`](commands/cmd-docs) [`list`](commands/list) [`seed`](commands/seed) [`snapshot`](commands/snapshot) [`source freshness`](commands/source) [`test`](commands/test) [`run`](commands/run) [`run-operation`](commands/run-operation)
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
Currently, [this page](https://docs.getdbt.com/reference/artifacts/manifest-json) is rendering like this:

<img width="650" alt="image" src="https://user-images.githubusercontent.com/44704949/214576430-f5f2b20b-388d-4e17-9e5d-c3ce4c0f0158.png">

After reverting, it will look like this:

<img width="650" alt="image" src="https://user-images.githubusercontent.com/44704949/214580624-0e5632cb-dadc-4fe1-aaa2-83ae8111b9ca.png">


I believe this issue was introduced in [#2662](https://github.com/dbt-labs/docs.getdbt.com/pull/2662/files) and can be seen in the preview for that PR [here](https://deploy-preview-2662--docs-getdbt-com.netlify.app/reference/artifacts/manifest-json).

My PR will merely restore the earlier formatting prior to the `VersionBlock`s being added. Someone else should follow-up with another PR that re-introduces the (helpful!) behavior intended by https://github.com/dbt-labs/docs.getdbt.com/pull/2662.

## Checklist
- [x] Visually confirmed behavior using the Netlify Preview [here](https://deploy-preview-2755--docs-getdbt-com.netlify.app/reference/artifacts/manifest-json)