### PR TITLE
`config` for metrics is singular rather than plural

### DIFF
--- a/website/docs/docs/build/metrics-overview.md
+++ b/website/docs/docs/build/metrics-overview.md
@@ -16,7 +16,7 @@ The keys for metrics definitions are:
 | `description` | Provide the description for your metric.   | Optional |
 | `type` | Define the type of metric, which can be `simple`, `ratio`, `cumulative`, or `derived`.  | Required |
 | `type_params` | Additional parameters used to configure metrics. `type_params` are different for each metric type. | Required |
-| `configs` | Provide the specific configurations for your metric.   | Optional |
+| `config` | Provide the specific configurations for your metric.   | Optional |
 | `label` | The display name for your metric. This value will be shown in downstream tools.   | Required |
 | `filter` | You can optionally add a filter string to any metric type, applying filters to dimensions, entities, or time dimensions during metric computation. Consider it as your WHERE clause.   | Optional |
 |  `meta` | Additional metadata you want to add to your metric. | Optional |
@@ -31,7 +31,7 @@ metrics:
     type: the type of the metric          ## Required
     type_params:                          ## Required
       - specific properties for the metric type
-    configs: here for `enabled`           ## Optional
+    config: here for `enabled`            ## Optional
     label: The display name for your metric. This value will be shown in downstream tools. ## Required
     filter: |                             ## Optional            
       {{  Dimension('entity__name') }} > 0 and {{ Dimension(' entity__another name') }} is not


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty-fix-config-key-name-dbt-labs.vercel.app/docs/build/metrics-overview)

## What are you changing in this pull request and why?

The `config` key for metrics is singular rather than plural, so we should change "configs" to "config" in the documentation.

## Checklist
- [ ] I have tested that the code examples work
- [x] I have tested that the changes look correct in the Vercel preview
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.