### PR TITLE
Add token field to oauth-secrets example

### DIFF
--- a/website/docs/reference/warehouse-setups/bigquery-setup.md
+++ b/website/docs/reference/warehouse-setups/bigquery-setup.md
@@ -111,7 +111,8 @@ my-bigquery-db:
       project: [GCP project id]
       dataset: [the name of your dbt dataset] # You can also use "schema" here
       threads: [1 or more]
-      refresh_token: [token]
+      token: [token]
+      refresh_token: [refresh_token]
       client_id: [client id]
       client_secret: [client secret]
       token_uri: [redirect URI]


### PR DESCRIPTION
I just now beat my head against the wall for half a day trying to get dbt to connect BQ following the example given here for the `oauth-secrets` method. Eventually I looked in the dbt Python code and found that the credentials are being created using the `token` field, which is in the JSON I'm pulling from but not the example in these docs. I didn't trace through the code to figure out where dbt is getting the token value into the profile_credentials dict, but I took a leap of faith and supplied the token value from my JSON in profiles.yml. And it worked immediately! So if a user follows the updated example, it should be problem solved.

## What are you changing in this pull request and why?
<!---
Describe your changes and why you're making them. If linked to an open
issue or a pull request on dbt Core, then link to them here! 

To learn more about the writing conventions used in the dbt Labs docs, see the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md).
-->

## Checklist
<!--
Uncomment if you're publishing docs for a prerelease version of dbt (delete if not applicable):
- [ ] Add versioning components, as described in [Versioning Docs](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-entire-pages)
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/guides/migration/versions)
-->
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [x] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."

