### PR TITLE
Update `dbt-cloud` config syntax links for `dbt_project.yml`

### DIFF
--- a/website/docs/reference/dbt_project.yml.md
+++ b/website/docs/reference/dbt_project.yml.md
@@ -11,7 +11,7 @@ By default, dbt will look for `dbt_project.yml` in your current working director
 
 By default, dbt will look for `dbt_project.yml` in your current working directory and its parents, but you can set a different directory using the `--project-dir` flag or the `DBT_PROJECT_DIR` environment variable.
 
-Starting from dbt v1.5 and higher, you can specify your dbt Cloud project ID in the `dbt_project.yml` file using the `dbt-cloud` config, which doesn't require validation or storage in the project config class. To find your project ID, check your dbt Cloud project URL, such as `https://cloud.getdbt.com/11/projects/123456`, where the project ID is `123456`.
+Starting from dbt v1.5 and higher, you can specify your dbt Cloud project ID in the `dbt_project.yml` file using `project-id` under the `dbt-cloud` config. To find your project ID, check your dbt Cloud project URL, such as `https://cloud.getdbt.com/11/projects/123456`, where the project ID is `123456`.
 
 </VersionBlock>
 
@@ -54,8 +54,8 @@ dbt uses YAML in a few different places. If you're new to YAML, it would be wort
 [require-dbt-version](/reference/project-configs/require-dbt-version): version-range | [version-range]
 
 [dbt-cloud](/docs/cloud/cloud-cli-installation):
-  project-id: project_id #Required
-  defer-env-id: 5678 #Optional
+  [project-id](/docs/cloud/configure-cloud-cli#configure-the-dbt-cloud-cli): project_id # Required
+  [defer-env-id](/docs/cloud/about-cloud-develop-defer#defer-in-dbt-cloud-cli): environment_id # Optional
 
 [quoting](/reference/project-configs/quoting):
   database: true | false


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty-dbt-cloud-syntax-dbt-labs.vercel.app/reference/dbt_project.yml)

## What are you changing in this pull request and why?

Provide links to read more details about:
- [project-id](https://docs.getdbt.com/docs/cloud/configure-cloud-cli#configure-the-dbt-cloud-cli) (required)
- [defer-env-id](https://docs.getdbt.com/docs/cloud/about-cloud-develop-defer#defer-in-dbt-cloud-cli) (optional)

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [x] I verified the preview looks correct
- [x] I verified the links in the preview go to the correct places