### PR TITLE
adds fill_nulls_with to all metric types

### DIFF
--- a/website/docs/docs/build/conversion-metrics.md
+++ b/website/docs/docs/build/conversion-metrics.md
@@ -33,6 +33,8 @@ The specification for conversion metrics is as follows:
 | `base_property` | The property from the base semantic model that you want to hold constant.  | Entity or Dimension | Optional |
 | `conversion_property` | The property from the conversion semantic model that you want to hold constant.  | Entity or Dimension | Optional |
 
+Refer to [additional settings](#additional-settings) to learn how to customize conversion metrics with settings for null values, calculation type, and constant properties.
+
 The following code example displays the complete specification for conversion metrics and details how they're applied:
 
 ```yaml

--- a/website/docs/docs/build/conversion-metrics.md
+++ b/website/docs/docs/build/conversion-metrics.md
@@ -32,6 +32,7 @@ The specification for conversion metrics is as follows:
 | `constant_properties` | List of constant properties.  | List | Optional |
 | `base_property` | The property from the base semantic model that you want to hold constant.  | Entity or Dimension | Optional |
 | `conversion_property` | The property from the conversion semantic model that you want to hold constant.  | Entity or Dimension | Optional |
+| `fill_nulls_with` | Set the value of a null conversion event to zero instead of null. | String | Optional |
 
 Refer to [additional settings](#additional-settings) to learn how to customize conversion metrics with settings for null values, calculation type, and constant properties.
 
@@ -40,10 +41,11 @@ The following code example displays the complete specification for conversion me
 ```yaml
 metrics:
   - name: The metric name # Required
-    description: the metric description # Optional
+    description: The metric description # Optional
     type: conversion # Required
     label: # Required
     type_params: # Required
+      fills_nulls_with: Set value to zero instead of null # Optional
       conversion_type_params: # Required
         entity: ENTITY # Required
         calculation: CALCULATION_TYPE # Optional. default: conversion_rate. options: conversions(buys) or conversion_rate (buys/visits), and more to come.
@@ -91,6 +93,7 @@ Next, define a conversion metric as follows:
   type: conversion
   label: Visit to Buy Conversion Rate (7-day window)
   type_params:
+    fills_nulls_with: 0
     conversion_type_params:
       base_measure: visits
       conversion_measure: sellers

--- a/website/docs/docs/build/conversion-metrics.md
+++ b/website/docs/docs/build/conversion-metrics.md
@@ -32,7 +32,7 @@ The specification for conversion metrics is as follows:
 | `constant_properties` | List of constant properties.  | List | Optional |
 | `base_property` | The property from the base semantic model that you want to hold constant.  | Entity or Dimension | Optional |
 | `conversion_property` | The property from the conversion semantic model that you want to hold constant.  | Entity or Dimension | Optional |
-| `fill_nulls_with` | Set the value of a null conversion event to zero instead of null. | String | Optional |
+| `fill_nulls_with` | Set the value in your metric definition instead of null (such as zero). | String | Optional |
 
 Refer to [additional settings](#additional-settings) to learn how to customize conversion metrics with settings for null values, calculation type, and constant properties.
 

--- a/website/docs/docs/build/conversion-metrics.md
+++ b/website/docs/docs/build/conversion-metrics.md
@@ -45,7 +45,7 @@ metrics:
     type: conversion # Required
     label: # Required
     type_params: # Required
-      fills_nulls_with: Set value to zero instead of null # Optional
+      fills_nulls_with: Set the value in your metric definition instead of null (such as zero) # Optional
       conversion_type_params: # Required
         entity: ENTITY # Required
         calculation: CALCULATION_TYPE # Optional. default: conversion_rate. options: conversions(buys) or conversion_rate (buys/visits), and more to come.

--- a/website/docs/docs/build/cumulative-metrics.md
+++ b/website/docs/docs/build/cumulative-metrics.md
@@ -31,7 +31,7 @@ metrics:
     type: cumulative # Required
     label: The value that will be displayed in downstream tools # Required
     type_params: # Required
-      fill_nulls_with: Set the value in your metric definition instead of null (such as zero)# Optional
+      fill_nulls_with: Set the value in your metric definition instead of null (such as zero) # Optional
       measure: The measure you are referencing # Required
       window: The accumulation window, such as 1 month, 7 days, 1 year. # Optional. Cannot be used with grain_to_date
       grain_to_date: Sets the accumulation grain, such as month will accumulate data for one month, then restart at the beginning of the next.  # Optional. Cannot be used with window

--- a/website/docs/docs/build/cumulative-metrics.md
+++ b/website/docs/docs/build/cumulative-metrics.md
@@ -31,7 +31,7 @@ metrics:
     type: cumulative # Required
     label: The value that will be displayed in downstream tools # Required
     type_params: # Required
-      fill_nulls_with: Set value to zero instead of null # Optional
+      fill_nulls_with: Set the value in your metric definition instead of null (such as zero)# Optional
       measure: The measure you are referencing # Required
       window: The accumulation window, such as 1 month, 7 days, 1 year. # Optional. Cannot be used with grain_to_date
       grain_to_date: Sets the accumulation grain, such as month will accumulate data for one month, then restart at the beginning of the next.  # Optional. Cannot be used with window

--- a/website/docs/docs/build/cumulative-metrics.md
+++ b/website/docs/docs/build/cumulative-metrics.md
@@ -20,7 +20,7 @@ This metric is common for calculating things like weekly active users, or month-
 | `measure` | The measure you are referencing. | Required |
 | `window` | The accumulation window, such as 1 month, 7 days, 1 year. This can't be used with `grain_to_date`. | Optional  |
 | `grain_to_date` | Sets the accumulation grain, such as month will accumulate data for one month. Then restart at the beginning of the next. This can't be used with `window`. | Optional |
-| `fill_nulls_with` | Set the value to zero instead of null in your metric definition. | Optional |
+| `fill_nulls_with` | Set the value in your metric definition instead of null (such as zero).| Optional |
 
 The following displays the complete specification for cumulative metrics, along with an example:
 

--- a/website/docs/docs/build/cumulative-metrics.md
+++ b/website/docs/docs/build/cumulative-metrics.md
@@ -21,6 +21,8 @@ This metric is common for calculating things like weekly active users, or month-
 | `window` | The accumulation window, such as 1 month, 7 days, 1 year. This can't be used with `grain_to_date`. | Optional  |
 | `grain_to_date` | Sets the accumulation grain, such as month will accumulate data for one month. Then restart at the beginning of the next. This can't be used with `window`. | Optional |
 
+Refer to [additional settings](#additional-settings) to learn how to customize conversion metrics with settings for null values, calculation type, and constant properties.
+
 The following displays the complete specification for cumulative metrics, along with an example:
 
 ```yaml
@@ -244,3 +246,35 @@ group by
   metric_time
 limit 100
 ```
+
+### Additional settings
+
+Use the following additional settings to customize your conversion metrics:
+
+- **Null conversion values:** Set null conversions to zero using `fill_nulls_with`.
+<!-- **Calculation type:** Choose between showing raw conversions or conversion rate.
+- **Constant property:** Add conditions for specific scenarios to join conversions on constant properties.-->
+
+To return zero in the final data set, you can set the value of a null conversion event to zero instead of null. You can add the `fill_nulls_with` parameter to your conversion metric definition like this:
+
+```yaml
+- name: vist_to_buy_conversion_rate_7_day_window
+  description: "Conversion rate from viewing a page to making a purchase"
+  type: conversion
+  label: Visit to Seller Conversion Rate (7 day window)
+  type_params:
+    conversion_type_params:
+      calculation: conversions
+      base_measure: visits
+      conversion_measure: 
+        name: buys
+        fill_nulls_with: 0
+      entity: user
+      window: 7 days 
+
+```
+
+This will return the following results:
+
+<Lightbox src="/img/docs/dbt-cloud/semantic-layer/conversion-metrics-fill-null.png" width="75%" title="Metric with fill nulls with parameter"/>
+

--- a/website/docs/docs/build/derived-metrics.md
+++ b/website/docs/docs/build/derived-metrics.md
@@ -33,7 +33,7 @@ metrics:
     type: derived # Required
     label: The value that will be displayed in downstream tools #Required
     type_params: # Required
-      fill_nulls_with: Set value to zero instead of null # Optional
+      fill_nulls_with: Set the value in your metric definition instead of null (such as zero) # Optional
       expr: the derived expression # Required
       metrics: # The list of metrics used in the derived metrics # Required
         - name: the name of the metrics. must reference a metric you have already defined # Required

--- a/website/docs/docs/build/derived-metrics.md
+++ b/website/docs/docs/build/derived-metrics.md
@@ -21,7 +21,7 @@ In MetricFlow, derived metrics are metrics created by defining an expression usi
 | `metrics` |  The list of metrics used in the derived metrics. | Required  |
 | `alias` | Optional alias for the metric that you can use in the expr. | Optional |
 | `filter` | Optional filter to apply to the metric. | Optional |
-| `fill_nulls_with` | Set the value to zero instead of null in your metric definition. | Optional |
+| `fill_nulls_with` | Set the value in your metric definition instead of null (such as zero). | Optional |
 | `offset_window` | Set the period for the offset window, such as 1 month. This will return the value of the metric one month from the metric time.  | Optional |
 
 The following displays the complete specification for derived metrics, along with an example.

--- a/website/docs/docs/build/derived-metrics.md
+++ b/website/docs/docs/build/derived-metrics.md
@@ -23,6 +23,8 @@ In MetricFlow, derived metrics are metrics created by defining an expression usi
 | `filter` | Optional filter to apply to the metric. | Optional |
 | `offset_window` | Set the period for the offset window, such as 1 month. This will return the value of the metric one month from the metric time.  | Required |
 
+Refer to [additional settings](#additional-settings) to learn how to customize conversion metrics with settings for null values, calculation type, and constant properties.
+
 The following displays the complete specification for derived metrics, along with an example.
 
 ```yaml
@@ -157,3 +159,35 @@ bookings - bookings_7_days_ago would be compile as 7438 - 7252 = 186.
 | d7_booking_change | metric_time__month |
 | ----------------- | ------------------ |
 | 186 | 2017-07-01 |
+
+
+### Additional settings
+
+Use the following additional settings to customize your conversion metrics:
+
+- **Null conversion values:** Set null conversions to zero using `fill_nulls_with`.
+<!-- **Calculation type:** Choose between showing raw conversions or conversion rate.
+- **Constant property:** Add conditions for specific scenarios to join conversions on constant properties.-->
+
+To return zero in the final data set, you can set the value of a null conversion event to zero instead of null. You can add the `fill_nulls_with` parameter to your conversion metric definition like this:
+
+```yaml
+- name: vist_to_buy_conversion_rate_7_day_window
+  description: "Conversion rate from viewing a page to making a purchase"
+  type: conversion
+  label: Visit to Seller Conversion Rate (7 day window)
+  type_params:
+    conversion_type_params:
+      calculation: conversions
+      base_measure: visits
+      conversion_measure: 
+        name: buys
+        fill_nulls_with: 0
+      entity: user
+      window: 7 days 
+
+```
+
+This will return the following results:
+
+<Lightbox src="/img/docs/dbt-cloud/semantic-layer/conversion-metrics-fill-null.png" width="75%" title="Metric with fill nulls with parameter"/>

--- a/website/docs/docs/build/metrics-overview.md
+++ b/website/docs/docs/build/metrics-overview.md
@@ -51,7 +51,7 @@ metrics:
     type: conversion # Required
     label: # Required
     type_params: # Required
-      fills_nulls_with: Set value to zero instead of null # Optional
+      fills_nulls_with: Set the value in your metric definition instead of null (such as zero) # Optional
       conversion_type_params: # Required
         entity: ENTITY # Required
         calculation: CALCULATION_TYPE # Optional. default: conversion_rate. options: conversions(buys) or conversion_rate (buys/visits), and more to come.

--- a/website/docs/docs/build/metrics-overview.md
+++ b/website/docs/docs/build/metrics-overview.md
@@ -9,7 +9,7 @@ pagination_next: "docs/build/cumulative"
   
 Once you've created your semantic models, it's time to start adding metrics! Metrics can be defined in the same YAML files as your semantic models, or split into separate YAML files into any other subdirectories (provided that these subdirectories are also within the same dbt project repo)
 
-The keys for metrics definitions are: 
+The keys for metrics definitions are:
 
 | Parameter | Description | Type |
 | --------- | ----------- | ---- |
@@ -21,7 +21,6 @@ The keys for metrics definitions are:
 | `label` | The display name for your metric. This value will be shown in downstream tools.   | Required |
 | `filter` | You can optionally add a filter string to any metric type, applying filters to dimensions, entities, or time dimensions during metric computation. Consider it as your WHERE clause.   | Optional |
 |  `meta` | Additional metadata you want to add to your metric. | Optional |
-
 
 Here's a complete example of the metrics spec configuration:
 
@@ -39,14 +38,7 @@ metrics:
       null
 ```
 
-This page explains the different supported metric types you can add to your dbt project. 
-<!--
-- [Cumulative](#cumulative-metrics) — Cumulative metrics aggregate a measure over a given window.
-- [Derived](#derived-metrics) — An expression of other metrics, which allows you to do calculations on top of metrics.
-- [Expression](#expression-metrics) — Allow measures to be modified using a SQL expression.
-- [Measure proxy](#measure-proxy-metrics) — Metrics that refer directly to one measure.
-- [Ratio](#ratio-metrics) — Create a ratio out of two measures. 
--->
+This page explains the different supported metric types you can add to your dbt project.
 
 ### Conversion metrics <Lifecycle status='new'/>
 
@@ -55,10 +47,11 @@ This page explains the different supported metric types you can add to your dbt 
 ```yaml
 metrics:
   - name: The metric name # Required
-    description: the metric description # Optional
+    description: The metric description # Optional
     type: conversion # Required
     label: # Required
     type_params: # Required
+      fills_nulls_with: Set value to zero instead of null # Optional
       conversion_type_params: # Required
         entity: ENTITY # Required
         calculation: CALCULATION_TYPE # Optional. default: conversion_rate. options: conversions(buys) or conversion_rate (buys/visits), and more to come.
@@ -82,9 +75,10 @@ metrics:
       - support@getdbt.com
     type: cumulative
     type_params:
+      fills_nulls_with: 0
       measures:
         - distinct_users
-    #Omitting window will accumulate the measure over all time
+    # Omitting window will accumulate the measure over all time
       window: 7 days
       
 ```
@@ -100,6 +94,7 @@ metrics:
     type: derived
     label: Order Gross Profit
     type_params:
+      fills_nulls_with: 0
       expr: revenue - cost
       metrics:
         - name: order_total
@@ -139,6 +134,7 @@ metrics:
 # Define the metrics from the semantic manifest as numerator or denominator
     type: ratio
     type_params:
+      fills_nulls_with: 0
       numerator: cancellations
       denominator: transaction_amount
       filter: |     # add optional constraint string. This applies to both the numerator and denominator
@@ -157,6 +153,7 @@ metrics:
       filter: |   #  add optional constraint string. This applies to both the numerator and denominator
         {{ Dimension('customer__country') }} = 'MX'  
 ```
+
 ### Simple metrics
 
 [Simple metrics](/docs/build/simple) point directly to a measure. You may think of it as a function that takes only one measure as the input.
@@ -171,6 +168,7 @@ metrics:
   - name: cancellations
     type: simple
     type_params:
+      fills_nulls_with: 0
       measure: cancellations_usd  # Specify the measure you are creating a proxy for.
     filter: |
       {{ Dimension('order__value')}} > 100 and {{Dimension('user__acquisition')}}
@@ -187,6 +185,7 @@ filter: |
 filter: |
   {{ TimeDimension('time_dimension', 'granularity') }}
 ```
+
 ### Further configuration 
 
 You can set more metadata for your metrics, which can be used by other tools later on. The way this metadata is used will vary based on the specific integration partner

--- a/website/docs/docs/build/ratio-metrics.md
+++ b/website/docs/docs/build/ratio-metrics.md
@@ -21,8 +21,7 @@ Ratio allows you to create a ratio between two metrics. You simply specify a num
 | `denominator` |  The name of the metric used for the denominator, or structure of properties. | Required  |
 | `filter` | Optional filter for the numerator or denominator. | Optional |
 | `alias` | Optional alias for the numerator or denominator. | Optional |
-
-Refer to [additional settings](#additional-settings) to learn how to customize conversion metrics with settings for null values, calculation type, and constant properties.
+| `fill_nulls_with` | Set the value to zero instead of null in your metric definition. | Optional |
 
 The following displays the complete specification for ratio metrics, along with an example.
 
@@ -33,6 +32,7 @@ metrics:
     type: ratio # Required
     label: The value that will be displayed in downstream tools #Required
     type_params: # Required
+      fill_nulls_with: Value to zero instead of null # Optional
       numerator: The name of the metric used for the numerator, or structure of properties # Required
         name: Name of metric used for the numerator # Required
         filter: Filter for the numerator # Optional
@@ -52,6 +52,7 @@ metrics:
     label: Food Order Ratio
     type: ratio
     type_params: 
+      fill_nulls_with: 0
       numerator: food_orders
       denominator: orders
 ```
@@ -117,6 +118,7 @@ metrics:
       - support@getdbt.com
     type: ratio
     type_params:
+      fill_nulls_with: 0
       numerator:
         name: distinct_purchasers
         filter: |
@@ -126,35 +128,7 @@ metrics:
         name: distinct_purchasers
 ```
 
-Note the `filter` and `alias` parameters for the metric referenced in the numerator. Use the `filter` parameter to apply a filter to the metric it's attached to. The `alias` parameter is used to avoid naming conflicts in the rendered SQL queries when the same metric is used with different filters. If there are no naming conflicts, the `alias` parameter can be left out.
-
-### Additional settings
-
-Use the following additional settings to customize your conversion metrics:
-
-- **Null conversion values:** Set null conversions to zero using `fill_nulls_with`.
-
-<!-- **Calculation type:** Choose between showing raw conversions or conversion rate.
-- **Constant property:** Add conditions for specific scenarios to join conversions on constant properties.-->
-
-To return zero in the final data set, you can set the value of a null conversion event to zero instead of null. You can add the `fill_nulls_with` parameter to your conversion metric definition like this:
-
-```yaml
-- name: vist_to_buy_conversion_rate_7_day_window
-  description: "Conversion rate from viewing a page to making a purchase"
-  type: conversion
-  label: Visit to Seller Conversion Rate (7 day window)
-  type_params:
-    conversion_type_params:
-      calculation: conversions
-      base_measure: visits
-      conversion_measure: 
-        name: buys
-        fill_nulls_with: 0
-      entity: user
-      window: 7 days 
-```
-
-This will return the following results:
-
-<Lightbox src="/img/docs/dbt-cloud/semantic-layer/conversion-metrics-fill-null.png" width="75%" title="Metric with fill nulls with parameter"/>
+Note the `filter` and `alias` parameters for the metric referenced in the numerator. 
+- Use the `filter` parameter to apply a filter to the metric it's attached to. 
+- The `alias` parameter is used to avoid naming conflicts in the rendered SQL queries when the same metric is used with different filters. 
+- If there are no naming conflicts, the `alias` parameter can be left out.

--- a/website/docs/docs/build/ratio-metrics.md
+++ b/website/docs/docs/build/ratio-metrics.md
@@ -21,7 +21,7 @@ Ratio allows you to create a ratio between two metrics. You simply specify a num
 | `denominator` |  The name of the metric used for the denominator, or structure of properties. | Required  |
 | `filter` | Optional filter for the numerator or denominator. | Optional |
 | `alias` | Optional alias for the numerator or denominator. | Optional |
-| `fill_nulls_with` | Set the value to zero instead of null in your metric definition. | Optional |
+| `fill_nulls_with` | Set the value in your metric definition instead of null (such as zero). | Optional |
 
 The following displays the complete specification for ratio metrics, along with an example.
 

--- a/website/docs/docs/build/ratio-metrics.md
+++ b/website/docs/docs/build/ratio-metrics.md
@@ -32,7 +32,7 @@ metrics:
     type: ratio # Required
     label: The value that will be displayed in downstream tools #Required
     type_params: # Required
-      fill_nulls_with: Value to zero instead of null # Optional
+      fill_nulls_with: Set value instead of null (such as zero)  # Optional
       numerator: The name of the metric used for the numerator, or structure of properties # Required
         name: Name of metric used for the numerator # Required
         filter: Filter for the numerator # Optional

--- a/website/docs/docs/build/ratio-metrics.md
+++ b/website/docs/docs/build/ratio-metrics.md
@@ -54,8 +54,8 @@ metrics:
     type_params: 
       numerator: food_orders
       denominator: orders
-  
 ```
+
 ## Ratio metrics using different semantic models
 
 The system will simplify and turn the numerator and denominator in a ratio metric from different semantic models by computing their values in sub-queries. It will then join the result set based on common dimensions to calculate the final ratio. Here's an example of the SQL generated for such a ratio metric.
@@ -133,6 +133,7 @@ Note the `filter` and `alias` parameters for the metric referenced in the numera
 Use the following additional settings to customize your conversion metrics:
 
 - **Null conversion values:** Set null conversions to zero using `fill_nulls_with`.
+
 <!-- **Calculation type:** Choose between showing raw conversions or conversion rate.
 - **Constant property:** Add conditions for specific scenarios to join conversions on constant properties.-->
 
@@ -152,7 +153,6 @@ To return zero in the final data set, you can set the value of a null conversion
         fill_nulls_with: 0
       entity: user
       window: 7 days 
-
 ```
 
 This will return the following results:

--- a/website/docs/docs/build/simple.md
+++ b/website/docs/docs/build/simple.md
@@ -68,6 +68,7 @@ If you've already defined the measure using the `create_metric: true` parameter,
 Use the following additional settings to customize your conversion metrics:
 
 - **Null conversion values:** Set null conversions to zero using `fill_nulls_with`.
+
 <!-- **Calculation type:** Choose between showing raw conversions or conversion rate.
 - **Constant property:** Add conditions for specific scenarios to join conversions on constant properties.-->
 
@@ -87,7 +88,6 @@ To return zero in the final data set, you can set the value of a null conversion
         fill_nulls_with: 0
       entity: user
       window: 7 days 
-
 ```
 
 This will return the following results:

--- a/website/docs/docs/build/simple.md
+++ b/website/docs/docs/build/simple.md
@@ -20,6 +20,8 @@ Simple metrics are metrics that directly reference a single measure, without any
 | `type_params` | The type parameters of the metric. | Required |
 | `measure` | The measure you're referencing. | Required |
 
+Refer to [additional settings](#additional-settings) to learn how to customize conversion metrics with settings for null values, calculation type, and constant properties.
+
 The following displays the complete specification for simple metrics, along with an example.
 
 
@@ -28,7 +30,7 @@ metrics:
   - name: The metric name # Required
     description: the metric description # Optional
     type: simple # Required
-    label: The value that will be displayed in downstream tools #Required
+    label: The value that will be displayed in downstream tools # Required
     type_params: # Required
       measure: The measure you're referencing # Required
 
@@ -50,7 +52,7 @@ If you've already defined the measure using the `create_metric: true` parameter,
       type: simple # Pointers to a measure you created in a semantic model
       label: Count of customers
       type_params:
-        measure: customers # The measure youre creating a proxy of.
+        measure: customers # The measure you're creating a proxy of.
     - name: large_orders
       description: "Order with order values over 20."
       type: SIMPLE
@@ -60,3 +62,34 @@ If you've already defined the measure using the `create_metric: true` parameter,
       filter: | # For any metric you can optionally include a filter on dimension values
         {{Dimension('customer__order_total_dim')}} >= 20
 ```
+
+### Additional settings
+
+Use the following additional settings to customize your conversion metrics:
+
+- **Null conversion values:** Set null conversions to zero using `fill_nulls_with`.
+<!-- **Calculation type:** Choose between showing raw conversions or conversion rate.
+- **Constant property:** Add conditions for specific scenarios to join conversions on constant properties.-->
+
+To return zero in the final data set, you can set the value of a null conversion event to zero instead of null. You can add the `fill_nulls_with` parameter to your conversion metric definition like this:
+
+```yaml
+- name: vist_to_buy_conversion_rate_7_day_window
+  description: "Conversion rate from viewing a page to making a purchase"
+  type: conversion
+  label: Visit to Seller Conversion Rate (7 day window)
+  type_params:
+    conversion_type_params:
+      calculation: conversions
+      base_measure: visits
+      conversion_measure: 
+        name: buys
+        fill_nulls_with: 0
+      entity: user
+      window: 7 days 
+
+```
+
+This will return the following results:
+
+<Lightbox src="/img/docs/dbt-cloud/semantic-layer/conversion-metrics-fill-null.png" width="75%" title="Metric with fill nulls with parameter"/>

--- a/website/docs/docs/build/simple.md
+++ b/website/docs/docs/build/simple.md
@@ -19,8 +19,7 @@ Simple metrics are metrics that directly reference a single measure, without any
 | `label` | The value that will be displayed in downstream tools. | Required |
 | `type_params` | The type parameters of the metric. | Required |
 | `measure` | The measure you're referencing. | Required |
-
-Refer to [additional settings](#additional-settings) to learn how to customize conversion metrics with settings for null values, calculation type, and constant properties.
+| `fill_nulls_with` | Set the value to zero instead of null in your metric definition. | Optional |
 
 The following displays the complete specification for simple metrics, along with an example.
 
@@ -33,6 +32,7 @@ metrics:
     label: The value that will be displayed in downstream tools # Required
     type_params: # Required
       measure: The measure you're referencing # Required
+      fill_nulls_with: Value to zero instead of null # Optional
 
 ```
 
@@ -52,44 +52,16 @@ If you've already defined the measure using the `create_metric: true` parameter,
       type: simple # Pointers to a measure you created in a semantic model
       label: Count of customers
       type_params:
+        fills_nulls_with: 0
         measure: customers # The measure you're creating a proxy of.
     - name: large_orders
       description: "Order with order values over 20."
       type: SIMPLE
       label: Large Orders
       type_params:
+        fill_nulls_with: 0
         measure: orders
       filter: | # For any metric you can optionally include a filter on dimension values
         {{Dimension('customer__order_total_dim')}} >= 20
 ```
 
-### Additional settings
-
-Use the following additional settings to customize your conversion metrics:
-
-- **Null conversion values:** Set null conversions to zero using `fill_nulls_with`.
-
-<!-- **Calculation type:** Choose between showing raw conversions or conversion rate.
-- **Constant property:** Add conditions for specific scenarios to join conversions on constant properties.-->
-
-To return zero in the final data set, you can set the value of a null conversion event to zero instead of null. You can add the `fill_nulls_with` parameter to your conversion metric definition like this:
-
-```yaml
-- name: vist_to_buy_conversion_rate_7_day_window
-  description: "Conversion rate from viewing a page to making a purchase"
-  type: conversion
-  label: Visit to Seller Conversion Rate (7 day window)
-  type_params:
-    conversion_type_params:
-      calculation: conversions
-      base_measure: visits
-      conversion_measure: 
-        name: buys
-        fill_nulls_with: 0
-      entity: user
-      window: 7 days 
-```
-
-This will return the following results:
-
-<Lightbox src="/img/docs/dbt-cloud/semantic-layer/conversion-metrics-fill-null.png" width="75%" title="Metric with fill nulls with parameter"/>

--- a/website/docs/docs/build/simple.md
+++ b/website/docs/docs/build/simple.md
@@ -32,7 +32,7 @@ metrics:
     label: The value that will be displayed in downstream tools # Required
     type_params: # Required
       measure: The measure you're referencing # Required
-      fill_nulls_with: Value to zero instead of null # Optional
+      fill_nulls_with: Set value instead of null  (such as zero) # Optional
 
 ```
 

--- a/website/docs/docs/build/simple.md
+++ b/website/docs/docs/build/simple.md
@@ -19,7 +19,7 @@ Simple metrics are metrics that directly reference a single measure, without any
 | `label` | The value that will be displayed in downstream tools. | Required |
 | `type_params` | The type parameters of the metric. | Required |
 | `measure` | The measure you're referencing. | Required |
-| `fill_nulls_with` | Set the value to zero instead of null in your metric definition. | Optional |
+| `fill_nulls_with` | Set the value in your metric definition instead of null (such as zero). | Optional |
 
 The following displays the complete specification for simple metrics, along with an example.
 


### PR DESCRIPTION
This PR adds the parameter `fill_nulls_with` to all metric types. it was already added for conversion metrics, but also needs to be added to ratio, derived, cumulative, and simple metrics. 