### PR TITLE
Info block on SSO config docs for single-tenant to contact support instead

### DIFF
--- a/website/docs/docs/cloud/manage-access/set-up-sso-azure-active-directory.md
+++ b/website/docs/docs/cloud/manage-access/set-up-sso-azure-active-directory.md
@@ -5,13 +5,9 @@ id: "set-up-sso-azure-active-directory"
 sidebar_label: "Set up SSO with Azure AD"
 ---
 
-:::info Enterprise Feature
-This guide describes a feature of the dbt Cloud Enterprise plan. If you’re
-interested in learning more about an Enterprise plan, contact us at
-sales@getdbt.com.
+import SetUpPages from '/snippets/_sso-docs-mt-available.md';
 
-If you are a [single-tenant (virtual private)](/docs/cloud/about-cloud/tenancy#single-tenant) customer, this SSO config docs is not for you. Instead, please [contact support](mailto:support@getdbt.com), if you wish to newly configure your SSO config or update your SSO config.
-:::
+<SetUpPages features={'/snippets/_sso-docs-mt-available.md'}/>
 
 dbt Cloud Enterprise supports single-sign on via Azure Active Directory (Azure AD).
 You will need permissions to create and manage a new Azure AD application.

--- a/website/docs/docs/cloud/manage-access/set-up-sso-azure-active-directory.md
+++ b/website/docs/docs/cloud/manage-access/set-up-sso-azure-active-directory.md
@@ -9,6 +9,8 @@ sidebar_label: "Set up SSO with Azure AD"
 This guide describes a feature of the dbt Cloud Enterprise plan. If you’re
 interested in learning more about an Enterprise plan, contact us at
 sales@getdbt.com.
+
+If you are a [single-tenant (virtual private)](/docs/cloud/about-cloud/tenancy#single-tenant) customer, this SSO config docs is not for you. Instead, please [contact support](mailto:support@getdbt.com), if you wish to newly configure your SSO config or update your SSO config.
 :::
 
 dbt Cloud Enterprise supports single-sign on via Azure Active Directory (Azure AD).

--- a/website/docs/docs/cloud/manage-access/set-up-sso-google-workspace.md
+++ b/website/docs/docs/cloud/manage-access/set-up-sso-google-workspace.md
@@ -4,13 +4,9 @@ description: "Learn how dbt Cloud administrators can use Single-Sign On (SSO) vi
 id: "set-up-sso-google-workspace"
 ---
 
-:::info Enterprise Feature
-This guide describes a feature of the dbt Cloud Enterprise plan. If you’re
-interested in learning more about an Enterprise plan, contact us at
-sales@getdbt.com.
+import SetUpPages from '/snippets/_sso-docs-mt-available.md';
 
-If you are a [single-tenant (virtual private)](/docs/cloud/about-cloud/tenancy#single-tenant) customer, this SSO config docs is not for you. Instead, please [contact support](mailto:support@getdbt.com), if you wish to newly configure your SSO config or update your SSO config.
-:::
+<SetUpPages features={'/snippets/_sso-docs-mt-available.md'}/>
 
 dbt Cloud Enterprise supports Single-Sign On (SSO) via Google GSuite. You will need
 permissions to create and manage a new Google OAuth2 application, as well as

--- a/website/docs/docs/cloud/manage-access/set-up-sso-google-workspace.md
+++ b/website/docs/docs/cloud/manage-access/set-up-sso-google-workspace.md
@@ -8,6 +8,8 @@ id: "set-up-sso-google-workspace"
 This guide describes a feature of the dbt Cloud Enterprise plan. If you’re
 interested in learning more about an Enterprise plan, contact us at
 sales@getdbt.com.
+
+If you are a [single-tenant (virtual private)](/docs/cloud/about-cloud/tenancy#single-tenant) customer, this SSO config docs is not for you. Instead, please [contact support](mailto:support@getdbt.com), if you wish to newly configure your SSO config or update your SSO config.
 :::
 
 dbt Cloud Enterprise supports Single-Sign On (SSO) via Google GSuite. You will need

--- a/website/docs/docs/cloud/manage-access/set-up-sso-okta.md
+++ b/website/docs/docs/cloud/manage-access/set-up-sso-okta.md
@@ -7,6 +7,8 @@ id: "set-up-sso-okta"
 
 This guide describes a feature of the dbt Cloud Enterprise plan. If you’re interested in learning more about an Enterprise plan, contact us at sales@getdbt.com.
 
+If you are a [single-tenant (virtual private)](/docs/cloud/about-cloud/tenancy#single-tenant) customer, this SSO config docs is not for you. Instead, please [contact support](mailto:support@getdbt.com), if you wish to newly configure your SSO config or update your SSO config.
+
 :::
 
 ## Okta SSO

--- a/website/docs/docs/cloud/manage-access/set-up-sso-okta.md
+++ b/website/docs/docs/cloud/manage-access/set-up-sso-okta.md
@@ -3,13 +3,9 @@ title: "Set up SSO with Okta"
 id: "set-up-sso-okta"
 ---
 
-:::info Enterprise Feature
+import SetUpPages from '/snippets/_sso-docs-mt-available.md';
 
-This guide describes a feature of the dbt Cloud Enterprise plan. If you’re interested in learning more about an Enterprise plan, contact us at sales@getdbt.com.
-
-If you are a [single-tenant (virtual private)](/docs/cloud/about-cloud/tenancy#single-tenant) customer, this SSO config docs is not for you. Instead, please [contact support](mailto:support@getdbt.com), if you wish to newly configure your SSO config or update your SSO config.
-
-:::
+<SetUpPages features={'/snippets/_sso-docs-mt-available.md'}/>
 
 ## Okta SSO
 

--- a/website/docs/docs/cloud/manage-access/set-up-sso-saml-2.0.md
+++ b/website/docs/docs/cloud/manage-access/set-up-sso-saml-2.0.md
@@ -8,6 +8,8 @@ id: "set-up-sso-saml-2.0"
 This guide describes a feature of the dbt Cloud Enterprise plan. If you’re interested in learning
 more about an Enterprise plan, contact us at sales@getdbt.com.
 
+If you are a [single-tenant (virtual private)](/docs/cloud/about-cloud/tenancy#single-tenant) customer, these SSO config docs is not for you. If you wish to newly configure or update SSO, please [contact support](mailto:support@getdbt.com).
+
 :::
 
 dbt Cloud Enterprise supports single-sign on (SSO) for any SAML 2.0-compliant identity provider (IdP).

--- a/website/docs/docs/cloud/manage-access/set-up-sso-saml-2.0.md
+++ b/website/docs/docs/cloud/manage-access/set-up-sso-saml-2.0.md
@@ -8,7 +8,7 @@ id: "set-up-sso-saml-2.0"
 This guide describes a feature of the dbt Cloud Enterprise plan. If you’re interested in learning
 more about an Enterprise plan, contact us at sales@getdbt.com.
 
-If you are a [single-tenant (virtual private)](/docs/cloud/about-cloud/tenancy#single-tenant) customer, these SSO config docs is not for you. If you wish to newly configure or update SSO, please [contact support](mailto:support@getdbt.com).
+If you are a [single-tenant (virtual private)](/docs/cloud/about-cloud/tenancy#single-tenant) customer, this SSO config docs is not for you. Instead, please [contact support](mailto:support@getdbt.com), if you wish to newly configure your SSO config or update your SSO config.
 
 :::
 

--- a/website/docs/docs/cloud/manage-access/set-up-sso-saml-2.0.md
+++ b/website/docs/docs/cloud/manage-access/set-up-sso-saml-2.0.md
@@ -3,14 +3,9 @@ title: "Set up SSO with SAML 2.0"
 id: "set-up-sso-saml-2.0"
 ---
 
-:::info Enterprise Feature
+import SetUpPages from '/snippets/_sso-docs-mt-available.md';
 
-This guide describes a feature of the dbt Cloud Enterprise plan. If you’re interested in learning
-more about an Enterprise plan, contact us at sales@getdbt.com.
-
-If you are a [single-tenant (virtual private)](/docs/cloud/about-cloud/tenancy#single-tenant) customer, this SSO config docs is not for you. Instead, please [contact support](mailto:support@getdbt.com), if you wish to newly configure your SSO config or update your SSO config.
-
-:::
+<SetUpPages features={'/snippets/_sso-docs-mt-available.md'}/>
 
 dbt Cloud Enterprise supports single-sign on (SSO) for any SAML 2.0-compliant identity provider (IdP).
 Currently supported features include:

--- a/website/snippets/_sso-docs-mt-available.md
+++ b/website/snippets/_sso-docs-mt-available.md
@@ -1,0 +1,7 @@
+:::info Enterprise feature
+
+This guide describes a feature of the dbt Cloud Enterprise plan. If you’re interested in learning more about an Enterprise plan, contact us at <sales@getdbt.com>.
+
+This SSO configuration document applies to multi-tenant Enterprise deployments only. [Single-tenant](/docs/cloud/about-cloud/tenancy#single-tenant) Virtual Private users can [email dbt Cloud Support](mailto:support@getdbt.com) to set up or update their SSO configuration. 
+
+:::

--- a/website/snippets/_sso-docs-mt-available.md
+++ b/website/snippets/_sso-docs-mt-available.md
@@ -2,6 +2,6 @@
 
 This guide describes a feature of the dbt Cloud Enterprise plan. If you’re interested in learning more about an Enterprise plan, contact us at <sales@getdbt.com>.
 
-This SSO configuration document applies to multi-tenant Enterprise deployments only. [Single-tenant](/docs/cloud/about-cloud/tenancy#single-tenant) Virtual Private users can [email dbt Cloud Support](mailto:support@getdbt.com) to set up or update their SSO configuration. 
+These SSO configuration documents apply to multi-tenant Enterprise deployments only. [Single-tenant](/docs/cloud/about-cloud/tenancy#single-tenant) Virtual Private users can [email dbt Cloud Support](mailto:support@getdbt.com) to set up or update their SSO configuration. 
 
 :::


### PR DESCRIPTION
## What are you changing in this pull request and why?
SSO config docs is only usable by multiTenant. Add an info blurb to the top of the page to inform ST customers to contact support instead.

Changes [here](https://deploy-preview-3611--docs-getdbt-com.netlify.app/docs/cloud/manage-access/set-up-sso-saml-2.0)

https://dbtlabs.atlassian.net/browse/ENTERPRISE-529

## Checklist
<!--
Uncomment if you're publishing docs for a prerelease version of dbt (delete if not applicable):
- [ ] Add versioning components, as described in [Versioning Docs](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-entire-pages)
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/guides/migration/versions)
-->
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [x] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."