### PR TITLE
Record that freshness tests are available for BQ

### DIFF
--- a/website/docs/reference/resource-properties/freshness.md
+++ b/website/docs/reference/resource-properties/freshness.md
@@ -47,10 +47,10 @@ If a source has a `freshness:` block, dbt will attempt to calculate freshness fo
 
 Currently, calculating freshness from warehouse metadata tables is supported on:
 - [Snowflake](/reference/resource-configs/snowflake-configs)
+- [BigQuery](/reference/resource-configs/bigquery-configs)
 
 Support is coming soon to the following adapters:
 - [Redshift](/reference/resource-configs/redshift-configs)
-- [BigQuery](/reference/resource-configs/bigquery-configs)
 - [Spark](/reference/resource-configs/spark-configs)
 
 Freshness blocks are applied hierarchically:


### PR DESCRIPTION
Freshness tests were added for BigQuery in https://github.com/dbt-labs/dbt-bigquery/pull/1072 and released with [`dbt-bigquery` 1.7.3](https://github.com/dbt-labs/dbt-bigquery/releases/tag/v1.7.3).

## What are you changing in this pull request and why?
Updates documentation to indicate that freshness tests are now available for BigQuery. Freshness tests were added for BigQuery in https://github.com/dbt-labs/dbt-bigquery/pull/1072 and released with [`dbt-bigquery` 1.7.3](https://github.com/dbt-labs/dbt-bigquery/releases/tag/v1.7.3).

## Checklist
<!--
Uncomment when publishing docs for a prerelease version of dbt:
- [ ] Add versioning components, as described in [Versioning Docs](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-entire-pages)
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [x] For [docs versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#about-versioning), review how to [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content).
- [ ] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
