### PR TITLE
Remove construction sign for groups and access

### DIFF
--- a/website/docs/docs/collaborate/publish/model-access.md
+++ b/website/docs/docs/collaborate/publish/model-access.md
@@ -38,10 +38,6 @@ By default, all models are `protected`. This means that other models in the same
 
 However, it is recommended to set the access modifier of a new model to `private` to prevent other project resources from taking dependencies on models not intentionally designed for sharing across groups.
 
-:::info Under construction 🚧
-The following syntax is currently under review and does not work.
-:::
-
 <File name="models/marts/customers.yml">
 
 ```yaml


### PR DESCRIPTION
## What are you changing in this pull request and why?

The syntax for groups and access works now and is no longer under construction.

## Checklist
- [X] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.