### PR TITLE
Remove callout from page

### DIFF
--- a/website/docs/docs/core/connect-data-platform/dremio-setup.md
+++ b/website/docs/docs/core/connect-data-platform/dremio-setup.md
@@ -15,12 +15,6 @@ meta:
   config_page: '/reference/resource-configs/no-configs'
 ---
 
-:::info Vendor plugin
-
-Some core functionality may be limited. If you're interested in contributing, check out the source code for each repository listed below.
-
-:::
-
 import SetUpPages from '/snippets/_setup-pages-intro.md';
 
 <SetUpPages meta={frontMatter.meta} />


### PR DESCRIPTION
## What are you changing in this pull request and why?

Remove the callout from the top of this page https://docs.getdbt.com/docs/core/connect-data-platform/dremio-setup

For more context, see [slack convo](https://dbt-labs.slack.com/archives/C02NCQ9483C/p1704307434776619) 

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [x] For [docs versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#about-versioning), review how to [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content).

