### PR TITLE
Update install-pip-os-prereqs.md

### DIFF
--- a/website/docs/faqs/Core/install-pip-os-prereqs.md
+++ b/website/docs/faqs/Core/install-pip-os-prereqs.md
@@ -57,7 +57,7 @@ pip install cryptography~=3.4
 
 ```
 
-#### Windows
+### Windows
 
 Windows requires Python and git to successfully install and run dbt Core.
 


### PR DESCRIPTION
"Windows" is no longer a sub-heading of Ubuntu/Debian.

## What are you changing in this pull request and why?
In the pip installation FAQ, "Windows" was previously a sub-heading of "Ubuntu/Debian". I modified the header declaration to put Windows at the same header level as the other operating systems in the FAQ.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [x] For [docs versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#about-versioning), review how to [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content).
- [x] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
