### PR TITLE
Restore Makefile and remove generation of redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ You can click a link available in a netlify bot PR comment to see and review you
 2. Clone this repo: `git clone https://github.com/dbt-labs/docs.getdbt.com.git`
 3. `cd` into the repo: `cd docs.getdbt.com`
 4. `cd` into the `website` subdirectory: `cd website`
-5. Install the required node packages: `npm install` (optional &mdash; install any updates)
-6. Build the website: `npm start`
+5. Install the required node packages: `make install` or `npm install` (optional &mdash; install any updates)
+6. Build the website: `make run` or `npm start`
+7. Before pushing your changes to a branch, run `make build` or `npm run build` and check that all links work
 
 Advisory:
 - If you run into an `fatal error: 'vips/vips8' file not found` error when you run `npm install`, you may need to run `brew install vips`. Warning: this one will take a while -- go ahead and grab some coffee!

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ You can click a link available in a netlify bot PR comment to see and review you
 4. `cd` into the `website` subdirectory: `cd website`
 5. Install the required node packages: `npm install` (optional &mdash; install any updates)
 6. Build the website: `npm start`
-7. Before pushing your changes to a branch, check that all links work by using the `make build` script.
 
 Advisory:
 - If you run into an `fatal error: 'vips/vips8' file not found` error when you run `npm install`, you may need to run `brew install vips`. Warning: this one will take a while -- go ahead and grab some coffee!

--- a/website/Makefile
+++ b/website/Makefile
@@ -8,15 +8,3 @@ install:
 
 build:
 	DOCS_ENV=build npm run build
-
-	# Create per-version redirects... hopefully we can phase these out as
-	# search engines de-index these absolute versioned URLs
-	cat ../_redirects > build/_redirects
-	cat ../_redirects | grep 'docs/' | awk '{ print "/v0.15" $$1 "\t" $$2 "\t" $$3 }' >> build/_redirects
-	cat ../_redirects | grep 'docs/' | awk '{ print "/v0.14" $$1 "\t" $$2 "\t" $$3 }' >> build/_redirects
-	cat ../_redirects | grep 'docs/' | awk '{ print "/v0.13" $$1 "\t" $$2 "\t" $$3 }' >> build/_redirects
-	cat ../_redirects | grep 'docs/' | awk '{ print "/v0.12" $$1 "\t" $$2 "\t" $$3 }' >> build/_redirects
-	cat ../_redirects | grep 'docs/' | awk '{ print "/v0.11" $$1 "\t" $$2 "\t" $$3 }' >> build/_redirects
-	cat ../_redirects | grep 'docs/' | awk '{ print "/v0.10" $$1 "\t" $$2 "\t" $$3 }' >> build/_redirects
-
-	cat ../_headers > build/_headers

--- a/website/Makefile
+++ b/website/Makefile
@@ -1,0 +1,22 @@
+.PHONY: run install build
+
+run:
+	npm start
+
+install:
+	npm install
+
+build:
+	DOCS_ENV=build npm run build
+
+	# Create per-version redirects... hopefully we can phase these out as
+	# search engines de-index these absolute versioned URLs
+	cat ../_redirects > build/_redirects
+	cat ../_redirects | grep 'docs/' | awk '{ print "/v0.15" $$1 "\t" $$2 "\t" $$3 }' >> build/_redirects
+	cat ../_redirects | grep 'docs/' | awk '{ print "/v0.14" $$1 "\t" $$2 "\t" $$3 }' >> build/_redirects
+	cat ../_redirects | grep 'docs/' | awk '{ print "/v0.13" $$1 "\t" $$2 "\t" $$3 }' >> build/_redirects
+	cat ../_redirects | grep 'docs/' | awk '{ print "/v0.12" $$1 "\t" $$2 "\t" $$3 }' >> build/_redirects
+	cat ../_redirects | grep 'docs/' | awk '{ print "/v0.11" $$1 "\t" $$2 "\t" $$3 }' >> build/_redirects
+	cat ../_redirects | grep 'docs/' | awk '{ print "/v0.10" $$1 "\t" $$2 "\t" $$3 }' >> build/_redirects
+
+	cat ../_headers > build/_headers


### PR DESCRIPTION
resolves #3578

## What are you changing in this pull request and why?

Two things:
1. Restore ability for users to use `make run` and `make build` to preview/build the docs site while developing locally.
2. Align with the goal in https://github.com/dbt-labs/docs.getdbt.com/pull/3284 to remove generation of redirects from the Makefile.

## Outstanding questions

### Question 1
The pull request template says the following:
```
- [ ] [Ran link testing](https://github.com/dbt-labs/docs.getdbt.com#running-the-cypress-tests-locally) to update the links that point to the deleted page
```

I'm assuming this is the most up-to-date approach for link testing? I haven't used it personally yet, so I don't know 🤷 

### Question 2

After the changes within this PR, there are no longer any references to any `make` commands within our README. Do we want to add them anywhere as an alternative method to running the `npm` commands directly?

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [x] Remove unnecessary parts of Makefile
- [x] Add @JKarlavige as a reviewer ("needs technical review")