### PR TITLE
Fix anchor link in setup azure

### DIFF
--- a/website/docs/docs/cloud/git/setup-azure.md
+++ b/website/docs/docs/cloud/git/setup-azure.md
@@ -13,7 +13,7 @@ To use our native integration with Azure DevOps in dbt Cloud, an account admin n
 
 1. [Register an Azure AD app](#register-an-azure-ad-app).
 2. [Add permissions to your new app](#add-permissions-to-your-new-app).
-3. [Add another redirect URI](#add-another-redirect-URI).
+3. [Add another redirect URI](#add-another-redirect-uri).
 4. [Connect Azure DevOps to your new app](#connect-azure-devops-to-your-new-app).
 5. [Add your Azure AD app to dbt Cloud](#add-your-azure-ad-app-to-dbt-cloud).
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

Navigating to anchor links seem to be case sensitive (at least for Chrome 113). I noticed that the link containing "URI" was not working as expected. I'm suggesting the docs consistently use lowercase.
- The link from the number list uses: `#add-another-redirect-URI`
- The anchor is: `#add-another-redirect-uri`

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- **N/A** Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
