### PR TITLE
Update cloud-feature-parity.md

### DIFF
--- a/website/snippets/cloud-feature-parity.md
+++ b/website/snippets/cloud-feature-parity.md
@@ -6,7 +6,8 @@ The following table outlines which dbt Cloud features are supported on the diffe
 | IDE 2.0                       | ✅           | ✅                     | ✅                   |  
 | Audit logs                    | ✅           | ✅ (select customers)  | ❌                   |  
 | Metadata API                  | ✅           | ✅ (select customers)  | ❌                   | 
-| Webhooks                      | ✅           | ❌                     | ❌                   |
+| Webhooks (Outbound)           | ✅           | ❌                     | ❌                   |
+| Slim CI                       | ✅           | ✅                     | ✅                   | 
 | Semantic Layer                | ✅ (North America Only) | ❌          | ❌                   | 
 | IP Restrictions               | ❌           | ✅                     | ✅                   | 
 | PrivateLink egress            | ✅           | ✅                     | ✅                   | 


### PR DESCRIPTION
## What are you changing in this pull request and why?
Updated Cloud Feature Partity Matrix entry "Webhooks" to include the word "(Outbound)" detail and added and entry for "Slim CI".

This comes from customer comments and questions that because their Azure ST didn't have "webhooks" that they couldn't use Slim CI (not true), since technically, it's a type of webhook (their deduction).

Adding that clarification and the second line allows us to be clear about both topics, as this was suddenly a source of major concerns about dbt Cloud adoption for one of our top 5 largest accounts that is just starting to onboard.

## Checklist
