### PR TITLE
Package-lock update to deps

### DIFF
--- a/website/docs/reference/commands/deps.md
+++ b/website/docs/reference/commands/deps.md
@@ -57,3 +57,31 @@ Installing calogica/dbt_date@0.4.0
 Updates available for packages: ['tailsdotcom/dbt_artifacts', 'dbt-labs/snowplow']
 Update your versions in packages.yml, then run dbt deps
 ```
+
+<VersionBlock firstVersion="1.7">
+
+The first time you run `dbt deps`, dbt will generate the `package-lock.yml` file in the _project_root_ where `packages.yml` is recorded, containing all of the resolved packages. Each Subsequent run will record the packages installed in this file. If the subsequent `dbt deps` runs contain no updated packages in `depenedencies.yml` or `packages.yml`, dbt-core will install from `package-lock.yml`. 
+
+When you update the package spec and run `dbt deps` again, the package-lock and package files will be updated accordingly. You can run `dbt deps --lock` to update the `package-lock.yml` with the most recent dependencies from `packages.
+
+The `--add` flag allows you to add a package to the `packages.yml` with configurable `--version` and `--source` information. The `--dry-run` flag, when set to `False`(default) will re-compile the `package-lock.yml` file after a new package is added to the `packages.yml` file. Set it to `True` and the changes will not persist. 
+
+Examples of the `--add` flag:
+```shell
+# add package from hub (--source arg defaults to "hub")
+dbt deps add --package dbt-labs/dbt_utils --version 1.0.0
+
+# add package from hub with semantic version
+dbt deps add --package dbt-labs/snowplow --version ">=0.7.0,<0.8.0"
+
+# add package from git
+dbt deps add --package https://github.com/fivetran/dbt_amplitude --version v0.3.0 --source git 
+
+# add package from local (--version not required for local)
+dbt deps add --package /opt/dbt/redshift --source local
+
+# add package to packages.yml WITHOUT updating package-lock.yml
+dbt deps add --package dbt-labs/dbt_utils --version 1.0.0 --dry-run True
+
+```
+</VersionBlock>

--- a/website/docs/reference/commands/deps.md
+++ b/website/docs/reference/commands/deps.md
@@ -60,11 +60,11 @@ Update your versions in packages.yml, then run dbt deps
 
 <VersionBlock firstVersion="1.7">
 
-The first time you run `dbt deps`, dbt will generate the `package-lock.yml` file in the _project_root_ where `packages.yml` is recorded, containing all of the resolved packages. Each Subsequent run will record the packages installed in this file. If the subsequent `dbt deps` runs contain no updated packages in `depenedencies.yml` or `packages.yml`, dbt-core will install from `package-lock.yml`. 
+dbt generates the `package-lock.yml` file in the _project_root_ where `packages.yml` is recorded, which contains all the resolved packages, the first time you run `dbt deps`. Each subsequent run records the packages installed in this file. If the subsequent `dbt deps` runs contain no updated packages in `depenedencies.yml` or `packages.yml`, dbt-core installs from `package-lock.yml`. 
 
-When you update the package spec and run `dbt deps` again, the package-lock and package files will be updated accordingly. You can run `dbt deps --lock` to update the `package-lock.yml` with the most recent dependencies from `packages.
+When you update the package spec and run `dbt deps` again, the package-lock and package files update accordingly. You can run `dbt deps --lock` to update the `package-lock.yml` with the most recent dependencies from `packages`.
 
-The `--add` flag allows you to add a package to the `packages.yml` with configurable `--version` and `--source` information. The `--dry-run` flag, when set to `False`(default) will re-compile the `package-lock.yml` file after a new package is added to the `packages.yml` file. Set it to `True` and the changes will not persist. 
+The `--add` flag allows you to add a package to the `packages.yml` with configurable `--version` and `--source` information. The `--dry-run` flag, when set to `False`(default), recompiles the `package-lock.yml` file after a new package is added to the `packages.yml` file. Set the flag to `True` for the changes to not persist. 
 
 Examples of the `--add` flag:
 ```shell


### PR DESCRIPTION
## What are you changing in this pull request and why?

Closes: https://github.com/dbt-labs/docs.getdbt.com/issues/4235

Updating `dbt deps` reference page to reflect new package-lock.yml file generated in v1.7 

## Checklist

Uncomment if you're publishing docs for a prerelease version of dbt (delete if not applicable):
- [x] Add versioning components, as described in [Versioning Docs](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-entire-pages)
- [x] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/guides/migration/versions)

- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [x] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
