### PR TITLE
RSS Feed Publish Date Adjustment

### DIFF
--- a/website/plugins/buildRSSFeeds/index.js
+++ b/website/plugins/buildRSSFeeds/index.js
@@ -34,11 +34,11 @@ module.exports = function buildRSSFeedsPlugin() {
 
         // Set post date
         // If date not set within `date` or `tags` properties
-        // Set default date to today
+        // Set default date to oldest releast note date.
+        // 
         feedItemObj.date = data?.date || data?.tags 
-          ? getDate(data?.date ? data.date : data.tags) 
-          : new Date()
-        
+          && getDate(data?.date ? data.date : data.tags) 
+
         return feedItemObj
       }).sort((a, b) => (a.date > b.date) ? -1 : 1)
       
@@ -65,7 +65,7 @@ module.exports = function buildRSSFeedsPlugin() {
       
       feedObj.updated = latestUpdate?.date
         ? latestUpdate.date
-        : new Date(2023, 1, 18)
+        : new Date()
 
       // Initialize feed
       const feed = new Feed(feedObj);
@@ -105,11 +105,16 @@ function getLink(data) {
 }
 
 function getDate(tags) {
+  if(!tags) return new Date('2020-01-01')
+
   // Find tag with the format 'day-year'
   const expr = /(-\d{4})/g
   const dateTag = tags.find(str => expr.test(str))
 
+  // If date not found, default to oldest release note date.
+  // This prevents the RSS feed from showing older release notes
+  // as recently published.
   return dateTag
     ? new Date(dateTag)
-    : new Date()
+    : new Date('2020-01-01')
 }

--- a/website/plugins/buildRSSFeeds/index.js
+++ b/website/plugins/buildRSSFeeds/index.js
@@ -33,9 +33,6 @@ module.exports = function buildRSSFeedsPlugin() {
         feedItemObj.link = getLink(data)
 
         // Set post date
-        // If date not set within `date` or `tags` properties
-        // Set default date to oldest releast note date.
-        // 
         feedItemObj.date = data?.date || data?.tags 
           && getDate(data?.date ? data.date : data.tags) 
 

--- a/website/plugins/buildRSSFeeds/index.js
+++ b/website/plugins/buildRSSFeeds/index.js
@@ -39,6 +39,8 @@ module.exports = function buildRSSFeedsPlugin() {
           ? getDate(data?.date ? data.date : data.tags) 
           : new Date()
 
+        console.log('feedItemObj.date', feedItemObj.date)
+        
         return feedItemObj
       }).sort((a, b) => (a.date > b.date) ? -1 : 1)
       
@@ -105,10 +107,13 @@ function getLink(data) {
 }
 
 function getDate(tags) {
+  console.log('Running getDate')
   // Find tag with the format 'day-year'
-  const expr = /(-.*\d-\d{4})/g
+  const expr = /(-\d{4})/g
   const dateTag = tags.find(str => expr.test(str))
-  
+
+  console.log('dateTag', dateTag)
+
   return dateTag
     ? new Date(dateTag)
     : new Date()

--- a/website/plugins/buildRSSFeeds/index.js
+++ b/website/plugins/buildRSSFeeds/index.js
@@ -38,8 +38,6 @@ module.exports = function buildRSSFeedsPlugin() {
         feedItemObj.date = data?.date || data?.tags 
           ? getDate(data?.date ? data.date : data.tags) 
           : new Date()
-
-        console.log('feedItemObj.date', feedItemObj.date)
         
         return feedItemObj
       }).sort((a, b) => (a.date > b.date) ? -1 : 1)
@@ -107,12 +105,9 @@ function getLink(data) {
 }
 
 function getDate(tags) {
-  console.log('Running getDate')
   // Find tag with the format 'day-year'
   const expr = /(-\d{4})/g
   const dateTag = tags.find(str => expr.test(str))
-
-  console.log('dateTag', dateTag)
 
   return dateTag
     ? new Date(dateTag)


### PR DESCRIPTION
This adjusts the release notes RSS feed plugin to get the correct date when date is added as a frontmatter `tag` with the format: `<month>-<year>`. 

Currently, the feed is not correctly picking up the date from the `tags` field, and defaults to today's date.

## Preview
In the feed preview below, verify the `pubDate` field for each item in the feed matches the correct directory for each release note.

For example, the items in the RSS feed under the `May-2023` [release notes](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/release-notes/08-May-2023) now correctly show a `pubDate` of May (defaults to May 1st).

![image](https://github.com/dbt-labs/docs.getdbt.com/assets/13647110/04146769-d893-414a-b7a2-3499fbfd6670)

https://deploy-preview-3543--docs-getdbt-com.netlify.app/feeds/rss.xml

The current RSS feed which incorrectly shows today's date for each item in the feed:
https://docs.getdbt.com/feeds/rss.xml