### PR TITLE
Revert "`merge` is not (yet) supported in dbt-redshift for v1.6"

### DIFF
--- a/website/docs/docs/build/incremental-models.md
+++ b/website/docs/docs/build/incremental-models.md
@@ -253,7 +253,7 @@ to build incremental models.
 
 Click the name of the adapter in the below table for more information about supported incremental strategies.
 
-The `merge` strategy is available in dbt-postgres beginning in dbt v1.6.
+The `merge` strategy is available in dbt-postgres and dbt-redshift beginning in dbt v1.6.
 
 <VersionBlock lastVersion="1.5">
 
@@ -276,7 +276,7 @@ The `merge` strategy is available in dbt-postgres beginning in dbt v1.6.
 | data platform adapter  | default strategy | additional supported strategies  |
 | :----------------- | :----------------| : ---------------------------------- |
 | [dbt-postgres](/reference/resource-configs/postgres-configs#incremental-materialization-strategies) | `append`         | `merge` , `delete+insert`                  |
-| [dbt-redshift](/reference/resource-configs/redshift-configs#incremental-materialization-strategies) | `append`         | `delete+insert`                  |
+| [dbt-redshift](/reference/resource-configs/redshift-configs#incremental-materialization-strategies) | `append`         | `merge`, `delete+insert`                  |
 | [dbt-bigquery](/reference/resource-configs/bigquery-configs#merge-behavior-incremental-models)      | `merge`          | `insert_overwrite`                       |
 | [dbt-spark](/reference/resource-configs/spark-configs#incremental-models)                           | `append`         | `merge` (Delta only)  `insert_overwrite` |
 | [dbt-databricks](/reference/resource-configs/databricks-configs#incremental-models)                 | `append`         | `merge` (Delta only) `insert_overwrite`  |


### PR DESCRIPTION
Reverts dbt-labs/docs.getdbt.com#3719

resolves #3720

## What are you changing in this pull request and why?

https://github.com/dbt-labs/dbt-redshift/pull/490 was merged, and it will be included in 1.6. That means we can add it back to the docs (by reverting the PR that removed it until we knew what would happen).