### PR TITLE
Relationship between `selected_resources` and `graph` context variable

### DIFF
--- a/website/docs/reference/dbt-jinja-functions/selected_resources.md
+++ b/website/docs/reference/dbt-jinja-functions/selected_resources.md
@@ -30,6 +30,8 @@ For a given run it will look like:
 ["model.my_project.model1", "model.my_project.model2", "snapshot.my_project.my_snapshot"]
 ```
 
+Each value corresponds to a key in the `nodes` object within the [graph](/reference/dbt-jinja-functions/graph) context variable.
+
 It can be used in macros in a `pre-hook`, `post-hook`, `on-run-start` or `on-run-end` 
 to evaluate what nodes are selected and trigger different logic whether a particular node
 is selected or not.


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty-graphselectedresources-dbt-labs.vercel.app/reference/dbt-jinja-functions/selected_resources#usage)

## What are you changing in this pull request and why?
The relationship between the [`selected_resources`](https://docs.getdbt.com/reference/dbt-jinja-functions/selected_resources) and [`graph`](https://docs.getdbt.com/reference/dbt-jinja-functions/graph) context variable might not be obvious... so let's make it so!

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.