### PR TITLE
Clarify the relationship between --quiet and --log-level

### DIFF
--- a/website/docs/reference/global-configs/logs.md
+++ b/website/docs/reference/global-configs/logs.md
@@ -122,16 +122,14 @@ dbt --quiet run
 
 ### dbt list logging
 
-In [dbt version 1.5](/docs/dbt-versions/core-upgrade/upgrading-to-v1.5#behavior-changes), there have been changes to the logging behavior of the [dbt list](/reference/commands/list) command. In version 1.5, the default behavior has been updated, and it now includes `INFO` level logs by default
+In [dbt version 1.5](/docs/dbt-versions/core-upgrade/upgrading-to-v1.5#behavior-changes), we updated the logging behavior of the [dbt list](/reference/commands/list) command to include `INFO` level logs by default.
 
-Previously, the list command (and only the list command) had `WARN`-level stdout logging, to support piping its results to [`jq`](https://jqlang.github.io/jq/manual/), a file, or another process.
 
-To achieve that goal, you can use either of the following parameters:
+You can use either of these parameters to ensure clean output that's compatible with downstream processes, such as piping results to [`jq`](https://jqlang.github.io/jq/manual/), a file, or another process:
 
 - `dbt --log-level warn list` (recommended; equivalent to previous default)
 - `dbt --quiet list` (suppresses all logging less than ERROR level, except for "printed" messages and list output)
 
-By using `--log-level warn list` or `--quiet list`, you ensure that the output is clean and compatible with downstream processes.
 
 
 ### Logging relational cache events

--- a/website/docs/reference/global-configs/logs.md
+++ b/website/docs/reference/global-configs/logs.md
@@ -118,8 +118,21 @@ Supply the `-q` or `--quiet` flag to `dbt run` to show only error logs and suppr
 ```text
 dbt --quiet run
 ...
-
 ```
+
+### dbt list logging
+
+In [dbt version 1.5](/docs/dbt-versions/core-upgrade/upgrading-to-v1.5#behavior-changes), there have been changes to the logging behavior of the [dbt list](/reference/commands/list) command. In version 1.5, the default behavior has been updated, and it now includes `INFO` level logs by default
+
+Previously, the list command (and only the list command) had `WARN`-level stdout logging, to support piping its results to [`jq`](https://jqlang.github.io/jq/manual/), a file, or another process.
+
+To achieve that goal, you can use either of the following parameters:
+
+- `dbt --log-level warn list` (recommended; equivalent to previous default)
+- `dbt --quiet list` (suppresses all logging less than ERROR level, except for "printed" messages and list output)
+
+By using `--log-level warn list` or `--quiet list`, you ensure that the output is clean and compatible with downstream processes.
+
 
 ### Logging relational cache events
 

--- a/website/docs/reference/global-configs/logs.md
+++ b/website/docs/reference/global-configs/logs.md
@@ -131,7 +131,6 @@ You can use either of these parameters to ensure clean output that's compatible 
 - `dbt --quiet list` (suppresses all logging less than ERROR level, except for "printed" messages and list output)
 
 
-
 ### Logging relational cache events
 
 The `LOG_CACHE_EVENTS` config allows detailed logging for [relational cache](reference/global-configs/cache) events, which are disabled by default.


### PR DESCRIPTION
Resolves #4822

adds info about dbt list command and log level warn and quiet to the log page per issue above. 

[preview](https://docs-getdbt-pflps5eie-dbt-labs.vercel.app/reference/global-configs/logs#dbt-list-logging)