### PR TITLE
update labeler to add label and not remove it

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -15,24 +15,32 @@ jobs:
       - uses: actions/github-script@v6
         with:
           script: |
-            const creator = context.payload.sender.login
+            const creator = context.payload.sender.login;
             const opts = github.rest.issues.listForRepo.endpoint.merge({
               ...context.issue,
               creator,
-              state: 'all'
-            })
-            const issues = await github.paginate(opts)
+              state: 'all',
+            });
+            
+            const issues = await github.paginate(opts);
+            
+            let isAlreadyContributor = false;
+            
             for (const issue of issues) {
               if (issue.number === context.issue.number) {
-                continue
+                continue;
               }
-              if (issue.pull_request) {
-                return // creator is already a contributor
+              if (issue.pull_request && issue.user.login === creator) {
+                isAlreadyContributor = true;
+                break;
               }
             }
-            await github.rest.issues.addLabels({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: ['new contributor']
-            })
+            
+            if (!isAlreadyContributor) {
+              await github.rest.issues.addLabels({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: ['new contributor'],
+              });
+            }


### PR DESCRIPTION
update gha workflow to ensure 'new contributor' label isn't removed. this gha wofklow adds a 'new contributor' label to new first time contributors that open a pr.

used [chatgpt](https://chat.openai.com/share/fb8500b8-a672-454d-b599-52ce87ad1e9a) to help corrct gha 