### PR TITLE
1.5 Feature deprecations for target and logs

### DIFF
--- a/website/docs/reference/project-configs/log-path.md
+++ b/website/docs/reference/project-configs/log-path.md
@@ -25,7 +25,23 @@ In the manner of a ["global" config](global-configs), the log path can be set in
 2. `DBT_LOG_PATH` environment variable
 3. `log-path` in `dbt_project.yml`
 
+<VersionBlock firstVersion="1.5">
+
+:::warning Feature deprecation
+
+As of dbt version 1.5, setting the `log-path` in the `dbt_project.yml` is deprecated. Backward compatibility is still supported in 1.5 but will be removed in a future update. Migrate to the CLI flag or environment variable methods to avoid potential errors or disruptions.
+
+:::
+
+The precedence order is: CLI flag > env var > `dbt_project.yml(deprecated)`
+
+</VersionBlock>
+
+<VersionBlock lastVersion="1.4">
+
 The precedence order is: CLI flag > env var > `dbt_project.yml`
+
+</VersionBlock>
 
 </VersionBlock>
 

--- a/website/docs/reference/project-configs/target-path.md
+++ b/website/docs/reference/project-configs/target-path.md
@@ -27,7 +27,23 @@ In the manner of a ["global" config](global-configs), the target path can be set
 2. `DBT_TARGET_PATH` environment variable
 3. `target-path` in `dbt_project.yml`
 
+<VersionBlock firstVersion="1.5">
+
+:::warning Feature deprecation
+
+As of dbt version 1.5, setting the `target-path` in the `dbt_project.yml` is deprecated. Backward compatibility is still supported in 1.5 but will be removed in a future update. Migrate to the CLI flag or environment variable methods to avoid potential errors or disruptions.
+
+:::
+
+The precedence order is: CLI flag > env var > `dbt_project.yml(deprecated)`
+
+</VersionBlock>
+
+<VersionBlock lastVersion="1.4">
+
 The precedence order is: CLI flag > env var > `dbt_project.yml`
+
+</VersionBlock>
 
 </VersionBlock>
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
We are deprecating two flags that can be set in the dbt project yml file. They will still have two other options to implement, and 1.5 supports backward compatibility, but users will need to migrate off the feature before a future version disables it entirely. 

## Checklist
<!--
Uncomment if you're publishing docs for a prerelease version of dbt (delete if not applicable):
- [ ] Add versioning components, as described in [Versioning Docs](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-entire-pages)
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/guides/migration/versions)
-->
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [x] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."

Adding new pages (delete if not applicable):
- [ ] Add page to `website/sidebars.js`
- [ ] Provide a unique filename for the new page

Removing or renaming existing pages (delete if not applicable):
- [ ] Remove page from `website/sidebars.js`
- [ ] Add an entry `_redirects`
- [ ] [Ran link testing](https://github.com/dbt-labs/docs.getdbt.com#running-the-cypress-tests-locally) to update the links that point to the deleted page
