### PR TITLE
add missing pages to sidebar

### DIFF
--- a/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-1-intro.md
+++ b/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-1-intro.md
@@ -2,6 +2,8 @@
 title: "Intro to MetricFlow"
 description: Getting started with the dbt and MetricFlow
 hoverSnippet: Learn how to get started with the dbt and MetricFlow
+pagination_next: "docs/best-practices/how-we-build-our-metrics/semantic-layer-2-setup"
+pagination_prev: null
 ---
 
 Flying cars, hoverboards, and true self-service analytics: this is the future we were promised. The first two might still be a few years out, but real self-service analytics is here today. With dbt Cloud's Semantic Layer, you can resolve the tension between accuracy and flexibility that has hampered analytics tools for years, empowering everybody in your organization to explore a shared reality of metrics. Best of all for analytics engineers, building with these new tools will significantly [DRY](https://docs.getdbt.com/terms/dry) up and simplify your codebase. As you'll see, the deep interaction between your dbt models and the Semantic Layer make your dbt project the ideal place to craft your metrics.

--- a/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-1-intro.md
+++ b/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-1-intro.md
@@ -2,7 +2,7 @@
 title: "Intro to MetricFlow"
 description: Getting started with the dbt and MetricFlow
 hoverSnippet: Learn how to get started with the dbt and MetricFlow
-pagination_next: "docs/best-practices/how-we-build-our-metrics/semantic-layer-2-setup"
+pagination_next: "best-practices/how-we-build-our-metrics/semantic-layer-2-setup"
 pagination_prev: null
 ---
 

--- a/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-2-setup.md
+++ b/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-2-setup.md
@@ -28,7 +28,7 @@ Next, before you start writing code, you need to install MetricFlow:
 <TabItem value="core" label="dbt Core">
 
 - Download MetricFlow as an extension of a dbt adapter from PyPI  (dbt Core users only). The MetricFlow is compatible with Python versions 3.8 through 3.11. 
-  - **Note**, you'll need to manage versioning between dbt Core, your adapter, and MetricFlow.
+  - **Note**: You'll need to manage versioning between dbt Core, your adapter, and MetricFlow.
 - We'll use pip to install MetricFlow and our dbt adapter:
 
 ```shell

--- a/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-2-setup.md
+++ b/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-2-setup.md
@@ -2,7 +2,7 @@
 title: "Set up MetricFlow"
 description: Getting started with the dbt and MetricFlow
 hoverSnippet: Learn how to get started with the dbt and MetricFlow
-pagination_next: "docs/best-practices/how-we-build-our-metrics/semantic-layer-3-build-semantic-models"
+pagination_next: "best-practices/how-we-build-our-metrics/semantic-layer-3-build-semantic-models"
 ---
 
 ## Getting started

--- a/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-2-setup.md
+++ b/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-2-setup.md
@@ -50,7 +50,7 @@ python -m pip install "dbt-metricflow[adapter name]"
 git checkout start-here
 ```
 
-For more information, refer to the [MetricFlow commands](/docs/build/metricflow-commands) or a [quickstart guides](/guides) to get more familiar with setting up a dbt project.
+For more information, refer to the [MetricFlow commands](/docs/build/metricflow-commands) or the [quickstart guides](/guides) to get more familiar with setting up a dbt project.
 
 ## Basic commands
 

--- a/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-2-setup.md
+++ b/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-2-setup.md
@@ -2,6 +2,7 @@
 title: "Set up MetricFlow"
 description: Getting started with the dbt and MetricFlow
 hoverSnippet: Learn how to get started with the dbt and MetricFlow
+pagination_next: "docs/best-practices/how-we-build-our-metrics/semantic-layer-3-build-semantic-models"
 ---
 
 ## Getting started

--- a/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-2-setup.md
+++ b/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-2-setup.md
@@ -13,9 +13,23 @@ git clone git@github.com:dbt-labs/jaffle-sl-template.git
 cd path/to/project
 ```
 
-Next, before you start writing code, you need to install MetricFlow as an extension of a dbt adapter from PyPI  (dbt Core users only). The MetricFlow is compatible with Python versions 3.8 through 3.11.
+Next, before you start writing code, you need to install MetricFlow:
 
-We'll use pip to install MetricFlow and our dbt adapter:
+<Tabs>
+
+<TabItem value="cloud" label="dbt Cloud">
+
+- [dbt Cloud CLI](/docs/cloud/cloud-cli-installation) &mdash; MetricFlow commands are embedded in the dbt Cloud CLI. This means you can immediately run them once you install the dbt Cloud CLI. Using dbt Cloud means you won't need to manage versioning — your dbt Cloud account will automatically manage the versioning.
+
+- [dbt Cloud IDE](/docs/cloud/dbt-cloud-ide/develop-in-the-cloud) &mdash; You can create metrics using MetricFlow in the dbt Cloud IDE. However, support for running MetricFlow commands in the IDE will be available soon.
+
+</TabItem>
+
+<TabItem value="core" label="dbt Core">
+
+- Download MetricFlow as an extension of a dbt adapter from PyPI  (dbt Core users only). The MetricFlow is compatible with Python versions 3.8 through 3.11. 
+  - **Note**, you'll need to manage versioning between dbt Core, your adapter, and MetricFlow.
+- We'll use pip to install MetricFlow and our dbt adapter:
 
 ```shell
 # activate a virtual environment for your project,
@@ -27,13 +41,16 @@ python -m pip install "dbt-metricflow[adapter name]"
 # e.g. python -m pip install "dbt-metricflow[snowflake]"
 ```
 
-Lastly, to get to the pre-Semantic Layer starting state, checkout the `start-here` branch.
+</TabItem>
+</Tabs>
+
+- Now that you're ready to use MetricFlow, get to the pre-Semantic Layer starting state by checking out the `start-here` branch:
 
 ```shell
 git checkout start-here
 ```
 
-For more information, refer to the [MetricFlow commands](/docs/build/metricflow-commands) or a [quickstart](/guides) to get more familiar with setting up a dbt project.
+For more information, refer to the [MetricFlow commands](/docs/build/metricflow-commands) or a [quickstart guides](/guides) to get more familiar with setting up a dbt project.
 
 ## Basic commands
 

--- a/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-2-setup.md
+++ b/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-2-setup.md
@@ -19,7 +19,7 @@ Next, before you start writing code, you need to install MetricFlow:
 
 <TabItem value="cloud" label="dbt Cloud">
 
-- [dbt Cloud CLI](/docs/cloud/cloud-cli-installation) &mdash; MetricFlow commands are embedded in the dbt Cloud CLI. This means you can immediately run them once you install the dbt Cloud CLI. Using dbt Cloud means you won't need to manage versioning — your dbt Cloud account will automatically manage the versioning.
+- [dbt Cloud CLI](/docs/cloud/cloud-cli-installation) &mdash; MetricFlow commands are embedded in the dbt Cloud CLI. You can immediately run them once you install the dbt Cloud CLI. Using dbt Cloud means you won't need to manage versioning — your dbt Cloud account will automatically manage the versioning.
 
 - [dbt Cloud IDE](/docs/cloud/dbt-cloud-ide/develop-in-the-cloud) &mdash; You can create metrics using MetricFlow in the dbt Cloud IDE. However, support for running MetricFlow commands in the IDE will be available soon.
 

--- a/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-3-build-semantic-models.md
+++ b/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-3-build-semantic-models.md
@@ -2,7 +2,7 @@
 title: "Building semantic models"
 description: Getting started with the dbt and MetricFlow
 hoverSnippet: Learn how to get started with the dbt and MetricFlow
-pagination_next: "docs/best-practices/how-we-build-our-metrics/semantic-layer-4-build-metrics"
+pagination_next: "best-practices/how-we-build-our-metrics/semantic-layer-4-build-metrics"
 ---
 
 ## How to build a semantic model

--- a/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-3-build-semantic-models.md
+++ b/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-3-build-semantic-models.md
@@ -2,6 +2,7 @@
 title: "Building semantic models"
 description: Getting started with the dbt and MetricFlow
 hoverSnippet: Learn how to get started with the dbt and MetricFlow
+pagination_next: "docs/best-practices/how-we-build-our-metrics/semantic-layer-4-build-metrics"
 ---
 
 ## How to build a semantic model

--- a/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-4-build-metrics.md
+++ b/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-4-build-metrics.md
@@ -2,6 +2,7 @@
 title: "Building metrics"
 description: Getting started with the dbt and MetricFlow
 hoverSnippet: Learn how to get started with the dbt and MetricFlow
+pagination_next: "docs/best-practices/how-we-build-our-metrics/semantic-layer-5-refactor-a-mart"
 ---
 
 ## How to build metrics

--- a/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-4-build-metrics.md
+++ b/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-4-build-metrics.md
@@ -2,7 +2,7 @@
 title: "Building metrics"
 description: Getting started with the dbt and MetricFlow
 hoverSnippet: Learn how to get started with the dbt and MetricFlow
-pagination_next: "docs/best-practices/how-we-build-our-metrics/semantic-layer-5-refactor-a-mart"
+pagination_next: "best-practices/how-we-build-our-metrics/semantic-layer-5-refactor-a-mart"
 ---
 
 ## How to build metrics

--- a/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-5-refactor-a-mart.md
+++ b/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-5-refactor-a-mart.md
@@ -2,7 +2,7 @@
 title: "Refactor an existing mart"
 description: Getting started with the dbt and MetricFlow
 hoverSnippet: Learn how to get started with the dbt and MetricFlow
-pagination_next: "docs/best-practices/how-we-build-our-metrics/semantic-layer-6-advanced-metrics"
+pagination_next: "best-practices/how-we-build-our-metrics/semantic-layer-6-advanced-metrics"
 ---
 
 ## A new approach

--- a/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-5-refactor-a-mart.md
+++ b/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-5-refactor-a-mart.md
@@ -2,6 +2,7 @@
 title: "Refactor an existing mart"
 description: Getting started with the dbt and MetricFlow
 hoverSnippet: Learn how to get started with the dbt and MetricFlow
+pagination_next: "docs/best-practices/how-we-build-our-metrics/semantic-layer-6-advanced-metrics"
 ---
 
 ## A new approach

--- a/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-6-advanced-metrics.md
+++ b/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-6-advanced-metrics.md
@@ -2,6 +2,7 @@
 title: "More advanced metrics"
 description: Getting started with the dbt and MetricFlow
 hoverSnippet: Learn how to get started with the dbt and MetricFlow
+pagination_next: "docs/best-practices/how-we-build-our-metrics/semantic-layer-7-conclusion"
 ---
 
 ## More advanced metric types

--- a/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-6-advanced-metrics.md
+++ b/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-6-advanced-metrics.md
@@ -2,7 +2,7 @@
 title: "More advanced metrics"
 description: Getting started with the dbt and MetricFlow
 hoverSnippet: Learn how to get started with the dbt and MetricFlow
-pagination_next: "docs/best-practices/how-we-build-our-metrics/semantic-layer-7-conclusion"
+pagination_next: "best-practices/how-we-build-our-metrics/semantic-layer-7-conclusion"
 ---
 
 ## More advanced metric types

--- a/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-7-conclusion.md
+++ b/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-7-conclusion.md
@@ -2,6 +2,7 @@
 title: "Best practices"
 description: Getting started with the dbt and MetricFlow
 hoverSnippet: Learn how to get started with the dbt and MetricFlow
+pagination_next: null
 ---
 
 ## Putting it all together

--- a/website/docs/docs/build/metricflow-commands.md
+++ b/website/docs/docs/build/metricflow-commands.md
@@ -17,15 +17,16 @@ MetricFlow is compatible with Python versions 3.8, 3.9, 3.10, and 3.11.
 
 MetricFlow is a dbt package that allows you to define and query metrics in your dbt project. You can use MetricFlow to query metrics in your dbt project in the dbt Cloud CLI, dbt Cloud IDE, or dbt Core.
 
-**Note** &mdash; MetricFlow commands aren't supported in dbt Cloud jobs yet. However, you can add MetricFlow validations with your git provider (such as GitHub Actions) by installing MetricFlow (`python -m pip install metricflow`). This allows you to run MetricFlow commands as part of your continuous integration checks on PRs.
+Using MetricFlow with dbt Cloud means you won't need to manage versioning &mdash; your dbt Cloud account will automatically manage the versioning.
+
+**dbt Cloud jobs** &mdash; MetricFlow commands aren't supported in dbt Cloud jobs yet. However, you can add MetricFlow validations with your git provider (such as GitHub Actions) by installing MetricFlow (`python -m pip install metricflow`). This allows you to run MetricFlow commands as part of your continuous integration checks on PRs.
 
 <Tabs>
 
 <TabItem value="cloudcli" label="dbt Cloud CLI">
 
-MetricFlow commands are embedded in the dbt Cloud CLI, which means you can immediately run them once you install the dbt Cloud CLI. 
-
-A benefit to using the dbt Cloud is that you won't need to manage versioning &mdash; your dbt Cloud account will automatically manage the versioning.
+- MetricFlow commands are embedded in the dbt Cloud CLI. This means you can immediately run them once you install the dbt Cloud CLI and don't need to install MetricFlow separately.
+- You don't need to manage versioning &mdash; your dbt Cloud account will automatically manage the versioning for you.
 
 </TabItem>
 
@@ -35,7 +36,7 @@ A benefit to using the dbt Cloud is that you won't need to manage versioning &md
 You can create metrics using MetricFlow in the dbt Cloud IDE. However, support for running MetricFlow commands in the IDE will be available soon.
 :::
 
-A benefit to using the dbt Cloud is that you won't need to manage versioning &mdash; your dbt Cloud account will automatically manage the versioning.
+
 
 </TabItem>
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -1027,6 +1027,8 @@ const sidebarSettings = {
             id: "best-practices/how-we-build-our-metrics/semantic-layer-1-intro",
           },
           items: [
+            "best-practices/how-we-build-our-metrics/semantic-layer-1-intro",
+            "best-practices/how-we-build-our-metrics/semantic-layer-2-setup",
             "best-practices/how-we-build-our-metrics/semantic-layer-3-build-semantic-models",
             "best-practices/how-we-build-our-metrics/semantic-layer-4-build-metrics",
             "best-practices/how-we-build-our-metrics/semantic-layer-5-refactor-a-mart",


### PR DESCRIPTION
the 'build our metrics' best practices guide is missing two pages in the sidebar. this pr adds the following pages and also makes changes to the 'semantic-layer-2-setup' page to add installation for the cloud cli:

:x: https://docs.getdbt.com/best-practices/how-we-build-our-metrics/semantic-layer-1-intro
:x: https://docs.getdbt.com/best-practices/how-we-build-our-metrics/semantic-layer-2-setup
:white_check_mark: https://docs.getdbt.com/best-practices/how-we-build-our-metrics/semantic-layer-3-build-semantic-models
:white_check_mark: https://docs.getdbt.com/best-practices/how-we-build-our-metrics/semantic-layer-4-build-metrics
:white_check_mark: https://docs.getdbt.com/best-practices/how-we-build-our-metrics/semantic-layer-5-refactor-a-mart
:white_check_mark: https://docs.getdbt.com/best-practices/how-we-build-our-metrics/semantic-layer-6-advanced-metrics
:white_check_mark: https://docs.getdbt.com/best-practices/how-we-build-our-metrics/semantic-layer-7-conclusion

slack thread: https://dbt-labs.slack.com/archives/C02HE19D51R/p1701865290213569