### PR TITLE
remove callout

### DIFF
--- a/website/docs/docs/build/join-logic.md
+++ b/website/docs/docs/build/join-logic.md
@@ -84,10 +84,6 @@ mf query --metrics average_purchase_price --dimensions metric_time,user_id__type
 
 ## Multi-hop joins
 
-:::info
-This feature is currently in development and not currently available. 
-:::
-
 MetricFlow allows users to join measures and dimensions across a graph of entities, which we refer to as a 'multi-hop join.' This is because users can move from one table to another like a 'hop' within a graph.
 
 Here's an example schema for reference:
@@ -134,9 +130,6 @@ semantic_models:
 
 ### Query multi-hop joins
 
-:::info 
-This feature is currently in development and not currently available.
-::: 
 
 To query dimensions _without_ a multi-hop join involved, you can use the fully qualified dimension name with the syntax entity double underscore (dunder) dimension, like `entity__dimension`. 
 


### PR DESCRIPTION
multi hop joins are supported now for the SL and MF so this pr removes callout that states multi hop joins aren't supported
