### PR TITLE
metric nodes `depends_on`

### DIFF
--- a/website/docs/docs/build/measures.md
+++ b/website/docs/docs/build/measures.md
@@ -220,18 +220,4 @@ mf query --metrics mrr_by_end_of_month --dimensions metric_time__month --order m
 mf query --metrics mrr_by_end_of_month --dimensions metric_time__week --order metric_time__week 
 ```
 
-## Dependencies
-
-Metric nodes will reflect dependencies on semantic models based on their _measures_. However, dependencies based on filters should not be reflected in:
-
-- [dbt selection syntax](/reference/node-selection/syntax)
-- Visualization of the <Term id="dag">DAG</Term> in dbt-docs and the [integrated development environment](/docs/cloud/dbt-cloud-ide/develop-in-the-cloud) (IDE).
-
-This is because metrics need to source nodes for their `depends_on` attribute from a few different places:
-
-- `RATIO` and `DERIVED` type metrics should reference `Metric.type_params.input_metrics`.
-- `SIMPLE` <!--and `CUMULATIVE`--> type metrics should reference `Metric.type_params.measure`.
-
-For example, when you run the command `dbt list --select my_semantic_model+`, it will show you the metrics that belong to the specified semantic model.
-
-But there's a condition: Only the metrics that actually use measures or derived metrics from that semantic model will be included in the list. In other words, if a metric only uses a dimension from the semantic model in its filters, it won't be considered as part of that semantic model.
+import SetUpPages from '/snippets/_metrics-dependencies.md';

--- a/website/docs/docs/build/measures.md
+++ b/website/docs/docs/build/measures.md
@@ -222,7 +222,7 @@ mf query --metrics mrr_by_end_of_month --dimensions metric_time__week --order me
 
 ## Dependencies
 
-Metric nodes will reflect dependencies on semantic models for their _measures_. However, dependencies based on filters should not be reflected in:
+Metric nodes will reflect dependencies on semantic models based on their _measures_. However, dependencies based on filters should not be reflected in:
 
 - [dbt selection syntax](/reference/node-selection/syntax)
 - Visualization of the <Term id="dag">DAG</Term> in dbt-docs and the [integrated development environment](/docs/cloud/dbt-cloud-ide/develop-in-the-cloud) (IDE).

--- a/website/docs/docs/build/measures.md
+++ b/website/docs/docs/build/measures.md
@@ -219,3 +219,15 @@ We can query the semi-additive metrics using the following syntax:
 mf query --metrics mrr_by_end_of_month --dimensions metric_time__month --order metric_time__month 
 mf query --metrics mrr_by_end_of_month --dimensions metric_time__week --order metric_time__week 
 ```
+
+## Dependencies
+
+Metric nodes will reflect dependencies on semantic models for their _measures_. However, dependencies based on filters should not be reflected in:
+
+- [dbt selection syntax](/reference/node-selection/syntax)
+- Visualization of the <Term id="dag">DAG</Term> in dbt-docs and the [integrated development environment](/docs/cloud/dbt-cloud-ide/develop-in-the-cloud) (IDE).
+
+This is because metrics need to source nodes for their `depends_on` attribute from a few different places:
+
+- `RATIO` and `DERIVED` type metrics should reference `Metric.type_params.input_metrics`.
+- `SIMPLE` <!--and `CUMULATIVE`--> type metrics should reference `Metric.type_params.measure`.

--- a/website/docs/docs/build/measures.md
+++ b/website/docs/docs/build/measures.md
@@ -231,3 +231,7 @@ This is because metrics need to source nodes for their `depends_on` attribute fr
 
 - `RATIO` and `DERIVED` type metrics should reference `Metric.type_params.input_metrics`.
 - `SIMPLE` <!--and `CUMULATIVE`--> type metrics should reference `Metric.type_params.measure`.
+
+For example, when you run the command `dbt list --select my_semantic_model+`, it will show you the metrics that belong to the specified semantic model.
+
+But there's a condition: Only the metrics that actually use measures or derived metrics from that semantic model will be included in the list. In other words, if a metric only uses a dimension from the semantic model in its filters, it won't be considered as part of that semantic model.

--- a/website/docs/docs/build/measures.md
+++ b/website/docs/docs/build/measures.md
@@ -221,3 +221,5 @@ mf query --metrics mrr_by_end_of_month --dimensions metric_time__week --order me
 ```
 
 import SetUpPages from '/snippets/_metrics-dependencies.md';
+
+<SetUpPages /> 

--- a/website/docs/docs/build/semantic-models.md
+++ b/website/docs/docs/build/semantic-models.md
@@ -175,6 +175,9 @@ This is because metrics need to source nodes for their `depends_on` attribute fr
 - `RATIO` and `DERIVED` type metrics should reference `Metric.type_params.input_metrics`.
 - `SIMPLE` <!--and `CUMULATIVE`--> type metrics should reference `Metric.type_params.measure`.
 
+For example, when you run the command `dbt list --select my_semantic_model+`, it will show you the metrics that belong to the specified semantic model.
+
+But there's a condition: Only the metrics that actually use measures or derived metrics from that semantic model will be included in the list. In other words, if a metric only uses a dimension from the semantic model in its filters, it won't be considered as part of that semantic model.
 
 ## Related docs
 

--- a/website/docs/docs/build/semantic-models.md
+++ b/website/docs/docs/build/semantic-models.md
@@ -165,7 +165,7 @@ _*Coming soon_
 
 ## Dependencies
 
-Metric nodes will reflect dependencies on semantic models for their _measures_. However, dependencies based on filters should not be reflected in:
+Metric nodes will reflect dependencies on semantic models based on their _measures_. However, dependencies based on filters should not be reflected in:
 
 - [dbt selection syntax](/reference/node-selection/syntax)
 - Visualization of the <Term id="dag">DAG</Term> in dbt-docs and the [integrated development environment](/docs/cloud/dbt-cloud-ide/develop-in-the-cloud) (IDE).

--- a/website/docs/docs/build/semantic-models.md
+++ b/website/docs/docs/build/semantic-models.md
@@ -161,6 +161,21 @@ For semantic models with a measure, you must have a primary time group.
 | `non_additive_dimension` | Non-additive dimensions can be specified for measures that cannot be aggregated over certain dimensions, such as bank account balances, to avoid producing incorrect results. | Optional |
 | `create_metric`* | You can create a metric directly from a measure with create_metric: True and specify its display name with create_metric_display_name. | Optional |
 _*Coming soon_
+
+
+## Dependencies
+
+Metric nodes will reflect dependencies on semantic models for their _measures_. However, dependencies based on filters should not be reflected in:
+
+- [dbt selection syntax](/reference/node-selection/syntax)
+- Visualization of the <Term id="dag">DAG</Term> in dbt-docs and the [integrated development environment](/docs/cloud/dbt-cloud-ide/develop-in-the-cloud) (IDE).
+
+This is because metrics need to source nodes for their `depends_on` attribute from a few different places:
+
+- `RATIO` and `DERIVED` type metrics should reference `Metric.type_params.input_metrics`.
+- `SIMPLE` <!--and `CUMULATIVE`--> type metrics should reference `Metric.type_params.measure`.
+
+
 ## Related docs
 
 - [About MetricFlow](/docs/build/about-metricflow)

--- a/website/docs/docs/build/semantic-models.md
+++ b/website/docs/docs/build/semantic-models.md
@@ -163,21 +163,9 @@ For semantic models with a measure, you must have a primary time group.
 _*Coming soon_
 
 
-## Dependencies
+import SetUpPages from '/snippets/_metrics-dependencies.md';
 
-Metric nodes will reflect dependencies on semantic models based on their _measures_. However, dependencies based on filters should not be reflected in:
-
-- [dbt selection syntax](/reference/node-selection/syntax)
-- Visualization of the <Term id="dag">DAG</Term> in dbt-docs and the [integrated development environment](/docs/cloud/dbt-cloud-ide/develop-in-the-cloud) (IDE).
-
-This is because metrics need to source nodes for their `depends_on` attribute from a few different places:
-
-- `RATIO` and `DERIVED` type metrics should reference `Metric.type_params.input_metrics`.
-- `SIMPLE` <!--and `CUMULATIVE`--> type metrics should reference `Metric.type_params.measure`.
-
-For example, when you run the command `dbt list --select my_semantic_model+`, it will show you the metrics that belong to the specified semantic model.
-
-But there's a condition: Only the metrics that actually use measures or derived metrics from that semantic model will be included in the list. In other words, if a metric only uses a dimension from the semantic model in its filters, it won't be considered as part of that semantic model.
+<SetUpPages />
 
 ## Related docs
 

--- a/website/snippets/_metrics-dependencies.md
+++ b/website/snippets/_metrics-dependencies.md
@@ -1,0 +1,15 @@
+## Dependencies
+
+Metric nodes will reflect dependencies on semantic models based on their _measures_. However, dependencies based on filters should not be reflected in:
+
+- [dbt selection syntax](/reference/node-selection/syntax)
+- Visualization of the <Term id="dag">DAG</Term> in dbt-docs and the [integrated development environment](/docs/cloud/dbt-cloud-ide/develop-in-the-cloud) (IDE).
+
+This is because metrics need to source nodes for their `depends_on` attribute from a few different places:
+
+- `RATIO` and `DERIVED` type metrics should reference `Metric.type_params.input_metrics`.
+- `SIMPLE` <!--and `CUMULATIVE`--> type metrics should reference `Metric.type_params.measure`.
+
+For example, when you run the command `dbt list --select my_semantic_model+`, it will show you the metrics that belong to the specified semantic model.
+
+But there's a condition: Only the metrics that actually use measures or derived metrics from that semantic model will be included in the list. In other words, if a metric only uses a dimension from the semantic model in its filters, it won't be considered as part of that semantic model.


### PR DESCRIPTION
adding language that metric nodes include dependencies on semantic models based on measures but not filters in dag and dbt selection.

Resolves #3682