### PR TITLE
Fix typo in advanced-config-usage.md

### DIFF
--- a/website/docs/reference/advanced-config-usage.md
+++ b/website/docs/reference/advanced-config-usage.md
@@ -17,7 +17,7 @@ select ...
 
 While dbt provides an alias for any core configurations (e.g. you should use `pre_hook` instead of `pre-hook` in a config block), your dbt project may contain custom configurations without aliases.
 
-If you want to specify these configurations inside of a model, use the altenative config block syntax:
+If you want to specify these configurations inside of a model, use the alternative config block syntax:
 
 
 <File name='models/events/base/base_events.sql'>


### PR DESCRIPTION
## What are you changing in this pull request and why?
Fix a small typo in advanced-config-usage.md

## Checklist
- [X] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [X] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."


