### PR TITLE
Update docs for prod environment setting

### DIFF
--- a/website/docs/docs/dbt-cloud-environments.md
+++ b/website/docs/docs/dbt-cloud-environments.md
@@ -42,6 +42,6 @@ To use the IDE, each developer will need to set up [personal development credent
 
 ## Deployment environment
 
-Deployment environments in dbt Cloud are crucial for executing scheduled jobs. A dbt Cloud project can have multiple deployment environments, allowing for flexibility and customization. 
+Deployment environments in dbt Cloud are necessary to execute scheduled jobs and use other features. A dbt Cloud project can have multiple deployment environments, allowing for flexibility and customization. However, a dbt Cloud project can only have one deployment environment that represents the production source of truth. 
 
-To learn more about dbt Cloud deployments and how to configure deployment environments, visit the [Deployment environments](/docs/deploy/deploy-environments) page. For our best practices guide, read [dbt Cloud environment best practices](https://docs.getdbt.com/guides/best-practices/environment-setup/1-env-guide-overview) for more info. 
+To learn more about dbt Cloud deployment environments and how to configure them, visit the [Deployment environments](/docs/deploy/deploy-environments) page. For our best practices guide, read [dbt Cloud environment best practices](https://docs.getdbt.com/guides/best-practices/environment-setup/1-env-guide-overview) for more info. 

--- a/website/docs/docs/deploy/deploy-environments.md
+++ b/website/docs/docs/deploy/deploy-environments.md
@@ -30,7 +30,7 @@ To create a new dbt Cloud development environment, navigate to **Deploy** -> **E
 
 ### Set as production environment
 
-You can set one deployment environment per dbt Cloud project as its production environment. You must set a production environment to use features like dbt Explorer and cross-project references, since it represents the source of truth for the production state of a dbt Cloud project.
+In dbt Cloud, each project can have one designated deployment environment, which serves as its production environment. This production environment is _essential_ for using features like dbt Explorer and cross-project references. It acts as the source of truth for the project's production state in dbt Cloud.
 
 ### Semantic Layer
 

--- a/website/docs/docs/deploy/deploy-environments.md
+++ b/website/docs/docs/deploy/deploy-environments.md
@@ -4,7 +4,7 @@ id: "deploy-environments"
 description: "Learn about dbt Cloud's deployment environment to seamlessly schedule jobs or enable CI."
 ---
 
-Deployment environments in dbt Cloud are crucial for deploying dbt jobs in production and using features or integrations that depend on dbt metadata/results. To execute dbt, environments determine the settings used during job runs, including:
+Deployment environments in dbt Cloud are crucial for deploying dbt jobs in production and using features or integrations that depend on dbt metadata or results. To execute dbt, environments determine the settings used during job runs, including:
 
 - The version of dbt Core that will be used to run your project
 - The warehouse connection information (including the target database/schema settings)

--- a/website/docs/docs/deploy/deploy-environments.md
+++ b/website/docs/docs/deploy/deploy-environments.md
@@ -15,7 +15,7 @@ A dbt Cloud project can have multiple deployment environments, providing you the
 :::tip Learn how to manage dbt Cloud environments
 To learn different approaches to managing dbt Cloud environments and recommendations for your organization's unique needs, read [dbt Cloud environment best practices](https://docs.getdbt.com/guides/best-practices/environment-setup/1-env-guide-overview).
 ::: 
-
+ 
 This page reviews the different types of environments and how to configure your deployment environment in dbt Cloud. 
 
 import CloudEnvInfo from '/snippets/_cloud-environments-info.md';
@@ -28,7 +28,11 @@ To create a new dbt Cloud development environment, navigate to **Deploy** -> **E
 
 <Lightbox src="/img/docs/dbt-cloud/cloud-configuring-dbt-cloud/create-deploy-env.jpg" width="85%" title="Navigate to Deploy ->  Environments to create a deployment environment" />
 
-### Set as production environment
+### Set as production environment (Beta)
+
+import ExpBeta from '/snippets/_explorer-beta-banner.md';  
+
+<ExpBeta/>
 
 In dbt Cloud, each project can have one designated deployment environment, which serves as its production environment. This production environment is _essential_ for using features like dbt Explorer and cross-project references. It acts as the source of truth for the project's production state in dbt Cloud.
 

--- a/website/docs/docs/deploy/deploy-environments.md
+++ b/website/docs/docs/deploy/deploy-environments.md
@@ -4,7 +4,7 @@ id: "deploy-environments"
 description: "Learn about dbt Cloud's deployment environment to seamlessly schedule jobs or enable CI."
 ---
 
-Deployment environments in dbt Cloud are crucial for deploying dbt jobs. To execute dbt, environments determine the settings used during job runs, including:
+Deployment environments in dbt Cloud are crucial for deploying dbt jobs in production and using features or integrations that depend on dbt metadata/results. To execute dbt, environments determine the settings used during job runs, including:
 
 - The version of dbt Core that will be used to run your project
 - The warehouse connection information (including the target database/schema settings)
@@ -16,7 +16,7 @@ A dbt Cloud project can have multiple deployment environments, providing you the
 To learn different approaches to managing dbt Cloud environments and recommendations for your organization's unique needs, read [dbt Cloud environment best practices](https://docs.getdbt.com/guides/best-practices/environment-setup/1-env-guide-overview).
 ::: 
 
-This page will go over the different types of environments and how to intuitively configure your deployment environment in dbt Cloud. 
+This page reviews the different types of environments and how to configure your deployment environment in dbt Cloud. 
 
 import CloudEnvInfo from '/snippets/_cloud-environments-info.md';
 
@@ -27,6 +27,10 @@ import CloudEnvInfo from '/snippets/_cloud-environments-info.md';
 To create a new dbt Cloud development environment, navigate to **Deploy** -> **Environments** and then click **Create Environment**. Select **Deployment** as the environment type.
 
 <Lightbox src="/img/docs/dbt-cloud/cloud-configuring-dbt-cloud/create-deploy-env.jpg" width="85%" title="Navigate to Deploy ->  Environments to create a deployment environment" />
+
+### Set as production environment
+
+You can set one deployment environment per dbt Cloud project as its production environment. You must set a production environment to use features like dbt Explorer and cross-project references, since it represents the source of truth for the production state of a dbt Cloud project.
 
 ### Semantic Layer
 

--- a/website/docs/guides/best-practices/environment-setup/1-env-guide-overview.md
+++ b/website/docs/guides/best-practices/environment-setup/1-env-guide-overview.md
@@ -39,7 +39,7 @@ Environments define the way that dbt will execute your code, including:
   - **Development** — the environment settings in which you work in the IDE on a development branch.
   - **Deployment** — the environment settings in which a dbt Cloud job runs.
 
-In this guide, we’re going to focus on **deployment environments**, which determine how your project is executed when a **dbt Cloud job executes**. When using both approaches, make sure to designate one environment as "Production." This will allow you to use features such as dbt Explorer and cross-project references.
+In this guide, we’re going to focus on **deployment environments**, which determine how your project is executed when a **dbt Cloud job executes**. When using both approaches, make sure to designate one environment as "Production." This will allow you to use features such as dbt Explorer and cross-project references. Refer to [Set product environment](/docs/deploy/deploy-environments#set-as-production-environment-beta) for details.
 
 Depending on your git workflow and testing strategy, you'll be choosing between one deployment environment or many deployment environments. We provide a high-level overview of how these two deployment strategies work here, but use each section of this guide to get a deep-dive into how these setups differ. 
 

--- a/website/docs/guides/best-practices/environment-setup/1-env-guide-overview.md
+++ b/website/docs/guides/best-practices/environment-setup/1-env-guide-overview.md
@@ -39,7 +39,7 @@ Environments define the way that dbt will execute your code, including:
   - **Development** — the environment settings in which you work in the IDE on a development branch.
   - **Deployment** — the environment settings in which a dbt Cloud job runs.
 
-In this guide, we’re going to focus on **deployment environments**, which determine how your project is executed when a **dbt Cloud job executes**.
+In this guide, we’re going to focus on **deployment environments**, which determine how your project is executed when a **dbt Cloud job executes**. For both approaches, be sure to set one environment as production in order to use features like dbt Explorer and cross-project refs.  
 
 Depending on your git workflow and testing strategy, you'll be choosing between one deployment environment or many deployment environments. We provide a high-level overview of how these two deployment strategies work here, but use each section of this guide to get a deep-dive into how these setups differ. 
 

--- a/website/docs/guides/best-practices/environment-setup/1-env-guide-overview.md
+++ b/website/docs/guides/best-practices/environment-setup/1-env-guide-overview.md
@@ -39,7 +39,7 @@ Environments define the way that dbt will execute your code, including:
   - **Development** — the environment settings in which you work in the IDE on a development branch.
   - **Deployment** — the environment settings in which a dbt Cloud job runs.
 
-In this guide, we’re going to focus on **deployment environments**, which determine how your project is executed when a **dbt Cloud job executes**. For both approaches, be sure to set one environment as production in order to use features like dbt Explorer and cross-project refs.  
+In this guide, we’re going to focus on **deployment environments**, which determine how your project is executed when a **dbt Cloud job executes**. When using both approaches, make sure to designate one environment as "Production." This will allow you to use features such as dbt Explorer and cross-project references.
 
 Depending on your git workflow and testing strategy, you'll be choosing between one deployment environment or many deployment environments. We provide a high-level overview of how these two deployment strategies work here, but use each section of this guide to get a deep-dive into how these setups differ. 
 

--- a/website/docs/guides/best-practices/environment-setup/2-one-deployment-environment.md
+++ b/website/docs/guides/best-practices/environment-setup/2-one-deployment-environment.md
@@ -11,7 +11,8 @@ hoverSnippet: Learn how to configure a single deployment environment setup in db
 ## What this looks like
 
 1. You have a **single *development* environment** where dbt users can access the dbt Cloud IDE and make changes to their code on feature branches created off of your default branch in your repository (most often the `main` branch).
-2. You have a **single *deployment* environment** (let’s call it “Production”) where your scheduled jobs run referencing the `main` branch. Be sure to set the environment as production to take advantage of features like dbt Explorer and cross-project refs. 
+2. You have a **single *deployment* environment** (let’s call it “Production”) where your scheduled jobs run referencing the `main` branch. 
+  * Make sure to set the environment to "Production" so you can take advantage of features like dbt Explorer and cross-project refs. 
 3. You also have a [**Slim CI job**](/docs/deploy/continuous-integration) that kicks off anytime you open a PR to merge a feature branch into `main`. This Slim CI job can run in your dbt “Production” environment.
 
 :::info

--- a/website/docs/guides/best-practices/environment-setup/2-one-deployment-environment.md
+++ b/website/docs/guides/best-practices/environment-setup/2-one-deployment-environment.md
@@ -11,7 +11,7 @@ hoverSnippet: Learn how to configure a single deployment environment setup in db
 ## What this looks like
 
 1. You have a **single *development* environment** where dbt users can access the dbt Cloud IDE and make changes to their code on feature branches created off of your default branch in your repository (most often the `main` branch).
-2. You have a **single *deployment* environment** (let’s call it “Production”) where your scheduled jobs run referencing the `main` branch.
+2. You have a **single *deployment* environment** (let’s call it “Production”) where your scheduled jobs run referencing the `main` branch. Be sure to set the environment as production to take advantage of features like dbt Explorer and cross-project refs. 
 3. You also have a [**Slim CI job**](/docs/deploy/continuous-integration) that kicks off anytime you open a PR to merge a feature branch into `main`. This Slim CI job can run in your dbt “Production” environment.
 
 :::info

--- a/website/docs/guides/best-practices/environment-setup/2-one-deployment-environment.md
+++ b/website/docs/guides/best-practices/environment-setup/2-one-deployment-environment.md
@@ -5,14 +5,16 @@ description: Learn how to configure a single deployment environment setup in dbt
 displayText: "dbt Cloud environment best practices"
 hoverSnippet: Learn how to configure a single deployment environment setup in dbt Cloud.
 ---
-
+import ExpNote from '/snippets/_explorer-beta-note.md';
 
 
 ## What this looks like
 
 1. You have a **single *development* environment** where dbt users can access the dbt Cloud IDE and make changes to their code on feature branches created off of your default branch in your repository (most often the `main` branch).
-2. You have a **single *deployment* environment** (let’s call it “Production”) where your scheduled jobs run referencing the `main` branch. 
-  * Make sure to set the environment to "Production" so you can take advantage of features like dbt Explorer and cross-project refs. 
+2. You have a **single *deployment* environment** (let’s call it “Production”) where your scheduled jobs run referencing the `main` branch. <br />
+ 
+ <ExpNote/>
+
 3. You also have a [**Slim CI job**](/docs/deploy/continuous-integration) that kicks off anytime you open a PR to merge a feature branch into `main`. This Slim CI job can run in your dbt “Production” environment.
 
 :::info

--- a/website/docs/guides/best-practices/environment-setup/3-many-deployment-environments.md
+++ b/website/docs/guides/best-practices/environment-setup/3-many-deployment-environments.md
@@ -5,15 +5,16 @@ description: Learn how to configure a many deployment environment setup in dbt C
 displayText: "dbt Cloud environment best practices"
 hoverSnippet: Learn how to configure a many deployment environment setup in dbt Cloud.
 ---
-
+import ExpNote from '/snippets/_explorer-beta-note.md';
 
 ## What this looks like
 
 1. You have a **single *development* environment** where dbt users can access the dbt Cloud IDE and make changes to their code. However, you’ll want to update the **[custom branch settings](faqs/Environments/custom-branch-settings)** to ensure that developers create feature branches off of the a non-production branch. For this example, we’ll refer to this as the `qa` branch.
 2. You have a **QA deployment environment**, running scheduled jobs from the `qa` branch that deploys your dbt project to a pre-production warehouse location.
-3. You have a **Production deployment environment,** running scheduled jobs from the `main` branch that deploys your dbt project to your production warehouse location. 
-  * Make sure to set the environment to "Production" so you can take advantage of features like dbt Explorer and cross-project refs. 
+3. You have a **Production deployment environment,** running scheduled jobs from the `main` branch that deploys your dbt project to your production warehouse location. <br />
 
+ <ExpNote/>
+ 
 4. You have **multiple Slim CI jobs** (one in each deployment environment) to ensure changes to each branch are tested.  
 
 <Lightbox src="/img/guides/best-practices/environment-setup/many-deployments-table.png" title="Table of basic setup for many deployment environment" />

--- a/website/docs/guides/best-practices/environment-setup/3-many-deployment-environments.md
+++ b/website/docs/guides/best-practices/environment-setup/3-many-deployment-environments.md
@@ -11,7 +11,7 @@ hoverSnippet: Learn how to configure a many deployment environment setup in dbt 
 
 1. You have a **single *development* environment** where dbt users can access the dbt Cloud IDE and make changes to their code. However, you’ll want to update the **[custom branch settings](faqs/Environments/custom-branch-settings)** to ensure that developers create feature branches off of the a non-production branch. For this example, we’ll refer to this as the `qa` branch.
 2. You have a **QA deployment environment**, running scheduled jobs from the `qa` branch that deploys your dbt project to a pre-production warehouse location.
-3. You have a **Production deployment environment,** running scheduled jobs from the `main` branch that deploys your dbt project to your production warehouse location.
+3. You have a **Production deployment environment,** running scheduled jobs from the `main` branch that deploys your dbt project to your production warehouse location. Be sure to set the environment as production to take advantage of features like dbt Explorer and cross-project refs. 
 4. You have **multiple Slim CI jobs** (one in each deployment environment) to ensure changes to each branch are tested.  
 
 <Lightbox src="/img/guides/best-practices/environment-setup/many-deployments-table.png" title="Table of basic setup for many deployment environment" />

--- a/website/docs/guides/best-practices/environment-setup/3-many-deployment-environments.md
+++ b/website/docs/guides/best-practices/environment-setup/3-many-deployment-environments.md
@@ -11,7 +11,9 @@ hoverSnippet: Learn how to configure a many deployment environment setup in dbt 
 
 1. You have a **single *development* environment** where dbt users can access the dbt Cloud IDE and make changes to their code. However, you’ll want to update the **[custom branch settings](faqs/Environments/custom-branch-settings)** to ensure that developers create feature branches off of the a non-production branch. For this example, we’ll refer to this as the `qa` branch.
 2. You have a **QA deployment environment**, running scheduled jobs from the `qa` branch that deploys your dbt project to a pre-production warehouse location.
-3. You have a **Production deployment environment,** running scheduled jobs from the `main` branch that deploys your dbt project to your production warehouse location. Be sure to set the environment as production to take advantage of features like dbt Explorer and cross-project refs. 
+3. You have a **Production deployment environment,** running scheduled jobs from the `main` branch that deploys your dbt project to your production warehouse location. 
+  * Make sure to set the environment to "Production" so you can take advantage of features like dbt Explorer and cross-project refs. 
+
 4. You have **multiple Slim CI jobs** (one in each deployment environment) to ensure changes to each branch are tested.  
 
 <Lightbox src="/img/guides/best-practices/environment-setup/many-deployments-table.png" title="Table of basic setup for many deployment environment" />

--- a/website/snippets/_explorer-beta-banner.md
+++ b/website/snippets/_explorer-beta-banner.md
@@ -1,0 +1,3 @@
+:::info Beta
+This feature is related to dbt Explorer and cross-project references [beta](/docs/dbt-versions/product-lifecycles#dbt-cloud) projects and subject to change. If you are interested in getting access to the beta, please [contact us](mailto:support@getdbt.com).
+:::

--- a/website/snippets/_explorer-beta-note.md
+++ b/website/snippets/_explorer-beta-note.md
@@ -1,0 +1,1 @@
+**Note:** Make sure to set the environment to "Production" so you can take advantage of features like dbt Explorer and cross-project references. Refer to [Set product environment](/docs/deploy/deploy-environments#set-as-production-environment-beta) for details.


### PR DESCRIPTION
## What are you changing in this pull request and why?
Add new default production environment language and guidance

Default prod environment is a new setting for deployment environments. 

Setting it is required to use new features like dbt Explorer and cross-project refs (Mesh/multi-project) which require a single source of truth for production metadata per dbt Cloud project. 

We need to educate customers so they set this, especially once these features are broadly available (currently all invite-only beta, feature flagged in launchdarkly) 