### PR TITLE
Describe behavior of `copy_grants`

### DIFF
--- a/website/docs/reference/resource-configs/snowflake-configs.md
+++ b/website/docs/reference/resource-configs/snowflake-configs.md
@@ -273,7 +273,7 @@ select * from index_sessions
 
 <VersionBlock firstVersion="1.2" lastVersion="1.5">
 
-When the `copy_grants` config is set to `true`, dbt will add the `copy grants` <Term id="ddl" /> qualifier when rebuilding tables and <Term id="view">views</Term>. The default value is `false`.
+When the `copy_grants` config is set to `true`, dbt will add the `copy grants` <Term id="ddl" /> qualifier when rebuilding tables and <Term id="view">views</Term>. The default value for the `copy_grants` config is set to `false`.
 
 </VersionBlock>
 

--- a/website/docs/reference/resource-configs/snowflake-configs.md
+++ b/website/docs/reference/resource-configs/snowflake-configs.md
@@ -265,9 +265,26 @@ select * from index_sessions
 </TabItem>
 </Tabs>
 
+<VersionBlock firstVersion="1.2">
+
 ## Copying grants
 
+</VersionBlock>
+
+<VersionBlock firstVersion="1.2" lastVersion="1.5">
+
 When the `copy_grants` config is set to `true`, dbt will add the `copy grants` <Term id="ddl" /> qualifier when rebuilding tables and <Term id="view">views</Term>. The default value is `false`.
+
+</VersionBlock>
+
+<VersionBlock firstVersion="1.6">
+
+When the `copy_grants` config is set to `true`, dbt will add the `copy grants` <Term id="ddl" /> qualifier when rebuilding tables and <Term id="view">views</Term>. After materialization, it will also apply the `grants` that are [configured](/reference/resource-configs/grants#configuring-grants). No grants are revoked when `copy_grants` config is set to `true`.
+
+When the `copy_grants` config is set to `false`, dbt will revoke any existing grants prior to applying the configured `grants`.
+
+The default value is `false`.
+</VersionBlock>
 
 <File name='dbt_project.yml'>
 


### PR DESCRIPTION
[Page preview](https://deploy-preview-3474--docs-getdbt-com.netlify.app/reference/resource-configs/snowflake-configs#copying-grants)

## What are you changing in this pull request and why?
See https://github.com/dbt-labs/dbt-snowflake/issues/567#issuecomment-1577441385 for context.

One page with edits:
- https://deploy-preview-3474--docs-getdbt-com.netlify.app/reference/resource-configs/snowflake-configs#copying-grants

One page that _could_ have edits, but doesn't currently:
- https://deploy-preview-3474--docs-getdbt-com.netlify.app/reference/resource-configs/grants#database-specific-requirements-and-notes

## Checklist
- [x] Add versioning components, as described in [Versioning Docs](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-entire-pages)
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [ ] Don't merge until the bug is fixed and released within dbt-snowflake
- [ ] Verify that the versioning components align with the intended versions