### PR TITLE
make weight more discoverable

### DIFF
--- a/website/docs/docs/build/groups.md
+++ b/website/docs/docs/build/groups.md
@@ -1,6 +1,6 @@
 ---
 title: "Add groups to your DAG"
-sidebar_title: "Groups"
+sidebar_label: "Groups"
 id: "groups"
 description: "When you define groups in dbt projects, you turn implicit relationships into an explicit grouping."
 keywords:

--- a/website/docs/docs/build/projects.md
+++ b/website/docs/docs/build/projects.md
@@ -18,6 +18,7 @@ At a minimum, all a project needs is the `dbt_project.yml` project configuration
 | [sources](/docs/build/sources) | A way to name and describe the data loaded into your warehouse by your Extract and Load tools. |
 | [exposures](/docs/build/exposures) | A way to define and describe a downstream use of your project. |
 | [metrics](/docs/build/metrics) | A way for you to define metrics for your project. |
+| [groups](/docs/build/groups) | Groups enable collaborative node organization in restricted collections. |
 | [analysis](/docs/build/analyses) | A way to organize analytical SQL queries in your project such as the general ledger from your QuickBooks. |
 
 When building out the structure of your project, you should consider these impacts on your organization's workflow:

--- a/website/docs/docs/build/tests.md
+++ b/website/docs/docs/build/tests.md
@@ -1,10 +1,12 @@
 ---
 title: "Add tests to your DAG"
-sidebar_title: "Tests"
+sidebar_label: "Tests"
 description: "Read this tutorial to learn how to use tests when building in dbt."
 id: "tests"
+keywords:
+  - test, tests, testing
 ---
-
+# Add tests to your DAG
 ## Related reference docs
 * [Test command](/reference/commands/test)
 * [Test properties](/reference/resource-properties/tests)

--- a/website/docs/docs/build/tests.md
+++ b/website/docs/docs/build/tests.md
@@ -2,6 +2,7 @@
 title: "Add tests to your DAG"
 sidebar_label: "Tests"
 description: "Read this tutorial to learn how to use tests when building in dbt."
+search_weight: "heavy"
 id: "tests"
 keywords:
   - test, tests, testing, dag

--- a/website/docs/docs/build/tests.md
+++ b/website/docs/docs/build/tests.md
@@ -6,7 +6,6 @@ id: "tests"
 keywords:
   - test, tests, testing, dag
 ---
-# Add tests to your DAG
 ## Related reference docs
 * [Test command](/reference/commands/test)
 * [Test properties](/reference/resource-properties/tests)

--- a/website/docs/docs/build/tests.md
+++ b/website/docs/docs/build/tests.md
@@ -4,7 +4,7 @@ sidebar_label: "Tests"
 description: "Read this tutorial to learn how to use tests when building in dbt."
 id: "tests"
 keywords:
-  - test, tests, testing
+  - test, tests, testing, dag
 ---
 # Add tests to your DAG
 ## Related reference docs

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -228,7 +228,6 @@ const sidebarSettings = {
           label: "Build your DAG",
           collapsed: true,
           items: [
-            "docs/build/sources",
             {
               type: "category",
               label: "Models",
@@ -238,11 +237,15 @@ const sidebarSettings = {
                 "docs/build/python-models",
               ],
             },
-            "docs/build/seeds",
             "docs/build/snapshots",
+            "docs/build/seeds",
+            "docs/build/tests",
+            "docs/build/jinja-macros",
+            "docs/build/sources",
             "docs/build/exposures",
             "docs/build/metrics",
             "docs/build/groups",
+            "docs/build/analyses",
           ],
         },
         {
@@ -291,7 +294,6 @@ const sidebarSettings = {
           label: "Enhance your models",
           collapsed: true,
           items: [
-            "docs/build/tests",
             "docs/build/materializations",
             "docs/build/incremental-models",
           ],
@@ -301,11 +303,9 @@ const sidebarSettings = {
           label: "Enhance your code",
           collapsed: true,
           items: [
-            "docs/build/jinja-macros",
             "docs/build/project-variables",
             "docs/build/environment-variables",
             "docs/build/packages",
-            "docs/build/analyses",
             "docs/build/hooks-operations",
           ],
         },


### PR DESCRIPTION
[Per slack thread](https://dbt-labs.slack.com/archives/C02NCQ9483C/p1692979653610069), this pr helps make 'tests' more discoverble and sits or moves the dbt project resources under the 'build your dag' sidebar. 