### PR TITLE
Fix release note placement

### DIFF
--- a/website/docs/docs/dbt-versions/release-notes/07-June-2023/admin-api-rn.md
+++ b/website/docs/docs/dbt-versions/release-notes/07-June-2023/admin-api-rn.md
@@ -3,6 +3,7 @@ title: "Update: dbt Cloud Administrative API docs for v2 and v3"
 description: "June 2023 release note: The Administrative API docs are now available for v2 and v3 with a different UI."
 sidebar_label: "Update: Admin API docs for v2 and v3 "
 tags: [June-2023, API]
+sidebar_position: 9
 ---
 
 dbt Labs updated the docs for the [dbt Cloud Administrative API](/docs/dbt-cloud-apis/admin-cloud-api) and they are now available for both [v2](/dbt-cloud/api-v2#/) and [v3](/dbt-cloud/api-v3#/). 

--- a/website/docs/docs/dbt-versions/release-notes/07-June-2023/ci-updates-phase1-rn.md
+++ b/website/docs/docs/dbt-versions/release-notes/07-June-2023/ci-updates-phase1-rn.md
@@ -4,6 +4,7 @@ description: "June 2023 release note: Improvements to dbt Cloud continuous integ
 sidebar_label: "Update: Improvements to continuous integration"
 tags: [June-2023, CI]
 date: 2023-06-20
+sidebar_position: 8
 ---
 
 dbt Cloud Slim CI is a critical part of the analytics engineering workflow. Large teams rely on process to ensure code quality is high, and they look to dbt Cloud CI to automate testing code changes in an efficient way, enabling speed while keep the bar high. With status checks directly posted to their dbt PRs, developers gain the confidence that their code changes will work as expected in production, and once you’ve grown accustomed to seeing that green status check in your PR, you won’t be able to work any other way.

--- a/website/docs/docs/dbt-versions/release-notes/07-June-2023/lint-format-rn.md
+++ b/website/docs/docs/dbt-versions/release-notes/07-June-2023/lint-format-rn.md
@@ -3,7 +3,7 @@ title: "New: You can now lint and format your code in the IDE"
 id: "lint-format-rn"
 description: "June 2023 release note: In the dbt Cloud IDE, you can perform linting and formatting on SQL, YAML, Markdown, Python, and JSON files using tools like SQLFluff, sqlfmt, Prettier, and Black."
 sidebar_label: "New: Lint and format in the IDE"
-sidebar_position: 1
+sidebar_position: 10
 tags: [June-2023, IDE]
 ---
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

Fix placement of June release notes by updating the YAML sidebar_position setting -- lowest number shows up at the top of the list. 

New release note must have the sidebar_position lowest number. 

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.

