### PR TITLE
change semantic model attribute to defaults

### DIFF
--- a/website/docs/docs/build/about-metricflow.md
+++ b/website/docs/docs/build/about-metricflow.md
@@ -129,7 +129,7 @@ semantic_models:
     description: "A record for every transaction that takes place. Carts are considered multiple transactions for each SKU."
     owners: support@getdbt.com
     model: (ref('transactions'))
-    default:
+    defaults:
         agg_time_dimension: metric_time
 
   # --- entities ---

--- a/website/docs/docs/build/dimensions.md
+++ b/website/docs/docs/build/dimensions.md
@@ -254,7 +254,7 @@ semantic_models:
   - name: sales_person_tiers
     description: SCD Type II table of tiers for sales people 
     model: {{ref(sales_person_tiers)}}
-    default:
+    defaults:
       agg_time_dimension: tier_start
 
     dimensions:


### PR DESCRIPTION
following up from pr #3715, changing the rest of the docs from `default` to `defaults` cc @jcohen6