### PR TITLE
Fix rendering of "Advice" for when to use materialized views

### DIFF
--- a/website/docs/docs/build/materializations.md
+++ b/website/docs/docs/build/materializations.md
@@ -140,8 +140,7 @@ required with incremental materializations
 less configuration options available, see your database platform's docs for more details
   * Materialized views may not be supported by every database platform
 * **Advice:**
-    * Consider materialized views for use cases where incremental models are sufficient, 
-but you would like the data platform to manage the incremental logic and refresh.
+  * Consider materialized views for use cases where incremental models are sufficient, but you would like the data platform to manage the incremental logic and refresh.
 
 ## Python materializations
 


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty-fix-mv-advice-rendering-dbt-labs.vercel.app/docs/build/materializations#materialized-view)

## What are you changing in this pull request and why?

Fix this rendering:
<img width="500" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/5835015a-d50e-419e-8ed4-f688cc72bfe4">

## Checklist
- [x] I have tested that the changes look correct in the Vercel preview
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.