### PR TITLE
document `merge` as supported `incremental_strategy` for both dbt-postgres & dbt-redshift

### DIFF
--- a/website/docs/docs/build/incremental-models.md
+++ b/website/docs/docs/build/incremental-models.md
@@ -257,8 +257,8 @@ Click the name of the adapter in the below table for more information about supp
 
 | data platform adapter                                                                               | default strategy | additional supported strategies          |
 | :-------------------------------------------------------------------------------------------------- | ---------------- | ---------------------------------------- |
-| [dbt-postgres](/reference/resource-configs/postgres-configs#incremental-materialization-strategies) | `append`         | `merge` `delete+insert`                  |
-| [dbt-redshift](/reference/resource-configs/redshift-configs#incremental-materialization-strategies) | `append`         | `merge` `delete+insert`                  |
+| [dbt-postgres](/reference/resource-configs/postgres-configs#incremental-materialization-strategies) | `append`         | `merge` , `delete+insert`                  |
+| [dbt-redshift](/reference/resource-configs/redshift-configs#incremental-materialization-strategies) | `append`         | `merge`, `delete+insert`                  |
 | [dbt-bigquery](/reference/resource-configs/bigquery-configs#merge-behavior-incremental-models)      | `merge`          | `insert_overwrite`                       |
 | [dbt-spark](/reference/resource-configs/spark-configs#incremental-models)                           | `append`         | `merge` (Delta only)  `insert_overwrite` |
 | [dbt-databricks](/reference/resource-configs/databricks-configs#incremental-models)                 | `append`         | `merge` (Delta only) `insert_overwrite`  |

--- a/website/docs/docs/build/incremental-models.md
+++ b/website/docs/docs/build/incremental-models.md
@@ -257,7 +257,7 @@ Click the name of the adapter in the below table for more information about supp
 
 | data platform adapter                                                                               | default strategy | additional supported strategies          |
 | :-------------------------------------------------------------------------------------------------- | ---------------- | ---------------------------------------- |
-| dbt-postgres                                                                                        | `append`         | `delete+insert`                          |
+| [dbt-postgres](/reference/resource-configs/postgres-configs#incremental-materialization-strategies) | `append`         | `merge` `delete+insert`                  |
 | [dbt-redshift](/reference/resource-configs/redshift-configs#incremental-materialization-strategies) | `append`         | `merge` `delete+insert`                  |
 | [dbt-bigquery](/reference/resource-configs/bigquery-configs#merge-behavior-incremental-models)      | `merge`          | `insert_overwrite`                       |
 | [dbt-spark](/reference/resource-configs/spark-configs#incremental-models)                           | `append`         | `merge` (Delta only)  `insert_overwrite` |

--- a/website/docs/docs/build/incremental-models.md
+++ b/website/docs/docs/build/incremental-models.md
@@ -255,15 +255,15 @@ to build incremental models.
 
 Click the name of the adapter in the below table for more information about supported incremental strategies.
 
-| data platform adapter                                                                            | default strategy | additional supported strategies                                      |
-| :----------------------------------------------------------------------------------------------- | -------- | ------------------------------------------------------- |
-| dbt-postgres                                                                                     | `append` | `delete+insert`                                         |
-| dbt-redshift                                                                                     | `append` | `delete+insert`                                         |
-| [dbt-bigquery](/reference/resource-configs/bigquery-configs#merge-behavior-incremental-models)   | `merge`  | `insert_overwrite`                                      |
-| [dbt-spark](/reference/resource-configs/spark-configs#incremental-models)                        | `append` | `merge` (Delta only)  `insert_overwrite` |
-| [dbt-databricks](/reference/resource-configs/databricks-configs#incremental-models)              | `append` | `merge` (Delta only) `insert_overwrite` |
-| [dbt-snowflake](/reference/resource-configs/snowflake-configs#merge-behavior-incremental-models) | `merge`  | `append`, `delete+insert`                                        |
-| [dbt-trino](/reference/resource-configs/trino-configs#incremental)                               | `append` | `merge` `delete+insert`                                 |
+| data platform adapter                                                                               | default strategy | additional supported strategies          |
+| :-------------------------------------------------------------------------------------------------- | ---------------- | ---------------------------------------- |
+| dbt-postgres                                                                                        | `append`         | `delete+insert`                          |
+| [dbt-redshift](/reference/resource-configs/redshift-configs#incremental-materialization-strategies) | `append`         | `merge` `delete+insert`                  |
+| [dbt-bigquery](/reference/resource-configs/bigquery-configs#merge-behavior-incremental-models)      | `merge`          | `insert_overwrite`                       |
+| [dbt-spark](/reference/resource-configs/spark-configs#incremental-models)                           | `append`         | `merge` (Delta only)  `insert_overwrite` |
+| [dbt-databricks](/reference/resource-configs/databricks-configs#incremental-models)                 | `append`         | `merge` (Delta only) `insert_overwrite`  |
+| [dbt-snowflake](/reference/resource-configs/snowflake-configs#merge-behavior-incremental-models)    | `merge`          | `append`, `delete+insert`                |
+| [dbt-trino](/reference/resource-configs/trino-configs#incremental)                                  | `append`         | `merge` `delete+insert`                  |
 
 <VersionBlock firstVersion="1.3">
 

--- a/website/docs/reference/resource-configs/postgres-configs.md
+++ b/website/docs/reference/resource-configs/postgres-configs.md
@@ -4,7 +4,7 @@ description: "Postgres Configurations - Read this in-depth guide to learn about 
 id: "postgres-configs"
 ---
 
-## Incremental Materialization Strategies
+## Incremental materialization strategies
 
 In dbt-postgres, the following incremental materialization strategies are supported:
 

--- a/website/docs/reference/resource-configs/postgres-configs.md
+++ b/website/docs/reference/resource-configs/postgres-configs.md
@@ -4,6 +4,14 @@ description: "Postgres Configurations - Read this in-depth guide to learn about 
 id: "postgres-configs"
 ---
 
+## Incremental Materialization Strategies
+
+In dbt-postgres, the following incremental materialization strategies are supported:
+
+- `append` (default)
+- `merge`
+- `delete+insert`
+
 
 ## Performance Optimizations
 

--- a/website/docs/reference/resource-configs/redshift-configs.md
+++ b/website/docs/reference/resource-configs/redshift-configs.md
@@ -10,7 +10,7 @@ To-do:
 - think about whether some of these should be outside of models
 --->
 
-## Incremental Materialization Strategies
+## Incremental materialization strategies
 
 In dbt-redshift, the following incremental materialization strategies are supported:
 
@@ -20,7 +20,7 @@ In dbt-redshift, the following incremental materialization strategies are suppor
 
 All of these strategies are inheirited via from dbt-postgres.
 
-## Performance Optimizations
+## Performance optimizations
 
 ### Using sortkey and distkey
 

--- a/website/docs/reference/resource-configs/redshift-configs.md
+++ b/website/docs/reference/resource-configs/redshift-configs.md
@@ -10,6 +10,16 @@ To-do:
 - think about whether some of these should be outside of models
 --->
 
+## Incremental Materialization Strategies
+
+In dbt-redshift, the following incremental materialization strategies are supported:
+
+- `append` (default)
+- `merge`
+- `delete+insert`
+
+All of these strategies are inheirited via from dbt-postgres.
+
 ## Performance Optimizations
 
 ### Using sortkey and distkey


### PR DESCRIPTION
## What are you changing in this pull request and why?
<!---
Describe your changes and why you're making them. If linked to an open
issue or a pull request on dbt Core, then link to them here! 

To learn more about the writing conventions used in the dbt Labs docs, see the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md).
-->
resolves: #3545

There are issues to add `merge` as an incremental strategy for `dbt-postgres` and `dbt-redshift`, and we want to add it to the documentation:
- https://github.com/dbt-labs/dbt-core/issues/6696
- https://github.com/dbt-labs/dbt-redshift/issues/402

## Checklist
- [ ] Add versioning components, as described in [Versioning Docs](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-entire-pages)
- [ ] https://github.com/dbt-labs/dbt-redshift/pull/490 should get merged first


