### PR TITLE
Removing contact support instructions

### DIFF
--- a/website/docs/docs/cloud/manage-access/enterprise-permissions.md
+++ b/website/docs/docs/cloud/manage-access/enterprise-permissions.md
@@ -189,11 +189,6 @@ Stakeholders can perform the following actions in projects they are assigned to:
 
 Role-Based Access Control (RBAC) is helpful for automatically assigning permissions to dbt admins based on their SSO provider group associations.
 
-- **If you are on a dbt Labs Hosted dbt Cloud instance:**
-Contact support via the webapp button or support@getdbt.com to turn on this feature.
-- **If you are on a customer deployed dbt Cloud instance:**
-Contact your account manager for instructions on how to turn on this feature.
-
 Click the gear icon to the top right and select **Account Settings**. From the **Team** section, click **Groups**
 
 <Lightbox src="/img/docs/dbt-cloud/Select-Groups-RBAC.png" title="Navigate to Groups"/>

--- a/website/docs/docs/cloud/manage-access/enterprise-permissions.md
+++ b/website/docs/docs/cloud/manage-access/enterprise-permissions.md
@@ -189,7 +189,7 @@ Stakeholders can perform the following actions in projects they are assigned to:
 
 Role-Based Access Control (RBAC) is helpful for automatically assigning permissions to dbt admins based on their SSO provider group associations.
 
-Click the gear icon to the top right and select **Account Settings**. From the **Team** section, click **Groups**
+1. Click the gear icon to the top right and select **Account Settings**. From the **Team** section, click **Groups**
 
 <Lightbox src="/img/docs/dbt-cloud/Select-Groups-RBAC.png" title="Navigate to Groups"/>
 

--- a/website/docs/docs/cloud/manage-access/set-up-sso-okta.md
+++ b/website/docs/docs/cloud/manage-access/set-up-sso-okta.md
@@ -156,7 +156,14 @@ the integration between Okta and dbt Cloud.
 
 ## Configuration in dbt Cloud
 
-To complete setup, follow the steps below in dbt Cloud. If you access dbt Cloud using virtual private cloud (VPC), enable the `native_okta` feature flag in the dbt Cloud admin backend.
+## Configuration in dbt Cloud
+
+To complete setup, follow the steps below in dbt Cloud. 
+
+### Enable Okta native auth (beta)
+
+If you access dbt Cloud using virtual private cloud (VPC), enable the `native_okta` feature flag in the dbt Cloud admin backend.
+
 
 ### Supplying credentials
 

--- a/website/docs/docs/cloud/manage-access/set-up-sso-okta.md
+++ b/website/docs/docs/cloud/manage-access/set-up-sso-okta.md
@@ -156,14 +156,7 @@ the integration between Okta and dbt Cloud.
 
 ## Configuration in dbt Cloud
 
-To complete setup, follow the steps below in dbt Cloud.
-
-### Enable Okta Native Auth (beta)
-
-There are two ways to enable Okta depending on how you access dbt Cloud:
-
-- If you access dbt Cloud using an [Access URL](/docs/cloud/about-cloud/regions-ip-addresses), such as `cloud.getdbt.com`, contact your account manager to gain access to the Okta configuration user interface.
-* If you access dbt Cloud using virtual private cloud (VPC), enable the `native_okta` feature flag in the dbt Cloud admin backend.
+To complete setup, follow the steps below in dbt Cloud. If you access dbt Cloud using virtual private cloud (VPC), enable the `native_okta` feature flag in the dbt Cloud admin backend.
 
 ### Supplying credentials
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
The Okta native auth and RBAC features no longer require contacting support to enable, so we've removed the language from our docs.

