### PR TITLE
Small formatting changes for configs & properties

### DIFF
--- a/website/docs/reference/configs-and-properties.md
+++ b/website/docs/reference/configs-and-properties.md
@@ -35,11 +35,11 @@ dbt prioritizes configurations in order of specificity, from most specificity to
 
 Note - Generic tests work a little differently when it comes to specificity. See [test configs](/reference/test-configs).
 
-Within the project file, configurations are also applied hierarchically. The most-specific config always "wins": In the project file, configurations applied to a `marketing` subdirectory will take precedence over configurations applied to the entire `jaffle_shop` project. To apply a configuration to a model, or directory of models, define the resource path as nested dictionary keys.
+Within the project file, configurations are also applied hierarchically. The most specific config always "wins": In the project file, configurations applied to a `marketing` subdirectory will take precedence over configurations applied to the entire `jaffle_shop` project. To apply a configuration to a model, or directory of models, define the resource path as nested dictionary keys.
 
 ### Combining configs
 
-Most configurations are "clobbered" when applied hierarchically. Whenever a more-specific value is available, it will completely replace the less-specific value. Note that a few configs have different merge behavior:
+Most configurations are "clobbered" when applied hierarchically. Whenever a more specific value is available, it will completely replace the less specific value. Note that a few configs have different merge behavior:
 - [`tags`](tags) are additive. If a model has some tags configured in `dbt_project.yml`, and more tags applied in its `.sql` file, the final set of tags will include all of them.
 - [`meta`](/reference/resource-configs/meta) dictionaries are merged (a more specific key-value pair replaces a less specific value with the same key)
 - [`pre-hook` and `post-hook`](/reference/resource-configs/pre-hook-post-hook) are also additive.

--- a/website/docs/reference/configs-and-properties.md
+++ b/website/docs/reference/configs-and-properties.md
@@ -11,7 +11,7 @@ A rule of thumb: properties declare things _about_ your project resources; confi
 
 For example, you can use resource **properties** to:
 * Describe models, snapshots, seed files, and their columns
-- Assert "truths" about a model, in the form of [tests](/docs/build/tests), e.g. "this `id` column is unique"
+* Assert "truths" about a model, in the form of [tests](/docs/build/tests), e.g. "this `id` column is unique"
 * Define pointers to existing tables that contain raw data, in the form of [sources](/docs/build/sources), and assert the expected "freshness" of this raw data
 * Define official downstream uses of your data models, in the form of [exposures](/docs/build/exposures)
 
@@ -67,12 +67,14 @@ Previous versions of the docs referred to these as `schema.yml` files — we've 
 dbt has the ability to define node configs in `.yml` files, in addition to `config()` blocks and `dbt_project.yml`. But the reverse isn't always true: there are some things in `.yml` files that can _only_ be defined there.
 
 Certain properties are special, because:
+
 - They have a unique Jinja rendering context
 - They create new project resources
 - They don't make sense as hierarchical configuration
 - They're older properties that haven't yet been redefined as configs
 
 These properties are:
+
 - [`description`](/reference/resource-properties/description)
 - [`tests`](/reference/resource-properties/tests)
 - [`docs`](/reference/resource-configs/docs)
@@ -202,3 +204,4 @@ Runtime Error
 ```
 
 This error occurred because a semicolon (`;`) was accidentally used instead of a colon (`:`) after the `description` field. To resolve issues like this, find the `.yml` file referenced in the error message and fix any syntax errors present in the file. There are online YAML validators that can be helpful here, but please be mindful of submitting sensitive information to third-party applications!
+

--- a/website/docs/reference/dbt_project.yml.md
+++ b/website/docs/reference/dbt_project.yml.md
@@ -1,5 +1,5 @@
 
-Every [dbt project](/docs/build/projects) needs a `dbt_project.yml` file — this is how dbt knows a directory is a dbt project. It also contains important information that tells dbt how to operate on your project.
+Every [dbt project](/docs/build/projects) needs a `dbt_project.yml` file — this is how dbt knows a directory is a dbt project. It also contains important information that tells dbt how to operate your project.
 
 <VersionBlock lastVersion="1.4">
 
@@ -95,6 +95,7 @@ vars:
 </VersionBlock>
 
 <VersionBlock lastVersion="1.5">
+
 
 <File name='dbt_project.yml'>
 

--- a/website/docs/reference/resource-configs/docs.md
+++ b/website/docs/reference/resource-configs/docs.md
@@ -17,9 +17,11 @@ default_value: {show: true}
     { label: 'Macros', value: 'macros', },
   ]
 }>
+
 <TabItem value="models">
 
 <File name='models/schema.yml'>
+
 
 ```yml
 version: 2
@@ -29,7 +31,6 @@ models:
     docs:
       show: true | false
       node_color: "black"
-
 ```
 
 </File>
@@ -53,9 +54,7 @@ seeds:
   - name: seed_name
     docs:
       show: true | false
-
 ```
-
 </File>
 
 </TabItem>
@@ -71,9 +70,7 @@ snapshots:
   - name: snapshot_name
     docs:
       show: true | false
-
 ```
-
 </File>
 
 </TabItem>
@@ -90,7 +87,6 @@ analyses:
     docs:
       show: true | false
 ```
-
 </File>
 
 </TabItem>
@@ -110,9 +106,7 @@ macros:
   - name: macro_name
     docs:
       show: true | false
-
 ```
-
 </File>
 Also refer to [macro properties](/reference/macro-properties).
 </TabItem>

--- a/website/docs/reference/source-properties.md
+++ b/website/docs/reference/source-properties.md
@@ -1,5 +1,5 @@
 ---
-title: "About source properties"
+title: "Source properties"
 description: "Learn how to use source properties in dbt."
 ---
 
@@ -8,9 +8,13 @@ description: "Learn how to use source properties in dbt."
 - [Declaring resource properties](/reference/configs-and-properties)
 
 ## Overview
-Source properties can be declared in `.yml` files in your `models/` directory (as defined by the [`model-paths` config](/reference/project-configs/model-paths)).
 
-You can name these files `whatever_you_want.yml`, and nest them arbitrarily deeply in subfolders within the `models/` directory.
+import PropsCallout from '/snippets/_config-prop-callout.md';
+
+Source properties can be declared in any `properties.yml` file in your `models/` directory (as defined by the [`model-paths` config](/reference/project-configs/model-paths)). <PropsCallout title={frontMatter.title}/>  <br /> 
+
+
+You can name these files `whatever_you_want.yml`, and nest them arbitrarily deeply in subfolders within the `models/` directory:
 
 <File name='models/<filename>.yml'>
 

--- a/website/docs/reference/source-properties.md
+++ b/website/docs/reference/source-properties.md
@@ -1,5 +1,5 @@
 ---
-title: "About source properties"
+title: "Source properties"
 description: "Learn how to use source properties in dbt."
 ---
 

--- a/website/docs/reference/source-properties.md
+++ b/website/docs/reference/source-properties.md
@@ -1,5 +1,5 @@
 ---
-title: "Source properties"
+title: "About source properties"
 description: "Learn how to use source properties in dbt."
 ---
 
@@ -8,13 +8,9 @@ description: "Learn how to use source properties in dbt."
 - [Declaring resource properties](/reference/configs-and-properties)
 
 ## Overview
+Source properties can be declared in `.yml` files in your `models/` directory (as defined by the [`model-paths` config](/reference/project-configs/model-paths)).
 
-import PropsCallout from '/snippets/_config-prop-callout.md';
-
-Source properties can be declared in any `properties.yml` file in your `models/` directory (as defined by the [`model-paths` config](/reference/project-configs/model-paths)). <PropsCallout title={frontMatter.title}/>  <br /> 
-
-
-You can name these files `whatever_you_want.yml`, and nest them arbitrarily deeply in subfolders within the `models/` directory:
+You can name these files `whatever_you_want.yml`, and nest them arbitrarily deeply in subfolders within the `models/` directory.
 
 <File name='models/<filename>.yml'>
 


### PR DESCRIPTION
### Previews
- [configs-and-properties](https://docs-getdbt-com-git-dbeatty-config-properties-f-871117-dbt-labs.vercel.app/reference/configs-and-properties)
- [dbt_project.yml](https://docs-getdbt-com-git-dbeatty-config-properties-f-871117-dbt-labs.vercel.app/reference/dbt_project.yml)
- [docs](https://docs-getdbt-com-git-dbeatty-config-properties-f-871117-dbt-labs.vercel.app/reference/resource-configs/docs)
- [source-properties](https://docs-getdbt-com-git-dbeatty-config-properties-f-871117-dbt-labs.vercel.app/reference/source-properties)

## What are you changing in this pull request and why?

These are small formatting these found while working on #3989, and @mirnawong1 is the original author.

Merging these changes independently will reduce the diffs in #3989 and make easier to review some of the tricky technical content in that PR.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [x] I have examined each preview to make sure it looks correct