### PR TITLE
Update the command reference to include retry for Cloud

### DIFF
--- a/website/docs/reference/dbt-commands.md
+++ b/website/docs/reference/dbt-commands.md
@@ -23,6 +23,7 @@ Use the following dbt commands in the [dbt Cloud IDE](/docs/cloud/dbt-cloud-ide/
 - [compile](/reference/commands/compile): compiles (but does not run) the models in a project
 - [deps](/reference/commands/deps): downloads dependencies for a project
 - [docs](/reference/commands/cmd-docs) : generates documentation for a project
+- [retry](/reference/commands/retry): retry the last run `dbt` command from the point of failure (requires dbt 1.6 or higher)
 - [run](/reference/commands/run): runs the models in a project
 - [run-operation](/reference/commands/run-operation): invoke a macro, including running arbitrary maintenance SQL against the database
 - [seed](/reference/commands/seed): loads CSV files into the database


### PR DESCRIPTION
## What are you changing in this pull request and why?
Per this [internal conversation](https://dbt-labs.slack.com/archives/C02NCQ9483C/p1689284760338829), it looks like `dbt retry` works in dbt Cloud when it has 1.6 or higher.


## Checklist

- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [x] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."

Adding new pages (delete if not applicable):
- [ ] Add page to `website/sidebars.js`
- [ ] Provide a unique filename for the new page

Removing or renaming existing pages (delete if not applicable):
- [ ] Remove page from `website/sidebars.js`
- [ ] Add an entry `website/static/_redirects`
- [ ] [Ran link testing](https://github.com/dbt-labs/docs.getdbt.com#running-the-cypress-tests-locally) to update the links that point to the deleted page
