### PR TITLE
add initial FAQ for BQ OAuth related to Google Drive scope

### DIFF
--- a/website/docs/docs/cloud/manage-access/set-up-bigquery-oauth.md
+++ b/website/docs/docs/cloud/manage-access/set-up-bigquery-oauth.md
@@ -74,3 +74,7 @@ You will then be redirected to BigQuery and asked to approve the drive, cloud pl
 <Lightbox src="/img/docs/dbt-cloud/using-dbt-cloud/dbt-cloud-enterprise/BQ-auth/BQ-access.png" title="BigQuery access request" />
 
 Select **Allow**. This redirects you back to dbt Cloud. You should now be an authenticated BigQuery user, ready to use the dbt Cloud IDE.
+
+## FAQs
+
+<FAQ path="Warehouse/bg-oauth-drive-scope"/>

--- a/website/docs/faqs/Warehouse/bq-oauth-drive-scope.md
+++ b/website/docs/faqs/Warehouse/bq-oauth-drive-scope.md
@@ -5,6 +5,6 @@ sidebar_label: "BigQuery OAuth GDrive Scopes"
 id: bq-oauth-drive-scope
 ---
 
-BigQuery supports external tables over both personal Drive files and shared files. For more information on Drive, see Drive training and help.
+BigQuery supports external tables over both personal Google Drive files and shared files. For more information, refer to [Create Google Drive external tables](https://cloud.google.com/bigquery/docs/external-data-drive).
 
 You can read more about this in the [BigQuery docs](https://cloud.google.com/bigquery/docs/external-data-drive) on this particular topics.

--- a/website/docs/faqs/Warehouse/bq-oauth-drive-scope.md
+++ b/website/docs/faqs/Warehouse/bq-oauth-drive-scope.md
@@ -1,6 +1,6 @@
 ---
 title: Why does the BigQuery OAuth application require scopes to Google Drive
-description: "Use this quick explainer to learn more about scopes in the BigQuery OAuth applicaton"
+description: "Learn more about Google Drive scopes in the BigQuery OAuth application"
 sidebar_label: "BigQuery OAuth GDrive Scopes"
 id: bq-oauth-drive-scope
 ---

--- a/website/docs/faqs/Warehouse/bq-oauth-drive-scope.md
+++ b/website/docs/faqs/Warehouse/bq-oauth-drive-scope.md
@@ -1,7 +1,7 @@
 ---
 title: Why does the BigQuery OAuth application require scopes to Google Drive?
 description: "Learn more about Google Drive scopes in the BigQuery OAuth application"
-sidebar_label: "BigQuery OAuth GDrive Scopes"
+sidebar_label: "BigQuery OAuth Drive Scopes"
 id: bq-oauth-drive-scope
 ---
 

--- a/website/docs/faqs/Warehouse/bq-oauth-drive-scope.md
+++ b/website/docs/faqs/Warehouse/bq-oauth-drive-scope.md
@@ -1,5 +1,5 @@
 ---
-title: Why does the BigQuery OAuth application require scopes to Google Drive
+title: Why does the BigQuery OAuth application require scopes to Google Drive?
 description: "Learn more about Google Drive scopes in the BigQuery OAuth application"
 sidebar_label: "BigQuery OAuth GDrive Scopes"
 id: bq-oauth-drive-scope

--- a/website/docs/faqs/Warehouse/bq-oauth-drive-scope.md
+++ b/website/docs/faqs/Warehouse/bq-oauth-drive-scope.md
@@ -1,0 +1,10 @@
+---
+title: Why does the BigQuery OAuth application require scopes to Google Drive
+description: "Use this quick explainer to learn more about scopes in the BigQuery OAuth applicaton"
+sidebar_label: "BigQuery OAuth GDrive Scopes"
+id: bq-oauth-drive-scope
+---
+
+BigQuery supports external tables over both personal Drive files and shared files. For more information on Drive, see Drive training and help.
+
+You can read more about this in the [BigQuery docs](https://cloud.google.com/bigquery/docs/external-data-drive) on this particular topics.

--- a/website/docs/faqs/Warehouse/bq-oauth-drive-scope.md
+++ b/website/docs/faqs/Warehouse/bq-oauth-drive-scope.md
@@ -6,5 +6,3 @@ id: bq-oauth-drive-scope
 ---
 
 BigQuery supports external tables over both personal Google Drive files and shared files. For more information, refer to [Create Google Drive external tables](https://cloud.google.com/bigquery/docs/external-data-drive).
-
-You can read more about this in the [BigQuery docs](https://cloud.google.com/bigquery/docs/external-data-drive) on this particular topics.


### PR DESCRIPTION
## What are you changing in this pull request and why?
The BigQuery OAuth application requires some scopes to access Google Drive files. This is adding a quick FAQ to the bottom of the page in order to clarify why this is needed as part of the BQ OAuth connection and links to external docs from the Google team.

## Checklist
- [ ] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [ ] Needs a technical review from the adapter team as a second opintion
