### PR TITLE
Display job title and org in more places in the devblog

### DIFF
--- a/website/src/theme/BlogPostItem/Header/Author/index.js
+++ b/website/src/theme/BlogPostItem/Header/Author/index.js
@@ -15,7 +15,7 @@ function MaybeLink(props) {
 */
 
 export default function BlogPostItemHeaderAuthor({author, className}) {
-  const {name, title, url, imageURL, email, key} = author;
+  const {name, url, imageURL, email, key, job_title, organization} = author;
   const link = url || (email && `mailto:${email}`) || undefined;
   return (
     <div className={clsx('avatar margin-bottom--sm', className)}>
@@ -36,9 +36,9 @@ export default function BlogPostItemHeaderAuthor({author, className}) {
               <span itemProp="name">{name}</span>
             </Link>
           </div>
-          {title && (
+          {job_title && organization && (
             <small className="avatar__subtitle" itemProp="description">
-              {title}
+              {job_title && job_title} {organization && `@ ${organization}`} 
             </small>
           )}
         </div>


### PR DESCRIPTION
## What are you changing in this pull request and why?
After the [discussion here](https://dbt-labs.slack.com/archives/C0101LM7Z89/p1687328973338709), we realised that authors' job titles and companies don't display on blog posts, only on their author bio pages. 

I poked around a bit and it looks like the blog views were relying on a property called `title`, which as far as I can see doesn't exist. It's possible that it's meant to be magically concatenated behind the scenes in a way that I don't understand, but I suspect it was actually just something that got renamed partway through development and wasn't noticed. 

To resolve this, I copied the logic from [website/src/components/author/index.js](https://github.com/dbt-labs/docs.getdbt.com/blob/7ec373e32ef3f1023a88f194d0a519a07748b50d/website/src/components/author/index.js#L46) and removed the unhelpful `title`. 

Before:
<img width="1440" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/7335046/ab100204-337c-45af-9b9b-fa29862fa6e8">


After: 
<img width="1435" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/7335046/704b5042-078e-42ac-b0cc-6779774e13fa">