### PR TITLE
Update link for anonymous usage stats

### DIFF
--- a/website/docs/reference/artifacts/dbt-artifacts.md
+++ b/website/docs/reference/artifacts/dbt-artifacts.md
@@ -38,7 +38,7 @@ All artifacts produced by dbt include a `metadata` dictionary with these propert
 - [`invocation_id`](/reference/dbt-jinja-functions/invocation_id): Unique identifier for this dbt invocation
 
 In the manifest, the `metadata` may also include:
-- `send_anonymous_usage_stats`: Whether this invocation sent [anonymous usage statistics](reference/global-configs/usage-stats) while executing.
+- `send_anonymous_usage_stats`: Whether this invocation sent [anonymous usage statistics](/reference/global-configs/usage-stats) while executing.
 - `project_id`: Project identifier, hashed from `project_name`, sent with anonymous usage stats if enabled.
 - `user_id`: User identifier, stored by default in `~/dbt/.user.yml`, sent with anonymous usage stats if enabled.
 

--- a/website/docs/reference/artifacts/dbt-artifacts.md
+++ b/website/docs/reference/artifacts/dbt-artifacts.md
@@ -38,7 +38,7 @@ All artifacts produced by dbt include a `metadata` dictionary with these propert
 - [`invocation_id`](/reference/dbt-jinja-functions/invocation_id): Unique identifier for this dbt invocation
 
 In the manifest, the `metadata` may also include:
-- `send_anonymous_usage_stats`: Whether this invocation sent [anonymous usage statistics](https://docs.getdbt.com/reference/profiles.yml/#send_anonymous_usage_stats) while executing.
+- `send_anonymous_usage_stats`: Whether this invocation sent [anonymous usage statistics](reference/global-configs/usage-stats) while executing.
 - `project_id`: Project identifier, hashed from `project_name`, sent with anonymous usage stats if enabled.
 - `user_id`: User identifier, stored by default in `~/dbt/.user.yml`, sent with anonymous usage stats if enabled.
 


### PR DESCRIPTION
[Preview](https://deploy-preview-3600--docs-getdbt-com.netlify.app/reference/artifacts/dbt-artifacts#common-metadata)

## What are you changing in this pull request and why?
There's a dead link here:
https://docs.getdbt.com/reference/artifacts/dbt-artifacts#common-metadata

The full link is the following, which no longer exists:
https://docs.getdbt.com/reference/profiles.yml/#send_anonymous_usage_stats

<img width="550" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/230a02f2-d3d9-45c2-a767-b1386518d021">


## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.