### PR TITLE
clarify permissions and profiles in enterprise permissions table

### DIFF
--- a/website/snippets/_enterprise-permissions-table.md
+++ b/website/snippets/_enterprise-permissions-table.md
@@ -78,12 +78,12 @@ The project roles enable you to work within the projects in various capacities. 
 | Credentials              |   W   |    W    |       W        |     W     |     R     |     W     |             |          |                |     R       |     R      |        |
 | Custom env. variables    |   W   |    W    |       W        |     W     |     W     |     W     |      R      |          |                |     R       |     W      |        |
 | dbt adapters             |   W   |    W    |       W        |     W     |     R     |     W     |             |          |                |     R       |     R      |        |
-| Develop (IDE or dbt Cloud CLI)            |   W   |    W    |                |     W     |           |           |             |          |                |             |            |        |
+| Develop <br />(IDE or dbt Cloud CLI)            |   W   |    W    |                |     W     |           |           |             |          |                |             |            |        |
 | Environments             |   W   |    R    |       R        |     R     |     R     |     W     |      R      |          |                |     R       |     R      |        |
 | Jobs                     |   W   |    R    |       R        |     W     |     R     |     W     |      R      |          |                |     R       |     R      |        |
 | Metadata                 |   R   |    R    |       R        |     R     |     R     |     R     |      R      |     R    |                |     R       |     R      |        |
-| Permissions              |   W   |         |       R        |     R     |     R     |           |             |          |                |             |     W      |        |
-| Profile                  |   W   |    R    |       W        |     R     |     R     |     R     |             |          |                |     R       |     R      |        |
+| Permissions (Groups & Licenses)              |   W   |         |       R        |     R     |     R     |           |             |          |                |             |     W      |        |
+| Profile (Credentials)                 |   W   |    R    |       W        |     R     |     R     |     R     |             |          |                |     R       |     R      |        |
 | Projects                 |   W   |    W    |       W        |     W     |     W     |     R     |      R      |          |                |     R       |     W      |        |
 | Repositories             |   W   |         |       R        |     R     |     W     |           |             |          |                |     R       |     R      |        |
 | Runs                     |   W   |    R    |       R        |     W     |     R     |     W     |      R      |          |                |     R       |     R      |        |


### PR DESCRIPTION
this PR clarifies the project permissions tables, and what 'Permissions' and 'Profile' means for Team Admin and Database admin in the context of how it maps to the dbt Cloud UI. 

Confirmed by Brian:
hey 
[@Brian Jan](https://dbt-labs.slack.com/team/U02BLTJ3P7S)
thanks so much for that explanation! i’m trying to understand how they map to the dbt cloud ui, so for:

- Permissions — you mean modify project permissions for users in the ‘groups/licenses’ dbt loud page??
- Profile — you mean a user can connect to snowflake via their developer credentials?

Related to https://github.com/dbt-labs/docs.getdbt.com/issues/2795