### PR TITLE
`unique_key` applies to the input rather than the output

### DIFF
--- a/website/docs/reference/resource-configs/unique_key.md
+++ b/website/docs/reference/resource-configs/unique_key.md
@@ -27,7 +27,7 @@ snapshots:
 </File>
 
 ## Description
-A column name or expression that is unique for the results of a snapshot. dbt uses this to match records between a result set and an existing snapshot, so that changes can be captured correctly.
+A column name or expression that is unique for the inputs of a snapshot. dbt uses this to match records between a result set and an existing snapshot, so that changes can be captured correctly.
 
 :::caution 
 


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty-unique-key-snapshots-dbt-labs.vercel.app/reference/resource-configs/unique_key#description)

## What are you changing in this pull request and why?

Small clarification about `unique_key` as it applies to snapshots.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.