### PR TITLE
Update the link for new Discussion

### DIFF
--- a/.github/ISSUE_TEMPLATE/a-improve-docs.yml
+++ b/.github/ISSUE_TEMPLATE/a-improve-docs.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        * You can ask questions or submit ideas for the dbt docs in [Discussions](https://discourse.getdbt.com)
+        * You can ask questions or submit ideas for the dbt docs in [Discussions](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose)
         * Before you file an issue read the [Contributing guide](https://github.com/dbt-labs/docs.getdbt.com#contributing).
         * Check to make sure someone hasn't already opened a similar [issue](https://github.com/dbt-labs/docs.getdbt.com/issues).
 

--- a/.github/ISSUE_TEMPLATE/a-improve-docs.yml
+++ b/.github/ISSUE_TEMPLATE/a-improve-docs.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        * You can ask questions or submit ideas for the dbt docs in [Discussions](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose)
+        * You can ask questions or submit ideas for the dbt docs in [Issues](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose)
         * Before you file an issue read the [Contributing guide](https://github.com/dbt-labs/docs.getdbt.com#contributing).
         * Check to make sure someone hasn't already opened a similar [issue](https://github.com/dbt-labs/docs.getdbt.com/issues).
 

--- a/.github/ISSUE_TEMPLATE/a-improve-docs.yml
+++ b/.github/ISSUE_TEMPLATE/a-improve-docs.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        * You can ask questions or submit ideas for the dbt docs in [Discussions](https://github.com/dbt-labs/docs.getdbt.com/discussions)
+        * You can ask questions or submit ideas for the dbt docs in [Discussions](https://discourse.getdbt.com)
         * Before you file an issue read the [Contributing guide](https://github.com/dbt-labs/docs.getdbt.com#contributing).
         * Check to make sure someone hasn't already opened a similar [issue](https://github.com/dbt-labs/docs.getdbt.com/issues).
 

--- a/.github/ISSUE_TEMPLATE/improve-the-site.yml
+++ b/.github/ISSUE_TEMPLATE/improve-the-site.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        * You can ask questions or submit ideas for the dbt docs in [Discussions](https://discourse.getdbt.com)
+        * You can ask questions or submit ideas for the dbt docs in [Discussions](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose)
         * Before you file an issue read the [Contributing guide](https://github.com/dbt-labs/docs.getdbt.com#contributing).
         * Check to make sure someone hasn't already opened a similar [issue](https://github.com/dbt-labs/docs.getdbt.com/issues).
 

--- a/.github/ISSUE_TEMPLATE/improve-the-site.yml
+++ b/.github/ISSUE_TEMPLATE/improve-the-site.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        * You can ask questions or submit ideas for the dbt docs in [Discussions](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose)
+        * You can ask questions or submit ideas for the dbt docs in [Issues](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose)
         * Before you file an issue read the [Contributing guide](https://github.com/dbt-labs/docs.getdbt.com#contributing).
         * Check to make sure someone hasn't already opened a similar [issue](https://github.com/dbt-labs/docs.getdbt.com/issues).
 

--- a/.github/ISSUE_TEMPLATE/improve-the-site.yml
+++ b/.github/ISSUE_TEMPLATE/improve-the-site.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        * You can ask questions or submit ideas for the dbt docs in [Discussions](https://github.com/dbt-labs/docs.getdbt.com/discussions)
+        * You can ask questions or submit ideas for the dbt docs in [Discussions](https://discourse.getdbt.com)
         * Before you file an issue read the [Contributing guide](https://github.com/dbt-labs/docs.getdbt.com#contributing).
         * Check to make sure someone hasn't already opened a similar [issue](https://github.com/dbt-labs/docs.getdbt.com/issues).
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Creating an inclusive and equitable environment for our documents is more import
 We welcome contributions from community members to this repo:
 - **Fixes**: When you notice an error, you can use the `Edit this page` button at the bottom of each page to suggest a change.
 - **New documentation**: If you contributed code in [dbt-core](https://github.com/dbt-labs/dbt-core), we encourage you to also write the docs here! Please reach out in the dbt community if you need help finding a place for these docs.
-- **Major rewrites**: You can [file an issue](https://github.com/dbt-labs/docs.getdbt.com/issues/new?assignees=&labels=content%2Cimprovement&template=improve-docs.yml) or [start a discussion](https://github.com/dbt-labs/docs.getdbt.com/discussions) to propose ideas for a content area that requires attention.
+- **Major rewrites**: You can [file an issue](https://github.com/dbt-labs/docs.getdbt.com/issues/new?assignees=&labels=content%2Cimprovement&template=improve-docs.yml) or [start a discussion](https://discourse.getdbt.com) to propose ideas for a content area that requires attention.
 
 You can use components documented in the [docusaurus library](https://v2.docusaurus.io/docs/markdown-features/).
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Creating an inclusive and equitable environment for our documents is more import
 We welcome contributions from community members to this repo:
 - **Fixes**: When you notice an error, you can use the `Edit this page` button at the bottom of each page to suggest a change.
 - **New documentation**: If you contributed code in [dbt-core](https://github.com/dbt-labs/dbt-core), we encourage you to also write the docs here! Please reach out in the dbt community if you need help finding a place for these docs.
-- **Major rewrites**: You can [file an issue](https://github.com/dbt-labs/docs.getdbt.com/issues/new?assignees=&labels=content%2Cimprovement&template=improve-docs.yml) or [start a discussion](https://discourse.getdbt.com) to propose ideas for a content area that requires attention.
+- **Major rewrites**: You can [file an issue](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) to propose ideas for a content area that requires attention.
 
 You can use components documented in the [docusaurus library](https://v2.docusaurus.io/docs/markdown-features/).
 

--- a/website/docs/community/resources/oss-expectations.md
+++ b/website/docs/community/resources/oss-expectations.md
@@ -4,7 +4,7 @@ title: "Expectations for OSS contributors"
 
 Whether it's a dbt package, a plugin, `dbt-core`, or this very documentation site, contributing to the open source code that supports the dbt ecosystem is a great way to level yourself up as a developer, and to give back to the community. The goal of this page is to help you understand what to expect when contributing to dbt open source software (OSS). While we can only speak for our own experience as open source maintainers, many of these guidelines apply when contributing to other open source projects, too.
 
-Have you seen things in other OSS projects that you quite like, and think we could learn from? [Open a discussion on the DBT Community Forum](https://discourse.getdbt.com), or start a conversation in the dbt Community Slack (for example: `#community-strategy`, `#dbt-core-development`, `#package-ecosystem`, `#adapter-ecosystem`). We always appreciate hearing from you!
+Have you seen things in other OSS projects that you quite like, and think we could learn from? [Open a discussion on the dbt Community Forum](https://discourse.getdbt.com), or start a conversation in the dbt Community Slack (for example: `#community-strategy`, `#dbt-core-development`, `#package-ecosystem`, `#adapter-ecosystem`). We always appreciate hearing from you!
 
 ## Principles
 

--- a/website/docs/community/resources/oss-expectations.md
+++ b/website/docs/community/resources/oss-expectations.md
@@ -51,7 +51,7 @@ An issue could be a bug you’ve identified while using the product or reading t
 
 ### Best practices for issues
 
-- Issues are **not** for support / troubleshooting / debugging help. Please [open a discussion on the DBT Community Forum](https://discourse.getdbt.com), so other future users can find and read proposed solutions. If you need help formulating your question, you can post in the `#advice-dbt-help` channel in the [dbt Community Slack](https://www.getdbt.com/community/).
+- Issues are **not** for support / troubleshooting / debugging help. Please [open a discussion on the dbt Community Forum](https://discourse.getdbt.com), so other future users can find and read proposed solutions. If you need help formulating your question, you can post in the `#advice-dbt-help` channel in the [dbt Community Slack](https://www.getdbt.com/community/).
 - Always search existing issues first, to see if someone else had the same idea / found the same bug you did.
 - Many repositories offer templates for creating issues, such as when reporting a bug or requesting a new feature. If available, please select the relevant template and fill it out to the best of your ability. This will help other people understand your issue and respond.
 

--- a/website/docs/community/resources/oss-expectations.md
+++ b/website/docs/community/resources/oss-expectations.md
@@ -4,7 +4,7 @@ title: "Expectations for OSS contributors"
 
 Whether it's a dbt package, a plugin, `dbt-core`, or this very documentation site, contributing to the open source code that supports the dbt ecosystem is a great way to level yourself up as a developer, and to give back to the community. The goal of this page is to help you understand what to expect when contributing to dbt open source software (OSS). While we can only speak for our own experience as open source maintainers, many of these guidelines apply when contributing to other open source projects, too.
 
-Have you seen things in other OSS projects that you quite like, and think we could learn from? [Open a discussion on the Developer Hub](https://github.com/dbt-labs/docs.getdbt.com/discussions/new), or start a conversation in the dbt Community Slack (for example: `#community-strategy`, `#dbt-core-development`, `#package-ecosystem`, `#adapter-ecosystem`). We always appreciate hearing from you!
+Have you seen things in other OSS projects that you quite like, and think we could learn from? [Open a discussion on the DBT Community Forum](https://discourse.getdbt.com), or start a conversation in the dbt Community Slack (for example: `#community-strategy`, `#dbt-core-development`, `#package-ecosystem`, `#adapter-ecosystem`). We always appreciate hearing from you!
 
 ## Principles
 
@@ -51,7 +51,7 @@ An issue could be a bug you’ve identified while using the product or reading t
 
 ### Best practices for issues
 
-- Issues are **not** for support / troubleshooting / debugging help. Please [open a discussion on the Developer Hub](https://github.com/dbt-labs/docs.getdbt.com/discussions/new), so other future users can find and read proposed solutions. If you need help formulating your question, you can post in the `#advice-dbt-help` channel in the [dbt Community Slack](https://www.getdbt.com/community/).
+- Issues are **not** for support / troubleshooting / debugging help. Please [open a discussion on the DBT Community Forum](https://discourse.getdbt.com), so other future users can find and read proposed solutions. If you need help formulating your question, you can post in the `#advice-dbt-help` channel in the [dbt Community Slack](https://www.getdbt.com/community/).
 - Always search existing issues first, to see if someone else had the same idea / found the same bug you did.
 - Many repositories offer templates for creating issues, such as when reporting a bug or requesting a new feature. If available, please select the relevant template and fill it out to the best of your ability. This will help other people understand your issue and respond.
 

--- a/website/docs/terms/materialization.md
+++ b/website/docs/terms/materialization.md
@@ -11,7 +11,7 @@ hoverSnippet: The exact Data Definition Language (DDL) that dbt will use when cr
 </head>
 
 :::important This page could use some love
-This term would benefit from additional depth and examples. Have knowledge to contribute? [Create a discussion in the DBT Community Forum](https://discourse.getdbt.com) to begin the process of becoming a glossary contributor!
+This term would benefit from additional depth and examples. Have knowledge to contribute? [Create an issue in the docs.getdbt.com repository](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) to begin the process of becoming a glossary contributor!
 :::
 
 The exact <Term id="ddl">Data Definition Language (DDL)</Term> that dbt will use when creating the model’s equivalent in a <Term id="data-warehouse" />. It's the manner in which the data is represented, and each of those options is defined either canonically (tables, views, incremental), or bespoke. 

--- a/website/docs/terms/materialization.md
+++ b/website/docs/terms/materialization.md
@@ -11,7 +11,7 @@ hoverSnippet: The exact Data Definition Language (DDL) that dbt will use when cr
 </head>
 
 :::important This page could use some love
-This term would benefit from additional depth and examples. Have knowledge to contribute? [Create a discussion in the docs.getdbt.com GitHub repository](https://github.com/dbt-labs/docs.getdbt.com/discussions) to begin the process of becoming a glossary contributor!
+This term would benefit from additional depth and examples. Have knowledge to contribute? [Create a discussion in the DBT Community Forum](https://discourse.getdbt.com) to begin the process of becoming a glossary contributor!
 :::
 
 The exact <Term id="ddl">Data Definition Language (DDL)</Term> that dbt will use when creating the model’s equivalent in a <Term id="data-warehouse" />. It's the manner in which the data is represented, and each of those options is defined either canonically (tables, views, incremental), or bespoke. 

--- a/website/docs/terms/table.md
+++ b/website/docs/terms/table.md
@@ -6,7 +6,7 @@ displayText:  table
 hoverSnippet: In simplest terms, a table is the direct storage of data in rows and columns.  Think excel sheet with raw values in each of the cells.  
 ---
 :::important This page could use some love
-This term would benefit from additional depth and examples. Have knowledge to contribute? [Create a discussion in the docs.getdbt.com GitHub repository](https://github.com/dbt-labs/docs.getdbt.com/discussions) to begin the process of becoming a glossary contributor!
+This term would benefit from additional depth and examples. Have knowledge to contribute? [Create a discussion in the DBT Community Forum](https://discourse.getdbt.com) to begin the process of becoming a glossary contributor!
 :::
 
 In simplest terms, a table is the direct storage of data in rows and columns.  Think excel sheet with raw values in each of the cells.  

--- a/website/docs/terms/table.md
+++ b/website/docs/terms/table.md
@@ -6,7 +6,7 @@ displayText:  table
 hoverSnippet: In simplest terms, a table is the direct storage of data in rows and columns.  Think excel sheet with raw values in each of the cells.  
 ---
 :::important This page could use some love
-This term would benefit from additional depth and examples. Have knowledge to contribute? [Create a discussion in the DBT Community Forum](https://discourse.getdbt.com) to begin the process of becoming a glossary contributor!
+This term would benefit from additional depth and examples. Have knowledge to contribute? [Create an issue in the docs.getdbt.com repository](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) to begin the process of becoming a glossary contributor!
 :::
 
 In simplest terms, a table is the direct storage of data in rows and columns.  Think excel sheet with raw values in each of the cells.  

--- a/website/docs/terms/view.md
+++ b/website/docs/terms/view.md
@@ -6,7 +6,7 @@ displayText: view
 hoverSnippet: A view (as opposed to a table) is a defined passthrough SQL query that can be run against a database (or data warehouse).
 ---
 :::important This page could use some love
-This term would benefit from additional depth and examples. Have knowledge to contribute? [Create a discussion in the docs.getdbt.com GitHub repository](https://github.com/dbt-labs/docs.getdbt.com/discussions) to begin the process of becoming a glossary contributor!
+This term would benefit from additional depth and examples. Have knowledge to contribute? [Create a discussion in the DBT Community Forum](https://discourse.getdbt.com) to begin the process of becoming a glossary contributor!
 :::
 
 A view (as opposed to a <Term id="table" />) is a defined passthrough SQL query that can be run against a database (or <Term id="data-warehouse" />). A view doesn’t store data, like a table does, but it defines the logic that you need to fetch the underlying data.

--- a/website/docs/terms/view.md
+++ b/website/docs/terms/view.md
@@ -6,7 +6,7 @@ displayText: view
 hoverSnippet: A view (as opposed to a table) is a defined passthrough SQL query that can be run against a database (or data warehouse).
 ---
 :::important This page could use some love
-This term would benefit from additional depth and examples. Have knowledge to contribute? [Create a discussion in the DBT Community Forum](https://discourse.getdbt.com) to begin the process of becoming a glossary contributor!
+This term would benefit from additional depth and examples. Have knowledge to contribute? [Create a discussion in the dbt Community Forum](https://discourse.getdbt.com) to begin the process of becoming a glossary contributor!
 :::
 
 A view (as opposed to a <Term id="table" />) is a defined passthrough SQL query that can be run against a database (or <Term id="data-warehouse" />). A view doesn’t store data, like a table does, but it defines the logic that you need to fetch the underlying data.

--- a/website/docs/terms/view.md
+++ b/website/docs/terms/view.md
@@ -6,7 +6,7 @@ displayText: view
 hoverSnippet: A view (as opposed to a table) is a defined passthrough SQL query that can be run against a database (or data warehouse).
 ---
 :::important This page could use some love
-This term would benefit from additional depth and examples. Have knowledge to contribute? [Create a discussion in the dbt Community Forum](https://discourse.getdbt.com) to begin the process of becoming a glossary contributor!
+This term would benefit from additional depth and examples. Have knowledge to contribute? [Create an issue in the docs.getdbt.com repository](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) to begin the process of becoming a glossary contributor!
 :::
 
 A view (as opposed to a <Term id="table" />) is a defined passthrough SQL query that can be run against a database (or <Term id="data-warehouse" />). A view doesn’t store data, like a table does, but it defines the logic that you need to fetch the underlying data.


### PR DESCRIPTION
## What are you changing in this pull request and why?
Based on the discussion here: https://github.com/dbt-labs/docs.getdbt.com/discussions/2553
The discourse will be the new forum where one can discuss new ideas.

This PR replaces the previous [link](https://github.com/dbt-labs/docs.getdbt.com/discussions) to start a new discussion to the [discourse link](https://discourse.getdbt.com/)



