### PR TITLE
Webhooks prereqs

### DIFF
--- a/website/docs/docs/deploy/webhooks.md
+++ b/website/docs/docs/deploy/webhooks.md
@@ -19,6 +19,7 @@ dbt Cloud retries sending each event five times. dbt Cloud keeps a log of each w
 
 ## Prerequisites
 - You have a dbt Cloud account that is on the [Team or Enterprise plan](https://www.getdbt.com/pricing/). 
+- You have a multi-tenant deployment environment setup. For information, refer to [Tenancy](/docs/cloud/about-cloud/tenancy) . 
 
 ## Create a webhook subscription {#create-a-webhook-subscription}
 From your **Account Settings** in dbt Cloud (using the gear menu in the top right corner), click **Create New Webhook** in the **Webhooks** section. You can find the appropriate dbt Cloud access URL for your region and plan with [Regions & IP addresses](/docs/cloud/about-cloud/regions-ip-addresses).

--- a/website/docs/docs/deploy/webhooks.md
+++ b/website/docs/docs/deploy/webhooks.md
@@ -19,7 +19,7 @@ dbt Cloud retries sending each event five times. dbt Cloud keeps a log of each w
 
 ## Prerequisites
 - You have a dbt Cloud account that is on the [Team or Enterprise plan](https://www.getdbt.com/pricing/). 
-- You have a multi-tenant deployment environment setup. For information, refer to [Tenancy](/docs/cloud/about-cloud/tenancy) . 
+- You have set up a multi-tenant deployment environment for your dbt jobs. For more information, refer to [Tenancy](/docs/cloud/about-cloud/tenancy). 
 
 ## Create a webhook subscription {#create-a-webhook-subscription}
 From your **Account Settings** in dbt Cloud (using the gear menu in the top right corner), click **Create New Webhook** in the **Webhooks** section. You can find the appropriate dbt Cloud access URL for your region and plan with [Regions & IP addresses](/docs/cloud/about-cloud/regions-ip-addresses).

--- a/website/docs/docs/deploy/webhooks.md
+++ b/website/docs/docs/deploy/webhooks.md
@@ -19,7 +19,7 @@ dbt Cloud retries sending each event five times. dbt Cloud keeps a log of each w
 
 ## Prerequisites
 - You have a dbt Cloud account that is on the [Team or Enterprise plan](https://www.getdbt.com/pricing/). 
-- You have set up a multi-tenant deployment environment for your dbt jobs. For more information, refer to [Tenancy](/docs/cloud/about-cloud/tenancy). 
+- You have a multi-tenant deployment in dbt Cloud. For more information, refer to [Tenancy](/docs/cloud/about-cloud/tenancy). 
 
 ## Create a webhook subscription {#create-a-webhook-subscription}
 From your **Account Settings** in dbt Cloud (using the gear menu in the top right corner), click **Create New Webhook** in the **Webhooks** section. You can find the appropriate dbt Cloud access URL for your region and plan with [Regions & IP addresses](/docs/cloud/about-cloud/regions-ip-addresses).


### PR DESCRIPTION
## What are you changing in this pull request and why?

Webhooks is not yet supported on single-tenant setups. Add this requirement to the prereqs section on the webhooks page:

https://docs.getdbt.com/docs/deploy/webhooks#prerequisites

