### PR TITLE
Initial documentation for `thread_id` context variable

### DIFF
--- a/website/dbt-versions.js
+++ b/website/dbt-versions.js
@@ -32,7 +32,11 @@ exports.versions = [
 
 exports.versionedPages = [
   {
-    "page": "reference/resource-properties/deprecation_date", 
+    "page": "reference/dbt-jinja-functions/thread_id",
+    "firstVersion": "1.6",
+  },
+  {
+    "page": "reference/resource-properties/deprecation_date",
     "firstVersion": "1.6",
   },
   {

--- a/website/docs/reference/dbt-jinja-functions/thread_id.md
+++ b/website/docs/reference/dbt-jinja-functions/thread_id.md
@@ -1,0 +1,14 @@
+---
+title: "About thread_id"
+sidebar_label: "thread_id"
+id: "thread_id"
+description: "The `thread_id` outputs an identifier for the current Python thread."
+---
+
+The `thread_id` outputs an identifier for the current Python thread that is executing a node. E.g. `Thread-1`. This value is useful when auditing or analyzing dbt invocation metadata. It corresponds to the `thread_id` within the [`Result` object](/reference/dbt-classes#result-objects) and [`run_results.json`](/reference/artifacts/run-results-json).
+
+If available, the `thread_id` is:
+- available in the compilation context of [`query-comment`](/reference/project-configs/query-comment)
+- included in the `info` dictionary in dbt [events and logs](/reference/events-logging#info)
+- included in the `metadata` dictionary in [dbt artifacts](/reference/artifacts/dbt-artifacts#common-metadata)
+- included as a label in all BigQuery jobs that dbt originates

--- a/website/docs/reference/dbt-jinja-functions/thread_id.md
+++ b/website/docs/reference/dbt-jinja-functions/thread_id.md
@@ -5,7 +5,9 @@ id: "thread_id"
 description: "The `thread_id` outputs an identifier for the current Python thread."
 ---
 
-The `thread_id` outputs an identifier for the current Python thread that is executing a node. E.g. `Thread-1`. This value is useful when auditing or analyzing dbt invocation metadata. It corresponds to the `thread_id` within the [`Result` object](/reference/dbt-classes#result-objects) and [`run_results.json`](/reference/artifacts/run-results-json).
+The `thread_id` outputs an identifier for the current Python thread that is executing a node, like `Thread-1`. 
+
+This value is useful when auditing or analyzing dbt invocation metadata. It corresponds to the `thread_id` within the [`Result` object](/reference/dbt-classes#result-objects) and [`run_results.json`](/reference/artifacts/run-results-json).
 
 If available, the `thread_id` is:
 - available in the compilation context of [`query-comment`](/reference/project-configs/query-comment)


### PR DESCRIPTION
resolves #3614

[Preview](https://deploy-preview-3729--docs-getdbt-com.netlify.app/reference/dbt-jinja-functions/thread_id)

## What are you changing in this pull request and why?

https://github.com/dbt-labs/dbt-core/pull/7942 / https://github.com/dbt-labs/dbt-core/issues/7941

This new `thread_id` context variable works in query tags because it's set by the (Python) worker thread.

### Utility
[Comment](https://github.com/dbt-labs/dbt-core/pull/7942#issuecomment-1605237587):
> @NiallRees you're my hero.
> 
> https://getdbt.slack.com/archives/C2JRRQDTL/p1656203829761049

## 🎩 

<img width="700" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/11ab64e8-f257-4981-b072-aac0b7b434ed">

## Checklist
- [x] Add versioning components, as described in [Versioning Docs](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-entire-pages)
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/guides/migration/versions)
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [ ] Confirm that the bullet points are actually true
- [x] ~Add page to `website/sidebars.js`~ didn't do this because it appeared unecessary
- [x] Provide a unique filename for the new page
