### PR TITLE
Add .vercel to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ website/i18n/*
 .netlify
 
 .eslintcache
+
+# Local Vercel folder
+.vercel

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -27,3 +27,6 @@ yarn-error.log*
 /static/feeds/atom.xml
 /static/feeds/rss.json
 /static/feeds/rss.xml
+
+# Local Vercel folder
+.vercel


### PR DESCRIPTION
## What are you changing in this pull request and why?

Adds `.vercel` to both `.gitignore` files to prevent Vercel build files from being included in repo.

_Opened this PR to test if the `deploy/netlify` check was disabled, but it looks like it still ran. But might as well git this edit in place while we're at it._