### PR TITLE
Update example for disabling a source table

### DIFF
--- a/website/docs/reference/resource-configs/resource-path.md
+++ b/website/docs/reference/resource-configs/resource-path.md
@@ -115,10 +115,10 @@ In the following project, this would only apply to the `payments` model:
             └── payments.sql
 
 ```
-### Apply config source nested in a subfolder 
+### Apply config to a source nested in a subfolder 
 
-To disable a source nested in a YAML file in a subfolder, you will need to supply the path to that YAML file, as well as the source name in the `dbt_project.yml` file.<br /><br /> 
-  The following example shows how to disable a source nested in a YAML file in a subfolder: 
+To disable a source table nested in a YAML file in a subfolder, you will need to supply the subfolder(s) within the path to that YAML file, as well as the source name and the table name in the `dbt_project.yml` file.<br /><br /> 
+  The following example shows how to disable a source table nested in a YAML file in a subfolder: 
 
   <File name='dbt_project.yml'>
 
@@ -126,8 +126,8 @@ To disable a source nested in a YAML file in a subfolder, you will need to suppl
   sources:
     your_project_name:
       subdirectory_name:
-        source_yaml_file_name:
-          source_name:
-            +enabled: false # This will apply to sources nested in subfolders.
+        source_name:
+          source_table_name:
+            +enabled: false
   ```
   </File>

--- a/website/docs/reference/source-configs.md
+++ b/website/docs/reference/source-configs.md
@@ -65,20 +65,20 @@ Sources can be configured via a `config:` block within their `.yml` definitions,
 
 You can disable sources imported from a package to prevent them from rendering in the documentation, or to prevent [source freshness checks](/docs/build/sources#snapshotting-source-data-freshness) from running on source tables imported from packages. 
 
-- **Note**: To disable a source nested in a YAML file in a subfolder, you will need to supply the path to that YAML file plus the source name in the dbt_project.yml file. For example:
+- **Note**: To disable a source table nested in a YAML file in a subfolder, you will need to supply the subfolder(s) within the path to that YAML file, as well as the source name and the table name in the `dbt_project.yml` file.<br /><br /> 
+  The following example shows how to disable a source table nested in a YAML file in a subfolder: 
 
   <File name='dbt_project.yml'>
 
-  ```yml
+  ```yaml
   sources:
     your_project_name:
       subdirectory_name:
-        source_yaml_file_name:
-          source_name:
-            +enabled: false # This will apply to sources nested in subfolders.
+        source_name:
+          source_table_name:
+            +enabled: false
   ```
   </File>
-
 
 
 ### Examples


### PR DESCRIPTION
Previews:
- [resource-path](https://docs-getdbt-com-git-dbeatty-sources-enabled-config-dbt-labs.vercel.app/reference/resource-configs/resource-path#apply-config-to-a-source-nested-in-a-subfolder)
- [source-configs](https://docs-getdbt-com-git-dbeatty-sources-enabled-config-dbt-labs.vercel.app/reference/source-configs#configuring-sources)

## What are you changing in this pull request and why?

Just tested this out and wrote an example [here](https://github.com/dbt-labs/dbt-core/issues/8960#issuecomment-1800667699). Using the learnings to update the docs.

Updated to use the lowest level of granularity (which is a source table).

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [x] I have verified that the preview looks good
- [x] I have verified that the code example works