### PR TITLE
Adding a message to Publishing Models

### DIFF
--- a/website/docs/docs/collaborate/publish/about-publishing-models.md
+++ b/website/docs/docs/collaborate/publish/about-publishing-models.md
@@ -1,0 +1,11 @@
+---
+title: "About publishing models"
+id: about-publishing-models
+description: "Information about new features related to publishing models"
+---
+
+:::info
+
+Publishing models contains features new in dbt Core v1.5, currently in beta. If you do not see the documentation related to publishing models in this directory, please change the version of the docs to v1.5 or higher from the dropdown menu at the top of this site.
+
+:::

--- a/website/docs/docs/collaborate/publish/about-publishing-models.md
+++ b/website/docs/docs/collaborate/publish/about-publishing-models.md
@@ -6,6 +6,6 @@ description: "Information about new features related to publishing models"
 
 :::info
 
-Publishing models contains features new in dbt Core v1.5, currently in beta. If you do not see the documentation related to publishing models in this directory, please change the version of the docs to v1.5 or higher from the dropdown menu at the top of this site.
+Publishing models contains features new in dbt Core v1.5, currently in beta. To see the documentation related to publishing models, make sure to [select v1.5 or higher](/docs/collaborate/publish/about-publishing-models?version=1.5).
 
 :::

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -275,6 +275,8 @@ const sidebarSettings = {
         {
           type: "category",
           label: "Publishing models",
+          collapsed: true,
+          link: {type: "doc", id: "docs/collaborate/publish/about-publishing-models"},
           items: [
             "docs/collaborate/publish/model-contracts",
             "docs/collaborate/publish/model-access",


### PR DESCRIPTION
## What are you changing in this pull request and why?
Publishing Models category contains articles only available in 1.5 but can't be versioned (yet). Adding a page to the category that points out the version must be set to 1.5 to view the docs. 

## Checklist
<!--
Uncomment if you're publishing docs for a prerelease version of dbt (delete if not applicable):
- [ ] Add versioning components, as described in [Versioning Docs](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/versioningdocs.md)
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/guides/migration/versions)
-->
- [ ] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [ ] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."

Adding new pages (delete if not applicable):
- [ ] Add page to `website/sidebars.js`
- [ ] Provide a unique filename for the new page

Removing or renaming existing pages (delete if not applicable):
- [ ] Remove page from `website/sidebars.js`
- [ ] Add an entry `_redirects`
- [ ] [Ran link testing](https://github.com/dbt-labs/docs.getdbt.com#running-the-cypress-tests-locally) to update the links that point to the deleted page
