### PR TITLE
Revert "Update add_issue_to_project.yml"

### DIFF
--- a/.github/workflows/add_issue_to_project.yml
+++ b/.github/workflows/add_issue_to_project.yml
@@ -12,4 +12,4 @@ jobs:
       - uses: actions/add-to-project@v0.5.0
         with:
           project-url: https://github.com/orgs/dbt-labs/projects/14 
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.DOCS_SECRET }}


### PR DESCRIPTION
Reverts dbt-labs/docs.getdbt.com#4839

Need to use a PAT for this workflow because as of 1/2024 the GITHUB_TOKEN can not be given write access to a project board. 

Refer to  [possible permissions here](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) for more information.