### PR TITLE
`target` name for `profile_template.yml` starting in v1.2

### DIFF
--- a/website/docs/reference/commands/init.md
+++ b/website/docs/reference/commands/init.md
@@ -4,10 +4,6 @@ sidebar_label: "init"
 id: "init"
 ---
 
-:::info Improved in v1.0!
-The `init` command is interactive and responsive like never before.
-:::
-
 `dbt init` helps get you started using dbt Core!
 
 ## New project

--- a/website/docs/reference/commands/init.md
+++ b/website/docs/reference/commands/init.md
@@ -33,6 +33,8 @@ If you've just cloned or downloaded an existing dbt project, `dbt init` can stil
 
 - **Existing project:** If you're the maintainer of an existing project, and you want to help new users get connected to your database quickly and easily, you can include your own custom `profile_template.yml` in the root of your project, alongside `dbt_project.yml`. For common connection attributes, set the values in `fixed`; leave user-specific attributes in `prompts`, but with custom hints and defaults as you'd like.
 
+<VersionBlock lastVersion="1.1">
+
 <File name='profile_template.yml'>
 
 ```yml
@@ -58,9 +60,43 @@ prompts:
 
 </File>
 
+</VersionBlock>
+
+<VersionBlock firstVersion="1.2">
+
+<File name='profile_template.yml'>
+
+```yml
+fixed:
+  account: abc123
+  authenticator: externalbrowser
+  database: analytics
+  role: transformer
+  type: snowflake
+  warehouse: transforming
+prompts:
+  target:
+    type: string
+    hint: your desired target name
+  user:
+    type: string
+    hint: yourname@jaffleshop.com
+  schema:
+    type: string
+    hint: usually dbt_<yourname>
+  threads:
+    hint: "your favorite number, 1-10"
+    type: int
+    default: 8
+```
+
+</File>
+
+</VersionBlock>
+
 ```
 $ dbt init
-Running with dbt=1.0.0-b2
+Running with dbt=1.0.0
 Setting up your profile.
 user (yourname@jaffleshop.com): summerintern@jaffleshop.com
 schema (usually dbt_<yourname>): dbt_summerintern


### PR DESCRIPTION
resolves #1389

[Preview](https://deploy-preview-3706--docs-getdbt-com.netlify.app/reference/commands/init?version=1.2)

## What are you changing in this pull request and why?

https://github.com/dbt-labs/dbt-core/issues/5179 added `target`, and this was released in v1.2. This PR adds docs for this feature using the appropriate versioning.

## 🎩 

### v1.1

https://deploy-preview-3706--docs-getdbt-com.netlify.app/reference/commands/init?version=1.1

<img width="600" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/4c5b48fc-e15e-4efe-bda6-1356986eb679">

### v1.2

https://deploy-preview-3706--docs-getdbt-com.netlify.app/reference/commands/init?version=1.2

<img width="600" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/f98d495b-8d32-47a8-b271-052b41f9cbfa">


## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.