### PR TITLE
Fixing set up ci forwarder

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -434,7 +434,7 @@
     },
     {
         "source": "/guides/orchestration/set-up-ci/lint-on-push",
-        "destination": " /guides/set-up-ci",
+        "destination": "/guides/set-up-ci",
         "permanent": true
     },
     {


### PR DESCRIPTION
## What are you changing in this pull request and why?

Fixing link so old search goes to an actual page for https://docs.getdbt.com/guides/orchestration/set-up-ci/lint-on-push.

It was forwarding to `https://docs.getdbt.com/%20/guides/set-up-ci` but now forwards correctly to `https://docs.getdbt.com/guides/set-up-ci`

❓ One question for reviewers: Is this forwarded  link helpful? I wavered between directly linking to Step 4 for SQL Fluff and linking to the entire guide. I opted for the guide because it feels less fragile. 