### PR TITLE
Correct row count figure in postgres-configs.md

### DIFF
--- a/website/docs/reference/resource-configs/postgres-configs.md
+++ b/website/docs/reference/resource-configs/postgres-configs.md
@@ -37,7 +37,7 @@ models:
 
 ### Indexes
 
-While Postgres works reasonably well for datasets smaller than about 10mm rows, database tuning is sometimes required. It's important to create indexes for columns that are commonly used in joins or where clauses.
+While Postgres works reasonably well for datasets smaller than about 10m rows, database tuning is sometimes required. It's important to create indexes for columns that are commonly used in joins or where clauses.
 
 <Changelog>
 


### PR DESCRIPTION
Should this read `10m` for 10 million?

## What are you changing in this pull request and why?
The docs quote a row count of `10mm` which, I believe, should instead say `10m` as a representation of 10 million.