### PR TITLE
Select resources with the `source` `resource_type`

### DIFF
--- a/website/docs/reference/node-selection/methods.md
+++ b/website/docs/reference/node-selection/methods.md
@@ -47,7 +47,7 @@ The `source` method is used to select models that select from a specified [sourc
   ```
 
 ### The "resource_type" method
-Use the `resource_type` method to select nodes of a particular type (`model`, `test`, `exposure`, etc). This is similar to the `--resource-type` flag used by the [`dbt ls` command](/reference/commands/list).
+Use the `resource_type` method to select nodes of a particular type (`model`, `test`, `exposure`, and so on). This is similar to the `--resource-type` flag used by the [`dbt ls` command](/reference/commands/list).
 
   ```bash
   $ dbt build --select resource_type:exposure    # build all resources upstream of exposures

--- a/website/docs/reference/node-selection/methods.md
+++ b/website/docs/reference/node-selection/methods.md
@@ -47,11 +47,17 @@ The `source` method is used to select models that select from a specified [sourc
   ```
 
 ### The "resource_type" method
-Use the `resource_type` method to select nodes of a particular type (`model`, `source`, `exposure`, etc). This is similar to the `--resource-type` flag used by the [`dbt ls` command](/reference/commands/list).
+Use the `resource_type` method to select nodes of a particular type (`model`, `test`, `exposure`, etc). This is similar to the `--resource-type` flag used by the [`dbt ls` command](/reference/commands/list).
 
   ```bash
   $ dbt build --select resource_type:exposure    # build all resources upstream of exposures
   $ dbt list --select resource_type:test    # list all tests in your project
+  ```
+
+Note: This method doesn't work for sources, so use the [`--resource-type`](/reference/commands/list) option of the list command instead:
+
+  ```bash
+  $ dbt list --resource-type source
   ```
 
 ### The "path" method


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty-source-resource-type-dbt-labs.vercel.app/reference/node-selection/methods#the-resource_type-method)

## What are you changing in this pull request and why?

https://github.com/dbt-labs/dbt-core/issues/8730 surfaced an area to provide more precise guidance how to select sources.


## 🎩 

Before:

<img width="832" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/5b97eb54-3669-417c-8332-581609d2fec1">

After:

<img width="839" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/056abc36-96f1-441e-8667-3208d074cc1d">


## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.