### PR TITLE
Correct example values for `dbt_updated_at`

### DIFF
--- a/website/docs/docs/build/snapshots.md
+++ b/website/docs/docs/build/snapshots.md
@@ -346,7 +346,7 @@ For the `timestamp` strategy, the configured `updated_at` column is used to popu
 <details>
 <summary>  Details for the timestamp strategy </summary>
 
-<summary>Snapshot query results at `2019-01-01 11:00`</summary>
+Snapshot query results at `2019-01-01 11:00`
 
 | id | status  | updated_at       |
 | -- | ------- | ---------------- |
@@ -368,7 +368,7 @@ Snapshot results (note that `11:30` is not used anywhere):
 
 | id | status  | updated_at       | dbt_valid_from   | dbt_valid_to     | dbt_updated_at   |
 | -- | ------- | ---------------- | ---------------- | ---------------- | ---------------- |
-| 1  | pending | 2019-01-01 10:47 | 2019-01-01 10:47 | 2019-01-01 11:05 | 2019-01-01 11:05 |
+| 1  | pending | 2019-01-01 10:47 | 2019-01-01 10:47 | 2019-01-01 11:05 | 2019-01-01 10:47 |
 | 1  | shipped | 2019-01-01 11:05 | 2019-01-01 11:05 |                  | 2019-01-01 11:05 |
 
 </details>
@@ -380,7 +380,7 @@ For the `check` strategy, the current timestamp is used to populate each column.
 <details>
 <summary>  Details for the check strategy </summary>
 
-<summary>Snapshot query results at `2019-01-01 11:00`</summary>
+Snapshot query results at `2019-01-01 11:00`
 
 | id | status  |
 | -- | ------- |
@@ -402,7 +402,7 @@ Snapshot results:
 
 | id | status  | dbt_valid_from   | dbt_valid_to     | dbt_updated_at   |
 | --- | ------- | ---------------- | ---------------- | ---------------- |
-| 1   | pending | 2019-01-01 11:00 | 2019-01-01 11:30 | 2019-01-01 11:30 |
+| 1   | pending | 2019-01-01 11:00 | 2019-01-01 11:30 | 2019-01-01 11:00 |
 | 1   | shipped | 2019-01-01 11:30 |                  | 2019-01-01 11:30 |
 
 </details>


### PR DESCRIPTION
[Preview](https://deploy-preview-3540--docs-getdbt-com.netlify.app/docs/build/snapshots#snapshot-meta-fields)

## What are you changing in this pull request and why?
The values in the examples for `dbt_updated_at` weren't an accurate portrayal.

See https://github.com/dbt-labs/dbt-core/issues/7869 for context.

### 🎩 

<img width="400" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/04170f33-3317-4d66-86f4-ce166bfa1b50">

Formatting of some timestamps was fixed as well:

<img width="200" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/7bd71f6d-c9b3-4c5a-974a-044d8f0a2773">

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.