### PR TITLE
Update auth0-migration.md

### DIFF
--- a/website/docs/docs/cloud/manage-access/auth0-migration.md
+++ b/website/docs/docs/cloud/manage-access/auth0-migration.md
@@ -24,7 +24,7 @@ The fields that will be updated are:
 - Single sign-on URL &mdash; `https://<YOUR_AUTH0_URI>/login/callback?connection={slug}`
 - Audience URI (SP Entity ID) &mdash; `urn:auth0:<YOUR_AUTH0_ENTITYID>:{slug}`
 
-Replace {slug} with your organization’s login slug. It must be unique across all dbt Cloud instances and is usually something like your company name separated by dashes (for example, `dbt-labs`).
+Replace `{slug}` with your organization’s login slug. It must be unique across all dbt Cloud instances and is usually something like your company name separated by dashes (for example, `dbt-labs`).
 
 Here is an example of an updated SAML 2.0 setup in Okta.
 

--- a/website/snippets/auth0-uri.md
+++ b/website/snippets/auth0-uri.md
@@ -1,6 +1,6 @@
 ## Auth0 Multi-tenant URIs
 
-The URI used for SSO connections on multi-tenant dbt Cloud instances will vary based on your dbt location. Use your login URL to determin the correct Auth0 URI for your environment.
+The URI used for SSO connections on multi-tenant dbt Cloud instances will vary based on your dbt Cloud hosted region. Use your login URL (also referred to as your Access URL) to determine the correct Auth0 URI for your environment.
 
 | Region | dbt Cloud Access URL | Auth0 SSO URI <YOUR_AUTH0_URI> | Auth0 Entity ID <YOUR_AUTH0_ENTITYID>  |
 |--------|-----------------------|-------------------------------|----------------------------------------|


### PR DESCRIPTION
fix typo and suggesting clarifying language wrt 'dbt location' as users can confuse that with their actual location, rather than the dbt cloud-hosted location

