### PR TITLE
Remove api v4 docs

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,4 +1,3 @@
-/dbt-cloud/api-v4 /docs/dbt-cloud-apis/admin-cloud-api 301
 /docs/building-a-dbt-project/building-models/python-models /docs/build/python-models 301
 /docs/deploy/regions  /docs/deploy/regions-ip-addresses 301
 

--- a/website/src/pages/dbt-cloud/api-v4.js
+++ b/website/src/pages/dbt-cloud/api-v4.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import Layout from '@theme/Layout';
+import classnames from 'classnames';
+
+import { RedocStandalone } from 'redoc';
+
+function dbtCloudAPI() {
+  const context = useDocusaurusContext();
+
+  return (
+    <Layout permalink="/">
+        <RedocStandalone
+            specUrl='https://raw.githubusercontent.com/fishtown-analytics/dbt-cloud-openapi-spec/master/openapi-v4.yaml'
+            options={{
+                requiredPropsFirst: true,
+                noAutoAuth: true,
+                hideDownloadButton: true,
+                onlyRequiredInSamples: true,
+                scrollYOffset: 60,
+                expandResponses: "200",
+                hideHostname: false,
+                pathInMiddlePanel: true,
+                theme: {
+                    colors: {
+                        primary: {
+                            main: "#033744"
+                        },
+                    },
+                },
+            }}
+        />
+    </Layout>
+  );
+}
+
+export default dbtCloudAPI;


### PR DESCRIPTION
## What are you changing in this pull request and why?

@iktl requested we remove these docs because v4 has been officially deprecated.

## Checklist
<!--
Uncomment if you're publishing docs for a prerelease version of dbt (delete if not applicable):
- [ ] Add versioning components, as described in [Versioning Docs](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-entire-pages)
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/guides/migration/versions)
-->
- [ ] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [ ] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."

Adding new pages (delete if not applicable):
- [ ] Add page to `website/sidebars.js`
- [ ] Provide a unique filename for the new page

Removing or renaming existing pages (delete if not applicable):
- [ ] Remove page from `website/sidebars.js`
- [ ] Add an entry `website/static/_redirects`
- [ ] [Ran link testing](https://github.com/dbt-labs/docs.getdbt.com#running-the-cypress-tests-locally) to update the links that point to the deleted page
