### PR TITLE
Fix rendering of hyperlink

### DIFF
--- a/website/docs/reference/resource-configs/docs.md
+++ b/website/docs/reference/resource-configs/docs.md
@@ -108,7 +108,9 @@ macros:
       show: true | false
 ```
 </File>
+
 Also refer to [macro properties](/reference/macro-properties).
+
 </TabItem>
 
 </Tabs>


### PR DESCRIPTION
### Preview
- Click on the "macros" tab:
    - https://docs-getdbt-com-git-dbeatty-docs-config-fix-link-dbt-labs.vercel.app/reference/resource-configs/docs

## What are you changing in this pull request and why?

This hyperlink isn't rendering correctly:

<img width="500" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/e4e8f7fb-70ef-4e4e-8faf-4354e9c5178d">

### 🎩 

Preview after the fix:

<img width="500" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/62b84d72-4db9-4357-8061-163c76b03233">

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [x] I have checked the preview renders correctly