### PR TITLE
1.6 GA Docs changes

### DIFF
--- a/website/dbt-versions.js
+++ b/website/dbt-versions.js
@@ -2,7 +2,6 @@ exports.versions = [
   {
     version: "1.6",
     EOLDate: "2024-07-31",
-    isPrerelease: true
   },
   {
     version: "1.5",

--- a/website/docs/guides/migration/versions/01-upgrading-to-v1.6.md
+++ b/website/docs/guides/migration/versions/01-upgrading-to-v1.6.md
@@ -18,7 +18,7 @@ dbt Labs is committed to providing backward compatibility for all versions 1.x, 
 
 - dbt Core v1.6 does not support Python 3.7, which reached End Of Life on June 23. Support Python versions are 3.8, 3.9, 3.10, and 3.11.
 - As part of the Semantic layer re-launch (in beta), the spec for `metrics` has changed significantly. Migration guide coming soon: https://github.com/dbt-labs/docs.getdbt.com/pull/3705
-- Manifest schema version is now v10, reflecting [TODO] changes
+- The manifest schema version is now v10.
 
 ### For consumers of dbt artifacts (metadata)
 

--- a/website/docs/guides/migration/versions/01-upgrading-to-v1.6.md
+++ b/website/docs/guides/migration/versions/01-upgrading-to-v1.6.md
@@ -1,15 +1,7 @@
 ---
-title: "Upgrading to v1.6 (prerelease)"
+title: "Upgrading to v1.6 (latest)"
 description: New features and changes in dbt Core v1.6
 ---
-
-:::warning Prerelease
-
-dbt Core v1.6 is available as a release candidate. [Final release is planned for July 31.](https://github.com/dbt-labs/dbt-core/issues/7990)
-
-Test it out, and [let us know](https://github.com/dbt-labs/dbt-core/issues/new/choose) if you run into any issues!
-
-:::
 
 ## Resources
 

--- a/website/docs/guides/migration/versions/02-upgrading-to-v1.5.md
+++ b/website/docs/guides/migration/versions/02-upgrading-to-v1.5.md
@@ -1,5 +1,5 @@
 ---
-title: "Upgrading to v1.5 (latest)"
+title: "Upgrading to v1.5"
 description: New features and changes in dbt Core v1.5
 ---
 

--- a/website/snippets/core-versions-table.md
+++ b/website/snippets/core-versions-table.md
@@ -1,14 +1,15 @@
 ### Latest Releases
 
 | dbt Core                                                   | Initial Release | Support Level | Critical Support Until  | 
-|------------------------------------------------------------|-----------------|---------------|-------------------------|
-| [**v1.5**](/guides/migration/versions/upgrading-to-v1.5)   | Apr 27, 2023    | Active        | Apr 27, 2024            | 
-| [**v1.4**](/guides/migration/versions/upgrading-to-v1.4)   | Jan 25, 2023    | Critical      | Jan 25, 2024            | 
-| [**v1.3**](/guides/migration/versions/upgrading-to-v1.3)   | Oct 12, 2022    | Critical      | Oct 12, 2023            | 
-| [**v1.2**](/guides/migration/versions/upgrading-to-v1.2)   | Jul 26, 2022    | Critical      | Jul 26, 2023            |
+|------------------------------------------------------------|-----------------|----------------|-------------------------|
+| [**v1.6**](/guides/migration/versions/upgrading-to-v1.6)   | Jul 31, 2023    | Active         | Jul 30, 2024            |
+| [**v1.5**](/guides/migration/versions/upgrading-to-v1.5)   | Apr 27, 2023    | Critical       | Apr 27, 2024            | 
+| [**v1.4**](/guides/migration/versions/upgrading-to-v1.4)   | Jan 25, 2023    | Critical       | Jan 25, 2024            | 
+| [**v1.3**](/guides/migration/versions/upgrading-to-v1.3)   | Oct 12, 2022    | Critical       | Oct 12, 2023            | 
+| [**v1.2**](/guides/migration/versions/upgrading-to-v1.2)   | Jul 26, 2022    | End of Life* ⚠️ | Jul 26, 2023            |
 | [**v1.1**](/guides/migration/versions/upgrading-to-v1.1) ⚠️ | Apr 28, 2022    | End of Life* ⚠️ | Apr 28, 2023            | 
 | [**v1.0**](/guides/migration/versions/upgrading-to-v1.0) ⚠️ | Dec 3, 2021     | End of Life* ⚠️ | Dec 3, 2022 ⚠️           | 
-|  **v0.X** ⛔️                                                | (Various dates) | Deprecated ⛔️ | Deprecated ⛔️            | 
+|  **v0.X** ⛔️                                               | (Various dates) | Deprecated ⛔️  | Deprecated ⛔️            | 
 _*All versions of dbt Core since v1.0 are available in dbt Cloud until further notice. Versions that are EOL do not receive any fixes. For the best support, we recommend upgrading to a version released within the past 12 months._
 ### Planned future releases
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

Changes to the docs pages to take 1.6 GA - adjusting prerelease tags, changing migration guide titles, and adjusting release table. 

## ChecklistUncomment if you're publishing docs for a prerelease version of dbt (delete if not applicable):
- [x] Add versioning components, as described in [Versioning Docs](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-entire-pages)
- [x] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/guides/migration/versions)

- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [x] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
