### PR TITLE
Adding package-lock to 1.7 guide

### DIFF
--- a/website/docs/docs/dbt-versions/core-upgrade/00-upgrading-to-v1.7.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/00-upgrading-to-v1.7.md
@@ -32,7 +32,7 @@ This is a relatively small behavior change, but worth calling out in case you no
 - Don't add a `freshness:` block.
 - Explicitly set `freshness: null`
 
-From v1.7 on, when [`dbt deps`](/reference/commands/deps) is run, it will create or update the `package-lock.yml` file in the _project_root_ where `packages.yml` is recorded. The `package-lock.yml` file contains a record of all packages installed and, if subsequent `dbt deps` runs contain no updated packages in `depenedencies.yml` or `packages.yml`, dbt-core installs from `package-lock.yml`. 
+Beginning with v1.7, running [`dbt deps`](/reference/commands/deps) creates or updates the `package-lock.yml` file in the _project_root_ where `packages.yml` is recorded. The `package-lock.yml` file contains a record of all packages installed and, if subsequent `dbt deps` runs contain no updated packages in `depenedencies.yml` or `packages.yml`, dbt-core installs from `package-lock.yml`. 
 
 ## New and changed features and functionality
 

--- a/website/docs/docs/dbt-versions/core-upgrade/00-upgrading-to-v1.7.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/00-upgrading-to-v1.7.md
@@ -32,6 +32,8 @@ This is a relatively small behavior change, but worth calling out in case you no
 - Don't add a `freshness:` block.
 - Explicitly set `freshness: null`
 
+From v1.7 on, when `dbt deps` is run, it will create/update the `package-lock.yml` file in the _project_root_ where `packages.yml` is recorded. The `package-lock.yml` file contains a record of all packages installed and, if subsequent `dbt deps` runs contain no updated packages in `depenedencies.yml` or `packages.yml`, dbt-core installs from `package-lock.yml`. 
+
 ## New and changed features and functionality
 
 - [`dbt docs generate`](/reference/commands/cmd-docs) now supports `--select` to generate [catalog metadata](/reference/artifacts/catalog-json) for a subset of your project. Currently available for Snowflake and Postgres only, but other adapters are coming soon. 

--- a/website/docs/docs/dbt-versions/core-upgrade/00-upgrading-to-v1.7.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/00-upgrading-to-v1.7.md
@@ -32,7 +32,7 @@ This is a relatively small behavior change, but worth calling out in case you no
 - Don't add a `freshness:` block.
 - Explicitly set `freshness: null`
 
-From v1.7 on, when `dbt deps` is run, it will create/update the `package-lock.yml` file in the _project_root_ where `packages.yml` is recorded. The `package-lock.yml` file contains a record of all packages installed and, if subsequent `dbt deps` runs contain no updated packages in `depenedencies.yml` or `packages.yml`, dbt-core installs from `package-lock.yml`. 
+From v1.7 on, when [`dbt deps`](/reference/commands/deps) is run, it will create or update the `package-lock.yml` file in the _project_root_ where `packages.yml` is recorded. The `package-lock.yml` file contains a record of all packages installed and, if subsequent `dbt deps` runs contain no updated packages in `depenedencies.yml` or `packages.yml`, dbt-core installs from `package-lock.yml`. 
 
 ## New and changed features and functionality
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

Adding the package-lock.ynl info to the v1.7 upgrade guide

## Checklist

- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [x] For [docs versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#about-versioning), review how to [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content).
- [x] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
