### PR TITLE
Document `DBT_PRINT` / `DBT_NO_PRINT` environment variables

### DIFF
--- a/website/docs/reference/global-configs/print-output.md
+++ b/website/docs/reference/global-configs/print-output.md
@@ -46,8 +46,6 @@ Supply `--no-print` flag to `dbt run` to suppress `print()` messages from showin
 
 ```text
 dbt --no-print run
-...
-
 ```
 
 ### Printer width

--- a/website/docs/reference/global-configs/print-output.md
+++ b/website/docs/reference/global-configs/print-output.md
@@ -10,29 +10,11 @@ sidebar: "Print output"
 
 By default, dbt includes `print()` messages in standard out (stdout). You can use the `DBT_NO_PRINT` environment variable to prevent these messages from showing up in stdout.
 
-<File name='profiles.yml'>
-
-```yaml
-config:
-  no_print: true
-```
-
-</File>
-
 </VersionBlock>
 
 <VersionBlock firstVersion="1.5">
 
 By default, dbt includes `print()` messages in standard out (stdout). You can use the `DBT_PRINT` environment variable to prevent these messages from showing up in stdout.
-
-<File name='profiles.yml'>
-
-```yaml
-config:
-  print: false
-```
-
-</File>
 
 :::warning Syntax deprecation
 

--- a/website/docs/reference/global-configs/print-output.md
+++ b/website/docs/reference/global-configs/print-output.md
@@ -8,7 +8,7 @@ sidebar: "Print output"
 
 <VersionBlock lastVersion="1.4">
 
-By default, dbt includes `print()` messages in standard out (stdout). You can use the `NO_PRINT` config to prevent these messages from showing up in stdout.
+By default, dbt includes `print()` messages in standard out (stdout). You can use the `DBT_NO_PRINT` environment variable to prevent these messages from showing up in stdout.
 
 <File name='profiles.yml'>
 
@@ -23,7 +23,7 @@ config:
 
 <VersionBlock firstVersion="1.5">
 
-By default, dbt includes `print()` messages in standard out (stdout). You can use the `PRINT` config to prevent these messages from showing up in stdout.
+By default, dbt includes `print()` messages in standard out (stdout). You can use the `DBT_PRINT` environment variable to prevent these messages from showing up in stdout.
 
 <File name='profiles.yml'>
 
@@ -36,7 +36,7 @@ config:
 
 :::warning Syntax deprecation
 
-The original `NO_PRINT` syntax has been deprecated, starting with dbt v1.5. Backward compatibility is supported but will be removed in an as-of-yet-undetermined future release.
+The original `DBT_NO_PRINT` environment variable has been deprecated, starting with dbt v1.5. Backward compatibility is supported but will be removed in an as-of-yet-undetermined future release.
 
 :::
 


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty-print-no-print-dbt-labs.vercel.app/reference/global-configs/print-output#suppress-print-messages-in-stdout)

resolves #4776

## What are you changing in this pull request and why?

I checked from v1.7 back to v1.1, and I couldn't get either of these to work in any version:

Up to 1.5:
```yaml
config:
  no_print: true
```

1.5 and after:
```yaml
config:
  print: false
```

However, the `DBT_NO_PRINT` / `DBT_PRINT` environment variables and `--no-print` and `--print` CLI flags _do_ work.

So I think the code example for `profiles.yml` was just accidentally introduced in the following PRs, and we should remove it because it's not actually an option for any versions.
- https://github.com/dbt-labs/docs.getdbt.com/pull/1319
- https://github.com/dbt-labs/docs.getdbt.com/pull/3134

For additional context, see:
- [Upgrading to v1.1](https://docs.getdbt.com/docs/dbt-versions/core-upgrade/upgrading-to-v1.1#advanced-and-experimental-functionality)
- [Upgrading to v1.5](https://docs.getdbt.com/docs/dbt-versions/core-upgrade/upgrading-to-v1.5#behavior-changes)
- https://github.com/dbt-labs/docs.getdbt.com/issues/1102
- https://github.com/dbt-labs/dbt-core/pull/4701
- https://github.com/dbt-labs/docs.getdbt.com/issues/3122
- https://github.com/dbt-labs/docs.getdbt.com/pull/3332

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [x] For [docs versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#about-versioning), review how to [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content).
