### PR TITLE
fixing changelog typo

### DIFF
--- a/website/docs/docs/build/packages.md
+++ b/website/docs/docs/build/packages.md
@@ -48,7 +48,6 @@ packages:
 
 </File>
 
-
 <Changelog>
 
 - **v1.0.0:** The default [`packages-install-path`](packages-install-path) has been updated to be `dbt_packages` instead of `dbt_modules`.

--- a/website/docs/docs/build/packages.md
+++ b/website/docs/docs/build/packages.md
@@ -48,6 +48,7 @@ packages:
 
 </File>
 
+
 <Changelog>
 
 - **v1.0.0:** The default [`packages-install-path`](packages-install-path) has been updated to be `dbt_packages` instead of `dbt_modules`.

--- a/website/docs/reference/resource-configs/tags.md
+++ b/website/docs/reference/resource-configs/tags.md
@@ -3,11 +3,6 @@ resource_types: all
 datatype: string | [string]
 ---
 
-<Changelog>
-    
-  - **v0.21.0** introduced the `config` property, thereby allowing you to configure resources in all `.yml` files
-</Changelog>
-
 <Tabs
   defaultValue="project-yaml"
   values={[

--- a/website/docs/reference/resource-configs/tags.md
+++ b/website/docs/reference/resource-configs/tags.md
@@ -4,7 +4,8 @@ datatype: string | [string]
 ---
 
 <Changelog>
-    - **v0.21.0** introduced the `config` property, thereby allowing you to configure resources in all `.yml` files
+    
+  - **v0.21.0** introduced the `config` property, thereby allowing you to configure resources in all `.yml` files
 </Changelog>
 
 <Tabs

--- a/website/docs/reference/resource-properties/config.md
+++ b/website/docs/reference/resource-properties/config.md
@@ -4,7 +4,9 @@ datatype: "{dictionary}"
 ---
 
 <Changelog>
-    - **v0.21.0** introduced the `config` property
+
+- **v0.21.0** introduced the `config` property
+
 </Changelog>
 
 <Tabs

--- a/website/docs/reference/resource-properties/config.md
+++ b/website/docs/reference/resource-properties/config.md
@@ -3,11 +3,6 @@ resource_types: [models, seeds, snapshots, tests, sources, metrics, exposures]
 datatype: "{dictionary}"
 ---
 
-<Changelog>
-
-- **v0.21.0** introduced the `config` property
-
-</Changelog>
 
 <Tabs
   defaultValue="models"


### PR DESCRIPTION
## What are you changing in this pull request and why?
@eddowh noticed markdown wasn't rendering in our changelog.

![Screenshot 2023-04-28 at 10 53 48 AM](https://user-images.githubusercontent.com/3880403/235219668-83ad20c5-b7e0-47eb-8cca-eb3e1f443003.png)

This should fix it, but now I wonder if we want these old .21 changelogs in here? @jtcohen6 or @matthewshaver Did we get rid of these?

UPDATE:
Removing old changelog as they are no longer necessary. Those version have been deprecated

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [x] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
