### PR TITLE
Flip the preference on the `union` item in the style guide ↔️

### DIFF
--- a/website/docs/guides/best-practices/how-we-style/2-how-we-style-our-sql.md
+++ b/website/docs/guides/best-practices/how-we-style/2-how-we-style-our-sql.md
@@ -26,7 +26,7 @@ id: 2-how-we-style-our-sql
 
 ## Joins
 
-- 👭🏻 Prefer `union all` to `union` unless you explicitly want to remove duplicates.
+- 👭🏻 Prefer `union` to `union all` unless you explicitly want to keep duplicates.
 - 👭🏻 If joining two or more tables, _always_ prefix your column names with the table name. If only selecting from one table, prefixes are not needed.
 - 👭🏻 Be explicit about your join type (i.e. write `inner join` instead of `join`).
 - 🥸 Avoid table aliases in join conditions (especially initialisms) — it's harder to understand what the table called "c" is as compared to "customers".


### PR DESCRIPTION
## What are you changing in this pull request and why?

### Summary

Flip the preference of `union` and `union all` so that `union` is preferred over `union all`.

(I appreciate that this is heavily opinion-based, so happy for this to be shut down if you disagree 😋)


### Rational

Given that tables usually have a well-defined primary key, using `union all` by default instead of `union` runs the risk of propagating _data quality_ duplicates throughout the project, _especially_ in cloud warehouses that don't verify the uniqueness of the primary keys. 

These should be caught by the DQ tests, but many people use `dbt run` rather than `dbt build` so their run would do a lot more "damage" before running the tests and catching these. For large data estates with numerous incremental models and aggregates over them, there would be a significant cost associated with running a full refresh to fix the issues caused by these DQ duplicates.

I don't have any evidence for this, but I suspect that most data pipelines will manipulate data with well-defined primary keys rather than data with genuine (non-DQ) duplicates -- so if there should be a preference, I think the safer approach is to be defensive against duplicates and prefer `union`, leaving it to the developers to choose `union all` when they explicitly want to keep duplicates.

For reference, this is adapted from:
- https://github.com/dbt-labs/corp/issues/96


## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [ ] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
