### PR TITLE
Mark 1.6 under critical support

### DIFF
--- a/website/snippets/core-versions-table.md
+++ b/website/snippets/core-versions-table.md
@@ -3,7 +3,7 @@
 | dbt Core                                                   | Initial Release | Support Level | Critical Support Until  | 
 |------------------------------------------------------------|-----------------|----------------|-------------------------|
 | [**v1.7**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.7)   | Nov 2, 2023     | Active         | Nov 1, 2024            |
-| [**v1.6**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.6)   | Jul 31, 2023    | Active         | Jul 30, 2024            |
+| [**v1.6**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.6)   | Jul 31, 2023    | Critical       | Jul 30, 2024            |
 | [**v1.5**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.5)   | Apr 27, 2023    | Critical       | Apr 27, 2024            | 
 | [**v1.4**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.4)   | Jan 25, 2023    | Critical       | Jan 25, 2024            | 
 | [**v1.3**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.3)   | Oct 12, 2022    | End of Life* ⚠️ | Oct 12, 2023            | 


### PR DESCRIPTION
## What are you changing in this pull request and why?
- Changing 1.6 from Active -> Critical support as of 1.7 GA.
- This is incorrectly marked as active, hence the change.

This is based on the policy from the same page (https://docs.getdbt.com/docs/dbt-versions/core#how-dbt-core-uses-semantic-versioning) :

> Newer minor versions transition the previous minor version into "Critical Support" with limited "security" releases for critical security and installation fixes.

## Checklist
<!--
Uncomment if you're publishing docs for a prerelease version of dbt (delete if not applicable):
- [ ] Add versioning components, as described in [Versioning Docs](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-entire-pages)
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.