### PR TITLE
Add setting up and loading data steps to prerequisites

### DIFF
--- a/website/docs/guides/manual-install-qs.md
+++ b/website/docs/guides/manual-install-qs.md
@@ -16,7 +16,7 @@ When you use dbt Core to work with dbt, you will be editing files locally using 
 
 * To use dbt Core, it's important that you know some basics of the Terminal. In particular, you should understand `cd`, `ls` and `pwd` to navigate through the directory structure of your computer easily.
 * Install dbt Core using the [installation instructions](/docs/core/installation-overview) for your operating system.
-* Complete appropriate Setting up and Loading data steps in the Quickstart for dbt Cloud series (For BigQuery adapter, for example, complete [Setting up (in BigQuery)](/guides/bigquery?step=2) and [Loading data (BigQuery)](/guides/bigquery?step=3).
+* Complete appropriate Setting up and Loading data steps in the Quickstart for dbt Cloud series. For example, for BigQuery, complete [Setting up (in BigQuery)](/guides/bigquery?step=2) and [Loading data (BigQuery)](/guides/bigquery?step=3).
 * [Create a GitHub account](https://github.com/join) if you don't already have one.
 
 ### Create a starter project

--- a/website/docs/guides/manual-install-qs.md
+++ b/website/docs/guides/manual-install-qs.md
@@ -16,7 +16,7 @@ When you use dbt Core to work with dbt, you will be editing files locally using 
 
 * To use dbt Core, it's important that you know some basics of the Terminal. In particular, you should understand `cd`, `ls` and `pwd` to navigate through the directory structure of your computer easily.
 * Install dbt Core using the [installation instructions](/docs/core/installation-overview) for your operating system.
-* Complete [Setting up (in BigQuery)](/guides/bigquery?step=2) and [Loading data (BigQuery)](/guides/bigquery?step=3).
+* Complete appropriate Setting up and Loading data steps in the Quickstart for dbt Cloud series (For BigQuery adapter, for example, complete [Setting up (in BigQuery)](/guides/bigquery?step=2) and [Loading data (BigQuery)](/guides/bigquery?step=3).
 * [Create a GitHub account](https://github.com/join) if you don't already have one.
 
 ### Create a starter project


### PR DESCRIPTION
Make clear that setting up and loading data steps are required for users using other adapters than BigQuery.

## What are you changing in this pull request and why?
The current documentation is unclear as to Setting up and Loading data steps are required for users using other adapters than BigQuery such as Snowflake. I missed the prerequisite and got stuck in the quickstart guide myself. This pull request is to make clearer above steps are a prerequisite for every dbt adapter.


## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [X] For [docs versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#about-versioning), review how to [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content).
- [X] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
