### PR TITLE
Standardize config titles

### DIFF
--- a/website/docs/reference/resource-configs/database.md
+++ b/website/docs/reference/resource-configs/database.md
@@ -1,5 +1,4 @@
 ---
-title: "About database configuration"
 sidebar_label: "database"
 resource_types: [models, seeds, tests]
 datatype: string

--- a/website/docs/reference/resource-configs/docs.md
+++ b/website/docs/reference/resource-configs/docs.md
@@ -1,5 +1,4 @@
 ---
-title: "About docs configuration"
 sidebar_label: "docs"
 resource_types: models
 description: "Docs - Read this in-depth guide to learn about configurations in dbt."

--- a/website/docs/reference/resource-configs/schema.md
+++ b/website/docs/reference/resource-configs/schema.md
@@ -1,5 +1,4 @@
 ---
-title: "About schema configuration"
 sidebar_label: "schema"
 resource_types: [models, seeds, tests]
 description: "Schema - Read this in-depth guide to learn about configurations in dbt."

--- a/website/docs/reference/resource-configs/tags.md
+++ b/website/docs/reference/resource-configs/tags.md
@@ -1,5 +1,4 @@
 ---
-title: "About tags configuration"
 sidebar_label: "tags"
 resource_types: all
 datatype: string | [string]


### PR DESCRIPTION
## Previews
- https://deploy-preview-3702--docs-getdbt-com.netlify.app/reference/resource-configs/database
- https://deploy-preview-3702--docs-getdbt-com.netlify.app/reference/resource-configs/schema
- https://deploy-preview-3702--docs-getdbt-com.netlify.app/reference/resource-configs/docs
- https://deploy-preview-3702--docs-getdbt-com.netlify.app/reference/resource-configs/tags

## What are you changing in this pull request and why?

There are about a dozen "general configs". Some of them have a page title that starts with "About", but most do not.

This PR standardizes to the latter by removing the customized page titles that include "About".

Alternatively, the rest of the pages could have "About" added if that is desired instead.

## Before

You can see the difference in the browser tabs here (before the changes in this PR):

<img width="541" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/943ba2db-9fdf-45e3-b499-71d2c352d535">

## 🎩 After

Here's what it looks like after the changes in this PR:
<img width="804" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/b73dbdfa-9ae8-4584-8932-dcebd84987ab">

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.