### PR TITLE
Correct typo in documentation

### DIFF
--- a/website/docs/faqs/Models/configurable-model-path.md
+++ b/website/docs/faqs/Models/configurable-model-path.md
@@ -12,7 +12,7 @@ id: configurable-model-path
 
 </Changelog>
 
-By default, dbt expects your seed files to be located in the `models` subdirectory of your project.
+By default, dbt expects the files defining your models to be located in the `models` subdirectory of your project.
 
 To change this, update the [model-paths](reference/project-configs/model-paths.md) configuration in your `dbt_project.yml`
 file, like so:


### PR DESCRIPTION
## What are you changing in this pull request and why?

This is just a very simple fix of a typo in the documentation – wrongly referencing seed files.