### PR TITLE
Bug Fix: DocItem content not showing

### DIFF
--- a/website/src/theme/DocItem/Content/index.js
+++ b/website/src/theme/DocItem/Content/index.js
@@ -42,25 +42,23 @@ export default function DocItemContent({children}) {
 
   return (
     <div className={clsx(ThemeClassNames.docs.docMarkdown, 'markdown')}>
-      {syntheticTitle && (
-        <>
-          {isSpotlightMember ? (
-            <div className={styles.spotlightMemberContain}>
-              <CommunitySpotlightCard
-                frontMatter={frontMatter} 
-                isSpotlightMember={true} 
-              />
-              <MDXContent>{children}</MDXContent>
-            </div>
-          ) : (
-            <>
-              <header>
-                <Heading as="h1">{syntheticTitle}</Heading>
-              </header>
-              <MDXContent>{children}</MDXContent>
-            </>
-          )}
-        </>
+      {syntheticTitle && !isSpotlightMember && (
+        <header>
+          <Heading as="h1">{syntheticTitle}</Heading>
+        </header>
+      )}
+
+      {/* Wrap with small container if spotlight member page */}
+      {isSpotlightMember ? (
+        <div className={styles.spotlightMemberContain}>
+          <CommunitySpotlightCard
+            frontMatter={frontMatter} 
+            isSpotlightMember={true} 
+            />
+          <MDXContent>{children}</MDXContent>
+        </div>
+      ) : (
+        <MDXContent>{children}</MDXContent>
       )}
     </div>
   );


### PR DESCRIPTION
If `syntheticTitle` was not true, the `MDXContent` component was not showing after the changes in PR #3067. This adjusts the DocItem component to always show `MDXContent`.

## Previews
https://deploy-preview-3311--docs-getdbt-com.netlify.app/guides/dbt-ecosystem/databricks-guides/how-to-set-up-your-databricks-dbt-project
https://deploy-preview-3311--docs-getdbt-com.netlify.app/guides/dbt-ecosystem/databricks-guides/dbt-unity-catalog-best-practices
https://deploy-preview-3311--docs-getdbt-com.netlify.app/community/resources/code-of-conduct

## Additional Links
[Original DocItem Content component for reference](https://github.com/facebook/docusaurus/blob/main/packages/docusaurus-theme-classic/src/theme/DocItem/Content/index.tsx)