### PR TITLE
Remove `--selector` flag from CLI unions and intersections

### DIFF
--- a/website/docs/reference/commands/list.md
+++ b/website/docs/reference/commands/list.md
@@ -14,7 +14,7 @@ dbt ls
      [--select SELECTION_ARG [SELECTION_ARG ...]]
      [--models SELECTOR [SELECTOR ...]]
      [--exclude SELECTOR [SELECTOR ...]]
-     [--selector YML_SELECTOR_NAME [YML_SELECTOR_NAME ...]]
+     [--selector YML_SELECTOR_NAME]
      [--output {json,name,path,selector}]
      [--output-keys KEY_NAME [KEY_NAME]]
 ```
@@ -26,7 +26,7 @@ See [resource selection syntax](/reference/node-selection/syntax) for more infor
 - `--select`: This flag specifies one or more selection-type arguments used to filter the nodes returned by the `dbt ls` command
 - `--models`: Like the `--select` flag, this flag is used to select nodes. It implies `--resource-type=model`, and will only return models in the results of the `dbt ls` command. Supported for backwards compatibility only.
 - `--exclude`: Specify selectors that should be _excluded_ from the list of returned nodes.
-- `--selector`: This flag specifies one or more named selectors, defined in a `selectors.yml` file.
+- `--selector`: This flag specifies one named selector, defined in a `selectors.yml` file.
 - `--output`: This flag controls the format of output from the `dbt ls` command.
 - `--output-keys`: If `--output json`, this flag controls which node properties are included in the output.
 

--- a/website/docs/reference/node-selection/set-operators.md
+++ b/website/docs/reference/node-selection/set-operators.md
@@ -3,7 +3,7 @@ title: "Set operators"
 ---
 
 ### Unions
-Providing multiple space-delineated arguments to the `--select`, `--exclude`, or `--selector` flags selects
+Providing multiple space-delineated arguments to the `--select` or `--exclude` flags selects
 the union of them all. If a resource is included in at least one selector, it will be
 included in the final set.
 
@@ -16,7 +16,7 @@ Run snowplow_sessions, all ancestors of snowplow_sessions, fct_orders, and all a
 
 ### Intersections
 
-If you separate multiple arguments for `--select`, `--exclude`, and `--selector` with commas and no whitespace in between, dbt will select only resources that satisfy _all_ arguments.
+If you separate multiple arguments for `--select` and `--exclude` with commas and no whitespace in between, dbt will select only resources that satisfy _all_ arguments.
 
 Run all the common ancestors of snowplow_sessions and fct_orders:
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

This PR is intended to address feedback given in https://github.com/dbt-labs/dbt-core/issues/7871

Namely, dbt does **not** support the following syntax, so we should update the docs to reflect this:
```shell
dbt ls --selector nodes_to_joy nodes_to_a_grecian_urn
dbt ls --selector nodes_to_joy,nodes_to_a_grecian_urn
```

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.