### PR TITLE
Fix warehouse->snowflake_warehouse in MV documentation

### DIFF
--- a/website/docs/reference/resource-configs/snowflake-configs.md
+++ b/website/docs/reference/resource-configs/snowflake-configs.md
@@ -374,7 +374,7 @@ The following examples create a dynamic table:
 {{
   config(
     materialized = 'dynamic_table',
-    warehouse = 'snowflake_warehouse',
+    snowflake_warehouse = 'snowflake_warehouse',
     target_lag = '10 minutes',
   )
 }}
@@ -388,7 +388,7 @@ The following examples create a dynamic table:
 models:
   path:
     materialized: dynamic_table
-    warehouse: snowflake_warehouse
+    snowflake_warehouse: snowflake_warehouse
     target_lag: '10 minutes'
 ```
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
As identified [here](https://getdbt.slack.com/archives/CJN7XRF1B/p1691005155588089?thread_ts=1690413647.202689&cid=CJN7XRF1B), the current documentation for Snowflake's Materialized Views pointed people to specify a warehouse with the variable `warehouse`. The correct variable is `snowflake_warehouse`. 

## Checklist
<!--
Uncomment if you're publishing docs for a prerelease version of dbt (delete if not applicable):
- [ ] Add versioning components, as described in [Versioning Docs](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-entire-pages)
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/guides/migration/versions)
-->
- [ ] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [ ] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."

Adding new pages (delete if not applicable):
- [ ] Add page to `website/sidebars.js`
- [ ] Provide a unique filename for the new page

Removing or renaming existing pages (delete if not applicable):
- [ ] Remove page from `website/sidebars.js`
- [ ] Add an entry `website/static/_redirects`
- [ ] [Ran link testing](https://github.com/dbt-labs/docs.getdbt.com#running-the-cypress-tests-locally) to update the links that point to the deleted page
