### PR TITLE
best-practice-workflows.md - change style guide link to docs.getdbt.com

### DIFF
--- a/website/docs/best-practices/best-practice-workflows.md
+++ b/website/docs/best-practices/best-practice-workflows.md
@@ -24,7 +24,7 @@ SQL styles, field naming conventions, and other rules for your dbt project shoul
 
 :::info Our style guide
 
-We've made our [style guide](/best-practices/how-we-style/0-how-we-style-our-dbt-projects.md) public – these can act as a good starting point for your own style guide.
+We've made our [style guide](/best-practices/how-we-style/0-how-we-style-our-dbt-projects) public – these can act as a good starting point for your own style guide.
 
 :::
 

--- a/website/docs/best-practices/best-practice-workflows.md
+++ b/website/docs/best-practices/best-practice-workflows.md
@@ -24,7 +24,7 @@ SQL styles, field naming conventions, and other rules for your dbt project shoul
 
 :::info Our style guide
 
-We've made our [style guide](https://github.com/dbt-labs/corp/blob/main/dbt_style_guide.md) public – these can act as a good starting point for your own style guide.
+We've made our [style guide](/best-practices/how-we-style/0-how-we-style-our-dbt-projects.md) public – these can act as a good starting point for your own style guide.
 
 :::
 


### PR DESCRIPTION
The GitHub link redirects to the page I have it now pointing to

Mirroring the URL format from other `best-practices` links here
