### PR TITLE
link to clone in ci job best practices

### DIFF
--- a/website/blog/2023-10-31-to-defer-or-to-clone.md
+++ b/website/blog/2023-10-31-to-defer-or-to-clone.md
@@ -102,7 +102,7 @@ Using the cheat sheet above, let’s explore a few common scenarios and explore 
     
     Therefore, we should use **defer** in this scenario
     
-4. **[Blue/Green Deployments](https://discourse.getdbt.com/t/performing-a-blue-green-deploy-of-your-dbt-project-on-snowflake/1349)**
+3. **[Blue/Green Deployments](https://discourse.getdbt.com/t/performing-a-blue-green-deploy-of-your-dbt-project-on-snowflake/1349)**
 
     In this scenario, we want to:
     1. Ensure that all tests are always passing on the production dataset, even if that dataset is slightly stale

--- a/website/blog/2023-10-31-to-defer-or-to-clone.md
+++ b/website/blog/2023-10-31-to-defer-or-to-clone.md
@@ -87,7 +87,7 @@ Using the cheat sheet above, let’s explore a few common scenarios and explore 
     1. Make a copy of our production dataset available in our downstream BI tool
     2. To safely iterate on this copy without breaking production datasets
     
-    Therefore, we should use **clone** in this scenario
+    Therefore, we should use **clone** in this scenario.
     
 2. **[Slim CI](https://discourse.getdbt.com/t/how-we-sped-up-our-ci-runs-by-10x-using-slim-ci/2603)**
 
@@ -96,13 +96,13 @@ Using the cheat sheet above, let’s explore a few common scenarios and explore 
     2. Only run and test models in the CI staging environment that have changed from the production environment
     3. Reference models from different environments – prod for unchanged models, and staging for modified models
     
-    Therefore, we should use **defer** in this scenario
+    Therefore, we should use **defer** in this scenario.
 
-    :::tip Use `dbt clone` in CI jobs to test incremental models
-   Learn how to [use `dbt clone` in CI jobs](/best-practices/clone-incremental-models) to efficiently test modified incremental models, simulating post-merge behavior while avoiding full-refresh costs.
-   :::
+:::tip Use `dbt clone` in CI jobs to test incremental models
+Learn how to [use `dbt clone` in CI jobs](/best-practices/clone-incremental-models) to efficiently test modified incremental models, simulating post-merge behavior while avoiding full-refresh costs.
+:::
     
-4. **[Blue/Green Deployments](https://discourse.getdbt.com/t/performing-a-blue-green-deploy-of-your-dbt-project-on-snowflake/1349)**
+3. **[Blue/Green Deployments](https://discourse.getdbt.com/t/performing-a-blue-green-deploy-of-your-dbt-project-on-snowflake/1349)**
 
     In this scenario, we want to:
     1. Ensure that all tests are always passing on the production dataset, even if that dataset is slightly stale

--- a/website/blog/2023-10-31-to-defer-or-to-clone.md
+++ b/website/blog/2023-10-31-to-defer-or-to-clone.md
@@ -91,18 +91,18 @@ Using the cheat sheet above, let’s explore a few common scenarios and explore 
     
 2. **[Slim CI](https://discourse.getdbt.com/t/how-we-sped-up-our-ci-runs-by-10x-using-slim-ci/2603)**
 
-   :::tip Use `dbt clone` in CI jobs to test incremental models
-   Learn how to [use `dbt clone` in CI jobs](/best-practices/clone-incremental-models) to efficiently test modified incremental models, simulating post-merge behavior while avoiding full-refresh costs.
-   :::
-
     In this scenario, we want to:
     1. Refer to production models wherever possible to speed up continuous integration (CI) runs
     2. Only run and test models in the CI staging environment that have changed from the production environment
     3. Reference models from different environments – prod for unchanged models, and staging for modified models
     
     Therefore, we should use **defer** in this scenario
+
+    :::tip Use `dbt clone` in CI jobs to test incremental models
+   Learn how to [use `dbt clone` in CI jobs](/best-practices/clone-incremental-models) to efficiently test modified incremental models, simulating post-merge behavior while avoiding full-refresh costs.
+   :::
     
-3. **[Blue/Green Deployments](https://discourse.getdbt.com/t/performing-a-blue-green-deploy-of-your-dbt-project-on-snowflake/1349)**
+4. **[Blue/Green Deployments](https://discourse.getdbt.com/t/performing-a-blue-green-deploy-of-your-dbt-project-on-snowflake/1349)**
 
     In this scenario, we want to:
     1. Ensure that all tests are always passing on the production dataset, even if that dataset is slightly stale

--- a/website/blog/2023-10-31-to-defer-or-to-clone.md
+++ b/website/blog/2023-10-31-to-defer-or-to-clone.md
@@ -91,7 +91,7 @@ Using the cheat sheet above, let’s explore a few common scenarios and explore 
     
 2. **[Slim CI](https://discourse.getdbt.com/t/how-we-sped-up-our-ci-runs-by-10x-using-slim-ci/2603)**
 
-   :::tip Use `dbt clone` in CI jobs
+   :::tip Use `dbt clone` in CI jobs to test incremental models
    Learn how to [use `dbt clone` in CI jobs](/best-practices/clone-incremental-models) to efficiently test modified incremental models, simulating post-merge behavior while avoiding full-refresh costs.
    :::
 

--- a/website/blog/2023-10-31-to-defer-or-to-clone.md
+++ b/website/blog/2023-10-31-to-defer-or-to-clone.md
@@ -91,6 +91,10 @@ Using the cheat sheet above, let’s explore a few common scenarios and explore 
     
 2. **[Slim CI](https://discourse.getdbt.com/t/how-we-sped-up-our-ci-runs-by-10x-using-slim-ci/2603)**
 
+   :::tip Use `dbt clone` in CI jobs
+   Learn how to [use `dbt clone` in CI jobs](/best-practices/clone-incremental-models) to efficiently test modified incremental models, simulating post-merge behavior while avoiding full-refresh costs.
+   :::
+
     In this scenario, we want to:
     1. Refer to production models wherever possible to speed up continuous integration (CI) runs
     2. Only run and test models in the CI staging environment that have changed from the production environment
@@ -98,7 +102,7 @@ Using the cheat sheet above, let’s explore a few common scenarios and explore 
     
     Therefore, we should use **defer** in this scenario
     
-3. **[Blue/Green Deployments](https://discourse.getdbt.com/t/performing-a-blue-green-deploy-of-your-dbt-project-on-snowflake/1349)**
+4. **[Blue/Green Deployments](https://discourse.getdbt.com/t/performing-a-blue-green-deploy-of-your-dbt-project-on-snowflake/1349)**
 
     In this scenario, we want to:
     1. Ensure that all tests are always passing on the production dataset, even if that dataset is slightly stale


### PR DESCRIPTION
this pr adds a link to the clone in a ci job best practices guide as a callout per slack request https://dbt-labs.slack.com/archives/C02NCQ9483C/p1702655617781059
