### PR TITLE
Time spine move from dbt-utils to dbt-core

### DIFF
--- a/website/docs/docs/build/metricflow-time-spine.md
+++ b/website/docs/docs/build/metricflow-time-spine.md
@@ -22,7 +22,7 @@ To create this table, you need to create a model in your dbt project called `met
 with days as (
 
     {{
-        dbt_utils.date_spine(
+        dbt_core.date_spine(
             'day',
             "to_date('01/01/2000','mm/dd/yyyy')",
             "to_date('01/01/2027','mm/dd/yyyy')"
@@ -45,7 +45,7 @@ select * from final
 -- BigQuery supports DATE() instead of TO_DATE(). Use this model if you're using BigQuery
 {{config(materialized='table')}}
 with days as (
-    {{dbt_utils.date_spine(
+    {{dbt_core.date_spine(
         'day',
         "DATE(2000,01,01)",
         "DATE(2030,01,01)"

--- a/website/docs/docs/build/metricflow-time-spine.md
+++ b/website/docs/docs/build/metricflow-time-spine.md
@@ -56,7 +56,6 @@ with days as (
 
     {{
         dbt.date_spine(
-        dbt.date_spine(
             'day',
             "to_date('01/01/2000','mm/dd/yyyy')",
             "to_date('01/01/2027','mm/dd/yyyy')"

--- a/website/docs/docs/build/metricflow-time-spine.md
+++ b/website/docs/docs/build/metricflow-time-spine.md
@@ -22,7 +22,7 @@ To create this table, you need to create a model in your dbt project called `met
 with days as (
 
     {{
-        dbt_core.date_spine(
+        dbt.date_spine(
             'day',
             "to_date('01/01/2000','mm/dd/yyyy')",
             "to_date('01/01/2027','mm/dd/yyyy')"
@@ -45,7 +45,7 @@ select * from final
 -- BigQuery supports DATE() instead of TO_DATE(). Use this model if you're using BigQuery
 {{config(materialized='table')}}
 with days as (
-    {{dbt_core.date_spine(
+    {{dbt.date_spine(
         'day',
         "DATE(2000,01,01)",
         "DATE(2030,01,01)"

--- a/website/docs/docs/build/metricflow-time-spine.md
+++ b/website/docs/docs/build/metricflow-time-spine.md
@@ -12,6 +12,8 @@ To create this table, you need to create a model in your dbt project called `met
 
 <File name='metricflow_time_spine.sql'>
 
+<VersionBlock lastVersion="1.6">
+
 ```sql
 {{
     config(
@@ -22,7 +24,7 @@ To create this table, you need to create a model in your dbt project called `met
 with days as (
 
     {{
-        dbt_core.date_spine(
+        dbt_utils.date_spine(
             'day',
             "to_date('01/01/2000','mm/dd/yyyy')",
             "to_date('01/01/2027','mm/dd/yyyy')"
@@ -38,14 +40,50 @@ final as (
 
 select * from final
 ```
+
+</VersionBlock>
+
+<VersionBlock firstVersion="1.7">
+
+```sql
+{{
+    config(
+        materialized = 'table',
+    )
+}}
+
+with days as (
+
+    {{
+        dbt.date_spine(
+            'day',
+            "to_date('01/01/2000','mm/dd/yyyy')",
+            "to_date('01/01/2027','mm/dd/yyyy')"
+        )
+    }}
+
+),
+
+final as (
+    select cast(date_day as date) as date_day
+    from days
+)
+
+select * from final
+```
+
+</VersionBlock>
+
 </File>
+
+<VersionBlock lastVersion="1.6">
 
 ```sql
 -- filename: metricflow_time_spine.sql
 -- BigQuery supports DATE() instead of TO_DATE(). Use this model if you're using BigQuery
 {{config(materialized='table')}}
 with days as (
-    {{dbt_core.date_spine(
+    {{dbt_utils.date_spine(
         'day',
         "DATE(2000,01,01)",
         "DATE(2030,01,01)"
@@ -61,4 +99,33 @@ final as (
 select *
 from final
 ```
+
+</VersionBlock>
+
+<VersionBlock firstVersion="1.7">
+
+```sql
+-- filename: metricflow_time_spine.sql
+-- BigQuery supports DATE() instead of TO_DATE(). Use this model if you're using BigQuery
+{{config(materialized='table')}}
+with days as (
+    {{dbt.date_spine(
+        'day',
+        "DATE(2000,01,01)",
+        "DATE(2030,01,01)"
+    )
+    }}
+),
+
+final as (
+    select cast(date_day as date) as date_day
+    from days
+)
+
+select *
+from final
+```
+
+</VersionBlock>
+
 You only need to include the `date_day` column in the table. MetricFlow can handle broader levels of detail, but it doesn't currently support finer grains.


### PR DESCRIPTION
Previews:
- [1.6](https://docs-getdbt-com-git-time-spine-dbt-labs.vercel.app/docs/build/metricflow-time-spine?version=1.6)
- [1.7](https://docs-getdbt-com-git-time-spine-dbt-labs.vercel.app/docs/build/metricflow-time-spine?version=1.7)

## What are you changing in this pull request and why?

Closes: https://github.com/dbt-labs/docs.getdbt.com/issues/4124

Move time_spine from dbt-utils to dbt-core


Uncomment if you're publishing docs for a prerelease version of dbt (delete if not applicable):
- [x] Add versioning components, as described in [Versioning Docs](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-entire-pages)
- [x] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/guides/migration/versions)

- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [x] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
