### PR TITLE
Update ratio metrics overview to reference metrics instead of measures

### DIFF
--- a/website/docs/docs/build/metrics-overview.md
+++ b/website/docs/docs/build/metrics-overview.md
@@ -98,7 +98,7 @@ metrics:
 
 ### Ratio metrics 
 
-[Ratio metrics](/docs/build/ratio) involve a numerator measure and a denominator measure. A  `constraint` string  can be applied, to both numerator and denominator, or applied separately to the numerator or denominator. 
+[Ratio metrics](/docs/build/ratio) involve a numerator metric and a denominator metric. A  `constraint` string  can be applied, to both numerator and denominator, or applied separately to the numerator or denominator. 
 
 ```yaml
 # Ratio Metric
@@ -106,25 +106,25 @@ metrics:
   - name: cancellation_rate
     owners:
       - support@getdbt.com
-# Ratio metrics create a ratio out of two measures.
-# Define the measures from the semantic model as numerator or denominator
+# Ratio metrics create a ratio out of two metrics.
+# Define the metrics from the semantic manifest as numerator or denominator
     type: ratio
     type_params:
-      numerator: cancellations_usd
-      denominator: transaction_amount_usd
+      numerator: cancellations
+      denominator: transaction_amount
       filter: |     # add optional constraint string. This applies to both the numerator and denominator
         {{ Dimension('customer__country') }} = 'MX'
   - name: enterprise_cancellation_rate
     owners:
       - support@getdbt.com
       # Ratio metrics create a ratio out of two measures. 
-      # Define the measures from the semantic model as numerator or denominator
+      # Define the metrics from the semantic model as numerator or denominator
     type: ratio
     type_params:
       numerator:
-        name: cancellations_usd
+        name: cancellations
         filter: {{ Dimension('company__tier' )}} = 'enterprise'  # constraint only applies to the numerator
-      denominator: transaction_amount_usd
+      denominator: transaction_amount
       filter: |   #  add optional constraint string. This applies to both the numerator and denominator
         {{ Dimension('customer__country') }} = 'MX'  
 ```


### PR DESCRIPTION
Ratio metrics take other metrics as input, but the documentation was pointing to measures rather than metrics.

## What are you changing in this pull request and why?
<!---
Describe your changes and why you're making them. If linked to an open
issue or a pull request on dbt Core, then link to them here! 

To learn more about the writing conventions used in the dbt Labs docs, see the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md).
-->

## Checklist
<!--
Uncomment if you're publishing docs for a prerelease version of dbt (delete if not applicable):
- [ ] Add versioning components, as described in [Versioning Docs](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-entire-pages)
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/guides/migration/versions)
-->
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [x] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
