### PR TITLE
Fix example for saved queries

### DIFF
--- a/website/docs/docs/build/saved-queries.md
+++ b/website/docs/docs/build/saved-queries.md
@@ -20,17 +20,17 @@ The following is an example of a saved query:
 
 ```yaml
 saved_queries:
-  name: p0_booking
-  description: Booking-related metrics that are of the highest priority.
-  query_params:
-    metrics:
-      - bookings
-      - instant_bookings
-    group_by:
-      - TimeDimension('metric_time', 'day')
-      - Dimension('listing__capacity_latest')
-    where:
-      - "{{ Dimension('listing__capacity_latest') }} > 3"
+  - name: p0_booking
+    description: Booking-related metrics that are of the highest priority.
+    query_params:
+      metrics:
+        - bookings
+        - instant_bookings
+      group_by:
+        - TimeDimension('metric_time', 'day')
+        - Dimension('listing__capacity_latest')
+      where:
+        - "{{ Dimension('listing__capacity_latest') }} > 3"
 ```
 
 ### FAQs 


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty-saved-queries-example-dbt-labs.vercel.app/docs/build/saved-queries)

## What are you changing in this pull request and why?

When I tried the example as-is, I got the following error:
```
Parsing Error
  The schema file at models/_properties.yml is invalid because the value of 'saved_queries' is not a list
```

But when I changed it to this, it worked:
```yaml
saved_queries:
  - name: p0_booking
    description: Booking-related metrics that are of the highest priority.
    query_params:
    ...
```

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.