### PR TITLE
Fix typo - pluralize 'projects'

### DIFF
--- a/website/docs/faqs/Project/multiple-resource-yml-files.md
+++ b/website/docs/faqs/Project/multiple-resource-yml-files.md
@@ -9,4 +9,4 @@ It's up to you:
 - Some folks find it useful to have one file per model (or source / snapshot / seed etc)
 - Some find it useful to have one per directory, documenting and testing multiple models in one file
 
-Choose what works for your team. We have more recommendations in our guide on [structuring dbt project](https://docs.getdbt.com/guides/best-practices/how-we-structure/1-guide-overview).
+Choose what works for your team. We have more recommendations in our guide on [structuring dbt projects](https://docs.getdbt.com/guides/best-practices/how-we-structure/1-guide-overview).


### PR DESCRIPTION
## What are you changing in this pull request and why?
Adding an 's' to fix a typo