### PR TITLE
Change `source-paths` to `model-paths`

### DIFF
--- a/website/docs/guides/dbt-ecosystem/dbt-python-snowpark/6-foundational-structure.md
+++ b/website/docs/guides/dbt-ecosystem/dbt-python-snowpark/6-foundational-structure.md
@@ -23,7 +23,7 @@ In this step, we’ll need to create a development branch and set up project lev
     profile: 'default'
 
     # These configurations specify where dbt should look for different types of files.
-    # The `source-paths` config, for example, states that models in this project can be
+    # The `model-paths` config, for example, states that models in this project can be
     # found in the "models/" directory. You probably won't need to change these!
     model-paths: ["models"]
     analysis-paths: ["analyses"]


### PR DESCRIPTION
## What are you changing in this pull request and why?
This config was renamed in dbt but many projects still refer to the unused `source-paths` name in the related comment. This commit updates it to match the value that follows.

## Checklist
- [X] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [X] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."