### PR TITLE
Update deployment-tools.md

### DIFF
--- a/website/docs/docs/deploy/deployment-tools.md
+++ b/website/docs/docs/deploy/deployment-tools.md
@@ -30,7 +30,7 @@ Invoking dbt Core jobs through the [BashOperator](https://registry.astronomer.io
 </TabItem>
 </Tabs>
 
-For more details on both of these methods, including example implementations, check out [this guide](https://www.astronomer.io/guides/airflow-dbt).
+For more details on both of these methods, including example implementations, check out [this guide](https://www.astronomer.io/guides/airflow-dbt](https://docs.astronomer.io/learn/airflow-dbt-cloud).
 
 ## Azure Data Factory
 

--- a/website/docs/docs/deploy/deployment-tools.md
+++ b/website/docs/docs/deploy/deployment-tools.md
@@ -30,7 +30,7 @@ Invoking dbt Core jobs through the [BashOperator](https://registry.astronomer.io
 </TabItem>
 </Tabs>
 
-For more details on both of these methods, including example implementations, check out [this guide](https://www.astronomer.io/guides/airflow-dbt](https://docs.astronomer.io/learn/airflow-dbt-cloud).
+For more details on both of these methods, including example implementations, check out [this guide](https://docs.astronomer.io/learn/airflow-dbt-cloud).
 
 ## Azure Data Factory
 


### PR DESCRIPTION

## What are you changing in this pull request and why?

adjusting docs link to take you to dbt cloud docs for astronomer, since it comes up first in the carousel. Astronomer used to have an overview page for cloud and core but they've separated it out, so the link was taking you to dbt core instructions


## Checklist
<!--
Uncomment if you're publishing docs for a prerelease version of dbt (delete if not applicable):
- [ ] Add versioning components, as described in [Versioning Docs](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-entire-pages)
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/guides/migration/versions)
-->

