### PR TITLE
Remove dbt updates tag from devblog

### DIFF
--- a/website/blog/2021-09-15-september-21-product-email.md
+++ b/website/blog/2021-09-15-september-21-product-email.md
@@ -4,7 +4,6 @@ description: "dbt v1.0 is coming up! Don't forget to update your projects to the
 slug: dbt-product-update-2021-september
 authors: [lauren_craigie] 
 
-tags: [dbt updates]
 hide_table_of_contents: false
 
 date: 2021-09-15

--- a/website/blog/2021-10-15-october-21-product-update-email.md
+++ b/website/blog/2021-10-15-october-21-product-update-email.md
@@ -4,7 +4,6 @@ description: "Stay up-to-date with the latest features in dbt. Read about our Oc
 slug: dbt-product-update-2021-october
 authors: [lauren_craigie]
 
-tags: [dbt updates]
 hide_table_of_contents: false
 
 date: 2021-10-15

--- a/website/blog/2021-11-15-november-21-product-email.md
+++ b/website/blog/2021-11-15-november-21-product-email.md
@@ -4,7 +4,6 @@ description: "Stay up-to-date with the latest features in dbt. Read about our No
 slug: dbt-product-update-2021-november
 authors: [lauren_craigie] 
 
-tags: [dbt updates]
 hide_table_of_contents: false
 
 date: 2021-11-15

--- a/website/blog/2022-08-31-august-product-update.md
+++ b/website/blog/2022-08-31-august-product-update.md
@@ -4,7 +4,6 @@ description: "Coalesce is less than 2 months away!"
 slug: dbt-product-update-2022-august
 authors: [lauren_craigie] 
 
-tags: [dbt updates]
 hide_table_of_contents: false
 
 date: 2022-08-31

--- a/website/blog/2022-10-19-polyglot-dbt-python-dataframes-and-sql.md
+++ b/website/blog/2022-10-19-polyglot-dbt-python-dataframes-and-sql.md
@@ -4,7 +4,7 @@ description: "Going polyglot is a major next step in the journey of dbt Core. It
 slug: polyglot-dbt-python-dataframes-sql
 
 authors: [doug_beatty]
-
+tags: [dbt tutorials]
 hide_table_of_contents: false
 
 date: 2022-10-18

--- a/website/blog/2022-10-19-polyglot-dbt-python-dataframes-and-sql.md
+++ b/website/blog/2022-10-19-polyglot-dbt-python-dataframes-and-sql.md
@@ -5,7 +5,6 @@ slug: polyglot-dbt-python-dataframes-sql
 
 authors: [doug_beatty]
 
-tags: [dbt product updates]
 hide_table_of_contents: false
 
 date: 2022-10-18

--- a/website/blog/2023-04-26-deprecating-dbt-metrics.md
+++ b/website/blog/2023-04-26-deprecating-dbt-metrics.md
@@ -5,7 +5,6 @@ slug: deprecating-dbt-metrics
 
 authors: [callum_mccann]
 
-tags: [dbt product updates]
 hide_table_of_contents: false
 
 date: 2023-04-26

--- a/website/blog/2023-05-01-evolving-data-engineer-craft.md
+++ b/website/blog/2023-05-01-evolving-data-engineer-craft.md
@@ -5,7 +5,6 @@ slug: evolving-data-engineer-craft
 
 authors: [sung_chung, kira_furuichi]
 
-tags: [dbt product updates]
 hide_table_of_contents: false
 
 date: 2023-05-01

--- a/website/blog/categories.yml
+++ b/website/blog/categories.yml
@@ -15,10 +15,6 @@
   display_title: dbt tutorials
   description: Best practices in the usage of our favorite data transformation tool.
   is_featured: true    
-- name: dbt updates
-  display_title: dbt product updates
-  description: An archive of monthly product updates from the dbt Labs team.
-  is_featured: true
 - name: SQL magic
   display_title: SQL magic
   description: Stories of dbt developers making SQL sing across warehouses.


### PR DESCRIPTION
## What are you changing in this pull request and why?
We experimented with product updates in the dev blog for a lil while, but it's now better implemented elsewhere. So that it doesn't look like we just stopped improving the product 18 months ago, we're going to remove this tag but keep the articles around so they don't 404. 

NB that a handful of new product feature articles were incorrectly tagged (using the label not its ID) so I've just removed those tags altogether as well.

Before and after: 

![Screenshot 2023-08-08 at 4 12 03 PM](https://github.com/dbt-labs/docs.getdbt.com/assets/7335046/868daa42-8982-497e-a48e-056207e023a3)
![Screenshot 2023-08-08 at 4 12 43 PM](https://github.com/dbt-labs/docs.getdbt.com/assets/7335046/d29c2e4c-b97d-4de7-b3ac-dbc2629cc124)
