### PR TITLE
Change pypi link from dbt to dbt-core

### DIFF
--- a/website/docs/docs/core/pip-install.md
+++ b/website/docs/docs/core/pip-install.md
@@ -5,7 +5,7 @@ description: "You can use pip to install dbt Core and adapter plugins from the c
 
 You need to use `pip` to install dbt Core on Windows or Linux operating systems. You can use `pip` or [Homebrew](/docs/core/homebrew-install) for installing dbt Core on a MacOS. 
 
-You can install dbt Core and plugins using `pip` because they are Python modules distributed on [PyPI](https://pypi.org/project/dbt/).
+You can install dbt Core and plugins using `pip` because they are Python modules distributed on [PyPI](https://pypi.org/project/dbt-core/).
 
 <FAQ path="Core/install-pip-os-prereqs" />
 <FAQ path="Core/install-python-compatibility" />


### PR DESCRIPTION
## What are you changing in this pull request and why?

This link goes to https://pypi.org/project/dbt/, which seems wrong, and seems to be confusing folks in Slack:
* [thread 1](https://getdbt.slack.com/archives/C50NEBJGG/p1697005271856969)
* [thread 2](https://getdbt.slack.com/archives/CBSQTAPLG/p1697065501782929)

I'm not sure why `dbt` is actively receiving new releases, which probably adds to the confusion, but I think this link should be to the `dbt-core` package regardless. 

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [x] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."