### PR TITLE
Remove-1.6 from future releases table

### DIFF
--- a/website/snippets/core-versions-table.md
+++ b/website/snippets/core-versions-table.md
@@ -17,7 +17,6 @@ _Future release dates are tentative and subject to change._
 
 | dbt Core | Planned Release | Critical & dbt Cloud Support Until  |
 |----------|-----------------|-------------------------------------|
-| **v1.6** | _July 2023_     | _July 2024_                         |
 | **v1.7** | _Oct 2023_      | _Oct 2024_                          |
 | **v1.8** | _Jan 2024_      | _Jan 2025_                          |
 | **v1.9** | _Apr 2024_      | _Apr 2025_                          |


### PR DESCRIPTION
Preview: [About dbt Core versions: Planned future releases](https://deploy-preview-4047--docs-getdbt-com.netlify.app/docs/dbt-versions/core#planned-future-releases)

## What are you changing in this pull request and why?

v1.6 is listed [here](https://docs.getdbt.com/docs/dbt-versions/core#planned-future-releases) as part of the "Planned future releases", so we should remove it now that it has been released.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
