### PR TITLE
Link to debug-level logging

### DIFF
--- a/website/docs/reference/commands/debug.md
+++ b/website/docs/reference/commands/debug.md
@@ -4,7 +4,7 @@ sidebar_label: "debug"
 id: "debug"
 ---
 
-`dbt debug` is a utility function to test the database connection and show information for debugging purposes. Not to be confused with [debug-level logging](https://docs.getdbt.com/reference/global-configs#debug-level-logging) via the `--debug` option which increases verbosity.
+`dbt debug` is a utility function to test the database connection and show information for debugging purposes. Not to be confused with [debug-level logging](/reference/global-configs#debug-level-logging) via the `--debug` option which increases verbosity.
 
 The `--config-dir` option to `dbt debug` will show the configured location for the `profiles.yml` file and exit:
 

--- a/website/docs/reference/commands/debug.md
+++ b/website/docs/reference/commands/debug.md
@@ -4,7 +4,7 @@ sidebar_label: "debug"
 id: "debug"
 ---
 
-`dbt debug` is a utility function to test the database connection and show information for debugging purposes. Not to be confused with the `--debug` option which increases verbosity.
+`dbt debug` is a utility function to test the database connection and show information for debugging purposes. Not to be confused with [debug-level logging](https://docs.getdbt.com/reference/global-configs#debug-level-logging) via the `--debug` option which increases verbosity.
 
 The `--config-dir` option to `dbt debug` will show the configured location for the `profiles.yml` file and exit:
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
When doing a Google search for increasing verbosity level via "debug", the first page that comes up is not the one you want.

This PR provides disambiguation and a link to the page that you want instead.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.