### PR TITLE
Update ratio-metrics.md to reflect use of metrics as inputs

### DIFF
--- a/website/docs/docs/build/ratio-metrics.md
+++ b/website/docs/docs/build/ratio-metrics.md
@@ -6,7 +6,7 @@ sidebar_label: Ratio
 tags: [Metrics, Semantic Layer]
 ---
 
-Ratio allows you to create a ratio between two measures. You simply specify a numerator and a denominator measure. Additionally, you can apply a dimensional filter to both the numerator and denominator using a constraint string when computing the metric. 
+Ratio allows you to create a ratio between two metrics. You simply specify a numerator and a denominator metric. Additionally, you can apply a dimensional filter to both the numerator and denominator using a constraint string when computing the metric. 
 
 The following displays the full spec for ratio metrics, along with an example:
 
@@ -17,12 +17,14 @@ metrics:
     type: ratio # Required
     label: The value that will be displayed in downstream tools #Required
     type_params: # Required
-      numerator: the measure used for the numerator # Required
-      filter: filter for the numerator# Optional
-      alias: alias for the numerator # Optional
-      denominator: the measure used for the denominator # Required
-      filter: filter for the denominator # Optional
-      alias: alias for the denominator # Optional
+      numerator: the name of the metric used for the numerator, or a struct of properties as below # Required
+        name: name of metric used for the numerator # Required
+        filter: filter for the numerator# Optional
+        alias: alias for the numerator # Optional
+      denominator: the name of the metric used for the denominator, or a struct of properties as below # Required
+        name: name of metric used for the denominator # Required
+        filter: filter for the denominator # Optional
+        alias: alias for the denominator # Optional
 ```
 
 ## Ratio metrics example
@@ -30,13 +32,13 @@ metrics:
 ```yaml
 # Ratio Metric
 metrics:
-  - name: food_order_total_pct
-    description: "The food order total as the % of the total order"
-    label: Food Order Total % 
+  - name: food_order_pct
+    description: "The food order count as a ratio of the total order count"
+    label: Food Order Ratio
     type: ratio
     type_params: 
-      numerator: food_order_total
-      denominator: order_total
+      numerator: food_orders
+      denominator: orders
   
 ```
 ## Ratio metrics using different semantic models
@@ -90,7 +92,7 @@ on
 
 ## Add filter
 
-Users can define constraints on input measures for a metric by applying a filter directly to the measure, like so:
+Users can define constraints on input metrics for a ratio metric by applying a filter directly to the input metric, like so:
 
 ```yaml
 metrics:
@@ -108,4 +110,4 @@ metrics:
         name: distinct_purchasers
 ```
 
-Note the `filter` and `alias` parameters for the measure referenced in the numerator. Use the `filter` parameter to apply a filter to the measure it's attached to. The `alias` parameter is used to avoid naming conflicts in the rendered SQL queries when the same measure is used with different filters. If there are no naming conflicts, the `alias` parameter can be left out.
+Note the `filter` and `alias` parameters for the metric referenced in the numerator. Use the `filter` parameter to apply a filter to the metric it's attached to. The `alias` parameter is used to avoid naming conflicts in the rendered SQL queries when the same metric is used with different filters. If there are no naming conflicts, the `alias` parameter can be left out.


### PR DESCRIPTION
Ratio metrics take metric inputs for the numerator and denominator, rather than measures.

This change makes the relevant updates to the ratio metrics details page.

## What are you changing in this pull request and why?
<!---
Describe your changes and why you're making them. If linked to an open
issue or a pull request on dbt Core, then link to them here! 

To learn more about the writing conventions used in the dbt Labs docs, see the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md).
-->

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [x] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
