### PR TITLE
Adds information about custom .sqlfluff and .sqlfluffignore files

### DIFF
--- a/website/docs/docs/cloud/dbt-cloud-ide/lint-format.md
+++ b/website/docs/docs/cloud/dbt-cloud-ide/lint-format.md
@@ -63,7 +63,7 @@ With the dbt Cloud IDE, you can seamlessly use [SQLFluff](https://sqlfluff.com/)
 
 ### Customize linting
 
-SQLFluff is a configurable SQL linter, which means you can configure your own linting rules instead of using the default linting settings in the IDE. You can exclude files and directories by using a standard `.sqlfluffignore` file. Learn more about the syntax in the [.sqlfluffignore syntax docs](https://docs.sqlfluff.com/en/stable/configuration.html#id2).
+SQLFluff is a configurable SQL linter, which means you can configure your own linting rules instead of using the default linting settings in the IDE. You can exclude files and directories by using a standard `.sqlfluffignore` file. Learn more about the syntax in the [.sqlfluffignore syntax docs](https://docs.sqlfluff.com/en/stable/configuration.html#id2). 
 
 To configure your own linting rules:
 
@@ -76,7 +76,7 @@ To configure your own linting rules:
 
 :::tip Configure dbtonic linting rules
 
-Use the following code example to incorporate well-written dbt code (or dbtonic) to your linting:
+Refer to the [SQLFluff config file](https://github.com/dbt-labs/jaffle-shop-template/blob/main/.sqlfluff) to add the dbt code (or dbtonic) rules we use for our own projects:
 
 <details>
 <summary>dbtonic config code example provided by dbt Labs</summary>
@@ -122,6 +122,8 @@ capitalisation_policy = lower
 group_by_and_order_by_style = implicit
 ```
 </details>
+
+Refer to [How we style our SQL](/guides/best-practices/how-we-style/2-how-we-style-our-sql) for more info. 
 :::
 
 <Lightbox src="/img/docs/dbt-cloud/cloud-ide/ide-sqlfluff-config.jpg" width="95%" title="Customize linting by configuring your own linting code rules, including dbtonic linting/styling."/>

--- a/website/docs/docs/cloud/dbt-cloud-ide/lint-format.md
+++ b/website/docs/docs/cloud/dbt-cloud-ide/lint-format.md
@@ -123,7 +123,7 @@ group_by_and_order_by_style = implicit
 ```
 </details>
 
-Refer to [How we style our SQL](/guides/best-practices/how-we-style/2-how-we-style-our-sql) for more info. 
+For more info on styling best practices, refer to [How we style our SQL](/guides/best-practices/how-we-style/2-how-we-style-our-sql).
 :::
 
 <Lightbox src="/img/docs/dbt-cloud/cloud-ide/ide-sqlfluff-config.jpg" width="95%" title="Customize linting by configuring your own linting code rules, including dbtonic linting/styling."/>

--- a/website/docs/docs/cloud/dbt-cloud-ide/lint-format.md
+++ b/website/docs/docs/cloud/dbt-cloud-ide/lint-format.md
@@ -63,7 +63,7 @@ With the dbt Cloud IDE, you can seamlessly use [SQLFluff](https://sqlfluff.com/)
 
 ### Customize linting
 
-SQLFluff is a configurable SQL linter, which means you can configure your own linting rules instead of using the default linting settings in the IDE.  
+SQLFluff is a configurable SQL linter, which means you can configure your own linting rules instead of using the default linting settings in the IDE. You can exclude files and directories by using a standard `.sqlfluffignore` file. Learn more about the syntax in the [.sqlfluffignore syntax docs](https://docs.sqlfluff.com/en/stable/configuration.html#id2).
 
 To configure your own linting rules:
 

--- a/website/docs/guides/best-practices/how-we-style/2-how-we-style-our-sql.md
+++ b/website/docs/guides/best-practices/how-we-style/2-how-we-style-our-sql.md
@@ -6,7 +6,9 @@ id: 2-how-we-style-our-sql
 ## Basics
 
 - ☁️ Use [SQLFluff](https://sqlfluff.com/) to maintain these style rules automatically.
-  - Reference this [SQLFluff config file](https://github.com/dbt-labs/jaffle-shop-template/blob/main/.sqlfluff) for the rules we use.
+  - Custom `.sqlfluff` configuration files are supported.
+  - Reference this [SQLFluff config file](https://github.com/dbt-labs/jaffle-shop-template/blob/main/.sqlfluff) for the rules we use in our own projects.
+  - We also support ignoring files and folders using a standard `.sqlfluffignore` file. Reference these docs for the syntax: [.sqlfluffignore syntax docs](https://docs.sqlfluff.com/en/stable/configuration.html#id2)
 - 👻 Use Jinja comments (`{# #}`) for comments that should not be included in the compiled SQL.
 - ⏭️ Use trailing commas.
 - 4️⃣ Indents should be four spaces.

--- a/website/docs/guides/best-practices/how-we-style/2-how-we-style-our-sql.md
+++ b/website/docs/guides/best-practices/how-we-style/2-how-we-style-our-sql.md
@@ -7,7 +7,7 @@ id: 2-how-we-style-our-sql
 
 - ☁️ Use [SQLFluff](https://sqlfluff.com/) to maintain these style rules automatically.
   - Customize `.sqlfluff` configuration files to your needs.
-  - Refer to our [SQLFluff config file](https://github.com/dbt-labs/jaffle-shop-template/blob/main/.sqlfluff) for the rules we us in our own projects. 
+  - Refer to our [SQLFluff config file](https://github.com/dbt-labs/jaffle-shop-template/blob/main/.sqlfluff) for the rules we use in our own projects. 
 
   - Exclude files and directories by using a standard `.sqlfluffignore` file. Learn more about the syntax in the [.sqlfluffignore syntax docs](https://docs.sqlfluff.com/en/stable/configuration.html#id2).
 - 👻 Use Jinja comments (`{# #}`) for comments that should not be included in the compiled SQL.

--- a/website/docs/guides/best-practices/how-we-style/2-how-we-style-our-sql.md
+++ b/website/docs/guides/best-practices/how-we-style/2-how-we-style-our-sql.md
@@ -6,7 +6,7 @@ id: 2-how-we-style-our-sql
 ## Basics
 
 - ☁️ Use [SQLFluff](https://sqlfluff.com/) to maintain these style rules automatically.
-  - Custom `.sqlfluff` configuration files are supported.
+  - Customize `.sqlfluff` configuration files to your needs.
   - Reference this [SQLFluff config file](https://github.com/dbt-labs/jaffle-shop-template/blob/main/.sqlfluff) for the rules we use in our own projects.
   - We also support ignoring files and folders using a standard `.sqlfluffignore` file. Reference these docs for the syntax: [.sqlfluffignore syntax docs](https://docs.sqlfluff.com/en/stable/configuration.html#id2)
 - 👻 Use Jinja comments (`{# #}`) for comments that should not be included in the compiled SQL.

--- a/website/docs/guides/best-practices/how-we-style/2-how-we-style-our-sql.md
+++ b/website/docs/guides/best-practices/how-we-style/2-how-we-style-our-sql.md
@@ -7,7 +7,8 @@ id: 2-how-we-style-our-sql
 
 - ☁️ Use [SQLFluff](https://sqlfluff.com/) to maintain these style rules automatically.
   - Customize `.sqlfluff` configuration files to your needs.
-  - Reference this [SQLFluff config file](https://github.com/dbt-labs/jaffle-shop-template/blob/main/.sqlfluff) for the rules we use in our own projects.
+  - Refer to our [SQLFluff config file](https://github.com/dbt-labs/jaffle-shop-template/blob/main/.sqlfluff) for the rules we us in our own projects. 
+
   - We also support ignoring files and folders using a standard `.sqlfluffignore` file. Reference these docs for the syntax: [.sqlfluffignore syntax docs](https://docs.sqlfluff.com/en/stable/configuration.html#id2)
 - 👻 Use Jinja comments (`{# #}`) for comments that should not be included in the compiled SQL.
 - ⏭️ Use trailing commas.

--- a/website/docs/guides/best-practices/how-we-style/2-how-we-style-our-sql.md
+++ b/website/docs/guides/best-practices/how-we-style/2-how-we-style-our-sql.md
@@ -9,7 +9,7 @@ id: 2-how-we-style-our-sql
   - Customize `.sqlfluff` configuration files to your needs.
   - Refer to our [SQLFluff config file](https://github.com/dbt-labs/jaffle-shop-template/blob/main/.sqlfluff) for the rules we us in our own projects. 
 
-  - We also support ignoring files and folders using a standard `.sqlfluffignore` file. Reference these docs for the syntax: [.sqlfluffignore syntax docs](https://docs.sqlfluff.com/en/stable/configuration.html#id2)
+  - Exclude files and directories by using a standard `.sqlfluffignore` file. Learn more about the syntax in the [.sqlfluffignore syntax docs](https://docs.sqlfluff.com/en/stable/configuration.html#id2).
 - 👻 Use Jinja comments (`{# #}`) for comments that should not be included in the compiled SQL.
 - ⏭️ Use trailing commas.
 - 4️⃣ Indents should be four spaces.


### PR DESCRIPTION
## What are you changing in this pull request and why?
The current docs are a bit unclear about the fact that we now support custom `.sqlfluff` and `.sqlfluffignore` files.  This PR adds that information, as well as links to docs and resources to configure them.

This changes comes from responding to customer questions.

## Checklist

