### PR TITLE
`merge` is not (yet) supported in dbt-redshift for v1.6

### DIFF
--- a/website/docs/docs/build/incremental-models.md
+++ b/website/docs/docs/build/incremental-models.md
@@ -253,7 +253,7 @@ to build incremental models.
 
 Click the name of the adapter in the below table for more information about supported incremental strategies.
 
-The `merge` strategy is available in dbt-postgres and dbt-redshift beginning in dbt v1.6.
+The `merge` strategy is available in dbt-postgres beginning in dbt v1.6.
 
 <VersionBlock lastVersion="1.5">
 
@@ -276,7 +276,7 @@ The `merge` strategy is available in dbt-postgres and dbt-redshift beginning in 
 | data platform adapter  | default strategy | additional supported strategies  |
 | :----------------- | :----------------| : ---------------------------------- |
 | [dbt-postgres](/reference/resource-configs/postgres-configs#incremental-materialization-strategies) | `append`         | `merge` , `delete+insert`                  |
-| [dbt-redshift](/reference/resource-configs/redshift-configs#incremental-materialization-strategies) | `append`         | `merge`, `delete+insert`                  |
+| [dbt-redshift](/reference/resource-configs/redshift-configs#incremental-materialization-strategies) | `append`         | `delete+insert`                  |
 | [dbt-bigquery](/reference/resource-configs/bigquery-configs#merge-behavior-incremental-models)      | `merge`          | `insert_overwrite`                       |
 | [dbt-spark](/reference/resource-configs/spark-configs#incremental-models)                           | `append`         | `merge` (Delta only)  `insert_overwrite` |
 | [dbt-databricks](/reference/resource-configs/databricks-configs#incremental-models)                 | `append`         | `merge` (Delta only) `insert_overwrite`  |


### PR DESCRIPTION
## Previews
- [1.5](https://deploy-preview-3719--docs-getdbt-com.netlify.app/docs/build/incremental-models?version=1.5#supported-incremental-strategies-by-adapter)
- [1.6](https://deploy-preview-3719--docs-getdbt-com.netlify.app/docs/build/incremental-models?version=1.6#supported-incremental-strategies-by-adapter)

## What are you changing in this pull request and why?

`merge` is not (yet) supported in dbt-redshift for v1.6, and we should back out this update until it is.

See https://github.com/dbt-labs/dbt-redshift/pull/490 for more context.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.