### PR TITLE
Add venv to install instructions page

### DIFF
--- a/website/docs/docs/core/pip-install.md
+++ b/website/docs/docs/core/pip-install.md
@@ -5,14 +5,32 @@ description: "You can use pip to install dbt Core and adapter plugins from the c
 
 You need to use `pip` to install dbt Core on Windows or Linux operating systems. You can use `pip` or [Homebrew](/docs/core/homebrew-install) for installing dbt Core on a MacOS. 
 
-You can install dbt Core and plugins using `pip` because they are Python modules distributed on [PyPI](https://pypi.org/project/dbt/). We recommend using virtual environments when installing with `pip`.
-
+You can install dbt Core and plugins using `pip` because they are Python modules distributed on [PyPI](https://pypi.org/project/dbt/).
 
 <FAQ path="Core/install-pip-os-prereqs" />
 <FAQ path="Core/install-python-compatibility" />
-<FAQ path="Core/install-pip-best-practices" />
 
+### Using virtual environments
+We recommend using virtual environments to namespace pip modules. To create a new venv:
 
+```shell
+python3 -m venv dbt-env				# create the environment
+```
+
+If you install dbt in a virtual environment, you need to reactivate that same virtual environment each time you create a shell window or session.
+
+```shell
+source dbt-env/bin/activate			# activate the environment for Mac and Linux OR
+dbt-env\Scripts\activate			# activate the environment for Windows
+```
+
+:::tip
+You can create an alias for the source command in your $HOME/.bashrc, $HOME/.zshrc, or whichever rc file your shell draws from. 
+
+For example, you can add a command like alias env_dbt='source <PATH_TO_VIRTUAL_ENV_CONFIG>/bin/activate', replacing <PATH_TO_VIRTUAL_ENV_CONFIG> with the path to your virtual environment configuration.
+:::
+
+### Installing the adapter
 Once you know [which adapter](/docs/supported-data-platforms) you're using, you can install it as `dbt-<adapter>`. For example, if using Postgres:
 
 ```shell

--- a/website/docs/docs/core/pip-install.md
+++ b/website/docs/docs/core/pip-install.md
@@ -27,7 +27,7 @@ dbt-env\Scripts\activate			# activate the environment for Windows
 ```
 
 #### Create an alias
-You can create an alias for the source command in your $HOME/.bashrc, $HOME/.zshrc, or whichever config file your shell draws from. 
+To activate your dbt environment with every new shell window or session, you can create an alias for the source command in your $HOME/.bashrc, $HOME/.zshrc, or whichever config file your shell draws from. 
 
 For example, add the following to your rc file, replacing <PATH_TO_VIRTUAL_ENV_CONFIG> with the path to your virtual environment configuration.
 

--- a/website/docs/docs/core/pip-install.md
+++ b/website/docs/docs/core/pip-install.md
@@ -27,7 +27,11 @@ dbt-env\Scripts\activate			# activate the environment for Windows
 :::tip
 You can create an alias for the source command in your $HOME/.bashrc, $HOME/.zshrc, or whichever rc file your shell draws from. 
 
-For example, you can add a command like alias env_dbt='source <PATH_TO_VIRTUAL_ENV_CONFIG>/bin/activate', replacing <PATH_TO_VIRTUAL_ENV_CONFIG> with the path to your virtual environment configuration.
+For example, add the following, replacing <PATH_TO_VIRTUAL_ENV_CONFIG> with the path to your virtual environment configuration.
+
+```shell
+alias env_dbt='source <PATH_TO_VIRTUAL_ENV_CONFIG>/bin/activate'
+```
 :::
 
 ### Installing the adapter

--- a/website/docs/docs/core/pip-install.md
+++ b/website/docs/docs/core/pip-install.md
@@ -27,7 +27,7 @@ dbt-env\Scripts\activate			# activate the environment for Windows
 :::tip
 You can create an alias for the source command in your $HOME/.bashrc, $HOME/.zshrc, or whichever rc file your shell draws from. 
 
-For example, add the following, replacing <PATH_TO_VIRTUAL_ENV_CONFIG> with the path to your virtual environment configuration.
+For example, add the following to your rc file, replacing <PATH_TO_VIRTUAL_ENV_CONFIG> with the path to your virtual environment configuration.
 
 ```shell
 alias env_dbt='source <PATH_TO_VIRTUAL_ENV_CONFIG>/bin/activate'

--- a/website/docs/docs/core/pip-install.md
+++ b/website/docs/docs/core/pip-install.md
@@ -17,7 +17,7 @@ We recommend using virtual environments to namespace pip modules. To create a ne
 python3 -m venv dbt-env				# create the environment
 ```
 
-If you install dbt in a virtual environment, you need to reactivate that same virtual environment each time you create a shell window or session.
+2. Activate that same virtual environment each time you create a shell window or session:
 
 ```shell
 source dbt-env/bin/activate			# activate the environment for Mac and Linux OR

--- a/website/docs/docs/core/pip-install.md
+++ b/website/docs/docs/core/pip-install.md
@@ -11,7 +11,9 @@ You can install dbt Core and plugins using `pip` because they are Python modules
 <FAQ path="Core/install-python-compatibility" />
 
 ### Using virtual environments
-We recommend using virtual environments to namespace pip modules. To create a new venv:
+We recommend using virtual environments (venv) to namespace pip modules. 
+
+1. Create a new venv:
 
 ```shell
 python3 -m venv dbt-env				# create the environment
@@ -24,15 +26,14 @@ source dbt-env/bin/activate			# activate the environment for Mac and Linux OR
 dbt-env\Scripts\activate			# activate the environment for Windows
 ```
 
-:::tip
-You can create an alias for the source command in your $HOME/.bashrc, $HOME/.zshrc, or whichever rc file your shell draws from. 
+#### Create an alias
+You can create an alias for the source command in your $HOME/.bashrc, $HOME/.zshrc, or whichever config file your shell draws from. 
 
 For example, add the following to your rc file, replacing <PATH_TO_VIRTUAL_ENV_CONFIG> with the path to your virtual environment configuration.
 
 ```shell
 alias env_dbt='source <PATH_TO_VIRTUAL_ENV_CONFIG>/bin/activate'
 ```
-:::
 
 ### Installing the adapter
 Once you know [which adapter](/docs/supported-data-platforms) you're using, you can install it as `dbt-<adapter>`. For example, if using Postgres:


### PR DESCRIPTION
From a convo with @jtcohen6, we'd really like all of our core users to be using a virtual environment of some kind.  This makes that recommendation more explicit by moving it from a collapsed tab to the install page itself.