### PR TITLE
Copy-pastable dbt Cloud CI check commands

### DIFF
--- a/website/docs/best-practices/clone-incremental-models.md
+++ b/website/docs/best-practices/clone-incremental-models.md
@@ -35,7 +35,7 @@ This can be suboptimal because:
 - Typically incremental models are your largest datasets, so they take a long time to build in their entirety which can slow down development time and incur high warehouse costs.
 - There are situations where a `full-refresh` of the incremental model passes successfully in your CI job but an _incremental_ build of that same table in prod would fail when the PR is merged into main (think schema drift where [on_schema_change](/docs/build/incremental-models#what-if-the-columns-of-my-incremental-model-change) config is set to `fail`)
 
-You can alleviate these problems by zero copy cloning the relevant, pre-exisitng incremental models into your PR-specific schema as the first step of the CI job using the `dbt clone` command. This way, the incremental models already exist in the PR-specific schema when you first execute the command `dbt build --select state:modified+` so the `is_incremental` flag will be `true`. 
+You can alleviate these problems by zero copy cloning the relevant, pre-existing incremental models into your PR-specific schema as the first step of the CI job using the `dbt clone` command. This way, the incremental models already exist in the PR-specific schema when you first execute the command `dbt build --select state:modified+` so the `is_incremental` flag will be `true`. 
 
 You'll have two commands for your dbt Cloud CI check to execute:
 1. Clone all of the pre-existing incremental models that have been modified or are downstream of another model that has been modified: `dbt clone --select state:modified+,config.materialized:incremental,state:old`

--- a/website/docs/best-practices/clone-incremental-models.md
+++ b/website/docs/best-practices/clone-incremental-models.md
@@ -44,7 +44,7 @@ You'll have two commands for your dbt Cloud CI check to execute:
   ```
 2. Build all of the models that have been modified and their downstream dependencies:
   ```shell
-  dbt build --select state:modified+`
+  dbt build --select state:modified+
   ```
 
 Because of your first clone step, the incremental models selected in your `dbt build` on the second step will run in incremental mode.

--- a/website/docs/best-practices/clone-incremental-models.md
+++ b/website/docs/best-practices/clone-incremental-models.md
@@ -38,8 +38,14 @@ This can be suboptimal because:
 You can alleviate these problems by zero copy cloning the relevant, pre-existing incremental models into your PR-specific schema as the first step of the CI job using the `dbt clone` command. This way, the incremental models already exist in the PR-specific schema when you first execute the command `dbt build --select state:modified+` so the `is_incremental` flag will be `true`. 
 
 You'll have two commands for your dbt Cloud CI check to execute:
-1. Clone all of the pre-existing incremental models that have been modified or are downstream of another model that has been modified: `dbt clone --select state:modified+,config.materialized:incremental,state:old`
-2. Build all of the models that have been modified and their downstream dependencies: `dbt build --select state:modified+`
+1. Clone all of the pre-existing incremental models that have been modified or are downstream of another model that has been modified:
+  ```shell
+  dbt clone --select state:modified+,config.materialized:incremental,state:old
+  ```
+2. Build all of the models that have been modified and their downstream dependencies:
+  ```shell
+  dbt build --select state:modified+`
+  ```
 
 Because of your first clone step, the incremental models selected in your `dbt build` on the second step will run in incremental mode.
 


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty-copy-pasteable-commands-dbt-labs.vercel.app/best-practices/clone-incremental-models#what-happens-when-one-of-the-modified-models-or-one-of-their-downstream-dependencies-is-an-incremental-model)

## What are you changing in this pull request and why?

The goal is to make these commands copy-pasteable:

<img width="530" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/ad9ad14f-2ff2-4452-86b8-947ba3d73d2c">

Right now, their associated code pieces are displaying like this (which is harder to quickly snag the piece you want):

<img width="650" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/12f838ba-a99e-40ad-b6ac-eb02d3ec189b">

## 🎩

Here's what is looks like with the changes in this PR:

<img width="600" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/bbde49ea-fe5e-46e3-a55b-46af66244393">

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.