### PR TITLE
Fix categories in sidebar

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -906,7 +906,6 @@ const sidebarSettings = {
             id: "guides/dbt-ecosystem/adapter-development/1-what-are-adapters",
           },
           items: [
-            "guides/dbt-ecosystem/adapter-development/1-what-are-adapters",
             "guides/dbt-ecosystem/adapter-development/2-prerequisites-for-a-new-adapter",
             "guides/dbt-ecosystem/adapter-development/3-building-a-new-adapter",
             "guides/dbt-ecosystem/adapter-development/4-testing-a-new-adapter",
@@ -947,7 +946,6 @@ const sidebarSettings = {
             id: "guides/dbt-ecosystem/databricks-guides/how-to-set-up-your-databricks-dbt-project",
           },
           items: [
-            "guides/dbt-ecosystem/databricks-guides/how-to-set-up-your-databricks-dbt-project",
             "guides/dbt-ecosystem/databricks-guides/dbt-unity-catalog-best-practices",
             "guides/dbt-ecosystem/databricks-guides/how_to_optimize_dbt_models_on_databricks",
             "guides/dbt-ecosystem/databricks-guides/productionizing-your-dbt-databricks-project",


### PR DESCRIPTION
## What are you changing in this pull request and why?

The "Next" link at the bottom of these two pages aren't behaving as expected (infinite looping):

- https://docs.getdbt.com/guides/dbt-ecosystem/databricks-guides/how-to-set-up-your-databricks-dbt-project
- https://docs.getdbt.com/guides/dbt-ecosystem/adapter-development/1-what-are-adapters 

Updating the categories for the guides in the sidebar so the links for `id` and `items` don't have duplicates --- following what we did for the Snowpark guide:

- https://docs.getdbt.com/guides/dbt-ecosystem/dbt-python-snowpark/1-overview-dbt-python-snowpark

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [x] Needs review from Partnerships team

