### PR TITLE
Add callout to PrivateLink docs about Environment Variables

### DIFF
--- a/website/docs/docs/cloud/secure/about-privatelink.md
+++ b/website/docs/docs/cloud/secure/about-privatelink.md
@@ -6,10 +6,11 @@ sidebar_label: "About PrivateLink"
 ---
 
 import SetUpPages from '/snippets/_available-tiers-privatelink.md';
+import PrivateLinkHostnameWarning from '/snippets/_privatelink-hostname-restriction.md';
 
 <SetUpPages features={'/snippets/_available-tiers-privatelink.md'}/>
 
-PrivateLink enables a private connection from any dbt Cloud Multi-Tenant environment to your data platform hosted on AWS using [AWS PrivateLink](https://aws.amazon.com/privatelink/) technology. PrivateLink allows dbt Cloud customers to meet security and compliance controls as it allows connectivity between dbt Cloud and your data platform without traversing the public internet. This feature is supported in most regions across NA, Europe, and Asia, but [contact us](https://www.getdbt.com/contact/) if you have questions about availability. 
+PrivateLink enables a private connection from any dbt Cloud Multi-Tenant environment to your data platform hosted on AWS using [AWS PrivateLink](https://aws.amazon.com/privatelink/) technology. PrivateLink allows dbt Cloud customers to meet security and compliance controls as it allows connectivity between dbt Cloud and your data platform without traversing the public internet. This feature is supported in most regions across NA, Europe, and Asia, but [contact us](https://www.getdbt.com/contact/) if you have questions about availability.
 
 ### Cross-region PrivateLink
 
@@ -24,3 +25,5 @@ dbt Cloud supports the following data platforms for use with the PrivateLink fea
 - [Redshift](/docs/cloud/secure/redshift-privatelink)
 - [Postgres](/docs/cloud/secure/postgres-privatelink)
 - [VCS](/docs/cloud/secure/vcs-privatelink)
+
+<PrivateLinkHostnameWarning features={'/snippets/_privatelink-hostname-restriction.md'}/>

--- a/website/snippets/_privatelink-hostname-restriction.md
+++ b/website/snippets/_privatelink-hostname-restriction.md
@@ -1,0 +1,5 @@
+:::caution Environment variables
+
+Using [Environment variables](/docs/build/environment-variables) when configuring PrivateLink endpoints isn't supported in dbt Cloud. Instead, use [Extended Attributes](/docs/deploy/deploy-environments#extended-attributes) to dynamically change these values in your dbt Cloud environment.
+
+:::


### PR DESCRIPTION
## What are you changing in this pull request and why?
<!---
Describe your changes and why you're making them. If related to an open 
issue or a pull request on dbt Core, then link to them here! 

To learn more about the writing conventions used in the dbt Labs docs, see the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md).
-->

This PR adds a callout snippet regarding the limitation in terms of using custom Environment Variables to populate the `hostname` of a PrivateLink endpoint (for the warehouses that support it). This is not supported in dbt Cloud and the suggested workaround is to use Extended Attributes.

Instructions were updated for:
- Databricks
- Redshift
- Postgres

Instructions were _not_ updated for:
- Snowflake
- VCS

[MUL-512](https://dbtlabs.atlassian.net/browse/MUL-512)

![image](https://github.com/dbt-labs/docs.getdbt.com/assets/4997781/69f207e1-e288-405f-a118-69fa4624674c)



## Checklist
<!--
Uncomment when publishing docs for a prerelease version of dbt:
- [ ] Add versioning components, as described in [Versioning Docs](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-entire-pages)
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [x] For [docs versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#about-versioning), review how to [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content).
- [x] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."

[MUL-512]: https://dbtlabs.atlassian.net/browse/MUL-512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ