### PR TITLE
Update cloud-seats-and-users.md

### DIFF
--- a/website/docs/docs/cloud/manage-access/cloud-seats-and-users.md
+++ b/website/docs/docs/cloud/manage-access/cloud-seats-and-users.md
@@ -21,7 +21,7 @@ The user's assigned license determines the specific capabilities they can access
 | API Access | ✅ | ❌ | ❌ |
 | Use [Source Freshness](/docs/deploy/source-freshness) | ✅ | ✅ | ❌ |
 | Use [Docs](/docs/collaborate/build-and-view-your-docs) | ✅ | ✅ | ❌ |
-| Receive [Job notifications](/docs/deploy/job-notifications) |  ✅ |  ✅ Note, that Read-Only users can't set job notifications. |  ✅ Note, that IT users can't set job notifications.| 
+| Receive [Job notifications](/docs/deploy/job-notifications) |  ✅ |  ✅ <br /> Can't set job notifications. |  ✅ <br /> Can't set job notifications.| 
 *Available on Enterprise and Team plans only and doesn't count toward seat usage. Please note, that IT seats are limited to 1 seat per Team or Enterprise account.
 
 ## Licenses

--- a/website/docs/docs/cloud/manage-access/cloud-seats-and-users.md
+++ b/website/docs/docs/cloud/manage-access/cloud-seats-and-users.md
@@ -8,8 +8,8 @@ sidebar: "Users and licenses"
 In dbt Cloud, _licenses_ are used to allocate users to your account. There are three different types of licenses in dbt Cloud:
 
 - **Developer** &mdash; Granted access to the Deployment and [Development](/docs/cloud/dbt-cloud-ide/develop-in-the-cloud) functionality in dbt Cloud.
-- **Read-Only** &mdash; Intended to view the [artifacts](/docs/deploy/artifacts) created in a dbt Cloud account.
-- **IT** &mdash; Can manage users, groups, and licenses, among other permissions. Available on Enterprise and Team plans only.
+- **Read-Only** &mdash; Intended to view the [artifacts](/docs/deploy/artifacts) created in a dbt Cloud account, can receive job notifications but not configure them.
+- **IT** &mdash; Can manage users, groups, and licenses, among other permissions. Can receive job notifications but not configure them. Available on Enterprise and Team plans only.
 
 The user's assigned license determines the specific capabilities they can access in dbt Cloud.
 
@@ -21,7 +21,7 @@ The user's assigned license determines the specific capabilities they can access
 | API Access | ✅ | ❌ | ❌ |
 | Use [Source Freshness](/docs/deploy/source-freshness) | ✅ | ✅ | ❌ |
 | Use [Docs](/docs/collaborate/build-and-view-your-docs) | ✅ | ✅ | ❌ |
-| Receive [Job notifications](/docs/deploy/job-notifications) |  ✅ |  ✅ <br /> Can't set job notifications. |  ✅ <br /> Can't set job notifications.| 
+| Receive [Job notifications](/docs/deploy/job-notifications) |  ✅ |  ✅  |  ✅ | 
 *Available on Enterprise and Team plans only and doesn't count toward seat usage. Please note, that IT seats are limited to 1 seat per Team or Enterprise account.
 
 ## Licenses

--- a/website/docs/docs/cloud/manage-access/cloud-seats-and-users.md
+++ b/website/docs/docs/cloud/manage-access/cloud-seats-and-users.md
@@ -21,7 +21,7 @@ The user's assigned license determines the specific capabilities they can access
 | API Access | ✅ | ❌ | ❌ |
 | Use [Source Freshness](/docs/deploy/source-freshness) | ✅ | ✅ | ❌ |
 | Use [Docs](/docs/collaborate/build-and-view-your-docs) | ✅ | ✅ | ❌ |
-| Receive [Job notifications](/docs/deploy/job-notifications) |  ✅ |  ✅ |  ✅ Note, that IT users set job notifications.| 
+| Receive [Job notifications](/docs/deploy/job-notifications) |  ✅ |  ✅ Note, that Read-Only users can't set job notifications. |  ✅ Note, that IT users can't set job notifications.| 
 *Available on Enterprise and Team plans only and doesn't count toward seat usage. Please note, that IT seats are limited to 1 seat per Team or Enterprise account.
 
 ## Licenses

--- a/website/docs/docs/cloud/manage-access/cloud-seats-and-users.md
+++ b/website/docs/docs/cloud/manage-access/cloud-seats-and-users.md
@@ -8,8 +8,8 @@ sidebar: "Users and licenses"
 In dbt Cloud, _licenses_ are used to allocate users to your account. There are three different types of licenses in dbt Cloud:
 
 - **Developer** &mdash; Granted access to the Deployment and [Development](/docs/cloud/dbt-cloud-ide/develop-in-the-cloud) functionality in dbt Cloud.
-- **Read-Only** &mdash; Intended to view the [artifacts](/docs/deploy/artifacts) created in a dbt Cloud account, can receive job notifications but not configure them.
-- **IT** &mdash; Can manage users, groups, and licenses, among other permissions. Can receive job notifications but not configure them. Available on Enterprise and Team plans only.
+- **Read-Only** &mdash; Intended to view the [artifacts](/docs/deploy/artifacts) created in a dbt Cloud account. Read-Only users can receive job notifications but not configure them.
+- **IT** &mdash; Can manage users, groups, and licenses, among other permissions. IT users can receive job notifications but not configure them. Available on Enterprise and Team plans only.
 
 The user's assigned license determines the specific capabilities they can access in dbt Cloud.
 

--- a/website/docs/docs/cloud/manage-access/cloud-seats-and-users.md
+++ b/website/docs/docs/cloud/manage-access/cloud-seats-and-users.md
@@ -21,8 +21,8 @@ The user's assigned license determines the specific capabilities they can access
 | API Access | ✅ | ❌ | ❌ |
 | Use [Source Freshness](/docs/deploy/source-freshness) | ✅ | ✅ | ❌ |
 | Use [Docs](/docs/collaborate/build-and-view-your-docs) | ✅ | ✅ | ❌ |
-| Receive [Job notifications](/docs/deploy/job-notifications) |  ✅ |  ✅ |  ✅ | 
-*Available on Enterprise and Team plans only and doesn't count toward seat usage. Please note, IT seats are limited to 1 seat per Team or Enterprise account.
+| Receive [Job notifications](/docs/deploy/job-notifications) |  ✅ |  ✅ |  ✅ Note, that IT users set job notifications.| 
+*Available on Enterprise and Team plans only and doesn't count toward seat usage. Please note, that IT seats are limited to 1 seat per Team or Enterprise account.
 
 ## Licenses
 

--- a/website/docs/docs/deploy/job-notifications.md
+++ b/website/docs/docs/deploy/job-notifications.md
@@ -9,10 +9,10 @@ Setting up notifications in dbt Cloud will allow you to receive alerts via Email
 
 ### Email
 
-These are the following options for setting up email notifications:
+These are the following options for setting up email notifications. Refer to [Users and licenses](/docs/cloud/manage-access/seats-and-users) for info on license types eligible for email notifications. 
 
-- As a **user** &mdash; You can set up email notifications for yourself under your Profile. 
-- As an **admin** &mdash; You can set up notifications on behalf of your team members. Refer to [Users and licenses](/docs/cloud/manage-access/seats-and-users) for info on license types eligible for email notifications.
+- As a **user** &mdash; You can set up email notifications for yourself under your Profile.
+- As an **admin** &mdash; You can set up notifications on behalf of your team members. 
 
 To set up job notifications, follow these steps:
 


### PR DESCRIPTION
users are confused and asking for more clarify on IT licenses and job notifications. this pr clarifies that IT users can't set job notifications, only receive them. eng and product determining whether this is something that will change in the future. until then, this pr confirms the above.
