### PR TITLE
add hyphen to read-only for consistency

### DIFF
--- a/website/docs/docs/cloud/manage-access/about-access.md
+++ b/website/docs/docs/cloud/manage-access/about-access.md
@@ -34,7 +34,7 @@ to access. dbt Cloud's three license types are:
 
  - **Developer** &mdash; User may be granted _any_ permissions.
  - **Read-Only** &mdash; User has read-only permissions applied to all dbt Cloud resources regardless of the role-based permissions that the user is assigned.
- - **IT** &mdash; User has [Security Admin](/docs/cloud/manage-access/enterprise-permissions#security-admin) and [Billing Admin](docs/cloud/manage-access/enterprise-permissions#billing-admin) permissions applied regardless of the role-based permissions that the user is assigned. 
+ - **IT** &mdash; User has [Security Admin](/docs/cloud/manage-access/enterprise-permissions#security-admin) and [Billing Admin](/docs/cloud/manage-access/enterprise-permissions#billing-admin) permissions applied regardless of the role-based permissions that the user is assigned. 
 
 For more information on these license types, see [Seats & Users](/docs/cloud/manage-access/seats-and-users).
 

--- a/website/docs/docs/cloud/manage-access/about-access.md
+++ b/website/docs/docs/cloud/manage-access/about-access.md
@@ -33,7 +33,7 @@ A user's license type controls the features in dbt Cloud that the user is able
 to access. dbt Cloud's three license types are:
 
  - **Developer** &mdash; User may be granted _any_ permissions.
- - **Read Only** &mdash; User has read-only permissions applied to all dbt Cloud resources regardless of the role-based permissions that the user is assigned.
+ - **Read-Only** &mdash; User has read-only permissions applied to all dbt Cloud resources regardless of the role-based permissions that the user is assigned.
  - **IT** &mdash; User has [Security Admin](/docs/cloud/manage-access/enterprise-permissions#security-admin) and [Billing Admin](docs/cloud/manage-access/enterprise-permissions#billing-admin) permissions applied regardless of the role-based permissions that the user is assigned. 
 
 For more information on these license types, see [Seats & Users](/docs/cloud/manage-access/seats-and-users).
@@ -153,7 +153,7 @@ Yes, see the documentation on [Manual Assignment](#manual-assignment) above for 
 Make sure you're not trying to edit your own user as this isn't allowed for security reasons. To edit the group membership of your own user, you'll need a different user to make those changes.
 
 - **How do I add or remove users**?  <br />
-Each dbt Cloud plan comes with a base number of Developer and Read Only licenses. You can add or remove licenses by modifying the number of users in your account settings. 
+Each dbt Cloud plan comes with a base number of Developer and Read-Only licenses. You can add or remove licenses by modifying the number of users in your account settings. 
   - If you're on an Enterprise plans and have the correct [permissions](/docs/cloud/manage-access/enterprise-permissions), you can add or remove developers by adjusting your developer user seat count in **Account settings** -> **Users**.
   - If you're on a Team plan and have the correct [permissions](/docs/cloud/manage-access/self-service-permissions), you can add or remove developers by making two changes: adjust your developer user seat count AND your developer billing seat count in **Account settings** -> **Users** and then in **Account settings** -> **Billing**.
 

--- a/website/docs/docs/cloud/manage-access/cloud-seats-and-users.md
+++ b/website/docs/docs/cloud/manage-access/cloud-seats-and-users.md
@@ -8,12 +8,12 @@ sidebar: "Users and licenses"
 In dbt Cloud, _licenses_ are used to allocate users to your account. There are three different types of licenses in dbt Cloud:
 
 - **Developer** &mdash; Granted access to the Deployment and [Development](/docs/cloud/dbt-cloud-ide/develop-in-the-cloud) functionality in dbt Cloud.
-- **Read-only** &mdash; Intended to view the [artifacts](/docs/deploy/artifacts) created in a dbt Cloud account.
+- **Read-Only** &mdash; Intended to view the [artifacts](/docs/deploy/artifacts) created in a dbt Cloud account.
 - **IT** &mdash; Can manage users, groups, and licenses, among other permissions. Available on Enterprise and Team plans only.
 
 The user's assigned license determines the specific capabilities they can access in dbt Cloud.
 
-| Functionality | Developer User | Read Only Users | IT Users* |
+| Functionality | Developer User | Read-Only Users | IT Users* |
 | ------------- | -------------- | --------------- | -------- |
 | Use the Developer IDE | ✅ | ❌ | ❌ |
 | Use Jobs | ✅ | ❌ | ❌ |
@@ -25,7 +25,7 @@ The user's assigned license determines the specific capabilities they can access
 
 ## Licenses
 
-Each dbt Cloud plan comes with a base number of Developer, IT, and Read Only licenses. You can add or remove licenses by modifying the number of users in your account settings. 
+Each dbt Cloud plan comes with a base number of Developer, IT, and Read-Only licenses. You can add or remove licenses by modifying the number of users in your account settings. 
 
 If you have a Developer plan account and want to add more people to your team, you'll need to upgrade to the Team plan. Refer to [dbt Pricing Plans](https://www.getdbt.com/pricing/) for more information about licenses available with each plan.
 
@@ -144,19 +144,19 @@ If your account is connected to an Identity Provider (IdP) for [Single Sign
 On](/docs/cloud/manage-access/sso-overview), you can automatically map IdP user
 groups to specific license types in dbt Cloud. To configure license mappings,
 navigate to the Account Settings &gt; Team &gt; License Mappings page. From
-here, you can create or edit SSO mappings for both Read Only and Developer
+here, you can create or edit SSO mappings for both Read-Only and Developer
 license types.
 
 By default, all new members of a dbt Cloud account will be assigned a Developer
-license. To assign Read Only licenses to certain groups of users, create a new
-License Mapping for the Read Only license type and include a comma separated
-list of IdP group names that should receive a Read Only license at sign-in time.
+license. To assign Read-Only licenses to certain groups of users, create a new
+License Mapping for the Read-Only license type and include a comma separated
+list of IdP group names that should receive a Read-Only license at sign-in time.
 
 <Lightbox src="/img/docs/dbt-cloud/access-control/license-mapping.png"
           title="Configuring IdP group license mapping"/>
 
 Usage notes:
-- If a user's IdP groups match both a Developer and Read Only license type
+- If a user's IdP groups match both a Developer and Read-Only license type
   mapping, a Developer license type will be assigned
 - If a user's IdP groups do not match _any_ license type mappings, a Developer
   license will be assigned

--- a/website/docs/docs/cloud/manage-access/enterprise-permissions.md
+++ b/website/docs/docs/cloud/manage-access/enterprise-permissions.md
@@ -93,7 +93,7 @@ Users with Project Creator permissions can:
 - **Has permissions on:** Authorized projects, account-level settings
 - **License restrictions:** must have a developer license
 
-Account Viewers have read only access to dbt Cloud accounts. Users with Account Viewer permissions can:
+Account Viewers have read-only access to dbt Cloud accounts. Users with Account Viewer permissions can:
 - View all projects in an account
 - View Account Settings
 - View account-level artifacts
@@ -201,12 +201,12 @@ Analysts can perform the following actions in projects they are assigned to:
 
 ### Stakeholder
 - **Has permissions on:** Authorized projects
-- **License restrictions:** Intended for use with Read Only licenses, but may be used with Developer licenses.
+- **License restrictions:** Intended for use with Read-Only licenses, but may be used with Developer licenses.
 
 Stakeholders can perform the following actions in projects they are assigned to:
 - View generated documentation
 - View generated source freshness reports
-- View the Read Only dashboard
+- View the Read-Only dashboard
 
 ## Diagram of the Permission Sets
 

--- a/website/docs/docs/cloud/manage-access/licenses-and-groups.md
+++ b/website/docs/docs/cloud/manage-access/licenses-and-groups.md
@@ -25,12 +25,12 @@ user can only have one type of license at any given time.
 
 A user's license type controls the features in dbt Cloud that the user is able
 to access. dbt Cloud's three license types are:
- - **Read Only**
+ - **Read-Only**
  - **Developer**
  - **IT**
 
 For more information on these license types, see [Seats & Users](/docs/cloud/manage-access/seats-and-users).
-At a high-level, Developers may be granted _any_ permissions, whereas Read Only
+At a high-level, Developers may be granted _any_ permissions, whereas Read-Only
 users will have read-only permissions applied to all dbt Cloud resources
 regardless of the role-based permissions that the user is assigned. IT users will have Security Admin and Billing Admin permissions applied regardless of the role-based permissions that the user is assigned.
 

--- a/website/docs/docs/cloud/manage-access/self-service-permissions.md
+++ b/website/docs/docs/cloud/manage-access/self-service-permissions.md
@@ -18,9 +18,9 @@ The permissions afforded to each role are described below:
 | Manage team permissions | ❌ | ✅ |
 | Invite Owners to the account | ❌ | ✅ |
 
-## Read Only vs. Developer License Types
+## Read-Only vs. Developer License Types
 
-Users configured with Read Only license types will experience a restricted set of permissions in dbt Cloud. If a user is associated with a _Member_ permission set and a Read Only seat license, then they will only have access to what a Read-Only seat allows. See [Seats and Users](/docs/cloud/manage-access/seats-and-users) for more information on the impact of licenses on these permissions.
+Users configured with Read-Only license types will experience a restricted set of permissions in dbt Cloud. If a user is associated with a _Member_ permission set and a Read-Only seat license, then they will only have access to what a Read-Only seat allows. See [Seats and Users](/docs/cloud/manage-access/seats-and-users) for more information on the impact of licenses on these permissions.
 
 ## Owner and Member Groups in dbt Cloud Enterprise  
 

--- a/website/docs/docs/cloud/manage-access/set-up-bigquery-oauth.md
+++ b/website/docs/docs/cloud/manage-access/set-up-bigquery-oauth.md
@@ -9,7 +9,6 @@ id: "set-up-bigquery-oauth"
 This guide describes a feature of the dbt Cloud Enterprise plan. If you’re interested in learning more about an Enterprise plan, contact us at sales@getdbt.com.
 
 :::
-### Overview
 
 
 dbt Cloud supports developer [OAuth](https://cloud.google.com/bigquery/docs/authentication) with BigQuery, providing an additional layer of security for dbt enterprise users. When BigQuery OAuth is enabled for a dbt Cloud project, all dbt Cloud developers must authenticate with BigQuery in order to use the dbt Cloud IDE. The project's deployment environments will still leverage the BigQuery service account key set in the project credentials.


### PR DESCRIPTION
per [slack thread](https://dbt-labs.slack.com/archives/C02NCQ9483C/p1688662424095829) raised by Will Stamatis, this pr addresses the inconsistency in how we use 'read-only' in the docs. adding a hyphen to all read-only for consistency. 