### PR TITLE
Remove build commands for branch

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,9 +1,2 @@
 [build]
   functions = "functions"
-
-# Temporary build command for preview
-[context."update-redirects-location"]
-  command = "npm run build"
-
-[context."test-redirect-change-build"]
-  command = "npm run build"


### PR DESCRIPTION
_Guess who didn't remove the temporary build commands they said they were going to remove in PR #3284, *raises hand._

Fortunately this doesn't have any effect on the main branch, but opening this PR for the sake of keeping our `netlify.toml` clean.