### PR TITLE
Update the custom `get_where_subquery` example macro to handle `None`

### DIFF
--- a/website/docs/reference/resource-configs/where.md
+++ b/website/docs/reference/resource-configs/where.md
@@ -164,7 +164,7 @@ models:
 ```sql
 {% macro get_where_subquery(relation) -%}
     {% set where = config.get('where', '') %}
-    {% if "__three_days_ago__" in where %}
+    {% if where and "__three_days_ago__" in where %}
         {# replace placeholder string with result of custom macro #}
         {% set three_days_ago = dbt.dateadd('day', -3, current_timestamp()) %}
         {% set where = where | replace("__three_days_ago__", three_days_ago) %}

--- a/website/docs/reference/resource-configs/where.md
+++ b/website/docs/reference/resource-configs/where.md
@@ -154,7 +154,7 @@ models:
         tests:
           - unique:
               config:
-                where: "date_column > __last_three_days__"  # placeholder string for static config
+                where: "date_column > __three_days_ago__"  # placeholder string for static config
 ```
 
 </File>


### PR DESCRIPTION
[Preview](https://deploy-preview-3683--docs-getdbt-com.netlify.app/reference/resource-configs/where#custom-logic)

## What are you changing in this pull request and why?

resolves #3677

## 🎩 

<img width="600" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/5dc3d343-0b63-430a-aaba-66b313b9397b">

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.