### PR TITLE
dbt debug --connection flag

### DIFF
--- a/website/docs/reference/commands/debug.md
+++ b/website/docs/reference/commands/debug.md
@@ -4,9 +4,6 @@ sidebar_label: "debug"
 id: "debug"
 ---
 
-<Changelog>
-* dbt v1.6: The <code>dbt debug --connection</code> flag is introduced to only test the data platform connection in your profile.
-</Changelog>
 
 `dbt debug` is a utility function to test the database connection and display information for debugging purposes, such as the validity of your project file and your installation of any requisite dependencies (like `git` when you run `dbt deps`).
 

--- a/website/docs/reference/commands/debug.md
+++ b/website/docs/reference/commands/debug.md
@@ -4,7 +4,15 @@ sidebar_label: "debug"
 id: "debug"
 ---
 
-`dbt debug` is a utility function to test the database connection and show information for debugging purposes. Not to be confused with [debug-level logging](/reference/global-configs/about-global-configs#debug-level-logging) via the `--debug` option which increases verbosity.
+<Changelog>
+* **dbt v1.6**: The `dbt debug --connection` flag is introduced to test the data platform connection _only_.
+</Changelog>
+
+<VersionBlock firstVersion="1.6">
+
+`dbt debug --connection` is a utility function that allows you to test the data platform connection _only_. To view information for debugging purposes, use `dbt debug` without the `--connection` flag.
+
+*Note: This is not to be confused with [debug-level logging](/reference/global-configs/about-global-configs#debug-level-logging) via the `--debug` option which increases verbosity.
 
 The `--config-dir` option to `dbt debug` will show the configured location for the `profiles.yml` file and exit:
 
@@ -14,3 +22,23 @@ To view your profiles.yml file, run:
 
 open /Users/alice/.dbt
 ```
+
+</VersionBlock>
+
+
+<VersionBlock lastVersion="1.5">
+
+`dbt debug` is a utility function to test the database connection and show information for debugging purposes. 
+
+*Note: Not to be confused with [debug-level logging](/reference/global-configs/about-global-configs#debug-level-logging) via the `--debug` option which increases verbosity.
+
+The `--config-dir` option to `dbt debug` will show the configured location for the `profiles.yml` file and exit:
+
+```text
+$ dbt debug --config-dir
+To view your profiles.yml file, run:
+
+open /Users/alice/.dbt
+```
+
+</VersionBlock>

--- a/website/docs/reference/commands/debug.md
+++ b/website/docs/reference/commands/debug.md
@@ -10,9 +10,11 @@ id: "debug"
 
 <VersionBlock firstVersion="1.6">
 
-`dbt debug --connection` is a utility function that allows you to test the data platform connection _only_. To view information for debugging purposes, use `dbt debug` without the `--connection` flag.
+`dbt debug` is a utility function to test the database connection and display information for debugging purposes, such as the validity of your project file and your installation of any requisite dependencies (like `git` when you run `dbt deps`).
 
-*Note: This is not to be confused with [debug-level logging](/reference/global-configs/about-global-configs#debug-level-logging) via the `--debug` option which increases verbosity.
+To test the data platform connection _only_, add the `--connection` flag at the end of the command. For example, `dbt debug --connection` will only test the connection to the data platform and skip the other checks `dbt debug` looks for. 
+
+*Note: Not to be confused with [debug-level logging](/reference/global-configs/about-global-configs#debug-level-logging) via the `--debug` option which increases verbosity.
 
 The `--config-dir` option to `dbt debug` will show the configured location for the `profiles.yml` file and exit:
 
@@ -28,7 +30,7 @@ open /Users/alice/.dbt
 
 <VersionBlock lastVersion="1.5">
 
-`dbt debug` is a utility function to test the database connection and show information for debugging purposes. 
+`dbt debug` is a utility function to test the database connection and show information for debugging purposes.  
 
 *Note: Not to be confused with [debug-level logging](/reference/global-configs/about-global-configs#debug-level-logging) via the `--debug` option which increases verbosity.
 

--- a/website/docs/reference/commands/debug.md
+++ b/website/docs/reference/commands/debug.md
@@ -5,7 +5,7 @@ id: "debug"
 ---
 
 <Changelog>
-* **dbt v1.6**: The `dbt debug --connection` flag is introduced to _only_ test the data platform connection in your profile.
+* dbt v1.6: The <code>dbt debug --connection</code> flag is introduced to only test the data platform connection in your profile.
 </Changelog>
 
 <VersionBlock firstVersion="1.6">

--- a/website/docs/reference/commands/debug.md
+++ b/website/docs/reference/commands/debug.md
@@ -12,17 +12,19 @@ id: "debug"
 
 *Note: Not to be confused with [debug-level logging](/reference/global-configs/about-global-configs#debug-level-logging) via the `--debug` option which increases verbosity.
 
+### Example usage
+
 <VersionBlock firstVersion="1.6">
 
-### `--connection` option
+Only test the connection to the data platform and skip the other checks `dbt debug` looks for:
 
-To test the data platform connection _only_, add the `--connection` flag at the end of the command. For example, `dbt debug --connection` will only test the connection to the data platform and skip the other checks `dbt debug` looks for. 
+```shell
+$ dbt debug --connection
+```
 
 </VersionBlock>
 
-### `--config-dir` option
-
-The `--config-dir` option to `dbt debug` will show the configured location for the `profiles.yml` file and exit:
+Show the configured location for the `profiles.yml` file and exit:
 
 ```text
 $ dbt debug --config-dir

--- a/website/docs/reference/commands/debug.md
+++ b/website/docs/reference/commands/debug.md
@@ -8,13 +8,19 @@ id: "debug"
 * dbt v1.6: The <code>dbt debug --connection</code> flag is introduced to only test the data platform connection in your profile.
 </Changelog>
 
+`dbt debug` is a utility function to test the database connection and display information for debugging purposes, such as the validity of your project file and your installation of any requisite dependencies (like `git` when you run `dbt deps`).
+
+*Note: Not to be confused with [debug-level logging](/reference/global-configs/about-global-configs#debug-level-logging) via the `--debug` option which increases verbosity.
+
 <VersionBlock firstVersion="1.6">
 
-`dbt debug` is a utility function to test the database connection and display information for debugging purposes, such as the validity of your project file and your installation of any requisite dependencies (like `git` when you run `dbt deps`).
+### `--connection` option
 
 To test the data platform connection _only_, add the `--connection` flag at the end of the command. For example, `dbt debug --connection` will only test the connection to the data platform and skip the other checks `dbt debug` looks for. 
 
-*Note: Not to be confused with [debug-level logging](/reference/global-configs/about-global-configs#debug-level-logging) via the `--debug` option which increases verbosity.
+</VersionBlock>
+
+### `--config-dir` option
 
 The `--config-dir` option to `dbt debug` will show the configured location for the `profiles.yml` file and exit:
 
@@ -24,23 +30,3 @@ To view your profiles.yml file, run:
 
 open /Users/alice/.dbt
 ```
-
-</VersionBlock>
-
-
-<VersionBlock lastVersion="1.5">
-
-`dbt debug` is a utility function to test the database connection and show information for debugging purposes.  
-
-*Note: Not to be confused with [debug-level logging](/reference/global-configs/about-global-configs#debug-level-logging) via the `--debug` option which increases verbosity.
-
-The `--config-dir` option to `dbt debug` will show the configured location for the `profiles.yml` file and exit:
-
-```text
-$ dbt debug --config-dir
-To view your profiles.yml file, run:
-
-open /Users/alice/.dbt
-```
-
-</VersionBlock>

--- a/website/docs/reference/commands/debug.md
+++ b/website/docs/reference/commands/debug.md
@@ -5,7 +5,7 @@ id: "debug"
 ---
 
 <Changelog>
-* **dbt v1.6**: The `dbt debug --connection` flag is introduced to test the data platform connection _only_.
+* **dbt v1.6**: The `dbt debug --connection` flag is introduced to _only_ test the data platform connection in your profile.
 </Changelog>
 
 <VersionBlock firstVersion="1.6">


### PR DESCRIPTION
Adds `dbt debug --connection` flag to test connection only  in 1.6.

Resolves  #3725

Not sure if i did this correctly @jtcohen6 