### PR TITLE
remove dup

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -135,7 +135,6 @@ const sidebarSettings = {
                 "docs/cloud/secure/redshift-privatelink",
                 "docs/cloud/secure/postgres-privatelink",
                 "docs/cloud/secure/vcs-privatelink",
-                "docs/cloud/secure/ip-restrictions",
               ],
             }, // PrivateLink
             "docs/cloud/billing",


### PR DESCRIPTION
'ip restrictions' is showing up twice under 'secure your tenant'. this pr removes the duplicate