### PR TITLE
Remove beta tabs/callouts for CI phase 2

### DIFF
--- a/website/docs/docs/dbt-versions/release-notes/04-Sept-2023/ci-updates-phase2-rn.md
+++ b/website/docs/docs/dbt-versions/release-notes/04-Sept-2023/ci-updates-phase2-rn.md
@@ -25,3 +25,8 @@ Below is a comparison table that describes how deploy jobs and CI jobs behave di
 | Execution mode | Runs execute sequentially, so as to not have collisions on the underlying DAG. | Runs execute in parallel to promote team velocity. |
 | Efficiency run savings | Detects over-scheduled jobs and cancels unnecessary runs to avoid queue clog. | Cancels existing runs when a newer commit is pushed to avoid redundant work. |
 | State comparison | Only sometimes needs to detect state. | Almost always needs to compare state against the production environment to build on modified code and its dependents. |
+
+
+## What you need to update
+
+If you previously set up a job using the [Create Job](/dbt-cloud/api-v2#/operations/Create%20Job) API endpoint before September 11, 2023, you must re-create the job as described in [Trigger a CI job with the API](/docs/deploy/ci-jobs#trigger-a-ci-job-with-the-api). This is because you must set the `job_type` to be `ci`. 

--- a/website/docs/docs/deploy/ci-jobs.md
+++ b/website/docs/docs/deploy/ci-jobs.md
@@ -6,14 +6,6 @@ description: "Learn how to create and set up CI checks to test code changes befo
 
 You can set up [continuous integration](/docs/deploy/continuous-integration) (CI) jobs to run when someone opens a new pull request (PR) in your dbt Git repository. By running and testing only _modified_ models, dbt Cloud ensures these jobs are as efficient and resource conscientious as possible on your data platform.
 
-:::tip Join our beta 
-
-dbt Labs is currently running a beta that provides improved UI updates for setting up CI jobs. For docs, refer to [Set up CI jobs (Beta version)](/docs/deploy/ci-jobs?version=beta#set-up-ci-jobs) on this page.
-
-If you're interested in joining our beta, please fill out our Google Form to [sign up](https://forms.gle/VxwBD1xjzouE84EQ6).
-
-:::
-
 
 ## Set up CI jobs {#set-up-ci-jobs}
 
@@ -26,23 +18,6 @@ dbt Labs recommends that you create your CI job in a dedicated dbt Cloud [deploy
     - If you’re using GitLab, you must use a paid or self-hosted account which includes support for GitLab webhooks.
     - If you previously configured your dbt project by providing a generic git URL that clones using SSH, you must reconfigure the project to connect through dbt Cloud's native integration.
 
-<Tabs queryString="version">
-<TabItem value="current" label="Current version" default>
-
-1. On your deployment environment page, click **Create One** to create a new CI job.
-2. In the **Execution Settings** section: 
-    - For the option **Defer to a previous run state**, choose whichever production job that's set to run often. If you don't see any jobs to select from the dropdown, you first need to run a production job successfully. Deferral tells dbt Cloud to compare the manifest of the current CI job against the project representation that was materialized the last time the deferred job was run successfully. By setting this option, dbt Cloud only checks the modified code and compares the changes against what’s running in production, instead of building the full table or the entire DAG.
-
-    <Lightbox src="/img/docs/dbt-cloud/using-dbt-cloud/ci-deferral.png" width="70%" title="Example of the dropdown for Defer to a previous run state"/>
-
-    - For the option **Commands**, enter `dbt build --select state:modified+` in the field. This informs dbt Cloud to build only new or changed models and their downstream dependents. Importantly, state comparison can only happen when there is a deferred job selected to compare state to.
-
-
-3. In the **Triggers** section, choose the **Continuous Integration** (CI) tab. Then, enable the **Run on Pull Requests** option. This configures pull requests and new commits to be a trigger for the CI job.
-
-</TabItem>
-
-<TabItem value="beta" label="Beta version">
 
 To make CI job creation easier, many options on the **CI job** page are set to default values that dbt Labs recommends that you use. If you don't want to use the defaults, you can change them.
 
@@ -74,10 +49,6 @@ To make CI job creation easier, many options on the **CI job** page are set to d
     - **Run source freshness** &mdash; Enable this option to invoke the `dbt source freshness` command before running this CI job. Refer to [Source freshness](/docs/deploy/source-freshness) for more details.
 
     <Lightbox src="/img/docs/dbt-cloud/using-dbt-cloud/ci-job-adv-settings.png" width="90%" title="Example of Advanced Settings on the CI Job page"/>
-
-</TabItem>
-
-</Tabs>
 
 
 ## Trigger a CI job with the API

--- a/website/docs/docs/deploy/deploy-jobs.md
+++ b/website/docs/docs/deploy/deploy-jobs.md
@@ -15,13 +15,6 @@ You can use deploy jobs to build production data assets. Deploy jobs make it eas
 
 You can create a deploy job and configure it to run on [scheduled days and times](#schedule-days) or enter a [custom cron schedule](#custom-cron-schedules). 
 
-:::tip Join our beta 
-
-dbt Labs is currently running a beta that provides improved UI updates for setting up deploy jobs. For docs, refer to [Create and schedule jobs (Beta version)](/docs/deploy/deploy-jobs?version=beta#create-and-schedule-jobs) on this page.
-
-If you're interested in joining our beta, please fill out our Google Form to [sign up](https://forms.gle/VxwBD1xjzouE84EQ6).
-
-:::
 
 ## Prerequisites
 
@@ -31,45 +24,6 @@ If you're interested in joining our beta, please fill out our Google Form to [si
 - You must set up a [deployment environment](/docs/deploy/deploy-environments). 
 
 ## Create and schedule jobs {#create-and-schedule-jobs}
-
-<Tabs queryString="version">
-<TabItem value="current" label="Current version" default>
-
-1. Create a new deploy job by clicking **Deploy** in the header, click **Jobs**, and then **Create job**.
-1. Provide a job name, for example "Hourly Customer Job". 
-1. Under **Environment**, add the following:
-    * **Environment** &mdash; Link to an existing deployment environment.
-    * **dbt Version** &mdash; Select the dbt [version](/docs/dbt-versions/core). dbt Labs recommends inheriting the version from the environment settings.
-    * **Target Name** &mdash; Define the [target name](/docs/build/custom-target-names) for any dbt cloud job to correspond to settings in your project.
-    * **Threads** &mdash; The default value is 4 [threads](/docs/core/connect-data-platform/connection-profiles#understanding-threads). Increase the thread count to increase model execution concurrency. 
-
-1. Define [environment variables](/docs/build/environment-variables) if you want to customize the behavior of your project.
-
-<Lightbox src ="/img/docs/dbt-cloud/using-dbt-cloud/create-new-job.jpg" width="85%" title="Configuring your environment job settings"/>
-
-5. Under **Execution Settings**, you can configure the fields needed to execute your job:
-
-    * **Run Timeout** &mdash; Configure the number of seconds a run will execute before dbt Cloud cancels it. Setting this to 0 means it'll never time out runs for that job.   
-    * **Defer to a previous run state** &mdash; Select a production job you want to defer to. This enables dbt Cloud to examine the artifacts from the most recent, successful run of that deferred job, enabling state comparison and rewiring of upstream dependencies to any model that doesn’t exist in the current run's schema. 
-    * **Generate docs on run** checkbox &mdash; Configure the job to automatically [generate project docs](/docs/collaborate/build-and-view-your-docs) each time this job runs.
-    * **Run on source freshness** checkbox &mdash;  Configure [dbt source freshness](/docs/deploy/source-freshness) as the first step of the job without breaking subsequent steps.
-    * **Commands** &mdash; Add or remove [job commands](/docs/deploy/job-commands), which are specific tasks you set in your dbt Cloud jobs.
-
-<Lightbox src ="/img/docs/dbt-cloud/using-dbt-cloud/execution-settings.jpg" width="85%" title="Configuring your execution job settings"/>
-
-6. Under the **Triggers** section, you can configure when and how dbt will trigger the deploy job.
-
-    * **Schedule** tab &mdash; Enable the **Run on schedule** option. Use either the [scheduled days](#schedule-days) or the [custom cron schedule](#custom-cron-schedule) method to configure your desired days, times, and intervals for running your deploy job.
-    * **Continuous Integration** tab &mdash; Configure [continuous integration (CI)](/docs/deploy/continuous-integration) to run when someone opens a new pull request in your dbt repository.
-    * **API** tab &mdash; Use the [dbt API](/docs/dbt-cloud-apis/overview) to trigger a job.
-
-<Lightbox src ="/img/docs/dbt-cloud/using-dbt-cloud/triggers.jpg" width="85%" title="Configuring your job triggers"/>
-
-7. Select **Save**, then click **Run Now** to run your deploy job. Click the run and watch its progress under **Run history**.
-
-</TabItem>
-
-<TabItem value="beta" label="Beta version">
 
 1. On your deployment environment page, click **Create Job** > **Deploy Job** to create a new deploy job. 
 2. Options in the **Job Description** section:
@@ -100,10 +54,6 @@ If you're interested in joining our beta, please fill out our Google Form to [si
     - **Threads** &mdash; By default, it’s set to 4 [threads](/docs/core/connect-data-platform/connection-profiles#understanding-threads). Increase the thread count to increase model execution concurrency.
 
     <Lightbox src="/img/docs/dbt-cloud/using-dbt-cloud/deploy-job-adv-settings.png" width="90%" title="Example of Advanced Settings on Deploy Job page"/>
-
-</TabItem>
-
-</Tabs>
 
 ### Schedule days
 

--- a/website/docs/docs/deploy/jobs.md
+++ b/website/docs/docs/deploy/jobs.md
@@ -5,25 +5,17 @@ description: "Learn about deploy jobs and continuous integration (CI) jobs in db
 tags: [scheduler]
 ---
 
-In dbt Cloud, you can create and set up triggers for these jobs:
-- [Deploy jobs](/docs/deploy/deploy-jobs)
-- [Continuous integration (CI) jobs](/docs/deploy/continuous-integration)  
-
-:::tip Join our beta 
-
-dbt Labs is currently running a beta that provides improved UI updates for setting up deploy jobs and CI jobs. For docs on deploy jobs, refer to [Create and schedule jobs (Beta version)](/docs/deploy/deploy-jobs?version=beta#create-and-schedule-jobs). For docs on CI jobs, refer to [Set up CI jobs (Beta version)](/docs/deploy/ci-jobs?version=beta#set-up-ci-jobs).
-
-If you're interested in joining our beta, please fill out our Google Form to [sign up](https://forms.gle/VxwBD1xjzouE84EQ6).
-
-:::
+In dbt Cloud, there are two types of jobs: 
+- [Deploy jobs](/docs/deploy/deploy-jobs) &mdash; To create and set up triggers for building production data assets
+- [Continuous integration (CI) jobs](/docs/deploy/continuous-integration) &mdash; To create and set up triggers for checking code changes
 
 Below is a comparison table that describes how deploy jobs and CI jobs behave differently:
 
 |  | Deploy Jobs | CI Jobs |
 | --- | --- | --- |
-| Purpose | Builds production data assets | Builds and tests new code before merging changes into production |
-| Trigger types | Triggered by a schedule or by API | Triggered by a webhook from a commit to a PR or by API |
-| Destination | Builds into a production database and schema | Builds into a staging database and ephemeral schema, lived for the lifetime of the PR |
-| Execution Mode | Runs execute sequentially, so as to not have collisions on the underlying DAG. | Runs execute in parallel to promote team velocity. |
-| Efficiency run savings | Detects over scheduled jobs and cancels unnecessary runs to avoid queue clog. | Cancels runs when an in-flight run becomes stale when a new commit is pushed to the pull request. |
-| State comparison | Only sometimes needs to detect state | Almost always needs to compare state against the production environment to build on modified code and its dependents. |
+| Purpose | Builds production data assets. | Builds and tests new code before merging changes into production. |
+| Trigger types | Triggered by a schedule or by API. | Triggered by a commit to a PR or by API. |
+| Destination | Builds into a production database and schema. | Builds into a staging database and ephemeral schema, lived for the lifetime of the PR. |
+| Execution mode | Runs execute sequentially, so as to not have collisions on the underlying DAG. | Runs execute in parallel to promote team velocity. |
+| Efficiency run savings | Detects over-scheduled jobs and cancels unnecessary runs to avoid queue clog. | Cancels existing runs when a newer commit is pushed to avoid redundant work. |
+| State comparison | Only sometimes needs to detect state. | Almost always needs to compare state against the production environment to build on modified code and its dependents. |

--- a/website/docs/guides/orchestration/set-up-ci/2-quick-setup.md
+++ b/website/docs/guides/orchestration/set-up-ci/2-quick-setup.md
@@ -4,13 +4,10 @@ slug: in-15-minutes
 description: Find issues before they are deployed to production with dbt Cloud's Slim CI.
 ---
 
-:::tip Join the beta
+In this guide, we're going to add a **CI environment**, where proposed changes can be validated in the context of the entire project without impacting production systems. We will use a single set of deployment credentials (like the Prod environment), but models are built in a separate location to avoid impacting others (like the Dev environment).
 
-dbt Labs is currently running a beta that provides improved UI updates for setting up CI jobs. For docs, refer to [Set up CI jobs (Beta version)](/docs/deploy/ci-jobs?version=beta#set-up-ci-jobs). This guide assumes you are using the improvements available in the beta.
-
-If you're interested in joining our beta, please fill out our Google Form to [sign up](https://forms.gle/VxwBD1xjzouE84EQ6).
-
-:::
+Your git flow will look like this:
+<Lightbox src="/img/guides/best-practices/environment-setup/one-branch-git.png" title="git flow diagram" />
 
 ## Prerequisites
 
@@ -18,11 +15,6 @@ As part of your initial dbt Cloud setup, you should already have Development and
 
 - Your **Development environment** powers the IDE. Each user has individual credentials, and builds into an individual dev schema. Nothing you do here impacts any of your colleagues.
 - Your **Production environment** brings the canonical version of your project to life for downstream consumers. There is a single set of deployment credentials, and everything is built into your production schema(s).
-
-In this guide, we're going to add a **CI environment**, where proposed changes can be validated in the context of the entire project without impacting production systems. We will use a single set of deployment credentials (like the Prod environment), but models are built in a separate location to avoid impacting others (like the Dev environment).
-
-Your git flow will look like this:
-<Lightbox src="/img/guides/best-practices/environment-setup/one-branch-git.png" title="git flow diagram" />
 
 ## Step 1: Create a new CI environment
 

--- a/website/docs/guides/orchestration/set-up-ci/5-multiple-checks.md
+++ b/website/docs/guides/orchestration/set-up-ci/5-multiple-checks.md
@@ -12,22 +12,15 @@ As such, it may slow down the time it takes to get new features into production.
 The team at Sunrun maintained a SOX-compliant deployment in dbt while reducing the number of environments. Check out [their Coalesce presentation](https://www.youtube.com/watch?v=vmBAO2XN-fM) to learn more.
 :::
 
-:::tip Join the beta
-
-dbt Labs is currently running a beta that provides improved UI updates for setting up CI jobs. For docs, refer to [Set up CI jobs (Beta version)](/docs/deploy/ci-jobs?version=beta#set-up-ci-jobs). This guide assumes you are using the improvements available in the beta.
-
-If you're interested in joining our beta, please fill out our Google Form to [sign up](https://forms.gle/VxwBD1xjzouE84EQ6).
-
-:::
-
-## Prerequisites
-
-This section assumes you already have the **Development**, **CI** and **Production** environments described in [the Baseline setup](/guides/orchestration/set-up-ci/in-15-minutes).
-
 In this section, we will add a new **QA** environment. New features will branch off from and be merged back into the associated `qa` branch, and a member of your team (the "Release Manager") will create a PR against `main` to be validated in the CI environment before going live.
 
 The git flow will look like this:
 <Lightbox src="/img/guides/best-practices/environment-setup/many-branch-git.png" title="git flow diagram with an intermediary branch" />
+
+## Prerequisites
+
+- You have the **Development**, **CI**, and **Production** environments, as described in [the Baseline setup](/guides/orchestration/set-up-ci/in-15-minutes).
+
 
 ## Step 1: Create a `release` branch in your git repo
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

For the CI phase 2 GA, remove related beta callouts and beta tabs

- Updated CI jobs page: https://docs.getdbt.com/docs/deploy/ci-jobs 
- Updated Deploy jobs page: https://docs.getdbt.com/docs/deploy/deploy-jobs
- Updated Jobs page: https://docs.getdbt.com/docs/deploy/jobs
- Updated guide on CI setup: https://docs.getdbt.com/guides/orchestration/set-up-ci/overview
- Updated release note to include a new section "What you need to update"

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [x] Needs review from product team

