### PR TITLE
Lowercase `sql` in Hook Docs

### DIFF
--- a/website/docs/reference/resource-configs/pre-hook-post-hook.md
+++ b/website/docs/reference/resource-configs/pre-hook-post-hook.md
@@ -277,11 +277,11 @@ select ...
 {{
   config(
     pre_hook={
-      "SQL": "SQL-statement",
+      "sql": "SQL-statement",
       "transaction": False
     },
     post_hook={
-      "SQL": "SQL-statement",
+      "sql": "SQL-statement",
       "transaction": False
     }
   )
@@ -301,10 +301,10 @@ select ...
 
 models:
   +pre-hook:
-    SQL: "SQL-statement"
+    sql: "SQL-statement"
     transaction: false
   +post-hook:
-    SQL: "SQL-statement"
+    sql: "SQL-statement"
     transaction: false
 
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

Attempts to fix what I think is a bug in the docs. The docs specify to use `SQL` as the key when defining a pre- or post- hook as a dictionary, but based on the error I got (see below), it appears that the correct thing to do is to use `sql` as the key.

## Checklist
<!--
Uncomment if you're publishing docs for a prerelease version of dbt (delete if not applicable):
- [ ] Add versioning components, as described in [Versioning Docs](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/versioningdocs.md)
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/guides/migration/versions)
-->
- [ ] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [ ] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."

## Error Message

```bash
(base) matt@Matt-Kayes-MBP treehouse % dbt build --select +dim_contracts
20:02:25  Running with dbt=1.3.1
20:02:25  Unable to do partial parsing because profile has changed
20:02:25  Unable to do partial parsing because a project config has changed
20:02:29  Encountered an error:
Field "post_hook" of type List[Hook] in NodeConfig has invalid value [{'SQL': 'GRANT SELECT ON {{ this }} TO GROUP <<group>>', 'transaction': False}]
20:02:29  Traceback (most recent call last):
  File "<string>", line 73, in from_dict
  File "<string>", line 73, in <listcomp>
  File "<string>", line 10, in from_dict
mashumaro.exceptions.MissingField: Field "sql" of type str is missing in Hook instance

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/Cellar/dbt-redshift/1.3.0/libexec/lib/python3.9/site-packages/dbt/main.py", line 135, in main
    results, succeeded = handle_and_check(args)
  File "/usr/local/Cellar/dbt-redshift/1.3.0/libexec/lib/python3.9/site-packages/dbt/main.py", line 198, in handle_and_check
    task, res = run_from_args(parsed)
  File "/usr/local/Cellar/dbt-redshift/1.3.0/libexec/lib/python3.9/site-packages/dbt/main.py", line 245, in run_from_args
    results = task.run()
  File "/usr/local/Cellar/dbt-redshift/1.3.0/libexec/lib/python3.9/site-packages/dbt/task/runnable.py", line 453, in run
    self._runtime_initialize()
  File "/usr/local/Cellar/dbt-redshift/1.3.0/libexec/lib/python3.9/site-packages/dbt/task/runnable.py", line 161, in _runtime_initialize
    super()._runtime_initialize()
  File "/usr/local/Cellar/dbt-redshift/1.3.0/libexec/lib/python3.9/site-packages/dbt/task/runnable.py", line 94, in _runtime_initialize
    self.load_manifest()
  File "/usr/local/Cellar/dbt-redshift/1.3.0/libexec/lib/python3.9/site-packages/dbt/task/runnable.py", line 81, in load_manifest
    self.manifest = ManifestLoader.get_full_manifest(self.config)
  File "/usr/local/Cellar/dbt-redshift/1.3.0/libexec/lib/python3.9/site-packages/dbt/parser/manifest.py", line 221, in get_full_manifest
    manifest = loader.load()
  File "/usr/local/Cellar/dbt-redshift/1.3.0/libexec/lib/python3.9/site-packages/dbt/parser/manifest.py", line 351, in load
    self.parse_project(
  File "/usr/local/Cellar/dbt-redshift/1.3.0/libexec/lib/python3.9/site-packages/dbt/parser/manifest.py", line 479, in parse_project
    parser.parse_file(block)
  File "/usr/local/Cellar/dbt-redshift/1.3.0/libexec/lib/python3.9/site-packages/dbt/parser/base.py", line 414, in parse_file
    self.parse_node(file_block)
  File "/usr/local/Cellar/dbt-redshift/1.3.0/libexec/lib/python3.9/site-packages/dbt/parser/base.py", line 382, in parse_node
    node = self._create_parsetime_node(
  File "/usr/local/Cellar/dbt-redshift/1.3.0/libexec/lib/python3.9/site-packages/dbt/parser/base.py", line 213, in _create_parsetime_node
    "config": self.config_dict(config),
  File "/usr/local/Cellar/dbt-redshift/1.3.0/libexec/lib/python3.9/site-packages/dbt/parser/base.py", line 357, in config_dict
    config_dict = config.build_config_dict(base=True)
  File "/usr/local/Cellar/dbt-redshift/1.3.0/libexec/lib/python3.9/site-packages/dbt/context/context_config.py", line 330, in build_config_dict
    return src.calculate_node_config_dict(
  File "/usr/local/Cellar/dbt-redshift/1.3.0/libexec/lib/python3.9/site-packages/dbt/context/context_config.py", line 205, in calculate_node_config_dict
    config = self.calculate_node_config(
  File "/usr/local/Cellar/dbt-redshift/1.3.0/libexec/lib/python3.9/site-packages/dbt/context/context_config.py", line 141, in calculate_node_config
    result = self._update_from_config(result, fqn_config)
  File "/usr/local/Cellar/dbt-redshift/1.3.0/libexec/lib/python3.9/site-packages/dbt/context/context_config.py", line 192, in _update_from_config
    return result.update_from(
  File "/usr/local/Cellar/dbt-redshift/1.3.0/libexec/lib/python3.9/site-packages/dbt/contracts/graph/model_config.py", line 349, in update_from
    return self.from_dict(dct)
  File "<string>", line 75, in from_dict
mashumaro.exceptions.InvalidFieldValue: Field "post_hook" of type List[Hook] in NodeConfig has invalid value [{'SQL': 'GRANT SELECT ON {{ this }} TO GROUP <<group>>', 'transaction': False}]
```