### PR TITLE
Revert "Fix duplicate title tags development"

### DIFF
--- a/website/docs/docs/about/overview.md
+++ b/website/docs/docs/about/overview.md
@@ -1,5 +1,5 @@
 ---
-title: "What is dbt? "
+title: "Overview"
 id: "overview"
 ---
 

--- a/website/docs/docs/build/exposures.md
+++ b/website/docs/docs/build/exposures.md
@@ -1,5 +1,5 @@
 ---
-title: "Build Your DAG - Exposures"
+title: "Exposures"
 id: "exposures"
 ---
 

--- a/website/docs/docs/build/metrics.md
+++ b/website/docs/docs/build/metrics.md
@@ -1,5 +1,5 @@
 ---
-title: "Build Your DAG - Metrics"
+title: "Metrics"
 id: "metrics"
 description: "When you define metrics in dbt projects, you encode crucial business logic in tested, version-controlled code. The dbt metrics layer helps you standardize metrics within your organization."
 keywords:

--- a/website/docs/docs/build/seeds.md
+++ b/website/docs/docs/build/seeds.md
@@ -1,5 +1,5 @@
 ---
-title: "Build Your DAG - Seeds"
+title: "Seeds"
 description: "Read this tutorial to learn how to use seeds when building in dbt."
 id: "seeds"
 ---

--- a/website/docs/docs/build/snapshots.md
+++ b/website/docs/docs/build/snapshots.md
@@ -1,5 +1,5 @@
 ---
-title: "Build Your DAG - Snapshots"
+title: "Snapshots"
 description: "Read this tutorial to learn how to use snapshots when building in dbt."
 id: "snapshots"
 ---

--- a/website/docs/docs/build/sources.md
+++ b/website/docs/docs/build/sources.md
@@ -1,5 +1,5 @@
 ---
-title: "Build Your DAG - Sources"
+title: "Sources"
 description: "Read this tutorial to learn how to use sources when building in dbt."
 id: "sources"
 search_weight: "heavy"

--- a/website/docs/docs/build/tests.md
+++ b/website/docs/docs/build/tests.md
@@ -1,5 +1,5 @@
 ---
-title: "Enhance Your Models - Tests"
+title: "Tests"
 description: "Read this tutorial to learn how to use tests when building in dbt."
 id: "tests"
 ---

--- a/website/docs/docs/dbt-cloud-apis/schema-metadata-exposures.mdx
+++ b/website/docs/docs/dbt-cloud-apis/schema-metadata-exposures.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Schema - Exposures"
+title: "Exposures"
 id: "metadata-schema-exposures"
 ---
 

--- a/website/docs/docs/dbt-cloud-apis/schema-metadata-metrics.mdx
+++ b/website/docs/docs/dbt-cloud-apis/schema-metadata-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Schema - Metrics "
+title: "Metrics"
 id: "metadata-schema-metrics"
 ---
 

--- a/website/docs/docs/dbt-cloud-apis/schema-metadata-model.mdx
+++ b/website/docs/docs/dbt-cloud-apis/schema-metadata-model.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Schema - Model"
+title: "Model"
 id: "metadata-schema-model"
 ---
 

--- a/website/docs/docs/dbt-cloud-apis/schema-metadata-seed.mdx
+++ b/website/docs/docs/dbt-cloud-apis/schema-metadata-seed.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Schema - Seed"
+title: "Seed"
 id: "metadata-schema-seed"
 ---
 

--- a/website/docs/docs/dbt-cloud-apis/schema-metadata-seeds.mdx
+++ b/website/docs/docs/dbt-cloud-apis/schema-metadata-seeds.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Schema - Seeds "
+title: "Seeds"
 id: "metadata-schema-seeds"
 ---
 

--- a/website/docs/docs/dbt-cloud-apis/schema-metadata-snapshots.mdx
+++ b/website/docs/docs/dbt-cloud-apis/schema-metadata-snapshots.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Schema - Snapshots"
+title: "Snapshots"
 id: "metadata-schema-snapshots"
 ---
 

--- a/website/docs/docs/dbt-cloud-apis/schema-metadata-source.mdx
+++ b/website/docs/docs/dbt-cloud-apis/schema-metadata-source.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Schema - Source"
+title: "Source"
 id: "metadata-schema-source"
 ---
 

--- a/website/docs/docs/dbt-cloud-apis/schema-metadata-tests.mdx
+++ b/website/docs/docs/dbt-cloud-apis/schema-metadata-tests.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Schema - Tests "
+title: "Tests"
 id: "metadata-schema-tests"
 ---
 

--- a/website/docs/reference/artifacts/dbt-artifacts.md
+++ b/website/docs/reference/artifacts/dbt-artifacts.md
@@ -1,5 +1,5 @@
 ---
-title: "dbt Artifacts - Overview "
+title: Overview
 ---
 
 With every invocation, dbt generates and saves one or more *artifacts*. Several of these are <Term id="json" /> files (`manifest.json`, `catalog.json`, `run_results.json`, and `sources.json`) that are used to power:

--- a/website/docs/reference/artifacts/sources-json.md
+++ b/website/docs/reference/artifacts/sources-json.md
@@ -1,5 +1,5 @@
 ---
-title: "dbt Artifacts - Source "
+title: Sources
 ---
 
 **Current schema:** [`v3`](https://schemas.getdbt.com/dbt/sources/v3/index.html)

--- a/website/docs/reference/commands/cmd-docs.md
+++ b/website/docs/reference/commands/cmd-docs.md
@@ -1,5 +1,5 @@
 ---
-title: "List of Commands - Docs "
+title: "docs"
 id: "cmd-docs"
 ---
 

--- a/website/docs/reference/commands/debug.md
+++ b/website/docs/reference/commands/debug.md
@@ -1,5 +1,5 @@
 ---
-title: "Commands - debug"
+title: "debug"
 id: "debug"
 ---
 

--- a/website/docs/reference/commands/seed.md
+++ b/website/docs/reference/commands/seed.md
@@ -1,5 +1,5 @@
 ---
-title: "List of Commands - Seed"
+title: "seed"
 id: "seed"
 ---
 

--- a/website/docs/reference/commands/source.md
+++ b/website/docs/reference/commands/source.md
@@ -1,5 +1,5 @@
 ---
-title: "Commands - Source"
+title: "source"
 id: "source"
 ---
 

--- a/website/docs/reference/commands/test.md
+++ b/website/docs/reference/commands/test.md
@@ -1,5 +1,5 @@
 ---
-title: "Commands - Test"
+title: "test"
 id: "test"
 ---
 

--- a/website/docs/reference/dbt-jinja-functions/config.md
+++ b/website/docs/reference/dbt-jinja-functions/config.md
@@ -1,5 +1,5 @@
 ---
-title: "dbt Jinga Functions - Config"
+title: "config"
 id: "config"
 description: "Read this guide to understand the config Jinja function in dbt."
 ---

--- a/website/docs/reference/dbt-jinja-functions/debug-method.md
+++ b/website/docs/reference/dbt-jinja-functions/debug-method.md
@@ -1,5 +1,5 @@
 ---
-title: "dbt Jinga Functions - debug"
+title: "debug"
 id: "debug-method"
 description: "The `{{ debug() }}` macro will open an iPython debugger."
 ---

--- a/website/docs/reference/dbt-jinja-functions/schema.md
+++ b/website/docs/reference/dbt-jinja-functions/schema.md
@@ -1,5 +1,5 @@
 ---
-title: "dbt Jinga Functions - Schema"
+title: "schema"
 id: "schema"
 description: "The schema that the model is configured to be materialized in."
 ---

--- a/website/docs/reference/dbt-jinja-functions/source.md
+++ b/website/docs/reference/dbt-jinja-functions/source.md
@@ -1,5 +1,5 @@
 ---
-title: "dbt Jinga Functions - Source"
+title: "source"
 id: "source"
 description: "Read this guide to understand the source Jinja function in dbt."
 ---

--- a/website/docs/reference/project-configs/quoting.md
+++ b/website/docs/reference/project-configs/quoting.md
@@ -1,5 +1,4 @@
 ---
-title: "Project Configs - Quoting"
 datatype: boolean # -ish, it's actually a dictionary of bools
 description: "Read this guide to understand the quoting configuration in dbt."
 default: true

--- a/website/docs/reference/resource-configs/database.md
+++ b/website/docs/reference/resource-configs/database.md
@@ -1,5 +1,4 @@
 ---
-title: "General Configs - Database"
 resource_types: [models, seeds, tests]
 datatype: string
 description: "Read this guide to understand the database configuration in dbt."

--- a/website/docs/reference/resource-configs/docs.md
+++ b/website/docs/reference/resource-configs/docs.md
@@ -1,5 +1,4 @@
 ---
-title: "General Configs - Docs"
 resource_types: models
 description: "Docs - Read this in-depth guide to learn about configurations in dbt."
 datatype: "{dictionary}"

--- a/website/docs/reference/resource-configs/schema.md
+++ b/website/docs/reference/resource-configs/schema.md
@@ -1,5 +1,4 @@
 ---
-title: "General Configs - Schema"
 resource_types: [models, seeds, tests]
 description: "Schema - Read this in-depth guide to learn about configurations in dbt."
 datatype: string

--- a/website/docs/reference/resource-configs/tags.md
+++ b/website/docs/reference/resource-configs/tags.md
@@ -1,5 +1,4 @@
 ---
-title: "General Configs - Tags"
 resource_types: all
 datatype: string | [string]
 ---

--- a/website/docs/reference/resource-properties/config.md
+++ b/website/docs/reference/resource-properties/config.md
@@ -1,5 +1,4 @@
 ---
-title: "General Properties - Config"
 resource_types: [models, seeds, snapshots, tests, sources, metrics, exposures]
 datatype: "{dictionary}"
 ---

--- a/website/docs/reference/resource-properties/database.md
+++ b/website/docs/reference/resource-properties/database.md
@@ -1,5 +1,4 @@
 ---
-title: "For Sources - Database"
 resource_types: sources
 datatype: database_name
 ---

--- a/website/docs/reference/resource-properties/quoting.md
+++ b/website/docs/reference/resource-properties/quoting.md
@@ -1,5 +1,4 @@
 ---
-title: "For Sources - Quoting"
 datatype: boolean # -ish, it's actually a dictionary of bools
 default: true
 ---

--- a/website/docs/reference/resource-properties/schema.md
+++ b/website/docs/reference/resource-properties/schema.md
@@ -1,5 +1,4 @@
 ---
-title: "For Sources - Schema"
 resource_types: sources
 datatype: schema_name
 ---

--- a/website/docs/reference/resource-properties/tests.md
+++ b/website/docs/reference/resource-properties/tests.md
@@ -1,5 +1,4 @@
 ---
-title: "General Properties - Tests "
 resource_types: all
 datatype: test
 ---

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -223,7 +223,7 @@ var siteSettings = {
           sidebarCollapsible: true,
         },
         blog: {
-          blogTitle: "Developer Blog | dbt Developer Hub",
+          blogTitle: "dbt Developer Blog",
           blogDescription: "Find tutorials, product updates, and developer insights in the dbt Developer Blog.",
           postsPerPage: 20,
           blogSidebarTitle: "Recent posts",

--- a/website/src/pages/community/forum.js
+++ b/website/src/pages/community/forum.js
@@ -7,7 +7,7 @@ function Events() {
   return (
     <Layout>
       <Head>
-        <title>Questions | dbt Developer Hub</title>
+        <title>dbt Community Forum</title>
         <meta name="description" content="Recent interesting discussions from across the dbt Forum" />
       </Head>
       <section className='discourse-forum-page'>


### PR DESCRIPTION
## What are you changing in this pull request and why?

Reverting https://github.com/dbt-labs/docs.getdbt.com/pull/3276 so Docs team can fix sidebar titles.

## Checklist
<!--
Uncomment if you're publishing docs for a prerelease version of dbt (delete if not applicable):
- [ ] Add versioning components, as described in [Versioning Docs](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-entire-pages)
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/guides/migration/versions)
-->
- [ ] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [ ] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."

Adding new pages (delete if not applicable):
- [ ] Add page to `website/sidebars.js`
- [ ] Provide a unique filename for the new page

Removing or renaming existing pages (delete if not applicable):
- [ ] Remove page from `website/sidebars.js`
- [ ] Add an entry `website/static/_redirects`
- [ ] [Ran link testing](https://github.com/dbt-labs/docs.getdbt.com#running-the-cypress-tests-locally) to update the links that point to the deleted page
