### PR TITLE
Auto collapse categories when new one is selected

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -51,6 +51,7 @@ var siteSettings = {
     docs:{
       sidebar: {
         hideable: true,
+        autoCollapseCategories: true,
       },
     },
     image: "/img/avatar.png",


### PR DESCRIPTION
## What are you changing in this pull request and why?

Adding a feature that auto-collapses a category on the sidebar when a new category at the same level is opened.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [x] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."

