### PR TITLE
Update about-cloud-ide.md

### DIFF
--- a/website/docs/docs/cloud/about-cloud/about-cloud-ide.md
+++ b/website/docs/docs/cloud/about-cloud/about-cloud-ide.md
@@ -5,7 +5,7 @@ description: "about dbt Cloud Integrated Development Environment"
 sidebar_label: About dbt Cloud IDE
 ---
 
-The dbt Cloud integrated development environment (IDE) is a single interface for building, testing, running, and version-controlling dbt projects from your browser. With the Cloud IDE, you can compile dbt code into SQL and run it against your database directly. The IDE leverages the open-source [dbt-rpc](/reference/commands/rpc) plugin to recompile only the changes made in your project.
+The dbt Cloud integrated development environment (IDE) is a single interface for building, testing, running, and version-controlling dbt projects from your browser. With the Cloud IDE, you can compile dbt code into SQL and run it against your database directly.
 
 
 With the Cloud IDE, you can:


### PR DESCRIPTION
## What are you changing in this pull request and why?

The IDE only uses dbt-rpc for dbt-core <1.5, and will not use it in the future, as the `dbt-rpc` package has been deprecated
