### PR TITLE
Initialize v1.5

### DIFF
--- a/website/dbt-versions.js
+++ b/website/dbt-versions.js
@@ -1,5 +1,10 @@
 exports.versions = [
   {
+    version: "1.5",
+    EOLDate: "2024-04-26",
+    isPrerelease: true,
+  },
+  {
     version: "1.4",
     EOLDate: "2024-01-25",
   },

--- a/website/docs/guides/migration/versions/02-upgrading-to-v1.5.md
+++ b/website/docs/guides/migration/versions/02-upgrading-to-v1.5.md
@@ -9,11 +9,15 @@ description: New features and changes in dbt Core v1.5
 - [Cloud upgrade guide](/docs/dbt-versions/upgrade-core-in-cloud)
 - [Release schedule](https://github.com/dbt-labs/dbt-core/issues/6715)
 
-**Planned final release:** April 26, 2023
+:::info
 
-dbt Core v1.5 is a feature release, with two big additions planned:
-1. **"Models as APIs,"** the first phase of [multi-project deployments](https://github.com/dbt-labs/dbt-core/discussions/6725)
-2. An initial **Python API for dbt-core,** supporting programmatic invocations at parity with the CLI
+Planned release date: April 26, 2023
+
+:::
+
+dbt Core v1.5 is a feature release with two significant additions planned:
+1. Models as APIs &mdash; the first phase of [multi-project deployments](https://github.com/dbt-labs/dbt-core/discussions/6725)
+2. An initial Python API for dbt-core supporting programmatic invocations at parity with the CLI.
 
 ## What to know before upgrading
 
@@ -21,13 +25,13 @@ dbt Labs is committed to providing backward compatibility for all versions 1.x, 
 
 ### Breaking changes
 
-As part of our refactor of `dbt-core` internals, we need to make some **very precise** changes to runtime configuration. The net result of these changes is more sensible configuration options, clearer documentation, cleaner APIs, and a more legible codebase.
+As part of our refactor of `dbt-core` internals, we must make precise changes to runtime configuration. The net result of these changes is more practical configuration options, clearer documentation, cleaner APIs, and a more legible codebase.
 
-Wherever possible, we will aim to provide backwards compatibility and deprecation warnings for at least one minor version, before actually removing the old functionality. In those cases, we still reserve the right to fully remove the backward-compatible functionality in a future v1.x minor version of `dbt-core`.
+Wherever possible, we will provide backward compatibility and deprecation warnings for at least one minor version before actually removing the old functionality. In those cases, we still reserve the right to fully remove the backward-compatible functionality in a future v1.x minor version of `dbt-core`.
 
 Changes planned for v1.5:
 - Renaming ["global configs"](global-configs) for consistency ([dbt-core#6903](https://github.com/dbt-labs/dbt-core/issues/6903))
-- Moving `log-path` and `target-path` out of `dbt_project.yml`, for consistency with other global configs ([dbt-core#6882](https://github.com/dbt-labs/dbt-core/issues/6882))
+- Moving `log-path` and `target-path` out of `dbt_project.yml` for consistency with other global configs ([dbt-core#6882](https://github.com/dbt-labs/dbt-core/issues/6882))
 
 ### For consumers of dbt artifacts (metadata)
 
@@ -35,11 +39,11 @@ The manifest schema version will be updated to `v9`. Specific changes to be note
 
 ### For maintainers of adapter plugins
 
-Forthcoming: GH discussion detailing interface changes, and offering a forum for Q&A
+Coming soon: GH discussion detailing interface changes and offering a forum for Q&A
 
 ## New and changed documentation
 
-Forthcoming!
+Coming soon
 
 ### "Models as APIs"
 - Model contracts ([#2839](https://github.com/dbt-labs/docs.getdbt.com/issues/2839))

--- a/website/docs/guides/migration/versions/02-upgrading-to-v1.5.md
+++ b/website/docs/guides/migration/versions/02-upgrading-to-v1.5.md
@@ -1,0 +1,50 @@
+---
+title: "Trying v1.5 (prerelease)"
+description: New features and changes in dbt Core v1.5
+---
+### Resources
+
+- [Changelog](https://github.com/dbt-labs/dbt-core/blob/main/CHANGELOG.md)
+- [CLI Installation guide](/docs/get-started/installation)
+- [Cloud upgrade guide](/docs/dbt-versions/upgrade-core-in-cloud)
+- [Release schedule](https://github.com/dbt-labs/dbt-core/issues/6715)
+
+**Planned final release:** April 26, 2023
+
+dbt Core v1.5 is a feature release, with two big additions planned:
+1. **"Models as APIs,"** the first phase of [multi-project deployments](https://github.com/dbt-labs/dbt-core/discussions/6725)
+2. An initial **Python API for dbt-core,** supporting programmatic invocations at parity with the CLI
+
+## What to know before upgrading
+
+dbt Labs is committed to providing backward compatibility for all versions 1.x, with the exception of any changes explicitly mentioned below. If you encounter an error upon upgrading, please let us know by [opening an issue](https://github.com/dbt-labs/dbt-core/issues/new).
+
+### Breaking changes
+
+As part of our refactor of `dbt-core` internals, we need to make some **very precise** changes to runtime configuration. The net result of these changes is more sensible configuration options, clearer documentation, cleaner APIs, and a more legible codebase.
+
+Wherever possible, we will aim to provide backwards compatibility and deprecation warnings for at least one minor version, before actually removing the old functionality. In those cases, we still reserve the right to fully remove the backward-compatible functionality in a future v1.x minor version of `dbt-core`.
+
+Changes planned for v1.5:
+- Renaming ["global configs"](global-configs) for consistency ([dbt-core#6903](https://github.com/dbt-labs/dbt-core/issues/6903))
+- Moving `log-path` and `target-path` out of `dbt_project.yml`, for consistency with other global configs ([dbt-core#6882](https://github.com/dbt-labs/dbt-core/issues/6882))
+
+### For consumers of dbt artifacts (metadata)
+
+The manifest schema version will be updated to `v9`. Specific changes to be noted here.
+
+### For maintainers of adapter plugins
+
+Forthcoming: GH discussion detailing interface changes, and offering a forum for Q&A
+
+## New and changed documentation
+
+Forthcoming!
+
+### "Models as APIs"
+- Model contracts ([#2839](https://github.com/dbt-labs/docs.getdbt.com/issues/2839))
+- Model groups & access ([#2840](https://github.com/dbt-labs/docs.getdbt.com/issues/2840))
+- Model versions ([#2841](https://github.com/dbt-labs/docs.getdbt.com/issues/2841))
+
+### dbt-core Python API
+- Auto-generated documentation ([#2674](https://github.com/dbt-labs/docs.getdbt.com/issues/2674)) for dbt-core CLI & Python API for programmatic invocations


### PR DESCRIPTION
resolves #2781

## What are you changing in this pull request and why?
Initialize v1.5!
- Add to `dbt-versions` list
- Create initial upgrade guide

## Timing
- We're planning to put out a first beta prerelease (v1.5.0-b1) next Wednesday (Feb 15)
- IMO we don't need to wait — we can merge this sooner if we want to
- From then on, we're planning to put out a new beta every 2 weeks. Check out our planned release schedule: https://github.com/dbt-labs/dbt-core/issues/6715