### PR TITLE
Mark v1.4 as EOL

### DIFF
--- a/website/snippets/core-versions-table.md
+++ b/website/snippets/core-versions-table.md
@@ -5,7 +5,7 @@
 | [**v1.7**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.7) | Nov 2, 2023   | <b>Active &mdash; Nov 1, 2024</b> | 
 | [**v1.6**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.6) | Jul 31, 2023  | Critical &mdash; Jul 30, 2024 |  
 | [**v1.5**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.5) | Apr 27, 2023  | Critical &mdash; Apr 27, 2024 |
-| [**v1.4**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.4) | Jan 25, 2023  | Critical &mdash; Jan 25, 2024 | 
+| [**v1.4**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.4) | Jan 25, 2023  | End of Life* ⚠️ | 
 | [**v1.3**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.3) | Oct 12, 2022  | End of Life* ⚠️ |
 | [**v1.2**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.2) | Jul 26, 2022  | End of Life* ⚠️ | 
 | [**v1.1**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.1) | Apr 28, 2022  | End of Life* ⚠️ |


### PR DESCRIPTION
## What are you changing in this pull request and why?

dbt Core v1.4 was released on 25 January 2023. As of today, it's considered "End of Life"