### PR TITLE
Fix typo in `append_new_columns` header

### DIFF
--- a/website/docs/reference/resource-configs/vertica-configs.md
+++ b/website/docs/reference/resource-configs/vertica-configs.md
@@ -99,7 +99,7 @@ You can use `on_schema_change` parameter with values `ignore`, `fail` and `appen
 </Tabs>
 
 
-#### Configuring the `apppend_new_columns` parameter
+#### Configuring the `append_new_columns` parameter
 
 
 <Tabs


### PR DESCRIPTION
## What are you changing in this pull request and why?
There's a typo in the [Vertica configurations](https://docs.getdbt.com/reference/resource-configs/vertica-configs) page.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [x] For [docs versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#about-versioning), review how to [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content).
- [x] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."