### PR TITLE
Fix missing end backtick for a config name in a heading

### DIFF
--- a/website/docs/docs/dbt-versions/core-upgrade/11-Older versions/upgrading-to-0-14-0.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/11-Older versions/upgrading-to-0-14-0.md
@@ -189,7 +189,7 @@ models:
 
 </File>
 
-**Configuring the `incremental_strategy for a single model:**
+**Configuring the `incremental_strategy` for a single model:**
 
 <File name='models/my_model.sql'>
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
Found a missing backtick in a heading while reading the various docs for the `incremental_strategy` config.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.