### PR TITLE
Fix slugs on materializations guide

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,54 +1,53 @@
-
-/docs/get-started/develop-in-the-cloud#set-up-environments  /docs/get-started/develop-in-the-cloud  301
-/docs/get-started/develop-in-the-cloud#developer-credentials  /docs/get-started/develop-in-the-cloud 301
-/docs/getting-started/develop-in-the-cloud#setting-up-developer-credentials  /docs/get-started/develop-in-the-cloud  301
-/docs/dbt-cloud/cloud-configuring-dbt-cloud/connecting-your-database#connecting-to-redshift-and-postgres  /docs/get-started/connect-your-database#connecting-to-postgres-redshift-and-alloydb 301
+/docs/get-started/develop-in-the-cloud#set-up-environments /docs/get-started/develop-in-the-cloud 301
+/docs/get-started/develop-in-the-cloud#developer-credentials /docs/get-started/develop-in-the-cloud 301
+/docs/getting-started/develop-in-the-cloud#setting-up-developer-credentials /docs/get-started/develop-in-the-cloud 301
+/docs/dbt-cloud/cloud-configuring-dbt-cloud/connecting-your-database#connecting-to-redshift-and-postgres /docs/get-started/connect-your-database#connecting-to-postgres-redshift-and-alloydb 301
 /docs/dbt-cloud/cloud-configuring-dbt-cloud/connecting-your-database#connecting-to-snowflake /docs/get-started/connect-your-database#connecting-to-snowflake 301
 
-
-/faqs/connecting-to-two-dbs-not-allowed  /faqs/warehouse/connecting-to-two-dbs-not-allowed 301
-/docs/dbt-cloud/cloud-ide/ide-beta  /docs/get-started/develop-in-the-cloud 301
+/faqs/connecting-to-two-dbs-not-allowed /faqs/warehouse/connecting-to-two-dbs-not-allowed 301
+/docs/dbt-cloud/cloud-ide/ide-beta /docs/get-started/develop-in-the-cloud 301
 
 ## dbt cloud feature page changes
 
 /docs/dbt-cloud/using-dbt-cloud/cloud-model-timing-tab /docs/get-started/dbt-cloud-features#model-timing-dashboard 301
-/docs/dbt-cloud  /docs/get-started/getting-started/set-up-dbt-cloud 
-/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-choosing-a-dbt-version  /docs/dbt-versions/upgrade-core-in-cloud 301
-/docs/dbt-cloud/cloud-ide/viewing-docs-in-the-ide  /docs/get-started/develop-in-the-cloud 301
+/docs/dbt-cloud /docs/get-started/getting-started/set-up-dbt-cloud
+/docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-choosing-a-dbt-version /docs/dbt-versions/upgrade-core-in-cloud 301
+/docs/dbt-cloud/cloud-ide/viewing-docs-in-the-ide /docs/get-started/develop-in-the-cloud 301
 /docs/dbt-cloud/cloud-overview /docs/get-started/getting-started/set-up-dbt-cloud 301
-/docs/dbt-cloud/using-dbt-cloud/artifacts  /docs/deploy/artifacts 301
+/docs/dbt-cloud/using-dbt-cloud/artifacts /docs/deploy/artifacts 301
 /dbt-cloud/api-v4 /docs/dbt-cloud-apis/admin-cloud-api 301
 
 /docs/building-a-dbt-project/building-models/python-models /docs/build/python-models 301
-/docs/deploy/regions  /docs/deploy/regions-ip-addresses 301
+/docs/deploy/regions /docs/deploy/regions-ip-addresses 301
 
 ## adapter redirects using diff formats
 
-/advanced/adapter-development/1-what-are-adapters  /guides/dbt-ecosystem/adapter-development/1-what-are-adapters 301!
-/advanced/adapter-development/2-prerequisites-for-a-new-adapter  /guides/dbt-ecosystem/adapter-development/2-prerequisites-for-a-new-adapter 301!
-/advanced/adapter-development/3-building-a-new-adapter  /guides/dbt-ecosystem/adapter-development/3-building-a-new-adapter 301!
+/advanced/adapter-development/1-what-are-adapters /guides/dbt-ecosystem/adapter-development/1-what-are-adapters 301!
+/advanced/adapter-development/2-prerequisites-for-a-new-adapter /guides/dbt-ecosystem/adapter-development/2-prerequisites-for-a-new-adapter 301!
+/advanced/adapter-development/3-building-a-new-adapter /guides/dbt-ecosystem/adapter-development/3-building-a-new-adapter 301!
 /advanced/adapter-development/4-testing-a-new-adapter /guides/dbt-ecosystem/adapter-development/4-testing-a-new-adapter 301!
-/advanced/adapter-development/5-documenting-a-new-adapter  /guides/dbt-ecosystem/adapter-development/5-documenting-a-new-adapter 301!
+/advanced/adapter-development/5-documenting-a-new-adapter /guides/dbt-ecosystem/adapter-development/5-documenting-a-new-adapter 301!
 /advanced/adapter-development/6-promoting-a-new-adapter /guides/dbt-ecosystem/adapter-development/6-promoting-a-new-adapter 301!
 /advanced/adapter-development/7-verifying-a-new-adapter /guides/dbt-ecosystem/adapter-development/7-verifying-a-new-adapter 301!
-/guides/advanced/adapter-development/1-what-are-adapters  /guides/dbt-ecosystem/adapter-development/1-what-are-adapters 301!
-/guides/advanced/adapter-development/2-prerequisites-for-a-new-adapter  /guides/dbt-ecosystem/adapter-development/2-prerequisites-for-a-new-adapter 301!
-/guides/advanced/adapter-development/3-building-a-new-adapter  /guides/dbt-ecosystem/adapter-development/3-building-a-new-adapter 301!
+/guides/advanced/adapter-development/1-what-are-adapters /guides/dbt-ecosystem/adapter-development/1-what-are-adapters 301!
+/guides/advanced/adapter-development/2-prerequisites-for-a-new-adapter /guides/dbt-ecosystem/adapter-development/2-prerequisites-for-a-new-adapter 301!
+/guides/advanced/adapter-development/3-building-a-new-adapter /guides/dbt-ecosystem/adapter-development/3-building-a-new-adapter 301!
 /guides/advanced/adapter-development/4-testing-a-new-adapter /guides/dbt-ecosystem/adapter-development/4-testing-a-new-adapter 301!
-/guides/advanced/adapter-development/5-documenting-a-new-adapter  /guides/dbt-ecosystem/adapter-development/5-documenting-a-new-adapter 301!
+/guides/advanced/adapter-development/5-documenting-a-new-adapter /guides/dbt-ecosystem/adapter-development/5-documenting-a-new-adapter 301!
 /guides/advanced/adapter-development/6-promoting-a-new-adapter /guides/dbt-ecosystem/adapter-development/6-promoting-a-new-adapter 301!
 /guides/advanced/adapter-development/7-verifying-a-new-adapter /guides/dbt-ecosystem/adapter-development/7-verifying-a-new-adapter 301!
-
 
 /guides/legacy/debugging-errors /guides/best-practices/debugging-errors 301!
 /guides/legacy/writing-custom-generic-tests /guides/best-practices/writing-custom-generic-tests 301!
 /guides/legacy/creating-new-materializations /guides/advanced/creating-new-materializations 301!
 
 # add new redirects to the top because they will override later ones
+
 # getting started guide
+
 /guides/getting-started /docs/get-started/getting-started/overview 301
 /docs/get-started/getting-started/building-your-first-project /docs/get-started/getting-started/building-your-first-project/build-your-first-models 301
-/docs/get-started/getting-started/create-a-project  /docs/get-started/getting-started/set-up-dbt-cloud 301
+/docs/get-started/getting-started/create-a-project /docs/get-started/getting-started/set-up-dbt-cloud 301
 /guides/getting-started/building-your-first-project /docs/get-started/getting-started/building-your-first-project/build-your-first-models 301
 
 /guides/getting-started/building-your-first-project/build-your-first-models /docs/get-started/getting-started/building-your-first-project/build-your-first-models 301
@@ -72,17 +71,20 @@
 /docs/running-a-dbt-project/profile /docs/get-started/connection-profiles 301
 
 # other redirects
-/docs/deploy/understanding-state  /docs/deploy/about-state 301!
-/guides/legacy/understanding-state  /docs/deploy/about-state 301!
+
+/guides/best-practices/materializations/guides/best-practices/materializations/1-overview /guides/best-practices/materializations/1-guide-overview
+
+/docs/deploy/understanding-state /docs/deploy/about-state 301!
+/guides/legacy/understanding-state /docs/deploy/about-state 301!
 /guides/migration/versions/Older%20versions/understanding-state /docs/deploy/about-state 301!
 
-/docs/collaborate/git/resolve-merge-conflicts  /docs/collaborate/git/merge-conflicts 301
-/docs/collaborate/environments  /docs/collaborate/environments/environments-in-dbt 301
+/docs/collaborate/git/resolve-merge-conflicts /docs/collaborate/git/merge-conflicts 301
+/docs/collaborate/environments /docs/collaborate/environments/environments-in-dbt 301
 /docs/running-a-dbt-project/running-dbt-in-production /docs/deploy/deployments 301
 /docs/dbt-cloud/using-dbt-cloud/cloud-slack-notifications /docs/deploy/job-notifications 301
 /docs/dbt-cloud/using-dbt-cloud /docs/develop/develop-in-the-cloud 301
-/docs/dbt-cloud/january-2020-pricing-updates https://www.getdbt.com/pricing/  301
-/docs/dbt-cloud/dbt-cloud-enterprise https://www.getdbt.com/pricing/  301
+/docs/dbt-cloud/january-2020-pricing-updates https://www.getdbt.com/pricing/ 301
+/docs/dbt-cloud/dbt-cloud-enterprise https://www.getdbt.com/pricing/ 301
 /docs/building-a-dbt-project/archival /docs/build/snapshots 301
 /docs/about/license /community/resources/contributor-license-agreements 301
 /docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-using-a-managed-repository /docs/collaborate/git/managed-repository 301
@@ -163,7 +165,7 @@
 /docs/building-a-dbt-project/using-sources /docs/build/sources 301
 /docs/building-a-dbt-project/projects /docs/build/projects 301
 /docs/building-a-dbt-project/building-models/python-models /docs/build/python-models 301
-/docs/building-a-dbt-project/macros  /docs/guides/building-packages 301
+/docs/building-a-dbt-project/macros /docs/guides/building-packages 301
 /docs/building-a-dbt-project/setting-up /docs/guides/building-packages 301
 /docs/building-a-dbt-project/dbt-jinja-functions /docs/guides/building-packages 301
 /docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-upgrading-dbt-versions /docs/dbt-versions/upgrade-core-in-cloud 301
@@ -227,9 +229,9 @@
 /docs/clean /reference/commands/clean 302
 /docs/cloud-choosing-a-dbt-version /docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-choosing-a-dbt-version 302
 /docs/cloud-configuring-dbt-cloud /docs/dbt-cloud/cloud-configuring-dbt-cloud 302
-/docs/cloud-enabling-continuous-integration-with-github   /docs/dbt-cloud/using-dbt-cloud/cloud-enabling-continuous-integration-with-github 302
-/docs/dbt-cloud/using-dbt-cloud/cloud-enabling-continuous-integration-with-github   /docs/dbt-cloud/using-dbt-cloud/cloud-enabling-continuous-integration 302
-/docs/dbt-cloud/using-dbt-cloud/cloud-enabling-continuous-integration-with-github/  /docs/dbt-cloud/using-dbt-cloud/cloud-enabling-continuous-integration 302
+/docs/cloud-enabling-continuous-integration-with-github /docs/dbt-cloud/using-dbt-cloud/cloud-enabling-continuous-integration-with-github 302
+/docs/dbt-cloud/using-dbt-cloud/cloud-enabling-continuous-integration-with-github /docs/dbt-cloud/using-dbt-cloud/cloud-enabling-continuous-integration 302
+/docs/dbt-cloud/using-dbt-cloud/cloud-enabling-continuous-integration-with-github/ /docs/dbt-cloud/using-dbt-cloud/cloud-enabling-continuous-integration 302
 /docs/cloud-generating-documentation /docs/dbt-cloud/using-dbt-cloud/cloud-generating-documentation 302
 /docs/cloud-import-a-project-by-git-url /docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-import-a-project-by-git-url 302
 /docs/cloud-installing-the-github-application /docs/dbt-cloud/cloud-configuring-dbt-cloud/cloud-installing-the-github-application 302
@@ -547,29 +549,28 @@ https://tutorial.getdbt.com/* https://docs.getdbt.com/:splat 301!
 # adapter development docs
 
 /docs/contributing/what-are-adapters /guides/advanced/adapter-development/1-what-are-adapters 302
-/docs/contributing/adapter-development/1-what-are-adapters  /guides/advanced/adapter-development/1-what-are-adapters 302
+/docs/contributing/adapter-development/1-what-are-adapters /guides/advanced/adapter-development/1-what-are-adapters 302
 /docs/contributing/prerequisites-for-a-new-adapter /guides/advanced/adapter-development/2-prerequisites-for-a-new-adapter 302
 
-/docs/contributing/adapter-development/2-prerequisites-for-a-new-adapter  /guides/advanced/adapter-development/2-prerequisites-for-a-new-adapter 302
-/docs/contributing/building-a-new-adapter  /guides/advanced/adapter-development/3-building-a-new-adapter 302
+/docs/contributing/adapter-development/2-prerequisites-for-a-new-adapter /guides/advanced/adapter-development/2-prerequisites-for-a-new-adapter 302
+/docs/contributing/building-a-new-adapter /guides/advanced/adapter-development/3-building-a-new-adapter 302
 
-/docs/contributing/adapter-development/3-building-a-new-adapter  /guides/advanced/adapter-development/3-building-a-new-adapter 302
-/docs/building-a-new-adapter  /guides/advanced/adapter-development/3-building-a-new-adapter302
+/docs/contributing/adapter-development/3-building-a-new-adapter /guides/advanced/adapter-development/3-building-a-new-adapter 302
+/docs/building-a-new-adapter /guides/advanced/adapter-development/3-building-a-new-adapter302
 
-/docs/contributing/testing-a-new-adapter  /guides/advanced/adapter-development/4-testing-a-new-adapter 302
-/docs/contributing/adapter-development/4-testing-a-new-adapter  /guides/advanced/adapter-development/4-testing-a-new-adapter 302
+/docs/contributing/testing-a-new-adapter /guides/advanced/adapter-development/4-testing-a-new-adapter 302
+/docs/contributing/adapter-development/4-testing-a-new-adapter /guides/advanced/adapter-development/4-testing-a-new-adapter 302
 
-/docs/contributing/documenting-a-new-adapter  /guides/advanced/adapter-development/5-documenting-a-new-adapter 302
-/docs/contributing/adapter-development/5-documenting-a-new-adapter  /guides/advanced/adapter-development/5-documenting-a-new-adapter 302
+/docs/contributing/documenting-a-new-adapter /guides/advanced/adapter-development/5-documenting-a-new-adapter 302
+/docs/contributing/adapter-development/5-documenting-a-new-adapter /guides/advanced/adapter-development/5-documenting-a-new-adapter 302
 
 /docs/contributing/promoting-a-new-adapter /guides/advanced/adapter-development/6-promoting-a-new-adapter 302
-/docs/contributing/adapter-development/6-promoting-a-new-adapter  /guides/advanced/adapter-development/6-promoting-a-new-adapter 302
+/docs/contributing/adapter-development/6-promoting-a-new-adapter /guides/advanced/adapter-development/6-promoting-a-new-adapter 302
 
-/docs/contributing/verifying-a-new-adapter  /guides/advanced/adapter-development/7-verifying-a-new-adapter 302
-/docs/contributing/adapter-development/7-verifying-a-new-adapter  /guides/advanced/adapter-development/7-verifying-a-new-adapter 302
+/docs/contributing/verifying-a-new-adapter /guides/advanced/adapter-development/7-verifying-a-new-adapter 302
+/docs/contributing/adapter-development/7-verifying-a-new-adapter /guides/advanced/adapter-development/7-verifying-a-new-adapter 302
 
-
-/docs/dbt-cloud/using-dbt-cloud/cloud-metrics-layer        /docs/use-dbt-semantic-layer/dbt-semantic-layer 301!
+/docs/dbt-cloud/using-dbt-cloud/cloud-metrics-layer /docs/use-dbt-semantic-layer/dbt-semantic-layer 301!
 /reference/warehouse-profiles/impala-profile /reference/warehouse-setups/impala-setup 302
 /reference/warehouse-profiles/exasol-profile /reference/warehouse-setups/exasol-setup 302
 /reference/warehouse-profiles/layer-profile /reference/warehouse-setups/layer-setup 302
@@ -606,16 +607,18 @@ https://tutorial.getdbt.com/* https://docs.getdbt.com/:splat 301!
 /reference/using-sources /docs/build/sources 302
 
 # ide ia redirects
-/docs/dbt-cloud/cloud-ide/the-dbt-ide  /docs/getting-started/dbt-cloud-features 301!
-/docs/dbt-cloud/cloud-ide/handling-merge-conflicts  /docs/collaborate/git/resolve-merge-conflicts 301!
-/dbt-cloud/cloud-ide/viewing-docs-in-the-ide  /docs/getting-started/develop-in-the-cloud 301!
-/docs/dbt-cloud/cloud-ide/ide-beta  /docs/getting-started/develop-in-the-cloud 301!
-/docs/running-a-dbt-project/using-the-dbt-ide  /docs/getting-started/develop-in-the-cloud 301!
-/dbt-cloud/cloud-ide/the-ide-git-button  /docs/collaborate/git/version-control-basics 301!
+
+/docs/dbt-cloud/cloud-ide/the-dbt-ide /docs/getting-started/dbt-cloud-features 301!
+/docs/dbt-cloud/cloud-ide/handling-merge-conflicts /docs/collaborate/git/resolve-merge-conflicts 301!
+/dbt-cloud/cloud-ide/viewing-docs-in-the-ide /docs/getting-started/develop-in-the-cloud 301!
+/docs/dbt-cloud/cloud-ide/ide-beta /docs/getting-started/develop-in-the-cloud 301!
+/docs/running-a-dbt-project/using-the-dbt-ide /docs/getting-started/develop-in-the-cloud 301!
+/dbt-cloud/cloud-ide/the-ide-git-button /docs/collaborate/git/version-control-basics 301!
 /docs/building-a-dbt-project/setting-up /guides/legacy/building-packages 301!
 /docs/building-a-dbt-project/dbt-jinja-functions /reference/dbt-jinja-functions 301!
 
 # Community docs
+
 /docs/contributing/long-lived-discussions-guidelines /community/resources/forum-guidelines 301
 /docs/guides/legacy/navigating-the-docs.md /community/contribute 301
 /community/writing-on-discourse/ /community/contributing/contributing-online-community 301
@@ -625,14 +628,16 @@ https://tutorial.getdbt.com/* https://docs.getdbt.com/:splat 301!
 /docs/contributing/oss-expectations /community/resources/oss-expectations 301
 /docs/contributing/slack-rules-of-the-road /community/resources/slack-rules-of-the-road 301
 /blog/getting-started-with-the-dbt-semantic-layer /blog/understanding-the-components-of-the-dbt-semantic-layer 301!
-/docs/getting-started/develop-in-the-cloud#creating-a-development-environment  /docs/get-started/develop-in-the-cloud#set-up-and-access-the-cloud-ide 301
+/docs/getting-started/develop-in-the-cloud#creating-a-development-environment /docs/get-started/develop-in-the-cloud#set-up-and-access-the-cloud-ide 301
 /docs/cloud-developer-ide /docs/build/custom-target-names#dbt-cloud-ide 301
 /website/docs/docs/contributing/building-a-new-adapter.md /guides/dbt-ecosystem/adapter-development/3-building-a-new-adapter 301
 
 # Blog docs
+
 /blog/tags/release-notes /docs/dbt-versions/dbt-cloud-release-notes 301
 
 # Faq docs
+
 /faqs/dbt-jinja-functions /reference/dbt-jinja-functions 301
 
 /website/docs/docs/contributing/documenting-a-new-adapter.md /docs/contributing/documenting-a-new-adapter 301
@@ -641,6 +646,6 @@ https://tutorial.getdbt.com/* https://docs.getdbt.com/:splat 301!
 /v0.8/reference / 301
 /v0.10/reference / 301
 /v0.12/reference / 301
-/v0.13/reference / 301 
+/v0.13/reference / 301
 /v0.13/docs/requiring-dbt-versions / 301
 /v0.14/docs/cloud-developer-ide / 301

--- a/website/docs/guides/best-practices/materializations/materializations-guide-1-guide-overview.md
+++ b/website/docs/guides/best-practices/materializations/materializations-guide-1-guide-overview.md
@@ -1,7 +1,7 @@
 ---
 title: "Materializations best practices"
 id: materializations-guide-1-guide-overview
-slug: guides/best-practices/materializations/1-overview
+slug: 1-guide-overview
 description: Learn how to utilize materializations in dbt.
 displayText: Materializations best practices
 hoverSnippet: Learn how to utilize materializations in dbt.

--- a/website/docs/guides/best-practices/materializations/materializations-guide-2-available-materializations.md
+++ b/website/docs/guides/best-practices/materializations/materializations-guide-2-available-materializations.md
@@ -1,7 +1,7 @@
 ---
 title: "Available materializations"
 id: materializations-guide-2-available-materializations
-slug: guides/best-practices/materializations/2-available-materializations
+slug: 2-available-materializations
 description: Learn how to utilize materializations in dbt.
 displayText: Materializations best practices
 hoverSnippet: Learn how to utilize materializations in dbt.

--- a/website/docs/guides/best-practices/materializations/materializations-guide-3-configuring-materializations.md
+++ b/website/docs/guides/best-practices/materializations/materializations-guide-3-configuring-materializations.md
@@ -1,7 +1,7 @@
 ---
 title: "Configuring materializations"
 id: materializations-guide-3-configuring-materializations
-slug: guides/best-practices/materializations/3-configuring-materializations
+slug: 3-configuring-materializations
 description: Learn how to utilize materializations in dbt.
 displayText: Materializations best practices
 hoverSnippet: Learn how to utilize materializations in dbt.

--- a/website/docs/guides/best-practices/materializations/materializations-guide-4-incremental-models.md
+++ b/website/docs/guides/best-practices/materializations/materializations-guide-4-incremental-models.md
@@ -1,7 +1,7 @@
 ---
 title: "Incremental models in-depth"
 id: materializations-guide-4-incremental-models
-slug: guides/best-practices/materializations/4-incremental-models
+slug: 4-incremental-models
 description: Learn how to utilize materializations in dbt.
 displayText: Materializations best practices
 hoverSnippet: Learn how to utilize materializations in dbt.

--- a/website/docs/guides/best-practices/materializations/materializations-guide-5-best-practices.md
+++ b/website/docs/guides/best-practices/materializations/materializations-guide-5-best-practices.md
@@ -1,7 +1,7 @@
 ---
 title: Best practices for materializations
 id: materializations-guide-5-best-practices
-slug: guides/best-practices/materializations/5-best-practices
+slug: 5-best-practices
 description: Learn how to utilize materializations in dbt.
 displayText: Materializations best practices
 hoverSnippet: Learn how to utilize materializations in dbt.

--- a/website/docs/guides/best-practices/materializations/materializations-guide-6-examining-builds.md
+++ b/website/docs/guides/best-practices/materializations/materializations-guide-6-examining-builds.md
@@ -1,7 +1,7 @@
 ---
 title: "Examining our builds"
 id: materializations-guide-6-examining-builds
-slug: guides/best-practices/materializations/6-examining-builds
+slug: 6-examining-builds
 description: Learn how to utilize materializations in dbt.
 displayText: Materializations best practices
 hoverSnippet: Learn how to utilize materializations in dbt.

--- a/website/docs/guides/best-practices/materializations/materializations-guide-7-conclusion.md
+++ b/website/docs/guides/best-practices/materializations/materializations-guide-7-conclusion.md
@@ -1,7 +1,7 @@
 ---
 title: "Conclusion"
 id: materializations-guide-7-conclusion
-slug: guides/best-practices/materializations/7-conclusion
+slug: 7-conclusion
 description: Learn how to utilize materializations in dbt.
 displayText: Materializations best practices
 hoverSnippet: Learn how to utilize materializations in dbt.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -235,67 +235,68 @@ const sidebarSettings = {
     {
       type: "category",
       label: "Collaborate with others",
-      items: [{
-        type: "category",
-        label: "Environments",
-        items: [
-          "docs/collaborate/environments/environments-in-dbt",
-          "docs/collaborate/environments/dbt-cloud-environments",
-          "docs/collaborate/environments/dbt-core-environments",
-        ],
-      },
-      {
-        type: "category",
-        label: "Git version control",
-        items: [
-          "docs/collaborate/git-version-control",
-          "docs/collaborate/git/version-control-basics",
-          "docs/collaborate/git/managed-repository",
-          "docs/collaborate/git/pr-template",
-          "docs/collaborate/git/merge-conflicts",
-          {
-            type: "category",
-            label: "Supported git providers",
-            items: [
-              "docs/collaborate/git/connect-github",
-              "docs/collaborate/git/connect-gitlab",
-              {
-                type: "category",
-                label: "Azure DevOps",
-                items: [
-                  "docs/collaborate/git/connect-azure-devops",
-                  "docs/collaborate/git/setup-azure",
-                  "docs/collaborate/git/authenticate-azure",
-                ],
-              },
-              "docs/collaborate/git/import-a-project-by-git-url",
-            ],
-          },
-        ],
-      },
-      {
-        type: "category",
-        label: "Document your dbt projects",
-        items: [
-          "docs/collaborate/documentation",
-          "docs/collaborate/build-and-view-your-docs",
-        ],
-      },
+      items: [
+        {
+          type: "category",
+          label: "Environments",
+          items: [
+            "docs/collaborate/environments/environments-in-dbt",
+            "docs/collaborate/environments/dbt-cloud-environments",
+            "docs/collaborate/environments/dbt-core-environments",
+          ],
+        },
+        {
+          type: "category",
+          label: "Git version control",
+          items: [
+            "docs/collaborate/git-version-control",
+            "docs/collaborate/git/version-control-basics",
+            "docs/collaborate/git/managed-repository",
+            "docs/collaborate/git/pr-template",
+            "docs/collaborate/git/merge-conflicts",
+            {
+              type: "category",
+              label: "Supported git providers",
+              items: [
+                "docs/collaborate/git/connect-github",
+                "docs/collaborate/git/connect-gitlab",
+                {
+                  type: "category",
+                  label: "Azure DevOps",
+                  items: [
+                    "docs/collaborate/git/connect-azure-devops",
+                    "docs/collaborate/git/setup-azure",
+                    "docs/collaborate/git/authenticate-azure",
+                  ],
+                },
+                "docs/collaborate/git/import-a-project-by-git-url",
+              ],
+            },
+          ],
+        },
+        {
+          type: "category",
+          label: "Document your dbt projects",
+          items: [
+            "docs/collaborate/documentation",
+            "docs/collaborate/build-and-view-your-docs",
+          ],
+        },
 
-      {
-        type: "category",
-        label: "Manage access",
-        items: [
-          "docs/collaborate/manage-access/about-access",
-          "docs/collaborate/manage-access/seats-and-users",
-          {
-            type: "category",
-            label: "Permissions",
-            items: [
-              "docs/collaborate/manage-access/self-service-permissions",
-              "docs/collaborate/manage-access/enterprise-permissions",
-            ],
-          },
+        {
+          type: "category",
+          label: "Manage access",
+          items: [
+            "docs/collaborate/manage-access/about-access",
+            "docs/collaborate/manage-access/seats-and-users",
+            {
+              type: "category",
+              label: "Permissions",
+              items: [
+                "docs/collaborate/manage-access/self-service-permissions",
+                "docs/collaborate/manage-access/enterprise-permissions",
+              ],
+            },
             {
               type: "category",
               label: "Single sign-on",
@@ -802,7 +803,6 @@ const sidebarSettings = {
             },
           ],
         },
-
       ],
     },
     {


### PR DESCRIPTION
## What are you changing in this pull request and why?
The `slugs` YAML frontmatter property was misused and resulting in double-length urls in production on the materializations guide. This will fix those and redirect the landing page for the guide at the double-length URL to the fixed URL.
