### PR TITLE
Too many backticks

### DIFF
--- a/website/docs/reference/resource-configs/access.md
+++ b/website/docs/reference/resource-configs/access.md
@@ -27,7 +27,7 @@ You can apply access modifiers in config files, including `the dbt_project.yml`,
 
 There are multiple approaches to configuring access:
 
-In the model configs of `dbt_project.yml``: 
+In the model configs of `dbt_project.yml`: 
 
 ```yaml
 models:


### PR DESCRIPTION
## What are you changing in this pull request and why?

There are too many backticks here, so it doesn't render as desired:

<img width="400" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/44a2c66d-7553-4fa9-b4dd-396ba9eaae38">

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.