### PR TITLE
Update earliest version for materialized views in adapters

### DIFF
--- a/website/docs/reference/resource-configs/bigquery-configs.md
+++ b/website/docs/reference/resource-configs/bigquery-configs.md
@@ -766,6 +766,7 @@ The `grant_access_to` config is not thread-safe when multiple views need to be a
 
 <VersionBlock firstVersion="1.6">
 
+
 ## Materialized view
 
 The BigQuery adapter supports [materialized views](https://cloud.google.com/bigquery/docs/materialized-views-intro) and refreshes them for every subsequent `dbt run` you execute. For more information, see [Refresh Materialized Views](https://cloud.google.com/bigquery/docs/materialized-views-manage#refresh) in the Google docs.

--- a/website/docs/reference/resource-configs/bigquery-configs.md
+++ b/website/docs/reference/resource-configs/bigquery-configs.md
@@ -764,6 +764,8 @@ Views with this configuration will be able to select from objects in `project_1.
 
 The `grant_access_to` config is not thread-safe when multiple views need to be authorized for the same dataset. The initial `dbt run` operation after a new `grant_access_to` config is added should therefore be executed in a single thread. Subsequent runs using the same configuration will not attempt to re-apply existing access grants, and can make use of multiple threads.
 
+<VersionBlock firstVersion="1.6">
+
 ## Materialized view
 
 The BigQuery adapter supports [materialized views](https://cloud.google.com/bigquery/docs/materialized-views-intro) and refreshes them for every subsequent `dbt run` you execute. For more information, see [Refresh Materialized Views](https://cloud.google.com/bigquery/docs/materialized-views-manage#refresh) in the Google docs.
@@ -804,3 +806,5 @@ models:
     materialized: materialized_view
 ```
 </File>
+
+</VersionBlock>

--- a/website/docs/reference/resource-configs/postgres-configs.md
+++ b/website/docs/reference/resource-configs/postgres-configs.md
@@ -105,6 +105,8 @@ models:
 
 </File>
 
+<VersionBlock firstVersion="1.6">
+
 ## Materialized view
 
 The Postgres adapter supports [materialized views](https://www.postgresql.org/docs/current/rules-materializedviews.html) and refreshes them for every subsequent `dbt run` you execute. For more information, see [Refresh Materialized Views](https://www.postgresql.org/docs/15/sql-refreshmaterializedview.html) in the Postgres docs.
@@ -145,3 +147,5 @@ models:
     materialized: materialized_view
 ```
 </File>
+
+</VersionBlock>

--- a/website/docs/reference/resource-configs/redshift-configs.md
+++ b/website/docs/reference/resource-configs/redshift-configs.md
@@ -96,6 +96,8 @@ models:
 
 </File>
 
+<VersionBlock firstVersion="1.6">
+
 ## Materialized view
 
 The Redshift adapter supports [materialized views](https://docs.aws.amazon.com/redshift/latest/dg/materialized-view-overview.html) and refreshes them for every subsequent `dbt run` that you execute. For more information, see [Refresh Materialized Views](https://docs.aws.amazon.com/redshift/latest/dg/materialized-view-refresh.html) in the Redshift docs.
@@ -133,3 +135,5 @@ models:
     materialized: materialized_view
 ```
 </File>
+
+</VersionBlock>


### PR DESCRIPTION
## What are you changing in this pull request and why?

Version blocks would help reduce confusion / surprise like in [this](https://github.com/dbt-labs/dbt-bigquery/issues/818) bug report.

What might be better, but I didn't do:
- Display the "Materialized view" subheading no matter the version, but make a call-out that it's new functionality starting in 1.6

## Previews

- [1.6 bigquery](https://deploy-preview-3750--docs-getdbt-com.netlify.app/reference/resource-configs/bigquery-configs?version=1.6#materialized-view)
- [1.6 postgres](https://deploy-preview-3750--docs-getdbt-com.netlify.app/reference/resource-configs/postgres-configs?version=1.6#materialized-view)
- [1.6 redshift](https://deploy-preview-3750--docs-getdbt-com.netlify.app/reference/resource-configs/redshift-configs?version=1.6#materialized-view)

## Checklist
- [x] Add versioning components, as described in [Versioning Docs](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-entire-pages)
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.