### PR TITLE
Adjusted link colors and added underlines on dark mode

### DIFF
--- a/website/src/components/card/index.js
+++ b/website/src/components/card/index.js
@@ -11,7 +11,7 @@ function Card({ title, body, link, icon }) {
   let imgClass = styles[icon] || ''
 
   return (
-    <div className={styles.cardWrapper}>
+    <div className={`${styles.cardWrapper} ${link && 'card--no-underline'}`}>
       {link ? <Link
         to={useBaseUrl(link)}>
         <article className={styles.card}>

--- a/website/src/components/card/styles.module.css
+++ b/website/src/components/card/styles.module.css
@@ -29,9 +29,9 @@
   margin-bottom: 20px;
 }
 
-/* .cardBody a, .cardBody a:hover {
+.cardBody p a, .cardBody p a:hover {
   text-decoration: underline;
-} */
+}
 
 .icon {
   margin-bottom: 0.5rem;

--- a/website/src/components/card/styles.module.css
+++ b/website/src/components/card/styles.module.css
@@ -29,9 +29,9 @@
   margin-bottom: 20px;
 }
 
-.cardBody a, .cardBody a:hover {
+/* .cardBody a, .cardBody a:hover {
   text-decoration: underline;
-}
+} */
 
 .icon {
   margin-bottom: 0.5rem;

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -108,7 +108,7 @@ html[data-theme="dark"] {
 }
 
 /* Underline only for links in text body */
-html[data-theme="dark"] main a {
+html[data-theme="dark"] main a:not(article a) {
   text-decoration: underline;
 }
 

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -105,12 +105,14 @@ html[data-theme="dark"] {
 /* Darkmode Links */
 html[data-theme="dark"] {
   --ifm-link-color: var(--color-white);
+  --ifm-link-decoration: var(underline)
 }
 
 /* Underline only for links in text body */
-html[data-theme="dark"] main a:not(article a) {
+/* html[data-theme="dark"] main a:not(article a) {
   text-decoration: underline;
-}
+  
+} */
 
 /* For /dbt-cloud/api REDOC Page */
 html[data-theme="dark"] .api-content h2,

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -111,6 +111,7 @@ html[data-theme="dark"] {
 /* Underline only for links in text body */
 html[data-theme="dark"] main a:not(.card--no-underline a) {
   text-decoration: underline;
+  --ifm-link-decoration: underline;
 }
 
 /* For /dbt-cloud/api REDOC Page */

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -102,6 +102,18 @@ html[data-theme="dark"] {
   --ifm-table-cell-color: var(--color-green-blue);
 }
 
+/* Darkmode Links */
+html[data-theme="dark"] {
+  --ifm-link-color: var(--color-white);
+}
+
+/* Underline only for links in text body */
+html[data-theme="dark"] main a {
+  text-decoration: underline;
+}
+
+
+
 /* For /dbt-cloud/api REDOC Page */
 html[data-theme="dark"] .api-content h2,
 html[data-theme="dark"] .api-content h3,

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -112,8 +112,6 @@ html[data-theme="dark"] main a:not(article a) {
   text-decoration: underline;
 }
 
-
-
 /* For /dbt-cloud/api REDOC Page */
 html[data-theme="dark"] .api-content h2,
 html[data-theme="dark"] .api-content h3,

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -105,7 +105,6 @@ html[data-theme="dark"] {
 /* Darkmode Links */
 html[data-theme="dark"] {
   --ifm-link-color: var(--color-white);
-  --ifm-link-decoration: var(underline)
 }
 
 /* Underline only for links in text body */

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -105,6 +105,7 @@ html[data-theme="dark"] {
 /* Darkmode Links */
 html[data-theme="dark"] {
   --ifm-link-color: var(--color-white);
+  --ifm-link-decoration: var(underline)
 }
 
 /* Underline only for links in text body */

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -105,13 +105,11 @@ html[data-theme="dark"] {
 /* Darkmode Links */
 html[data-theme="dark"] {
   --ifm-link-color: var(--color-white);
-  --ifm-link-decoration: var(underline)
 }
 
 /* Underline only for links in text body */
-html[data-theme="dark"] main a:not(article a) {
+html[data-theme="dark"] main a:not(.card--no-underline a) {
   text-decoration: underline;
-  --ifm-link-decoration: var(underline)
 }
 
 /* For /dbt-cloud/api REDOC Page */

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -109,10 +109,10 @@ html[data-theme="dark"] {
 }
 
 /* Underline only for links in text body */
-/* html[data-theme="dark"] main a:not(article a) {
+html[data-theme="dark"] main a:not(article a) {
   text-decoration: underline;
-  
-} */
+  --ifm-link-decoration: var(underline)
+}
 
 /* For /dbt-cloud/api REDOC Page */
 html[data-theme="dark"] .api-content h2,


### PR DESCRIPTION
## What are you changing in this pull request and why?
- [Updating page content links to be accessible in dark mode](https://app.asana.com/0/1200099998847559/1205507946650672/f)
  - Matching the homepage initial link state: making every page body link white with an underline 

## Preview Links
the following are different links from various pages on dbt docs. Switch over to dark mode and confirm if all links in the page body are accessible/white.

- https://docs-getdbt-com-git-bug-link-colors-dbt-labs.vercel.app/community/spotlight/faith-lierheimer
- https://docs-getdbt-com-git-bug-link-colors-dbt-labs.vercel.app/docs/deploy/deployments
- https://docs-getdbt-com-git-bug-link-colors-dbt-labs.vercel.app/community/join

## Checklist
- [ ] Assure that there are no conflicts in the navbar or footer