### PR TITLE
Add slash to fix broken link

### DIFF
--- a/website/docs/docs/build/project-variables.md
+++ b/website/docs/docs/build/project-variables.md
@@ -3,7 +3,7 @@ title: "Project variables"
 id: "project-variables"
 ---
 
-dbt provides a mechanism, [variables](reference/dbt-jinja-functions/var), to provide data to models for
+dbt provides a mechanism, [variables](/reference/dbt-jinja-functions/var), to provide data to models for
 compilation. Variables can be used to [configure timezones](https://github.com/dbt-labs/snowplow/blob/0.3.9/dbt_project.yml#L22),
 [avoid hardcoding table names](https://github.com/dbt-labs/quickbooks/blob/v0.1.0/dbt_project.yml#L23)
 or otherwise provide data to models to configure how they are compiled.


### PR DESCRIPTION
## What are you changing in this pull request and why?
without the slash, the link assumes the same directory, but this file is not under `/build` it's under `/reference`.

## Checklist
