### PR TITLE
Hyperlink to relevant docs for log format, log levels, log colorization, and cache population

### DIFF
--- a/website/docs/guides/migration/versions/02-upgrading-to-v1.5.md
+++ b/website/docs/guides/migration/versions/02-upgrading-to-v1.5.md
@@ -148,4 +148,4 @@ Run `dbt --help` to see new & improved help documentation :)
 - The [`version: 2` top-level key](/reference/project-configs/version) is now **optional** in all YAML files. Also, the [`config-version: 2`](/reference/project-configs/config-version) and `version:` top-level keys are now optional in `dbt_project.yml` files.
 - [Events and logging](/reference/events-logging): Added `node_relation` (`database`, `schema`, `identifier`) to the `node_info` dictionary, available on node-specific events
 - Support setting `--project-dir` via environment variable: [`DBT_PROJECT_DIR`](/reference/dbt_project.yml)
-- More granular [configurations](/reference/global-configs/about-global-configs) for logging (to set log format, log levels, and colorization) and cache population
+- More granular configurations for logging (to set [log format](/reference/global-configs/logs#log-formatting), [log levels](/reference/global-configs/logs#log-level), and [colorization](/reference/global-configs/logs#color)) and [cache population](/reference/global-configs/cache#cache-population)


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty-links-to-affected-c-c1ed68-dbt-labs.vercel.app/guides/migration/versions/upgrading-to-v1.5#quick-hits)

## What are you changing in this pull request and why?

Currently, the upgrade docs for 1.5 are pointed at ["About Global Configs"](https://docs.getdbt.com/reference/global-configs/about-global-configs), which is a dead end.

This PR removes the dead-end link and replaces it with four links that are relevant instead.

## 🎩 

<img width="450" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/81a94b22-e257-4383-b233-bc81b321006d">


## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [x] I have verified the preview renders correctly
- [x] I have verified any new links work correctly