### PR TITLE
changing release tag to be month and year only

### DIFF
--- a/website/docs/docs/dbt-versions/release-notes/08-May-2023/discovery-api-public-preview.md
+++ b/website/docs/docs/dbt-versions/release-notes/08-May-2023/discovery-api-public-preview.md
@@ -4,7 +4,7 @@ id: "discovery-api-public-preview"
 description: "Public preview of the dbt Cloud Discovery API is now available."
 sidebar_label: "New: Latest environment state in the Discovery API"
 sidebar_position: 5
-tags: [May-24-2023, API]
+tags: [May-2023, API]
 ---
 
 Users of the Discovery API can now query the latest state of their environment, meaning there's no need to consolidate results across jobs or artifact files. The environment essentially represents the latest production state of a dbt project. The new `environment` endpoint is in public preview and can be used with the existing `modelByEnvironment` endpoint for historical analysis. For details, refer to these docs:

--- a/website/docs/docs/dbt-versions/release-notes/08-May-2023/run-details-and-logs-improvements.md
+++ b/website/docs/docs/dbt-versions/release-notes/08-May-2023/run-details-and-logs-improvements.md
@@ -2,7 +2,7 @@
 title: "Run details and logs usability and design improvements"
 sidebar_label: "Update: Improvements to run details and logs"
 sidebar_position: 3
-tags: [May-25-2023, Scheduler]
+tags: [May-2023, Scheduler]
 ---
 
 New usability and design improvements to the run details and logs in dbt Cloud are now available. The ability to triage errors in logs is a big benefit of using dbt Cloud's job and scheduler functionality. These updates help make the process of finding the root cause much easier.

--- a/website/docs/docs/dbt-versions/release-notes/08-May-2023/run-history-endpoint.md
+++ b/website/docs/docs/dbt-versions/release-notes/08-May-2023/run-history-endpoint.md
@@ -3,7 +3,7 @@ title: "Older Run History retrieval change"
 id: "run-history-endpoint"
 sidebar_label: "Update: Older Run History retrieval change"
 sidebar_position: 6
-tags: [May-22-2023, API, Scheduler]
+tags: [May-2023, API, Scheduler]
 ---
 
 dbt Labs is making a change to the metadata retrieval policy for Run History in dbt Cloud. 

--- a/website/docs/docs/dbt-versions/release-notes/08-May-2023/run-history-improvements.md
+++ b/website/docs/docs/dbt-versions/release-notes/08-May-2023/run-history-improvements.md
@@ -2,7 +2,7 @@
 title: "Run History usability and design improvements"
 sidebar_label: "Update: Run History improvements"
 sidebar_position: 4
-tags: [May-25-2023, Scheduler]
+tags: [May-2023, Scheduler]
 ---
 
 New usability and design improvements to the **Run History** dashboard in dbt Cloud are now available. These updates allow people to discover the information they need more easily by reducing the number of clicks, surfacing more relevant information, keeping people in flow state, and designing the look and feel to be more intuitive to use.   

--- a/website/docs/docs/dbt-versions/release-notes/09-April-2023/api-endpoint-restriction.md
+++ b/website/docs/docs/dbt-versions/release-notes/09-April-2023/api-endpoint-restriction.md
@@ -3,7 +3,7 @@ title: "List Runs API Endpoint `order_by` restrictions"
 id: "api-endpoint-restriction"
 sidebar_label: "Deprecation: List Runs API Endpoint order_by restrictions"
 sidebar_position: 10
-tags: [Apr-6-2023, API]
+tags: [Apr-2023, API]
 ---
 
 Starting May 15, 2023, we will support only the following `order_by` functionality for the List Runs endpoint:

--- a/website/docs/docs/dbt-versions/release-notes/09-April-2023/apr-ide-updates.md
+++ b/website/docs/docs/dbt-versions/release-notes/09-April-2023/apr-ide-updates.md
@@ -4,7 +4,7 @@ id: "apr-ide-updates"
 description: "Apr 2023 release note: We've enhanced the IDE by displaying load times when previewing models, showing live previews of Markdown and CSV files, adding the ability to duplicate files in the File Tree, and more."
 sidebar_label: "Update and fixes: IDE"
 sidebar_position: 7
-tags: [Apr-30-2023, IDE]
+tags: [Apr-2023, IDE]
 ---
 
 To continue improving your [Cloud IDE](https://docs.getdbt.com/docs/cloud/develop-in-the-cloud) development experience, the dbt Labs team continue to work on adding new features, fixing bugs, and increasing reliability ✨.

--- a/website/docs/docs/dbt-versions/release-notes/09-April-2023/scheduler-optimized.md
+++ b/website/docs/docs/dbt-versions/release-notes/09-April-2023/scheduler-optimized.md
@@ -4,7 +4,7 @@ id: "scheduler-optimized"
 description: "April 2023: "
 sidebar_label: "Update: Scheduler optimizes job queue"
 sidebar_position: 9
-tags: [Apr-12-2023, scheduler]
+tags: [Apr-2023, scheduler]
 ---
 
 The dbt Cloud Scheduler now prevents queue clog by canceling unnecessary runs of over-scheduled jobs. 

--- a/website/docs/docs/dbt-versions/release-notes/09-April-2023/starburst-trino-ga.md
+++ b/website/docs/docs/dbt-versions/release-notes/09-April-2023/starburst-trino-ga.md
@@ -3,7 +3,7 @@ title: "Integrate Starburst and Trino with dbt-trino in dbt Cloud"
 id: "starburst-trino-ga"
 sidebar_label: "New: Integrate Starburst and Trino in dbt Cloud"
 sidebar_position: 8
-tags: [Apr-27-2023]
+tags: [Apr-2023]
 ---
 
 The Starburst (Trino compatible) connection is now generally available in dbt Cloud. This means you can now use dbt Cloud to connect with Starburst Galaxy, Starburst Enterprise, and self-hosted Trino. This feature is powered by the [`dbt-trino`](https://github.com/starburstdata/dbt-trino) adapter.

--- a/website/docs/docs/dbt-versions/release-notes/10-Mar-2023/1.0-deprecation.md
+++ b/website/docs/docs/dbt-versions/release-notes/10-Mar-2023/1.0-deprecation.md
@@ -3,7 +3,7 @@ title: "dbt Cloud requires dbt version 1.0 or later"
 id: "1.0-deprecation"
 description: "Mar 2023: dbt Cloud now requires dbt version 1.0 or later and non-compliant jobs or environments were automatically upgraded to v1.4"
 sidebar_label: "Deprecation: dbt Cloud requires dbt v1.0 or later."
-tags: [Mar-1-2023]
+tags: [Mar-2023]
 ---
 
 

--- a/website/docs/docs/dbt-versions/release-notes/10-Mar-2023/apiv2-limit.md
+++ b/website/docs/docs/dbt-versions/release-notes/10-Mar-2023/apiv2-limit.md
@@ -3,7 +3,7 @@ title: "API requests have a maximum limit of `100`"
 id: apiv2-limit"
 description: "Mar 2023: In order to ease pressure on our API, we have implemented a maximum limit of `100` for all API requests to our `list` endpoints. This limit is applicable to multi-tenant instances only."
 sidebar_label: "Update: API requests have a maximum limit of `100`"
-tags: [Mar-6-2023, API]
+tags: [Mar-2023, API]
 ---
 
 

--- a/website/docs/docs/dbt-versions/release-notes/10-Mar-2023/mar-ide-updates.md
+++ b/website/docs/docs/dbt-versions/release-notes/10-Mar-2023/mar-ide-updates.md
@@ -3,7 +3,7 @@ title: "March IDE updates and fixes"
 id: "mar-ide-updates"
 description: "Mar 2023 release note: We've enhanced the IDE by adding add common dbt commands to the command palette, creating PRs even if you have uncommitted changes, autocompleting suggestions when editing a yml file, editing directly in the git diff view, improved the DAG selector, upgraded sqlfmt, improved syntax error messaging, and more."
 sidebar_label: "Update and fixes: IDE"
-tags: [Mar-31-2023, IDE]
+tags: [Mar-2023, IDE]
 ---
 
 To continue improving your [Cloud IDE](/docs/cloud/dbt-cloud-ide/develop-in-the-cloud) development experience, the dbt Labs team continue to work on adding new features, fixing bugs, and increasing reliability ✨.

--- a/website/docs/docs/dbt-versions/release-notes/10-Mar-2023/public-preview-trino-in-dbt-cloud.md
+++ b/website/docs/docs/dbt-versions/release-notes/10-Mar-2023/public-preview-trino-in-dbt-cloud.md
@@ -3,7 +3,7 @@ title: "Starbust integration with public preview of dbt-trino in dbt Cloud"
 id: "public-preview-trino-in-dbt-cloud"
 description: "Public preview of dbt Cloud integrations with Starburst and Trino clusters is now available."
 sidebar_label: "New: Starbust integration with public preview of dbt-trino in dbt Cloud"
-tags: [March-30-2023]
+tags: [Mar-2023]
 ---
 
 dbt Labs is introducing the newest connection option in dbt Cloud: the `dbt-trino` adapter is now available in Public Preview. This allows you to connect to Starburst Galaxy, Starburst Enterprise, and self-hosted Trino from dbt Cloud.

--- a/website/docs/docs/dbt-versions/release-notes/11-Feb-2023/feb-ide-updates.md
+++ b/website/docs/docs/dbt-versions/release-notes/11-Feb-2023/feb-ide-updates.md
@@ -3,7 +3,7 @@ title: "Feb IDE updates and fixes"
 id: "feb-ide-updates"
 description: "Feb 2023 release note: We've enhanced the IDE by adding custom node colors in the DAG, ref autocomplete, double-click files to rename them, add link to repo from the branch name, enabled syntax highlighting for jinja, improve file tree render time, and more."
 sidebar_label: "Update and fixes: IDE"
-tags: [Mar-1-2023, IDE]
+tags: [Feb-2023, IDE]
 ---
 
 To continue improving our [Cloud IDE](/docs/cloud/dbt-cloud-ide/develop-in-the-cloud) experience, the dbt Labs team worked on fixing bugs, increasing reliability, and adding new features ✨.

--- a/website/docs/docs/dbt-versions/release-notes/11-Feb-2023/no-partial-parse-config.md
+++ b/website/docs/docs/dbt-versions/release-notes/11-Feb-2023/no-partial-parse-config.md
@@ -3,7 +3,7 @@ title: "Disable partial parsing in dbt Cloud job commands"
 id: "no-partial-parse-config"
 description: "You can now disable partial parsing in dbt Cloud job commands."
 sidebar_label: "New: Disable partial parsing in job commands"
-tags: [Feb-15-2023]
+tags: [Feb-2023]
 ---
 
 You can now use the `--no-partial-parse` flag to disable partial parsing in your dbt Cloud job commands. 

--- a/website/docs/docs/dbt-versions/release-notes/12-Jan-2023/ide-updates.md
+++ b/website/docs/docs/dbt-versions/release-notes/12-Jan-2023/ide-updates.md
@@ -3,7 +3,7 @@ title: "Jan IDE updates and fixes"
 id: "ide-updates"
 description: "Jan 2023 release note: We've enhanced the IDE with improved syntax highlighting, faster and snappier IDE, improved error messaging, view repo status, added an easter egg, and more."
 sidebar_label: "Update and fixes: IDE"
-tags: [Feb-1-2023, IDE]
+tags: [Jan-2023, IDE]
 ---
 
 In the spirit of continuing to improve our [Cloud IDE](/docs/cloud/dbt-cloud-ide/develop-in-the-cloud) experience, the dbt Labs team worked on fixing bugs, increasing reliability, and adding new features ✨.

--- a/website/docs/docs/dbt-versions/release-notes/23-Dec-2022/default-thread-value.md
+++ b/website/docs/docs/dbt-versions/release-notes/23-Dec-2022/default-thread-value.md
@@ -3,7 +3,7 @@ title: "Threads default value changed to 4"
 id: "default-thread-value"
 description: "Threads now default to 4 users' profile."
 sidebar_label: "Enhancement: Threads default value changed to 4 "
-tags: [Dec-12-2022]
+tags: [Dec-2022]
 ---
 
 Threads help parallelize node execution in the dbt directed acyclic graph [(DAG)](https://docs.getdbt.com/terms/dag). 

--- a/website/docs/docs/dbt-versions/release-notes/23-Dec-2022/new-jobs-default-as-off.md
+++ b/website/docs/docs/dbt-versions/release-notes/23-Dec-2022/new-jobs-default-as-off.md
@@ -3,7 +3,7 @@ title: "Creating a new job no longer triggers a run by default"
 id: "new-jobs-default-as-off.md"
 description: "You need to click **Run on schedule** before a job will be scheduled to run"
 sidebar_label: "Improvement: New jobs no longer run by default"
-tags: [Dec-05-2022]
+tags: [Dec-2022]
 ---
 
 To help save compute time, new jobs will no longer be triggered to run by default. When you create a new job in dbt Cloud, you can trigger the job to run by selecting **Run on schedule** and completing the desired schedule and timing information.

--- a/website/docs/docs/dbt-versions/release-notes/23-Dec-2022/private-packages-clone-git-token.md
+++ b/website/docs/docs/dbt-versions/release-notes/23-Dec-2022/private-packages-clone-git-token.md
@@ -2,7 +2,7 @@
 title: "Private packages must be cloned using access tokens provided by environment variables"
 description: "Private GitHub packages must be cloned using access tokens provided by environment variables."
 sidebar_label: "Deprecation: Private packages must be cloned using access tokens"
-tags: [Dec-23-2022]
+tags: [Dec-2022]
 ---
 
 The supported method for cloning private GitHub packages is the [git token method](/docs/build/packages#git-token-method), where an appropriate access token is passed into the package repository URL with an environment variable. 

--- a/website/docs/docs/dbt-versions/release-notes/24-Nov-2022/dbt-databricks-unity-catalog-support.md
+++ b/website/docs/docs/dbt-versions/release-notes/24-Nov-2022/dbt-databricks-unity-catalog-support.md
@@ -3,7 +3,7 @@ title: "The dbt Cloud + Databricks experience is getting even better"
 id: "cloud-databricks-unitycatalog"
 description: "The dbt-databricks adapter is now available for use with dbt Cloud"
 sidebar_label: "Enhancement: Support for Databricks Unity Catalog with dbt-databricks"
-tags: [Nov-17-2022, v1.1.66.15]
+tags: [Nov-2022, v1.1.66.15]
 ---
 
 dbt Cloud is the easiest and most reliable way to develop and deploy a dbt project. It helps remove complexity while also giving you more features and better performance. A simpler Databricks connection experience with support for Databricks’ Unity Catalog and better modeling defaults is now available for your use.

--- a/website/docs/docs/dbt-versions/release-notes/24-Nov-2022/ide-features-ide-deprecation.md
+++ b/website/docs/docs/dbt-versions/release-notes/24-Nov-2022/ide-features-ide-deprecation.md
@@ -5,7 +5,7 @@ id: "ide-features-ide-deprecation"
 description: "Nov 2022 release note: We've enhanced the IDE by adding a button to automatically format your SQL. Added dark mode, Git diff view, and 4 new autocomplete options. We have deprecated the classic IDE."
 sidebar_label: "Enhancement and deprecation: New IDE features and classic IDE deprecation"
 tags: 
-  - Nov-29-2022
+  - Nov-2022
   - v1.1.67.0 
   - IDE
 

--- a/website/docs/docs/dbt-versions/release-notes/25-Oct-2022/cloud-integration-azure.md
+++ b/website/docs/docs/dbt-versions/release-notes/25-Oct-2022/cloud-integration-azure.md
@@ -3,7 +3,7 @@ title: "Announcing dbt Cloud’s native integration with Azure DevOps"
 id: "cloud-integration-azure"
 description: "dbt Cloud native integration with Azure DevOps"
 sidebar_label: "Improvement: Native integration with Azure DevOps"
-tags: [Oct-11-2022, v1.1.64]
+tags: [Oct-2022, v1.1.64]
 ---
 
 dbt Cloud now offers a native integration with Azure DevOps for dbt Cloud customers on the enterprise plan.  We built this integration to remove friction, increase security, and unlock net new product experiences for our customers. [Setting up the Azure DevOps integration](/docs/cloud/git/connect-azure-devops) in dbt Cloud provides:

--- a/website/docs/docs/dbt-versions/release-notes/25-Oct-2022/new-ide-launch.md
+++ b/website/docs/docs/dbt-versions/release-notes/25-Oct-2022/new-ide-launch.md
@@ -3,7 +3,7 @@ title: "Enhancement: New Cloud IDE launch"
 id: "new-ide-launch"
 description: "Oct 2022 release note: Introducing a new dbt Cloud IDE that's faster, has performance upgrades, ergonomics improvements, and other delightful enhancements."
 sidebar_label: "Snappier, faster, and new Cloud IDE"
-tags: [Oct-18-2022, IDE]
+tags: [Oct-2022, IDE]
 ---
 
 ## Introducing a snappier, improved, and powerful Cloud IDE

--- a/website/docs/docs/dbt-versions/release-notes/26-Sept-2022/liststeps-endpoint-deprecation.md
+++ b/website/docs/docs/dbt-versions/release-notes/26-Sept-2022/liststeps-endpoint-deprecation.md
@@ -3,7 +3,7 @@ title: "List Steps API endpoint deprecation warning"
 id: "liststeps-endpoint-deprecation.md"
 description: "List Steps API deprecation"
 sidebar_label: "Deprecation: List Steps API endpoint"
-tags: [Sept-15-2022]
+tags: [Sept-2022]
 ---
 
 On October 14th, 2022 dbt Labs is deprecating the [List Steps](https://docs.getdbt.com/dbt-cloud/api-v2#tag/Runs/operation/listSteps) API endpoint. From October 14th, any GET requests to this endpoint will fail. Please prepare to stop using the List Steps endpoint as soon as possible. 

--- a/website/docs/docs/dbt-versions/release-notes/26-Sept-2022/metadata-api-data-retention-limits.md
+++ b/website/docs/docs/dbt-versions/release-notes/26-Sept-2022/metadata-api-data-retention-limits.md
@@ -3,7 +3,7 @@ title: "Query the previous three months of data using the metadata API"
 id: "metadata-api-data-retention-limits.md"
 description: "Metadata API data retention limits"
 sidebar_label: "Fix: Metadata API data retention limits"
-tags: [Sept-29-2022]
+tags: [Sept-2022]
 ---
 
 In order to make the metadata API more scalable and improve its latency, we’ve implemented data retention limits. The metadata API can now query data from the previous three months. For example, if today was March 1, you could query data back to January 1st.

--- a/website/docs/docs/dbt-versions/release-notes/27-Aug-2022/ide-improvement-beta.md
+++ b/website/docs/docs/dbt-versions/release-notes/27-Aug-2022/ide-improvement-beta.md
@@ -3,7 +3,7 @@ title: "Enhancement: New Cloud IDE beta"
 id: "ide-improvements-beta.md"
 description: "Aug 2022 release note: Launch of the IDE beta, which focuses on performance and reliability improvements."
 sidebar_label: "Enhancement: New cloud IDE beta"
-tags: [Aug-16-2022, IDE]
+tags: [Aug-2022, IDE]
 ---
 
 :::info Beta feature 

--- a/website/docs/docs/dbt-versions/release-notes/27-Aug-2022/support-redshift-ra3.md
+++ b/website/docs/docs/dbt-versions/release-notes/27-Aug-2022/support-redshift-ra3.md
@@ -3,7 +3,7 @@ title: "Enhancement: Support for cross-database sources on Redshift RA3 instance
 id: "support-redshift-ra3.md"
 description: "Adding support for cross-database queries for RA3"
 sidebar_label: "Enhancement: Support for RA3"
-tags: [Aug-31-2022, 1.1.61.5]
+tags: [Aug-2022, 1.1.61.5]
 
 ---
 

--- a/website/docs/docs/dbt-versions/release-notes/28-July-2022/render-lineage-feature.md
+++ b/website/docs/docs/dbt-versions/release-notes/28-July-2022/render-lineage-feature.md
@@ -3,7 +3,7 @@ title: "Enhancement: Large DAG feature"
 id: "render-lineage-feature"
 description: "Jul 2022 release note: Use the Render Lineage button to visualize large DAGs"
 sidebar_label: "Enhancement: Large DAG feature"
-tags: [July-5-2022, v1.1.56, IDE]
+tags: [July-2022, v1.1.56, IDE]
 
 ---
 

--- a/website/docs/docs/dbt-versions/release-notes/29-May-2022/gitlab-auth.md
+++ b/website/docs/docs/dbt-versions/release-notes/29-May-2022/gitlab-auth.md
@@ -3,7 +3,7 @@ title: "Refresh expired access tokens in the IDE when using GitLab"
 id: "gitlab-auth"
 description: "Adding support for expiring OAuth access tokens."
 sidebar_label: "Enhancement: Refreshing GitLab OAuth Access"
-tags: [May-19-2022, v1.1.52]
+tags: [May-2022, v1.1.52]
 ---
 
 On May 22, GitLab changed how they treat [OAuth access tokens that don't expire](https://docs.gitlab.com/ee/update/deprecations.html#oauth-tokens-without-expiration). We updated our IDE logic to handle OAuth token expiration more gracefully. Now, the first time your token expires after 2 hours of consecutive IDE usage, you will have to re-authenticate in GitLab to refresh your expired OAuth access token. We will handle subsequent refreshes for you if you provide the authorization when you re-authenticate.


### PR DESCRIPTION
## What are you changing in this pull request and why?

Changing the tag to be month/year so you can see all releases per month if you're curious. Just doing this for the last year because it's probably not necessary before that.

Here's how it looks to search by month tag: https://deploy-preview-3444--docs-getdbt-com.netlify.app/tags/may-2023

## Checklist

- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [x] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
