### PR TITLE
Update earliest version for access selection method and colocate with group

### DIFF
--- a/website/docs/reference/node-selection/methods.md
+++ b/website/docs/reference/node-selection/methods.md
@@ -292,7 +292,7 @@ Supported in v1.5 or newer.
 
 <VersionBlock firstVersion="1.5">
 
-The `group` method is used to select models defined within a group.
+The `group` method is used to select models defined within a [group](/reference/resource-configs/group).
 
 
   ```bash

--- a/website/docs/reference/node-selection/methods.md
+++ b/website/docs/reference/node-selection/methods.md
@@ -292,14 +292,32 @@ Supported in v1.5 or newer.
 
 <VersionBlock firstVersion="1.5">
 
-Supported in v1.5 or newer.
-
 The `group` method is used to select models defined within a group.
 
 
   ```bash
   dbt run --select group:finance # run all models that belong to the finance group.
   ```
+
+</VersionBlock>
+
+### The "access" method
+
+<VersionBlock lastVersion="1.4">
+
+Supported in v1.5 or newer.
+
+</VersionBlock>
+
+<VersionBlock firstVersion="1.6">
+
+The `access` method selects models based on their [access](/reference/resource-properties/access) property.
+
+```bash
+dbt list --select access:public       # list all public models
+dbt list --select access:private       # list all private models
+dbt list --select access:protected       # list all protected models
+```
 
 </VersionBlock>
 
@@ -321,26 +339,6 @@ dbt list --select version:prerelease  # versions newer than the 'latest' version
 dbt list --select version:old         # versions older than the 'latest' version
 
 dbt list --select version:none        # models that are *not* versioned
-```
-
-</VersionBlock>
-
-### The "access" method
-
-<VersionBlock lastVersion="1.5">
-
-Supported in v1.6 or newer.
-
-</VersionBlock>
-
-<VersionBlock firstVersion="1.6">
-
-The `access` method selects models based on their [access](/reference/resource-properties/access) property.
-
-```bash
-dbt list --select access:public       # list all public models
-dbt list --select access:private       # list all private models
-dbt list --select access:protected       # list all protected models
 ```
 
 </VersionBlock>

--- a/website/docs/reference/node-selection/methods.md
+++ b/website/docs/reference/node-selection/methods.md
@@ -309,7 +309,7 @@ Supported in v1.5 or newer.
 
 </VersionBlock>
 
-<VersionBlock firstVersion="1.6">
+<VersionBlock firstVersion="1.5">
 
 The `access` method selects models based on their [access](/reference/resource-properties/access) property.
 


### PR DESCRIPTION
[Preview](https://deploy-preview-3613--docs-getdbt-com.netlify.app/reference/node-selection/methods#the-group-method)

## What are you changing in this pull request and why?
- Rearranged to colocate "group" and "access" methods
- Update "access" from v1.6 to v1.5 since it was [backported](https://github.com/dbt-labs/dbt-core/pull/7739#issuecomment-1578921745)

## 🎩 

### v1.4

<img width="500" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/e0bc9b93-e440-41a4-8a2f-f97cd530c8ae">

### v1.5 and v1.6

<img width="500" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/eb4a6e69-aa43-4df3-8d28-ee2d559dc3c4">


## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.