### PR TITLE
refine trusted adapter issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/zzz_add-adapter-to-trusted-list.yml
+++ b/.github/ISSUE_TEMPLATE/zzz_add-adapter-to-trusted-list.yml
@@ -1,12 +1,14 @@
 name: Add adapter to Trusted list
-description: >
-  For adapter maintainers who wish to have theirs added to the list of [Trusted adapters](https://docs.getdbt.com/docs/trusted-adapters)
+description: For adapter maintainers who wish to have theirs added to the list of Trusted adapters.
+title: "Trust dbt-myadapter"
 labels: ["adapter maintainers"]
+assignees:
+  - dataders
 body:
   - type: markdown
     attributes:
       value: |
-        We're excited that you'd like to support your adapter formally as "Trusted"! This template will ensure that you are aware of the process and the guidelines. Additionally, that you can vouch that your adapter currently meets the standards of a Trusted adapter
+        We're excited that you'd like to support your adapter formally as "Trusted"! This template will ensure that you are aware of the process and the guidelines. Additionally, that you can vouch that your adapter currently meets the standards of a Trusted adapter. For more information, see [Trusted adapters](https://docs.getdbt.com/docs/trusted-adapters)
 
   - type: input
     id: adapter-repo
@@ -25,13 +27,15 @@ body:
     validations:
       required: true
 
-  - type: checkboxes
+  - type: dropdown
     id: author_type
     attributes:
       label: Which of these best describes you?
       options:
-        - label: I am a dbt Community member
-        - label: I work for the vendor on top of which the dbt adapter functions
+        - I am a dbt Community member
+        - I work for the vendor on top of which the dbt adapter functions
+    validations:
+      required: true
 
   - type: checkboxes
     id: read-program-guide
@@ -39,7 +43,20 @@ body:
       label: Please agree to the each of the following
       options:
         - label: I am a maintainer of the adapter being submited for Trusted status
+          required: true
         - label: I have read both the [Trusted adapters](https://docs.getdbt.com/docs/trusted-adapters) and [Building a Trusted Adapter](https://docs.getdbt.com/guides/dbt-ecosystem/adapter-development/8-building-a-trusted-adapter) pages.
+          required: true
         - label: I believe that the adapter currently meets the expectations given above
-        - label: I will ensure this adapter stays in compliance with the guidelines 
+          required: true
+        - label: I will ensure this adapter stays in compliance with the guidelines
+          required: true
         - label: I understand that dbt Labs reserves the right to remove an adapter from the trusted adapter list at any time, should any of the below guidelines not be met
+          required: true
+
+  - type: textarea
+    id: icon
+    attributes:
+      label: What icon should be used?
+      description: |
+        Please share an svg image that you'd like to be displayed in for your adapter. Normally, this is the logo for the data platform on top of which your adapter works. If there's a dark mode version, please also share that.
+        Pasting the image from your clipboard will upload the file to GitHub and create markdown formatting for it to be rendered inline


### PR DESCRIPTION
## What are you changing in this pull request and why?
<!---
Describe your changes and why you're making them. If linked to an open
issue or a pull request on dbt Core, then link to them here! 

To learn more about the writing conventions used in the dbt Labs docs, see the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md).
-->

#4022, the first issue generated by this new template, presented some opportunities for refinement, predominantly:
- markdown doesn't work in the template description, so I moved it to the `markdown` element
- auto-assign me (@dataders)
- make fields required
- allow for submitters to provide the svg icon file (to save me time)