### PR TITLE
Hyperlink to `clean-targets` config

### DIFF
--- a/website/docs/reference/commands/clean.md
+++ b/website/docs/reference/commands/clean.md
@@ -10,6 +10,6 @@ id: "clean"
 
 </Changelog>
 
-`dbt clean` is a utility function that deletes all folders specified in the [`clean-targets`](reference/project-configs/clean-targets) list specified in `dbt_project.yml`. You can use this to delete the `dbt_packages` and `target` directories.
+`dbt clean` is a utility function that deletes all folders specified in the [`clean-targets`](/reference/project-configs/clean-targets) list specified in `dbt_project.yml`. You can use this to delete the `dbt_packages` and `target` directories.
 
 To avoid complex permissions issues and potentially deleting crucial aspects of the remote file system without access to fix them, this command does not work when interfacing with the RPC server that powers the dbt Cloud IDE. Instead, when working in dbt Cloud, the `dbt deps` command cleans before it installs packages automatically. The `target` folder can be manually deleted from the sidebar file tree if needed.

--- a/website/docs/reference/commands/clean.md
+++ b/website/docs/reference/commands/clean.md
@@ -10,6 +10,6 @@ id: "clean"
 
 </Changelog>
 
-`dbt clean` is a utility function that deletes all folders specified in the `clean-targets` list specified in `dbt_project.yml`. You can use this to delete the `dbt_packages` and `target` directories.
+`dbt clean` is a utility function that deletes all folders specified in the [`clean-targets`](reference/project-configs/clean-targets) list specified in `dbt_project.yml`. You can use this to delete the `dbt_packages` and `target` directories.
 
 To avoid complex permissions issues and potentially deleting crucial aspects of the remote file system without access to fix them, this command does not work when interfacing with the RPC server that powers the dbt Cloud IDE. Instead, when working in dbt Cloud, the `dbt deps` command cleans before it installs packages automatically. The `target` folder can be manually deleted from the sidebar file tree if needed.


### PR DESCRIPTION
## What are you changing in this pull request and why?

Without reading the docs for configuring `clean-targets`, it might not be clear how to customize the behavior of the `dbt clean` command. So this PR adds a hyperlink to encourage visiting other relevant docs.

See https://github.com/dbt-labs/docs.getdbt.com/pull/3485 for more context.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.