### PR TITLE
Fix syntax examples for model versions

### DIFF
--- a/website/docs/docs/collaborate/govern/model-versions.md
+++ b/website/docs/docs/collaborate/govern/model-versions.md
@@ -93,12 +93,11 @@ The above configuration will create two models (one for each version), and produ
 
 By convention, dbt will expect those two models to be defined in files named `dim_customers_v1.sql` and `dim_customers_v2.sql`. It is possible to override this by setting a `defined_in` property.
 
-You can reconfigure each version independently. For example, if you wanted `dim_customers.v1` to continue populating the database table named `dim_customers` (its previous location), you could use the `alias` configuration:
+You can reconfigure each version independently. For example, if you wanted `dim_customers.v1` to continue populating the database table named `dim_customers` (its original name), you could use the `defined_in` configuration:
 
 ```yml
-  - v: 1
-    config:
-      alias: dim_customers # keep old relation location
+      - v: 1
+        defined_in: dim_customers # keep original relation name
 ```
 
 :::info

--- a/website/docs/docs/collaborate/govern/model-versions.md
+++ b/website/docs/docs/collaborate/govern/model-versions.md
@@ -55,7 +55,7 @@ models:
         data_type: int
       - name: country_name
         description: Where this customer lives
-        data_type: string
+        data_type: varchar
 ```
 
 </File>
@@ -75,10 +75,10 @@ models:
     columns:
       - name: customer_id
         description: This is the primary key
-        data_type: float
+        data_type: int
       - name: country_name
         description: Where this customer lives
-        data_type: string
+        data_type: varchar
     versions:
       - v: 2
         columns:

--- a/website/docs/docs/collaborate/govern/model-versions.md
+++ b/website/docs/docs/collaborate/govern/model-versions.md
@@ -83,7 +83,8 @@ models:
       - v: 2
         columns:
           - include: "*"
-            exclude: country_name # this is the breaking change!
+            exclude:
+              - country_name # this is the breaking change!
       - v: 1
 ```
 


### PR DESCRIPTION
resolves #3194

[Page preview](https://deploy-preview-3195--docs-getdbt-com.netlify.app/docs/collaborate/govern/model-versions#how-to-create-a-new-version-of-a-model)

## What are you changing in this pull request and why?

Update code examples for `defined_in` and `exclude` to align with the implementation (and code examples) in [dbt-labs/dbt-core#7287](https://github.com/dbt-labs/dbt-core/pull/7287):

- e27c2da Example using `defined_in` property
- 9da3e00 Fix the example to `exclude` column(s)
- d0f5396 Use postgres-specific data types (since it is a neutral database platform and its data types can be easily ported)

## Checklist

- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [x] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."