### PR TITLE
Create snapshot-target-is-not-a-snapshot-table.md

### DIFF
--- a/website/docs/docs/build/snapshots.md
+++ b/website/docs/docs/build/snapshots.md
@@ -10,7 +10,6 @@ id: "snapshots"
 * [Snapshot properties](/reference/snapshot-properties)
 * [`snapshot` command](/reference/commands/snapshot)
 
-## Overview
 
 ### What are snapshots?
 Analysts often need to "look back in time" at previous data states in their mutable tables. While some source data systems are built in a way that makes accessing historical data possible, this is not always the case. dbt provides a mechanism, **snapshots**, which records changes to a mutable <Term id="table" /> over time.
@@ -415,3 +414,4 @@ Snapshot results:
 <FAQ src="Snapshots/snapshot-hooks" />
 <FAQ src="Snapshots/snapshot-target-schema" />
 <FAQ src="Accounts/configurable-snapshot-path" />
+<FAQ src="Snapshots/snapshot-target-is-not-a-snapshot-table" />

--- a/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
+++ b/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
@@ -1,7 +1,7 @@
 ---
 title: Debug "Snapshot target is not a snapshot table errors"
 description: "Debugging 'Snapshot target is not a snapshot table (missing "dbt_scd_id", "dbt_valid_from", "dbt_valid_to")' errors"
-sidebar: "Snapshot target is not a snapshot table"
+sidebar_label: "Snapshot target is not a snapshot table"
 id: snapshot-target-is-not-a-snapshot-table
 ---
 

--- a/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
+++ b/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
@@ -1,6 +1,6 @@
 ---
 title: "Debug Snapshot target is not a snapshot table errors"
-description: "Debugging Snapshot target is not a snapshot table (missing "dbt_scd_id", "dbt_valid_from", "dbt_valid_to") errors"
+description: "Debugging Snapshot target is not a snapshot table"
 sidebar_label: "Snapshot target is not a snapshot table"
 id: snapshot-target-is-not-a-snapshot-table
 ---

--- a/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
+++ b/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
@@ -1,7 +1,7 @@
 ---
 title: Debug "Snapshot target is not a snapshot table errors"
 description: "Debugging 'Snapshot target is not a snapshot table (missing "dbt_scd_id", "dbt_valid_from", "dbt_valid_to")' errors"
-sidebar_label: "Snapshot target is not a snapshot table"
+sidebar: "Snapshot target is not a snapshot table"
 id: snapshot-target-is-not-a-snapshot-table
 ---
 

--- a/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
+++ b/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
@@ -9,7 +9,7 @@ If you see the following error when trying to snapshot:
 
 > Snapshot target is not a snapshot table (missing `dbt_scd_id`, `dbt_valid_from`, `dbt_valid_to`)
 
-Double check that you have not inadvertantly caused your snapshot to behave like table materializations by setting its `materialized` config to be `table`. Prior to dbt versions 1.4,
+Double check that you have not inadvertently caused your snapshot to behave like table materializations by setting its `materialized` config to be `table`. Prior to dbt versions 1.4,
 it was possible to have a snapshot like:
 
 ```sql

--- a/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
+++ b/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
@@ -18,7 +18,7 @@ Double check that you have not inadvertently caused your snapshot to behave like
 {% endsnapshot %}
 ```
 
-What would happen then is dbt treated snapshots like tables (issuing `create or replace table ...` statements) **silently** instead of actually snapshotting data (SCD2 via `insert` / `merge` statements). When upgrading to dbt versions 1.4 and above, dbt now rases a Parsing Error (instead of silently treating snapshots like tables) that reads:
+What would happen then is dbt treated snapshots like tables (issuing `create or replace table ...` statements) **silently** instead of actually snapshotting data (SCD2 via `insert` / `merge` statements). When upgrading to dbt versions 1.4 and above, dbt now raises a Parsing Error (instead of silently treating snapshots like tables) that reads:
 
 ```
 A snapshot must have a materialized value of 'snapshot'

--- a/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
+++ b/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
@@ -24,6 +24,6 @@ dbt is treating snapshots like tables (issuing `create or replace table ...` sta
 A snapshot must have a materialized value of 'snapshot'
 ```
 
-This tells you to change your `materialized` config to `snapshot`. However, as soon as you do that, you may run into the error above (missing "dbt_scd_id", etc). This is because, previously, when dbt treated snapshots like tables - there were no [snapshot meta-fields](/docs/build/snapshots#snapshot-meta-fields) added to your snapshot target table - and because those meta-fields don't exist, dbt correctly identifies and tells you that you intend to snapshot into a table that isn't a snapshot.
+This tells you to change your `materialized` config to `snapshot`. But when you make that change, you might encounter an error message saying that certain fields like `dbt_scd_id` are missing. This error happens because, previously, when dbt treated snapshots as tables, it didn't include the necessary [snapshot meta-fields](/docs/build/snapshots#snapshot-meta-fields) in your target table. Since those meta-fields don't exist, dbt correctly identifies that you're trying to create a snapshot in a table that isn't actually a snapshot.
 
 When this happens, you have to start from scratch &mdash; re-snapshotting your source data as if it was the first time by dropping your "snapshot" which isn't a real snapshot table. Then dbt snapshot will create a new snapshot and insert the snapshot meta-fields as expected.

--- a/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
+++ b/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
@@ -1,0 +1,34 @@
+---
+title: Debugging 'Snapshot target is not a snapshot table (missing "dbt_scd_id", "dbt_valid_from", "dbt_valid_to")' errors.
+description: "Debugging 'Snapshot target is not a snapshot table (missing "dbt_scd_id", "dbt_valid_from", "dbt_valid_to")' errors"
+sidebar_label: 'Snapshot target is not a snapshot table (missing "dbt_scd_id", "dbt_valid_from", "dbt_valid_to")'
+id: snapshot-target-is-not-a-snapshot-table
+---
+
+If you see the following error when trying to snapshot:
+
+> Snapshot target is not a snapshot table (missing "dbt_scd_id", "dbt_valid_from", "dbt_valid_to")
+
+Double check that you have not inadvertantly caused your snapshot to behave like table materializations by setting its `materialized` config to be `table`. Prior to dbt versions 1.4,
+it was possible to have a snapshot like:
+
+```sql
+{% snapshot snappy %}
+  {{ config(materialized = 'table', ...) }}
+  ...
+{% endsnapshot %}
+```
+
+What would happen then is dbt treated snapshots like tables (issuing `create or replace table ...` statements) **silently** instead of actually snapshotting data (SCD2 via `insert` / `merge` statements). When upgrading to dbt
+versions 1.4 and above, dbt now rases a Parsing Error (instead of silently treating snapshots like tables) that reads:
+
+```
+A snapshot must have a materialized value of 'snapshot'
+```
+
+This tells you to change your `materialzed` config to `snapshot`. However, as soon as you do that, you may run into the error above (missing "dbt_scd_id", etc). This is because, previously, when
+dbt treated snapshots like tables - there was no [snapshot meta-fields](https://docs.getdbt.com/docs/build/snapshots#snapshot-meta-fields) added to your snapshot target table - and because those
+meta-fields don't exist, dbt correctly identifies and tells you that you intend to snapshot into a table that isn't a snapshot.
+
+When this happens, it means you have to start from scratch - resnapshotting your source data as if it was the first time by dropping your "snapshot" that isn't a real snapshot table. Then dbt snapshot
+will create the snapshot a new and insert the snapshot meta-fields as expected.

--- a/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
+++ b/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
@@ -1,7 +1,7 @@
 ---
 title: Debugging "Snapshot target is not a snapshot table (missing `dbt_scd_id`, `dbt_valid_from`, `dbt_valid_to`)' errors"
 description: "Debugging 'Snapshot target is not a snapshot table (missing "dbt_scd_id", "dbt_valid_from", "dbt_valid_to")' errors"
-sidebar_label: Snapshot target is not a snapshot table
+sidebar_label: "Snapshot target is not a snapshot table"
 id: snapshot-target-is-not-a-snapshot-table
 ---
 

--- a/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
+++ b/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
@@ -9,7 +9,7 @@ If you see the following error when trying to snapshot:
 
 > Snapshot target is not a snapshot table (missing `dbt_scd_id`, `dbt_valid_from`, `dbt_valid_to`)
 
-Double check that you have not inadvertently caused your snapshot to behave like table materializations by setting its `materialized` config to be `table`. Prior to dbt version 1.4, it was possible to have a snapshot like this:
+Double check that you haven't inadvertently caused your snapshot to behave like table materializations by setting its `materialized` config to be `table`. Prior to dbt version 1.4, it was possible to have a snapshot like this:
 
 ```sql
 {% snapshot snappy %}

--- a/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
+++ b/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
@@ -27,7 +27,7 @@ A snapshot must have a materialized value of 'snapshot'
 ```
 
 This tells you to change your `materialized` config to `snapshot`. However, as soon as you do that, you may run into the error above (missing "dbt_scd_id", etc). This is because, previously, when
-dbt treated snapshots like tables - there was no [snapshot meta-fields](https://docs.getdbt.com/docs/build/snapshots#snapshot-meta-fields) added to your snapshot target table - and because those
+dbt treated snapshots like tables - there were no [snapshot meta-fields](/docs/build/snapshots#snapshot-meta-fields) added to your snapshot target table - and because those
 meta-fields don't exist, dbt correctly identifies and tells you that you intend to snapshot into a table that isn't a snapshot.
 
 When this happens, it means you have to start from scratch - resnapshotting your source data as if it was the first time by dropping your "snapshot" that isn't a real snapshot table. Then dbt snapshot

--- a/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
+++ b/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
@@ -30,5 +30,5 @@ This tells you to change your `materialized` config to `snapshot`. However, as s
 dbt treated snapshots like tables - there were no [snapshot meta-fields](/docs/build/snapshots#snapshot-meta-fields) added to your snapshot target table - and because those
 meta-fields don't exist, dbt correctly identifies and tells you that you intend to snapshot into a table that isn't a snapshot.
 
-When this happens, it means you have to start from scratch - resnapshotting your source data as if it was the first time by dropping your "snapshot" that isn't a real snapshot table. Then dbt snapshot
+When this happens, you have to start from scratch &mdash; re-snapshotting your source data as if it was the first time by dropping your "snapshot" which isn't a real snapshot table. Then dbt snapshot
 will create the snapshot a new and insert the snapshot meta-fields as expected.

--- a/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
+++ b/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
@@ -26,7 +26,7 @@ versions 1.4 and above, dbt now rases a Parsing Error (instead of silently treat
 A snapshot must have a materialized value of 'snapshot'
 ```
 
-This tells you to change your `materialzed` config to `snapshot`. However, as soon as you do that, you may run into the error above (missing "dbt_scd_id", etc). This is because, previously, when
+This tells you to change your `materialized` config to `snapshot`. However, as soon as you do that, you may run into the error above (missing "dbt_scd_id", etc). This is because, previously, when
 dbt treated snapshots like tables - there was no [snapshot meta-fields](https://docs.getdbt.com/docs/build/snapshots#snapshot-meta-fields) added to your snapshot target table - and because those
 meta-fields don't exist, dbt correctly identifies and tells you that you intend to snapshot into a table that isn't a snapshot.
 

--- a/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
+++ b/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
@@ -1,7 +1,7 @@
 ---
 title: Debugging 'Snapshot target is not a snapshot table (missing "dbt_scd_id", "dbt_valid_from", "dbt_valid_to")' errors.
 description: "Debugging 'Snapshot target is not a snapshot table (missing "dbt_scd_id", "dbt_valid_from", "dbt_valid_to")' errors"
-sidebar_label: 'Snapshot target is not a snapshot table'
+sidebar_label: Snapshot target is not a snapshot table
 id: snapshot-target-is-not-a-snapshot-table
 ---
 

--- a/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
+++ b/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
@@ -7,7 +7,7 @@ id: snapshot-target-is-not-a-snapshot-table
 
 If you see the following error when trying to snapshot:
 
-> Snapshot target is not a snapshot table (missing "dbt_scd_id", "dbt_valid_from", "dbt_valid_to")
+> Snapshot target is not a snapshot table (missing `dbt_scd_id`, `dbt_valid_from`, `dbt_valid_to`)
 
 Double check that you have not inadvertantly caused your snapshot to behave like table materializations by setting its `materialized` config to be `table`. Prior to dbt versions 1.4,
 it was possible to have a snapshot like:

--- a/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
+++ b/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
@@ -1,6 +1,6 @@
 ---
-title: Debug "Snapshot target is not a snapshot table errors"
-description: "Debugging 'Snapshot target is not a snapshot table (missing "dbt_scd_id", "dbt_valid_from", "dbt_valid_to")' errors"
+title: "Debug Snapshot target is not a snapshot table errors"
+description: "Debugging Snapshot target is not a snapshot table (missing "dbt_scd_id", "dbt_valid_from", "dbt_valid_to") errors"
 sidebar_label: "Snapshot target is not a snapshot table"
 id: snapshot-target-is-not-a-snapshot-table
 ---
@@ -9,7 +9,7 @@ If you see the following error when trying to snapshot:
 
 > Snapshot target is not a snapshot table (missing `dbt_scd_id`, `dbt_valid_from`, `dbt_valid_to`)
 
-Double check that you have not inadvertently caused your snapshot to behave like table materializations by setting its `materialized` config to be `table`. Prior to dbt versions 1.4, it was possible to have a snapshot like this:
+Double check that you have not inadvertently caused your snapshot to behave like table materializations by setting its `materialized` config to be `table`. Prior to dbt version 1.4, it was possible to have a snapshot like this:
 
 ```sql
 {% snapshot snappy %}

--- a/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
+++ b/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
@@ -18,7 +18,7 @@ Double check that you haven't inadvertently caused your snapshot to behave like 
 {% endsnapshot %}
 ```
 
-What would happen then is dbt treated snapshots like tables (issuing `create or replace table ...` statements) **silently** instead of actually snapshotting data (SCD2 via `insert` / `merge` statements). When upgrading to dbt versions 1.4 and above, dbt now raises a Parsing Error (instead of silently treating snapshots like tables) that reads:
+dbt is treating snapshots like tables (issuing `create or replace table ...` statements) **silently** instead of actually snapshotting data (SCD2 via `insert` / `merge` statements). When upgrading to dbt versions 1.4 and higher, dbt now raises a Parsing Error (instead of silently treating snapshots like tables) that reads:
 
 ```
 A snapshot must have a materialized value of 'snapshot'

--- a/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
+++ b/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
@@ -1,5 +1,5 @@
 ---
-title: Debugging 'Snapshot target is not a snapshot table (missing "dbt_scd_id", "dbt_valid_from", "dbt_valid_to")' errors.
+title: Debugging "Snapshot target is not a snapshot table (missing `dbt_scd_id`, `dbt_valid_from`, `dbt_valid_to`)' errors"
 description: "Debugging 'Snapshot target is not a snapshot table (missing "dbt_scd_id", "dbt_valid_from", "dbt_valid_to")' errors"
 sidebar_label: Snapshot target is not a snapshot table
 id: snapshot-target-is-not-a-snapshot-table

--- a/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
+++ b/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
@@ -26,4 +26,4 @@ A snapshot must have a materialized value of 'snapshot'
 
 This tells you to change your `materialized` config to `snapshot`. However, as soon as you do that, you may run into the error above (missing "dbt_scd_id", etc). This is because, previously, when dbt treated snapshots like tables - there were no [snapshot meta-fields](/docs/build/snapshots#snapshot-meta-fields) added to your snapshot target table - and because those meta-fields don't exist, dbt correctly identifies and tells you that you intend to snapshot into a table that isn't a snapshot.
 
-When this happens, you have to start from scratch &mdash; re-snapshotting your source data as if it was the first time by dropping your "snapshot" which isn't a real snapshot table. Then dbt snapshot will create the snapshot a new and insert the snapshot meta-fields as expected.
+When this happens, you have to start from scratch &mdash; re-snapshotting your source data as if it was the first time by dropping your "snapshot" which isn't a real snapshot table. Then dbt snapshot will create a new snapshot and insert the snapshot meta-fields as expected.

--- a/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
+++ b/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
@@ -1,7 +1,7 @@
 ---
 title: Debugging 'Snapshot target is not a snapshot table (missing "dbt_scd_id", "dbt_valid_from", "dbt_valid_to")' errors.
 description: "Debugging 'Snapshot target is not a snapshot table (missing "dbt_scd_id", "dbt_valid_from", "dbt_valid_to")' errors"
-sidebar_label: 'Snapshot target is not a snapshot table (missing "dbt_scd_id", "dbt_valid_from", "dbt_valid_to")'
+sidebar_label: 'Snapshot target is not a snapshot table'
 id: snapshot-target-is-not-a-snapshot-table
 ---
 

--- a/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
+++ b/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
@@ -10,7 +10,7 @@ If you see the following error when trying to snapshot:
 > Snapshot target is not a snapshot table (missing `dbt_scd_id`, `dbt_valid_from`, `dbt_valid_to`)
 
 Double check that you have not inadvertently caused your snapshot to behave like table materializations by setting its `materialized` config to be `table`. Prior to dbt versions 1.4,
-it was possible to have a snapshot like:
+it was possible to have a snapshot like this:
 
 ```sql
 {% snapshot snappy %}

--- a/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
+++ b/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
@@ -5,7 +5,7 @@ sidebar_label: "Snapshot target is not a snapshot table"
 id: snapshot-target-is-not-a-snapshot-table
 ---
 
-If you see the following error when trying to snapshot:
+If you see the following error when you try executing the snapshot command:
 
 > Snapshot target is not a snapshot table (missing `dbt_scd_id`, `dbt_valid_from`, `dbt_valid_to`)
 

--- a/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
+++ b/website/docs/faqs/Snapshots/snapshot-target-is-not-a-snapshot-table.md
@@ -1,5 +1,5 @@
 ---
-title: Debugging "Snapshot target is not a snapshot table (missing `dbt_scd_id`, `dbt_valid_from`, `dbt_valid_to`)' errors"
+title: Debug "Snapshot target is not a snapshot table errors"
 description: "Debugging 'Snapshot target is not a snapshot table (missing "dbt_scd_id", "dbt_valid_from", "dbt_valid_to")' errors"
 sidebar_label: "Snapshot target is not a snapshot table"
 id: snapshot-target-is-not-a-snapshot-table
@@ -9,8 +9,7 @@ If you see the following error when trying to snapshot:
 
 > Snapshot target is not a snapshot table (missing `dbt_scd_id`, `dbt_valid_from`, `dbt_valid_to`)
 
-Double check that you have not inadvertently caused your snapshot to behave like table materializations by setting its `materialized` config to be `table`. Prior to dbt versions 1.4,
-it was possible to have a snapshot like this:
+Double check that you have not inadvertently caused your snapshot to behave like table materializations by setting its `materialized` config to be `table`. Prior to dbt versions 1.4, it was possible to have a snapshot like this:
 
 ```sql
 {% snapshot snappy %}
@@ -19,16 +18,12 @@ it was possible to have a snapshot like this:
 {% endsnapshot %}
 ```
 
-What would happen then is dbt treated snapshots like tables (issuing `create or replace table ...` statements) **silently** instead of actually snapshotting data (SCD2 via `insert` / `merge` statements). When upgrading to dbt
-versions 1.4 and above, dbt now rases a Parsing Error (instead of silently treating snapshots like tables) that reads:
+What would happen then is dbt treated snapshots like tables (issuing `create or replace table ...` statements) **silently** instead of actually snapshotting data (SCD2 via `insert` / `merge` statements). When upgrading to dbt versions 1.4 and above, dbt now rases a Parsing Error (instead of silently treating snapshots like tables) that reads:
 
 ```
 A snapshot must have a materialized value of 'snapshot'
 ```
 
-This tells you to change your `materialized` config to `snapshot`. However, as soon as you do that, you may run into the error above (missing "dbt_scd_id", etc). This is because, previously, when
-dbt treated snapshots like tables - there were no [snapshot meta-fields](/docs/build/snapshots#snapshot-meta-fields) added to your snapshot target table - and because those
-meta-fields don't exist, dbt correctly identifies and tells you that you intend to snapshot into a table that isn't a snapshot.
+This tells you to change your `materialized` config to `snapshot`. However, as soon as you do that, you may run into the error above (missing "dbt_scd_id", etc). This is because, previously, when dbt treated snapshots like tables - there were no [snapshot meta-fields](/docs/build/snapshots#snapshot-meta-fields) added to your snapshot target table - and because those meta-fields don't exist, dbt correctly identifies and tells you that you intend to snapshot into a table that isn't a snapshot.
 
-When this happens, you have to start from scratch &mdash; re-snapshotting your source data as if it was the first time by dropping your "snapshot" which isn't a real snapshot table. Then dbt snapshot
-will create the snapshot a new and insert the snapshot meta-fields as expected.
+When this happens, you have to start from scratch &mdash; re-snapshotting your source data as if it was the first time by dropping your "snapshot" which isn't a real snapshot table. Then dbt snapshot will create the snapshot a new and insert the snapshot meta-fields as expected.


### PR DESCRIPTION
## What are you changing in this pull request and why?
Users could get into a state where snapshots were not actually snapshots previously. We added some enhancements with dbt 1.4 https://github.com/dbt-labs/dbt-core/pull/6025/files. However, this could still cause confusion so I added a lengthly FAQ.

Adding new pages (delete if not applicable):
- [ ] Add page to `website/sidebars.js`
- [ ] Provide a unique filename for the new page

Removing or renaming existing pages (delete if not applicable):
- [ ] Remove page from `website/sidebars.js`
- [ ] Add an entry `website/static/_redirects`
- [ ] [Ran link testing](https://github.com/dbt-labs/docs.getdbt.com#running-the-cypress-tests-locally) to update the links that point to the deleted page
