### PR TITLE
Update number of indirect selection modes for Core 1.5+

### DIFF
--- a/website/docs/reference/node-selection/test-selection-examples.md
+++ b/website/docs/reference/node-selection/test-selection-examples.md
@@ -74,7 +74,7 @@ The "buildable" and "cautious" modes can be useful in environments when you're o
 
 <VersionBlock firstVersion="1.5" >
 
-There are four modes to configure the behavior when performing indirect selection (with `eager` as the default):
+These are the modes to configure the behavior when performing indirect selection (with `eager` as the default):
 
 1. `eager` (default) - include ANY test that references the selected nodes
 1. `cautious` - restrict to tests that ONLY refer to selected nodes

--- a/website/docs/reference/node-selection/test-selection-examples.md
+++ b/website/docs/reference/node-selection/test-selection-examples.md
@@ -74,7 +74,7 @@ The "buildable" and "cautious" modes can be useful in environments when you're o
 
 <VersionBlock firstVersion="1.5" >
 
-There are three modes to configure the behavior when performing indirect selection (with `eager` as the default):
+There are four modes to configure the behavior when performing indirect selection (with `eager` as the default):
 
 1. `eager` (default) - include ANY test that references the selected nodes
 1. `cautious` - restrict to tests that ONLY refer to selected nodes


### PR DESCRIPTION
[Preview](https://deploy-preview-3811--docs-getdbt-com.netlify.app/reference/node-selection/test-selection-examples?version=1.5&indirect-selection-mode=empty#indirect-selection)

## What are you changing in this pull request and why?

The count is off by one [here](https://docs.getdbt.com/reference/node-selection/test-selection-examples?version=1.5&indirect-selection-mode=empty#indirect-selection):

<img width="650" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/ef63b00a-a922-4da0-b796-0e930a237f0f">

## 🎩 

After the fix:
<img width="650" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/18fe97d6-e313-435a-a788-8e5910b3fb8f">


## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.