### PR TITLE
Fix version-based listing of supported incremental strategies

### DIFF
--- a/website/docs/reference/resource-configs/postgres-configs.md
+++ b/website/docs/reference/resource-configs/postgres-configs.md
@@ -9,13 +9,18 @@ id: "postgres-configs"
 In dbt-postgres, the following incremental materialization strategies are supported:
 
 <VersionBlock lastVersion="1.5">
+
 - `append` (default)
 - `delete+insert`
+
 </VersionBlock>
+
 <VersionBlock firstVersion="1.6">
+
 - `append` (default)
 - `merge`
 - `delete+insert`
+
 </VersionBlock>
 
 


### PR DESCRIPTION
## 🎩 Previews

- [1.5](https://docs-getdbt-com-git-dbeatty-postgres-incrementa-4406cb-dbt-labs.vercel.app/reference/resource-configs/postgres-configs?version=1.5#incremental-materialization-strategies)
- [1.6](https://docs-getdbt-com-git-dbeatty-postgres-incrementa-4406cb-dbt-labs.vercel.app/reference/resource-configs/postgres-configs?version=1.6#incremental-materialization-strategies)

## What are you changing in this pull request and why?

This PR fixes the following problem -- the Markdown [here](https://docs.getdbt.com/reference/resource-configs/postgres-configs) isn't rendering correctly for 1.5 or 1.6:

### v1.5

<img width="400" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/310e3b2f-d876-463b-b8f0-d1baca9bf567">

### v1.6

<img width="400" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/03d3eba0-5724-4d57-93bd-8579fc0329d8">

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.