### PR TITLE
User-defined custom incremental strategies

### DIFF
--- a/website/docs/docs/build/incremental-models.md
+++ b/website/docs/docs/build/incremental-models.md
@@ -450,7 +450,7 @@ The syntax depends on how you configure your `incremental_strategy`:
 
 </VersionBlock>
 
-### Built-in strategies and their corresponding macros
+### Built-in strategies
 
 Before diving into [custom strategies](#custom-strategies), it's important to understand the built-in incremental strategies in dbt and their corresponding macros:
 

--- a/website/docs/docs/build/incremental-models.md
+++ b/website/docs/docs/build/incremental-models.md
@@ -486,6 +486,8 @@ For example, a built-in strategy for the `append` can be defined and used with t
 
 {% endmacro %}
 ```
+</File>
+
 Define a model models/my_model.sql:
 
 ```sql
@@ -570,7 +572,6 @@ To use the `merge_null_safe` custom incremental strategy from the `example` pack
 ```
 
 </File>
-
 </VersionBlock>
 
 <Snippet path="discourse-help-feed-header" />

--- a/website/docs/docs/build/incremental-models.md
+++ b/website/docs/docs/build/incremental-models.md
@@ -557,7 +557,9 @@ For example, a user-defined strategy named `insert_only` can be defined and used
 
 ### Custom strategies from a package
 
-To use the `merge_null_safe` custom incremental strategy from the `example` package, first [install the package](/docs/build/packages#how-do-i-add-a-package-to-my-project), then add this macro to your project:
+To use the `merge_null_safe` custom incremental strategy from the `example` package:
+- [Install the package](/docs/build/packages#how-do-i-add-a-package-to-my-project)
+- Then add the following macro to your project:
 
 <File name='macros/my_custom_strategies.sql'>
 

--- a/website/docs/docs/build/incremental-models.md
+++ b/website/docs/docs/build/incremental-models.md
@@ -462,8 +462,8 @@ Custom incremental strategies can be defined beginning in dbt v1.2.
 
 As an easier alternative to [creating an entirely new materialization](/guides/create-new-materializations), users can define and use their own "custom" user-defined incremental strategies by:
 
-1. defining a macro named `get_incremental_{STRATEGY}_sql`
-2. configuring `incremental_strategy: {STRATEGY}` within an incremental model
+1. defining a macro named `get_incremental_STRATEGY_sql`
+2. configuring `incremental_strategy: STRATEGY` within an incremental model
 
 
 For example, a user-defined strategy named `insert_only` can be defined and used with the following files:

--- a/website/docs/docs/build/incremental-models.md
+++ b/website/docs/docs/build/incremental-models.md
@@ -507,6 +507,16 @@ For example, a user-defined strategy named `insert_only` can be defined and used
 
 </File>
 
+### Custom strategies from a package
+
+To use the `merge_null_safe` custom incremental strategy from the `example` package, first [install the package](/build/packages#how-do-i-add-a-package-to-my-project), then add this macro to your project:
+
+```sql
+{% macro get_incremental_merge_null_safe_sql(arg_dict) %}
+    {% do return(example.get_incremental_merge_null_safe_sql(arg_dict)) %}
+{% endmacro %}
+```
+
 </VersionBlock>
 
 <Snippet path="discourse-help-feed-header" />

--- a/website/docs/docs/build/incremental-models.md
+++ b/website/docs/docs/build/incremental-models.md
@@ -511,11 +511,15 @@ For example, a user-defined strategy named `insert_only` can be defined and used
 
 To use the `merge_null_safe` custom incremental strategy from the `example` package, first [install the package](/build/packages#how-do-i-add-a-package-to-my-project), then add this macro to your project:
 
+<File name='macros/my_custom_strategies.sql'>
+
 ```sql
 {% macro get_incremental_merge_null_safe_sql(arg_dict) %}
     {% do return(example.get_incremental_merge_null_safe_sql(arg_dict)) %}
 {% endmacro %}
 ```
+
+</File>
 
 </VersionBlock>
 

--- a/website/docs/docs/build/incremental-models.md
+++ b/website/docs/docs/build/incremental-models.md
@@ -236,7 +236,7 @@ Instead, whenever the logic of your incremental changes, execute a full-refresh 
 
 ## About `incremental_strategy`
 
-There are various ways (strategies) to implement the concept of an incremental materializations. The value of each strategy depends on:
+There are various ways (strategies) to implement the concept of incremental materializations. The value of each strategy depends on:
 
 * the volume of data,
 * the reliability of your `unique_key`, and
@@ -450,6 +450,53 @@ The syntax depends on how you configure your `incremental_strategy`:
 
 </VersionBlock>
 
+### Built-in strategies and their corresponding macros
+
+Before diving into [custom strategies](#custom-strategies), it's important to understand the built-in incremental strategies in dbt and their corresponding macros:
+
+| `incremental_strategy` | Corresponding macro                    |
+|------------------------|----------------------------------------|
+| `append`               | `get_incremental_append_sql`           |
+| `delete+insert`        | `get_incremental_delete_insert_sql`    |
+| `merge`                | `get_incremental_merge_sql`            |
+| `insert_overwrite`     | `get_incremental_insert_overwrite_sql` |
+
+
+For example, a built-in strategy for the `append` can be defined and used with the following files:
+
+<File name='macros/append.sql'>
+
+```sql
+{% macro get_incremental_append_sql(arg_dict) %}
+
+  {% do return(some_custom_macro_with_sql(arg_dict["target_relation"], arg_dict["temp_relation"], arg_dict["unique_key"], arg_dict["dest_columns"], arg_dict["incremental_predicates"])) %}
+
+{% endmacro %}
+
+
+{% macro some_custom_macro_with_sql(target_relation, temp_relation, unique_key, dest_columns, incremental_predicates) %}
+
+    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute="name")) -%}
+
+    insert into {{ target_relation }} ({{ dest_cols_csv }})
+    (
+        select {{ dest_cols_csv }}
+        from {{ temp_relation }}
+    )
+
+{% endmacro %}
+```
+Define a model models/my_model.sql:
+
+```sql
+{{ config(
+    materialized="incremental",
+    incremental_strategy="append",
+) }}
+
+select * from {{ ref("some_model") }}
+```
+
 ### Custom strategies
 
 <VersionBlock lastVersion="1.1">
@@ -462,9 +509,10 @@ Custom incremental strategies can be defined beginning in dbt v1.2.
 
 As an easier alternative to [creating an entirely new materialization](/guides/create-new-materializations), users can define and use their own "custom" user-defined incremental strategies by:
 
-1. defining a macro named `get_incremental_STRATEGY_sql`
+1. defining a macro named `get_incremental_STRATEGY_sql`. Note that `STRATEGY` is a placeholder and you should replace it with the name of your custom incremental strategy.
 2. configuring `incremental_strategy: STRATEGY` within an incremental model
 
+dbt won't validate user-defined strategies, it will just look for the macro by that name, and raise an error if it can't find one.
 
 For example, a user-defined strategy named `insert_only` can be defined and used with the following files:
 

--- a/website/docs/docs/build/incremental-models.md
+++ b/website/docs/docs/build/incremental-models.md
@@ -509,7 +509,7 @@ For example, a user-defined strategy named `insert_only` can be defined and used
 
 ### Custom strategies from a package
 
-To use the `merge_null_safe` custom incremental strategy from the `example` package, first [install the package](/build/packages#how-do-i-add-a-package-to-my-project), then add this macro to your project:
+To use the `merge_null_safe` custom incremental strategy from the `example` package, first [install the package](/docs/build/packages#how-do-i-add-a-package-to-my-project), then add this macro to your project:
 
 <File name='macros/my_custom_strategies.sql'>
 

--- a/website/docs/docs/build/incremental-models.md
+++ b/website/docs/docs/build/incremental-models.md
@@ -466,6 +466,8 @@ As an easier alternative to [creating an entirely new materialization](/guides/c
 2. configuring `incremental_strategy: {STRATEGY}` within an incremental model
 
 
+For example, a user-defined strategy named `insert_only` can be defined and used with the following files:
+
 <File name='macros/my_custom_strategies.sql'>
 
 ```sql


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty-custom-incremental-d92d96-dbt-labs.vercel.app/docs/build/incremental-models#custom-strategies)

## What are you changing in this pull request and why?

This addresses the "**For end users**" portion of https://github.com/dbt-labs/docs.getdbt.com/issues/1761.

The feature request in https://github.com/dbt-labs/dbt-core/issues/5245 describes the value proposition as well as the previous and new behavior:

#### Functional Requirement
- Advanced users that wish to specify a custom incremental strategy must be able to do so.

#### Previous behavior
- Advanced dbt users who wished to specify a custom incremental strategy must override the same boilerplate Jinja macro by copy pasting it into their dbt project.

#### New behavior
- Advanced dbt users who wish to specify a custom incremental strategy will only need to create a macro that conforms to the naming convention `get_incremental_NAME_sql` that produces the correct SQL for the target warehouse.

## Also

To address the questions raised in https://github.com/dbt-labs/dbt-core/issues/8769, we also want to document how to utilize custom incremental macros that come from a package.

For example, to use the `merge_null_safe` custom incremental strategy from the `example` package, first [install the package](/build/packages#how-do-i-add-a-package-to-my-project), then add this macro to your project:

```sql
{% macro get_incremental_merge_null_safe_sql(arg_dict) %}
    {% do return(example.get_incremental_merge_null_safe_sql(arg_dict)) %}
{% endmacro %}
```

## 🎩 

<img width="503" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/51c3266e-e3fb-49bd-9428-7c43920a5412">

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [x] For [docs versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#about-versioning), review how to [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content).