### PR TITLE
Link to reference/resource-configs/schema#tests

### DIFF
--- a/website/docs/reference/resource-configs/store_failures.md
+++ b/website/docs/reference/resource-configs/store_failures.md
@@ -10,7 +10,7 @@ Optionally set a test to always or never store its failures in the database.
 - If specified as `true` or `false`, the
 `store_failures` config will take precedence over the presence or absence of the `--store-failures` flag.
 - If the `store_failures` config is `none` or omitted, the resource will use the value of the `--store-failures` flag.
-- When true, `store_failures` save all the record(s) that failed the test only if [limit](/reference/resource-configs/limit) is not set or if there are fewer records than the limit. `store_failures` are saved in a new table with the name of the test. By default, `store_failures` use a schema named `dbt_test__audit`, but, you can configure the schema to a different value. 
+- When true, `store_failures` save all the record(s) that failed the test only if [limit](/reference/resource-configs/limit) is not set or if there are fewer records than the limit. `store_failures` are saved in a new table with the name of the test. By default, `store_failures` use a schema named `dbt_test__audit`, but, you can [configure](/reference/resource-configs/schema#tests) the schema to a different value. 
 
 This logic is encoded in the [`should_store_failures()`](https://github.com/dbt-labs/dbt-core/blob/98c015b7754779793e44e056905614296c6e4527/core/dbt/include/global_project/macros/materializations/helpers.sql#L77) macro.
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

Current text reads "you can configure the schema to a different value," alluding to https://docs.getdbt.com/reference/resource-configs/schema#tests, but does not link to it. Adding such a link.

I believe this link will help dbt practitioners find the --store-failures schema configuration, in particular because when you google "--store-failures schema," this page https://docs.getdbt.com/reference/resource-configs/store_failures is the 1st result, but the page you actually want https://docs.getdbt.com/reference/resource-configs/schema#tests does not appear at all, as google hides it "In order to show you the most relevant results, we have omitted some entries very similar to the 100 already displayed." This has been the case since at least 2022.

In the existing text "you can configure the schema to a different value," I added the link to the word "configure." This seemed consistent with other links on this page. However, if you believe a different word should get the link, or a wordier addition should be made such as "For more information, refer to the schema configurations" (with the link going on "schema configurations"), or something similar, please do go ahead and make the adjustment as you see fit, or ask me to do it in a comment.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [x] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."

