### PR TITLE
`merge` strategy added in v1.6 for Postgres and Redshift

### DIFF
--- a/website/docs/docs/build/incremental-models.md
+++ b/website/docs/docs/build/incremental-models.md
@@ -4,8 +4,6 @@ description: "Read this tutorial to learn how to use incremental models when bui
 id: "incremental-models"
 ---
 
-## Overview
-
 Incremental models are built as tables in your <Term id="data-warehouse" />. The first time a model is run, the <Term id="table" /> is built by transforming _all_ rows of source data. On subsequent runs, dbt transforms _only_ the rows in your source data that you tell dbt to filter for, inserting them into the target table which is the table that has already been built.
 
 Often, the rows you filter for on an incremental run will be the rows in your source data that have been created or updated since the last time dbt ran. As such, on each dbt run, your model gets built incrementally.
@@ -258,9 +256,10 @@ Click the name of the adapter in the below table for more information about supp
 The `merge` strategy is available in dbt-postgres and dbt-redshift beginning in dbt v1.6.
 
 <VersionBlock lastVersion="1.5">
+
     
-| data platform adapter                                                                               | default strategy | additional supported strategies          |
-| :-------------------------------------------------------------------------------------------------- | ---------------- | ---------------------------------------- |
+| data platform adapter   | default strategy | additional supported strategies   |
+| :-------------------| ---------------- | -------------------- |
 | [dbt-postgres](/reference/resource-configs/postgres-configs#incremental-materialization-strategies) | `append`         | `delete+insert`                          |
 | [dbt-redshift](/reference/resource-configs/redshift-configs#incremental-materialization-strategies) | `append`         | `delete+insert`                          |
 | [dbt-bigquery](/reference/resource-configs/bigquery-configs#merge-behavior-incremental-models)      | `merge`          | `insert_overwrite`                       |
@@ -272,9 +271,10 @@ The `merge` strategy is available in dbt-postgres and dbt-redshift beginning in 
 </VersionBlock>
 
 <VersionBlock firstVersion="1.6">
+
     
-| data platform adapter                                                                               | default strategy | additional supported strategies          |
-| :-------------------------------------------------------------------------------------------------- | ---------------- | ---------------------------------------- |
+| data platform adapter  | default strategy | additional supported strategies  |
+| :----------------- | :----------------| : ---------------------------------- |
 | [dbt-postgres](/reference/resource-configs/postgres-configs#incremental-materialization-strategies) | `append`         | `merge` , `delete+insert`                  |
 | [dbt-redshift](/reference/resource-configs/redshift-configs#incremental-materialization-strategies) | `append`         | `merge`, `delete+insert`                  |
 | [dbt-bigquery](/reference/resource-configs/bigquery-configs#merge-behavior-incremental-models)      | `merge`          | `insert_overwrite`                       |
@@ -282,6 +282,7 @@ The `merge` strategy is available in dbt-postgres and dbt-redshift beginning in 
 | [dbt-databricks](/reference/resource-configs/databricks-configs#incremental-models)                 | `append`         | `merge` (Delta only) `insert_overwrite`  |
 | [dbt-snowflake](/reference/resource-configs/snowflake-configs#merge-behavior-incremental-models)    | `merge`          | `append`, `delete+insert`                |
 | [dbt-trino](/reference/resource-configs/trino-configs#incremental)                                  | `append`         | `merge` `delete+insert`                  |
+
 </VersionBlock>
 
 <VersionBlock firstVersion="1.3">

--- a/website/docs/docs/build/incremental-models.md
+++ b/website/docs/docs/build/incremental-models.md
@@ -258,7 +258,7 @@ The `merge` strategy is available in dbt-postgres and dbt-redshift beginning in 
 <VersionBlock lastVersion="1.5">
 
     
-| data platform adapter   | default strategy | additional supported strategies   |
+| data platform adapter   | default strategy | additional supported strategies    |
 | :-------------------| ---------------- | -------------------- |
 | [dbt-postgres](/reference/resource-configs/postgres-configs#incremental-materialization-strategies) | `append`         | `delete+insert`                          |
 | [dbt-redshift](/reference/resource-configs/redshift-configs#incremental-materialization-strategies) | `append`         | `delete+insert`                          |

--- a/website/docs/docs/build/incremental-models.md
+++ b/website/docs/docs/build/incremental-models.md
@@ -255,6 +255,22 @@ to build incremental models.
 
 Click the name of the adapter in the below table for more information about supported incremental strategies.
 
+The `merge` strategy is available in dbt-postgres and dbt-redshift beginning in dbt v1.6.
+
+<VersionBlock lastVersion="1.5">
+| data platform adapter                                                                               | default strategy | additional supported strategies          |
+| :-------------------------------------------------------------------------------------------------- | ---------------- | ---------------------------------------- |
+| [dbt-postgres](/reference/resource-configs/postgres-configs#incremental-materialization-strategies) | `append`         | `delete+insert`                          |
+| [dbt-redshift](/reference/resource-configs/redshift-configs#incremental-materialization-strategies) | `append`         | `delete+insert`                          |
+| [dbt-bigquery](/reference/resource-configs/bigquery-configs#merge-behavior-incremental-models)      | `merge`          | `insert_overwrite`                       |
+| [dbt-spark](/reference/resource-configs/spark-configs#incremental-models)                           | `append`         | `merge` (Delta only)  `insert_overwrite` |
+| [dbt-databricks](/reference/resource-configs/databricks-configs#incremental-models)                 | `append`         | `merge` (Delta only) `insert_overwrite`  |
+| [dbt-snowflake](/reference/resource-configs/snowflake-configs#merge-behavior-incremental-models)    | `merge`          | `append`, `delete+insert`                |
+| [dbt-trino](/reference/resource-configs/trino-configs#incremental)                                  | `append`         | `merge` `delete+insert`                  |
+
+</VersionBlock>
+
+<VersionBlock firstVersion="1.6">
 | data platform adapter                                                                               | default strategy | additional supported strategies          |
 | :-------------------------------------------------------------------------------------------------- | ---------------- | ---------------------------------------- |
 | [dbt-postgres](/reference/resource-configs/postgres-configs#incremental-materialization-strategies) | `append`         | `merge` , `delete+insert`                  |
@@ -264,6 +280,7 @@ Click the name of the adapter in the below table for more information about supp
 | [dbt-databricks](/reference/resource-configs/databricks-configs#incremental-models)                 | `append`         | `merge` (Delta only) `insert_overwrite`  |
 | [dbt-snowflake](/reference/resource-configs/snowflake-configs#merge-behavior-incremental-models)    | `merge`          | `append`, `delete+insert`                |
 | [dbt-trino](/reference/resource-configs/trino-configs#incremental)                                  | `append`         | `merge` `delete+insert`                  |
+</VersionBlock>
 
 <VersionBlock firstVersion="1.3">
 

--- a/website/docs/docs/build/incremental-models.md
+++ b/website/docs/docs/build/incremental-models.md
@@ -258,6 +258,7 @@ Click the name of the adapter in the below table for more information about supp
 The `merge` strategy is available in dbt-postgres and dbt-redshift beginning in dbt v1.6.
 
 <VersionBlock lastVersion="1.5">
+    
 | data platform adapter                                                                               | default strategy | additional supported strategies          |
 | :-------------------------------------------------------------------------------------------------- | ---------------- | ---------------------------------------- |
 | [dbt-postgres](/reference/resource-configs/postgres-configs#incremental-materialization-strategies) | `append`         | `delete+insert`                          |
@@ -271,6 +272,7 @@ The `merge` strategy is available in dbt-postgres and dbt-redshift beginning in 
 </VersionBlock>
 
 <VersionBlock firstVersion="1.6">
+    
 | data platform adapter                                                                               | default strategy | additional supported strategies          |
 | :-------------------------------------------------------------------------------------------------- | ---------------- | ---------------------------------------- |
 | [dbt-postgres](/reference/resource-configs/postgres-configs#incremental-materialization-strategies) | `append`         | `merge` , `delete+insert`                  |


### PR DESCRIPTION
resolves #3646

## Previews
- [1.5](https://deploy-preview-3650--docs-getdbt-com.netlify.app/docs/build/incremental-models?version=1.5#supported-incremental-strategies-by-adapter)
- [1.6](https://deploy-preview-3650--docs-getdbt-com.netlify.app/docs/build/incremental-models?version=1.6#supported-incremental-strategies-by-adapter)

## What are you changing in this pull request and why?

We got a regression report in dbt-core since the user could see `merge` listed in the documentation as an option, but it didn't work when they tried it:
https://github.com/dbt-labs/dbt-core/issues/7997

It's because it won't be released until v1.6 -- so we just need to add some version tags to get this all straightened out 😎 

See more detail in #3646

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.