### PR TITLE
update handlescroll

### DIFF
--- a/website/src/components/detailsToggle/index.js
+++ b/website/src/components/detailsToggle/index.js
@@ -1,41 +1,68 @@
 import React, { useState, useEffect } from 'react';
 import styles from './styles.module.css';
 
-function detailsToggle({ children, alt_header = null }) {
+function DetailsToggle({ children, alt_header = null, index }) {
   const [isOn, setOn] = useState(false);
-  const [isScrolling, setIsScrolling] = useState(false); // New state to track scrolling
+  const [isScrolling, setIsScrolling] = useState(false);
   const [hoverTimeout, setHoverTimeout] = useState(null);
 
   const handleToggleClick = () => {
-    setOn(current => !current); // Toggle the current state
+    if (isOn) {
+      closeToggle();
+    } else {
+      closePreviouslyOpenToggle();
+      openToggle();
+    }
   };
 
   const handleMouseEnter = () => {
-    if (isOn || isScrolling) return; // Ignore hover if already open or if scrolling
+    if (isScrolling) return;
     const timeout = setTimeout(() => {
-      if (!isScrolling) setOn(true);
-    }, 700); // 
+      closeToggle(); // close the toggle first
+      openToggle(); // then open it
+    }, 700);
     setHoverTimeout(timeout);
+    closePreviouslyOpenToggle();
   };
-  
+
   const handleMouseLeave = () => {
     if (!isOn) {
       clearTimeout(hoverTimeout);
-      setOn(false);
+      closeToggle();
     }
   };
 
   const handleScroll = () => {
-    if (isOn)  {
-      setIsScrolling(true);
-      clearTimeout(hoverTimeout);
-      setOn(false);
-  }
+    setIsScrolling(true);
+    clearTimeout(hoverTimeout);
 
-    // Reset scrolling state after a  delay
+    if (isOn) {
+      closeToggle();
+    }
+
     setTimeout(() => {
       setIsScrolling(false);
-    }, 800);
+    }, 300);
+  };
+
+  const openToggle = () => {
+    setOn(true);
+  };
+
+  const closeToggle = () => {
+    setOn(false);
+  };
+
+  const closePreviouslyOpenToggle = () => {
+    const allToggles = document.querySelectorAll('.detailsToggle');
+    allToggles.forEach((toggle, toggleIndex) => {
+      if (toggleIndex !== index) {
+        const toggleIsOpen = toggle.querySelector(`.${styles.body}`).style.display === 'block';
+        if (toggleIsOpen) {
+          toggle.querySelector(`.${styles.body}`).style.display = 'none';
+        }
+      }
+    });
   };
 
   useEffect(() => {
@@ -72,4 +99,4 @@ function detailsToggle({ children, alt_header = null }) {
   );
 }
 
-export default detailsToggle;
+export default DetailsToggle;

--- a/website/src/components/detailsToggle/index.js
+++ b/website/src/components/detailsToggle/index.js
@@ -1,68 +1,39 @@
 import React, { useState, useEffect } from 'react';
 import styles from './styles.module.css';
 
-function DetailsToggle({ children, alt_header = null, index }) {
+function detailsToggle({ children, alt_header = null }) {
   const [isOn, setOn] = useState(false);
-  const [isScrolling, setIsScrolling] = useState(false);
+  const [isScrolling, setIsScrolling] = useState(false); // New state to track scrolling
   const [hoverTimeout, setHoverTimeout] = useState(null);
 
   const handleToggleClick = () => {
-    if (isOn) {
-      closeToggle();
-    } else {
-      closePreviouslyOpenToggle();
-      openToggle();
-    }
+    setOn(current => !current); // Toggle the current state
   };
 
   const handleMouseEnter = () => {
-    if (isScrolling) return;
+    if (isOn || isScrolling) return; // Ignore hover if already open or if scrolling
     const timeout = setTimeout(() => {
-      closeToggle(); // close the toggle first
-      openToggle(); // then open it
-    }, 700);
+      if (!isScrolling) setOn(true);
+    }, 700); // 
     setHoverTimeout(timeout);
-    closePreviouslyOpenToggle();
   };
-
+  
   const handleMouseLeave = () => {
     if (!isOn) {
       clearTimeout(hoverTimeout);
-      closeToggle();
+      setOn(false);
     }
   };
 
   const handleScroll = () => {
     setIsScrolling(true);
     clearTimeout(hoverTimeout);
+    //setOn(false);
 
-    if (isOn) {
-      closeToggle();
-    }
-
+    // Reset scrolling state after a  delay
     setTimeout(() => {
       setIsScrolling(false);
-    }, 300);
-  };
-
-  const openToggle = () => {
-    setOn(true);
-  };
-
-  const closeToggle = () => {
-    setOn(false);
-  };
-
-  const closePreviouslyOpenToggle = () => {
-    const allToggles = document.querySelectorAll('.detailsToggle');
-    allToggles.forEach((toggle, toggleIndex) => {
-      if (toggleIndex !== index) {
-        const toggleIsOpen = toggle.querySelector(`.${styles.body}`).style.display === 'block';
-        if (toggleIsOpen) {
-          toggle.querySelector(`.${styles.body}`).style.display = 'none';
-        }
-      }
-    });
+    }, 800);
   };
 
   useEffect(() => {
@@ -99,4 +70,4 @@ function DetailsToggle({ children, alt_header = null, index }) {
   );
 }
 
-export default DetailsToggle;
+export default detailsToggle;

--- a/website/src/components/detailsToggle/index.js
+++ b/website/src/components/detailsToggle/index.js
@@ -3,33 +3,51 @@ import styles from './styles.module.css';
 
 function detailsToggle({ children, alt_header = null }) {
   const [isOn, setOn] = useState(false);
-  const [hoverActive, setHoverActive] = useState(true);
+  const [isScrolling, setIsScrolling] = useState(false); // New state to track scrolling
   const [hoverTimeout, setHoverTimeout] = useState(null);
 
   const handleToggleClick = () => {
-    setHoverActive(true); // Disable hover when clicked
     setOn(current => !current); // Toggle the current state
-};
+  };
 
-const handleMouseEnter = () => {
-  if (isOn) return; // Ignore hover if already open
-  setHoverActive(true); // Enable hover
-  const timeout = setTimeout(() => {
-      if (hoverActive) setOn(true);
-  }, 500); 
-  setHoverTimeout(timeout);
-};
+  const handleMouseEnter = () => {
+    if (isOn || isScrolling) return; // Ignore hover if already open or if scrolling
+    const timeout = setTimeout(() => {
+      if (!isScrolling) setOn(true);
+    }, 700); // 
+    setHoverTimeout(timeout);
+  };
+  
+  const handleMouseLeave = () => {
+    if (!isOn) {
+      clearTimeout(hoverTimeout);
+      setOn(false);
+    }
+  };
 
-const handleMouseLeave = () => {
-  if (!isOn) {
+  const handleScroll = () => {
+    if (isOn)  {
+      setIsScrolling(true);
       clearTimeout(hoverTimeout);
       setOn(false);
   }
-};
 
-useEffect(() => {
-  return () => clearTimeout(hoverTimeout);
-}, [hoverTimeout]);
+    // Reset scrolling state after a  delay
+    setTimeout(() => {
+      setIsScrolling(false);
+    }, 800);
+  };
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll);
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
+
+  useEffect(() => {
+    return () => clearTimeout(hoverTimeout);
+  }, [hoverTimeout]);
 
   return (
     <div className='detailsToggle'>

--- a/website/src/components/detailsToggle/styles.module.css
+++ b/website/src/components/detailsToggle/styles.module.css
@@ -27,6 +27,7 @@
     width: 1.25rem;
     vertical-align: middle;
     transition: transform 0.3s; /* Smooth transition for toggle icon */
+
 }
 
 :local(.toggleUpsideDown) {


### PR DESCRIPTION
this pr updates the handlescroll function and removes setOn(false so that the toggle will no longer close automatically when the user starts scrolling. this is to allow the user to continue reading the content inside the toggle without interruption

per slack feedback here: https://dbt-labs.slack.com/archives/C069P1RQ8LT/p1705925559782539?thread_ts=1705925278.391799&cid=C069P1RQ8LT