### PR TITLE
Document dataproc_batch field for configuring Dataproc Serverless jobs

### DIFF
--- a/website/docs/docs/build/python-models.md
+++ b/website/docs/docs/build/python-models.md
@@ -679,6 +679,8 @@ models:
       submission_method: serverless
 ```
 
+Python models running on Dataproc Serverless can be further configured in your [BigQuery profile](/reference/warehouse-setups/bigquery-setup#running-python-models-on-dataproc).
+
 Any user or service account that runs dbt Python models will need the following permissions(in addition to the required BigQuery permissions) ([docs](https://cloud.google.com/dataproc/docs/concepts/iam/iam)):
 ```
 dataproc.batches.create

--- a/website/docs/docs/build/python-models.md
+++ b/website/docs/docs/build/python-models.md
@@ -679,7 +679,7 @@ models:
       submission_method: serverless
 ```
 
-Python models running on Dataproc Serverless can be further configured in your [BigQuery profile](/reference/warehouse-setups/bigquery-setup#running-python-models-on-dataproc).
+Python models running on Dataproc Serverless can be further configured in your [BigQuery profile](/docs/core/connect-data-platform/bigquery-setup#running-python-models-on-dataproc).
 
 Any user or service account that runs dbt Python models will need the following permissions(in addition to the required BigQuery permissions) ([docs](https://cloud.google.com/dataproc/docs/concepts/iam/iam)):
 ```

--- a/website/docs/docs/core/connect-data-platform/bigquery-setup.md
+++ b/website/docs/docs/core/connect-data-platform/bigquery-setup.md
@@ -501,11 +501,43 @@ my-profile:
       project: abc-123
       dataset: my_dataset
       
-      # for dbt Python models
+      # for dbt Python models to be run on a Dataproc cluster
       gcs_bucket: dbt-python
       dataproc_cluster_name: dbt-python
       dataproc_region: us-central1
 ```
+
+Alternatively, Dataproc Serverless can be used:
+
+```yaml
+my-profile:
+  target: dev
+  outputs:
+    dev:
+      type: bigquery
+      method: oauth
+      project: abc-123
+      dataset: my_dataset
+      
+      # for dbt Python models to be run on Dataproc Serverless
+      gcs_bucket: dbt-python
+      dataproc_region: us-central1
+      submission_method: serverless
+      dataproc_batch:
+        environment_config:
+          execution_config:
+            service_account: dbt@abc-123.iam.gserviceaccount.com
+            subnetwork_uri: regions/us-central1/subnetworks/dataproc-dbt
+        labels:
+          project: my-project
+          role: dev
+        runtime_config:
+          properties:
+            spark.executor.instances: 3
+            spark.driver.memory: 1g
+```
+
+For a full list of possible configuration fields that can be passed in `dataproc_batch`, refer to the [Dataproc Serverless Batch](https://cloud.google.com/dataproc-serverless/docs/reference/rpc/google.cloud.dataproc.v1#google.cloud.dataproc.v1.Batch) documentation.
 
 </VersionBlock>
 


### PR DESCRIPTION
Resolves #3382

## What are you changing in this pull request and why?
The dataproc_batch config field for configuring Python models running on GCP Dataproc Serverless was added in [dbt-labs/dbt-bigquery#578](https://github.com/dbt-labs/dbt-bigquery/pull/578), but it isn't documented yet. This PR adds the missing documentation for this field.

## Checklist
- [ ] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [ ] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."