### PR TITLE
align commands for on run start/end

### DIFF
--- a/website/docs/docs/build/hooks-operations.md
+++ b/website/docs/docs/build/hooks-operations.md
@@ -4,6 +4,8 @@ description: "Read this tutorial to learn how to use hooks and operations when b
 id: "hooks-operations"
 ---
 
+import OnRunCommands from '/snippets/_onrunstart-onrunend-commands.md';
+
 ## Related documentation
 * [pre-hook & post-hook](/reference/resource-configs/pre-hook-post-hook)
 * [on-run-start & on-run-end](/reference/project-configs/on-run-start-on-run-end)
@@ -33,8 +35,8 @@ dbt provides hooks and operations so you can version control and execute these s
 Hooks are snippets of SQL that are executed at different times:
   * `pre-hook`: executed _before_ a model, seed or snapshot is built.
   * `post-hook`: executed _after_ a model, seed or snapshot is built.
-  * `on-run-start`: executed at the _start_ of `dbt run`, `dbt test`, `dbt seed` or `dbt snapshot`
-  * `on-run-end`: executed at the _end_ of `dbt run`, `dbt test`, `dbt seed` or `dbt snapshot`
+  * `on-run-start`: executed at the _start_ of <OnRunCommands/>
+  * `on-run-end`: executed at the _end_ of <OnRunCommands/>
 
 Hooks are a more-advanced capability that enable you to run custom SQL, and leverage database-specific actions, beyond what dbt makes available out-of-the-box with standard materializations and configurations.
 

--- a/website/docs/reference/project-configs/on-run-start-on-run-end.md
+++ b/website/docs/reference/project-configs/on-run-start-on-run-end.md
@@ -4,6 +4,8 @@ description: "Read this guide to understand the on-run-start and on-run-end conf
 datatype: sql-statement | [sql-statement]
 ---
 
+import OnRunCommands from '/snippets/_onrunstart-onrunend-commands.md';
+
 <File name='dbt_project.yml'>
 
 ```yml
@@ -15,14 +17,8 @@ on-run-end: sql-statement | [sql-statement]
 
 
 ## Definition
-A SQL statement (or list of SQL statements) to be run at the start, or end, of the following commands:
-- `dbt run`
-- `dbt test`
-- `dbt seed`
-- `dbt snapshot`
-- `dbt build`
-- `dbt compile`
-- `dbt docs generate`
+
+A SQL statement (or list of SQL statements) to be run at the start or end of the following commands: <OnRunCommands />
 
 `on-run-start` and `on-run-end` hooks can also call macros that return SQL statements
 

--- a/website/snippets/_onrunstart-onrunend-commands.md
+++ b/website/snippets/_onrunstart-onrunend-commands.md
@@ -1,0 +1,1 @@
+<code>dbt run</code>, <code>dbt test</code>, <code>dbt seed</code>, <code>dbt snapshot</code>, <code>dbt build</code>, <code>dbt compile</code>, or <code>dbt docs generate</code>.

--- a/website/snippets/_onrunstart-onrunend-commands.md
+++ b/website/snippets/_onrunstart-onrunend-commands.md
@@ -1,1 +1,1 @@
-<code>dbt run</code>, <code>dbt test</code>, <code>dbt seed</code>, <code>dbt snapshot</code>, <code>dbt build</code>, <code>dbt compile</code>, or <code>dbt docs generate</code>.
+<code>dbt build</code>, <code>dbt compile</code>, <code>dbt docs generate</code>, <code>dbt run</code>, <code>dbt seed</code>, <code>dbt snapshot</code>, or <code>dbt test</code>.


### PR DESCRIPTION
per [community slack](https://getdbt.slack.com/archives/C0441GSRU04/p1695989576306639) feedback, this change adds a partial to ensure the two docs that explain which commands should be used for on run start and on run end.