### PR TITLE
Configure a `unique_key` for incremental materialization

### DIFF
--- a/website/docs/docs/building-a-dbt-project/building-models/python-models.md
+++ b/website/docs/docs/building-a-dbt-project/building-models/python-models.md
@@ -242,7 +242,10 @@ For incremental models, like SQL models, you will need to filter incoming tables
 import snowflake.snowpark.functions as F
 
 def model(dbt, session):
-    dbt.config(materialized = "incremental")
+    dbt.config(
+        materialized = "incremental",
+        unique_key = "id",
+    )
     df = dbt.ref("upstream_table")
 
     if dbt.is_incremental:
@@ -271,7 +274,10 @@ def model(dbt, session):
 import pyspark.sql.functions as F
 
 def model(dbt, session):
-    dbt.config(materialized = "incremental")
+    dbt.config(
+        materialized = "incremental",
+        unique_key = "id",
+    )
     df = dbt.ref("upstream_table")
 
     if dbt.is_incremental:


### PR DESCRIPTION
[Preview](https://deploy-preview-3306--docs-getdbt-com.netlify.app/docs/building-a-dbt-project/building-models/python-models#about-python-models-in-dbt)

## What are you changing in this pull request and why?
[This](https://dbt-labs.slack.com/archives/C03C17F0PC6/p1682457083839459) convo in Slack that included:

> I think it's an oversight that [the code snippet here](https://docs.getdbt.com/docs/building-a-dbt-project/building-models/python-models#materializations) doesn't have a unique_key configured
> ```
> def model(dbt, session):
>     dbt.config(
>         materialized = "incremental",
>         unique_key = "id"
>     )
> ```

## Implementation

Updated both the "Snowpark" and "PySpark" tabs to include a `unique_key` configuration.

## 🎩 

<img width="600" alt="image" src="https://user-images.githubusercontent.com/44704949/235247571-85e06ef1-a01a-4c6d-88f3-ca91e8c25617.png">


## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.