### PR TITLE
Remove rogue hyperlink

### DIFF
--- a/website/docs/reference/dbt-jinja-functions/config.md
+++ b/website/docs/reference/dbt-jinja-functions/config.md
@@ -25,8 +25,6 @@ is responsible for handling model code that looks like this:
 ```
 
 Review [Model configurations](/reference/model-configs) for examples and more information on valid arguments.
-https://docs.getdbt.com/reference/model-configs
-
 
 ## config.get
 __Args__:


### PR DESCRIPTION
## What are you changing in this pull request and why?

There's a hyperlink [here](https://docs.getdbt.com/reference/dbt-jinja-functions/config) that I'm guessing was unintentional:

<img width="650" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/2d0e7d19-2361-42e4-b225-a9cc941a8058">

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.