### PR TITLE
Adding docs generate to syntax table

### DIFF
--- a/website/docs/reference/node-selection/syntax.md
+++ b/website/docs/reference/node-selection/syntax.md
@@ -14,6 +14,7 @@ dbt's node selection syntax makes it possible to run only specific resources in 
 | [compile](/reference/commands/compile)     | `--select`, `--exclude`, `--selector`, `--inline`                    |
 | [freshness](/reference/commands/source)    | `--select`, `--exclude`, `--selector`                                |
 | [build](/reference/commands/build)         | `--select`, `--exclude`, `--selector`, `--resource-type`, `--defer`  |
+| [docs generate](/reference/commands/cmd-docs) | `--select`                                                        |
 
 :::info Nodes and resources
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

Closes: https://github.com/dbt-labs/docs.getdbt.com/issues/4242

Adding `docs generate` to the syntax table since it now supports `--select`

## Checklist

- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [x] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
