### PR TITLE
Only display intro (rather than entire article) during listing of blog posts

### DIFF
--- a/website/blog/2023-05-02-modeling-ragged-time-varying-hierarchies.md
+++ b/website/blog/2023-05-02-modeling-ragged-time-varying-hierarchies.md
@@ -16,6 +16,8 @@ This article covers an approach to handling time-varying ragged hierarchies in a
 
 To help visualize this data, we're going to pretend we are a company that manufactures and rents out eBikes in a ride share application.  When we build a bike, we keep track of the serial numbers of the components that make up the bike.  Any time something breaks and needs to be replaced, we track the old parts that were removed and the new parts that were installed.  We also precisely track the mileage accumulated on each of our bikes.  Our primary analytical goal is to be able to report on the expected lifetime of each component, so we can prioritize improving that component and reduce costly maintenance.
 
+<!--truncate-->
+
 ## Data model
 
 Obviously, a real bike could have a hundred or more separate components.  To keep things simple for this article, let's just consider the bike, the frame, a wheel, the wheel rim, tire, and tube.  Our component hierarchy looks like:


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/blog)

## What are you changing in this pull request and why?

This article is missing the `<!--truncate-->` we expect to delineate the intro from the rest of the article. The consequence is that the entire article renders in the listing of blog posts [here](https://docs.getdbt.com/blog) (rather than just a preview).

<img width="317" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/32722785-472c-4816-8c08-5431fa1fbf34">


## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.