### PR TITLE
Add cache action to lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,8 +12,16 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: '18.12.0'
+      
+    - name: Cache Node Modules
+      uses: actions/cache@v3
+      id: cache-node-mods
+      with:
+        path: node_modules
+        key: node-modules-cache-v3-${{ hashFiles('package.json', 'package-lock.json') }}
 
     - name: Install Packages
+      if: steps.cache-node-mods.outputs.cache-hit != 'true'
       run: cd website && npm ci
       
     - name: Run ESLint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,8 +17,8 @@ jobs:
       uses: actions/cache@v3
       id: cache-node-mods
       with:
-        path: node_modules
-        key: node-modules-cache-v3-${{ hashFiles('package.json', 'package-lock.json') }}
+        path: website/node_modules
+        key: node-modules-cache-v3-${{ hashFiles('**/package.json', '**/package-lock.json') }}
 
     - name: Install Packages
       if: steps.cache-node-mods.outputs.cache-hit != 'true'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "docs.getdbt.com",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
## What are you changing in this pull request and why?

Adds caching to `lint` workflow to attempt to reduce bandwidth usage in Vercel. This also speeds up the workflow checks for Docs PRs as it no longer needs to wait to install all packages on each run.

Initial run where node mods was cached (Under `Post Cache Node Modules`)
https://github.com/dbt-labs/docs.getdbt.com/actions/runs/6936641309/job/18869155154

2nd run where `lint` workflow detects and uses cache (Under `Cache Node Modules`)
https://github.com/dbt-labs/docs.getdbt.com/actions/runs/6936659386/job/18869211562

Ensure site is not nuked:
https://docs-getdbt-com-git-cache-node-mods-ci-dbt-labs.vercel.app/