### PR TITLE
Remove "new in 0.9.0" callout

### DIFF
--- a/website/docs/reference/dbt-jinja-functions/ref.md
+++ b/website/docs/reference/dbt-jinja-functions/ref.md
@@ -29,7 +29,7 @@ from {{ref('model_a')}}
 
 `ref()` is, under the hood, actually doing two important things. First, it is interpolating the schema into your model file to allow you to change your deployment schema via configuration. Second, it is using these references between models to automatically build the dependency graph. This will enable dbt to deploy models in the correct order when using `dbt run`.
 
-The `{{ ref }}` function returns a `Relation` object that has the same `table`, `schema`, and `name` attributes as the [{{ this }}](/reference/dbt-jinja-functions/this) variable.
+The `{{ ref }}` function returns a `Relation` object that has the same `table`, `schema`, and `name` attributes as the [{{ this }} variable](/reference/dbt-jinja-functions/this).
 
 ## Advanced ref usage
 

--- a/website/docs/reference/dbt-jinja-functions/ref.md
+++ b/website/docs/reference/dbt-jinja-functions/ref.md
@@ -29,11 +29,7 @@ from {{ref('model_a')}}
 
 `ref()` is, under the hood, actually doing two important things. First, it is interpolating the schema into your model file to allow you to change your deployment schema via configuration. Second, it is using these references between models to automatically build the dependency graph. This will enable dbt to deploy models in the correct order when using `dbt run`.
 
-:::info New in 0.9.0
-
-The `{{ ref }}` function returns a `Relation` object that has the same `table`, `schema`, and `name` attributes at the [{{ this }}](/reference/dbt-jinja-functions/this) variable.
-
-:::
+The `{{ ref }}` function returns a `Relation` object that has the same `table`, `schema`, and `name` attributes as the [{{ this }}](/reference/dbt-jinja-functions/this) variable.
 
 ## Advanced ref usage
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
The functionality changed in 0.9.0, which came out in October 2017. I don't think it deserves a "new!" callout anymore, but it's still useful information. 
