### PR TITLE
Cross-project reference (via "project" dependency) requires upstream public model

### DIFF
--- a/website/docs/docs/collaborate/govern/project-dependencies.md
+++ b/website/docs/docs/collaborate/govern/project-dependencies.md
@@ -33,6 +33,7 @@ Refer to the [FAQs](#faqs) for more info.
 
 In order to add project dependencies and resolve cross-project `ref`, you must:
 - Use dbt v1.6 or higher for **both** the upstream ("producer") project and the downstream ("consumer") project.
+- Define models in an upstream ("producer") project that are configured with [`access: public`](/reference/resource-configs/access)
 - Have a deployment environment in the upstream ("producer") project [that is set to be your production environment](/docs/deploy/deploy-environments#set-as-production-environment)
 - Have a successful run of the upstream ("producer") project
 - Have a multi-tenant or single-tenant [dbt Cloud Enterprise](https://www.getdbt.com/pricing) account (Azure ST is not supported but coming soon)


### PR DESCRIPTION
## What are you changing in this pull request and why?

Per @patkearns10:

[Let's] consider enabling upstream project model access (public) as a pre-requisite [here](https://docs.getdbt.com/docs/collaborate/govern/project-dependencies). I have seen [customers](https://dbtcloud.zendesk.com/agent/tickets/60657) not add that yml config and confused when they get an error downstream, like:
```
Model 'model.this_project.some_model' (models/some_model.sql) depends on a node named 'upstream_model' in package or project 'upstream_project' which was not found.
```