### PR TITLE
Testing for uniqueness prior to snapshots

### DIFF
--- a/website/docs/reference/resource-configs/unique_key.md
+++ b/website/docs/reference/resource-configs/unique_key.md
@@ -31,7 +31,7 @@ A column name or expression that is unique for the results of a snapshot. dbt us
 
 :::caution 
 
-Providing a non-unique key will result in unexpected snapshot results. dbt **will not** test the uniqueness of this key, consider adding a test to your project to ensure that this key is indeed unique.
+Providing a non-unique key will result in unexpected snapshot results. dbt **will not** test the uniqueness of this key, consider [testing](/blog/primary-key-testing) the source data to ensure that this key is indeed unique.
 
 :::
 

--- a/website/docs/reference/resource-configs/unique_key.md
+++ b/website/docs/reference/resource-configs/unique_key.md
@@ -31,7 +31,7 @@ A column name or expression that is unique for the results of a snapshot. dbt us
 
 :::caution 
 
-Providing a non-unique key will result in unexpected snapshot results. dbt **will not** test the uniqueness of this key, consider [testing](blog/primary-key-testing#how-to-test-primary-keys-with-dbt) the source data to ensure that this key is indeed unique.
+Providing a non-unique key will result in unexpected snapshot results. dbt **will not** test the uniqueness of this key, consider [testing](/blog/primary-key-testing#how-to-test-primary-keys-with-dbt) the source data to ensure that this key is indeed unique.
 
 :::
 

--- a/website/docs/reference/resource-configs/unique_key.md
+++ b/website/docs/reference/resource-configs/unique_key.md
@@ -31,7 +31,7 @@ A column name or expression that is unique for the results of a snapshot. dbt us
 
 :::caution 
 
-Providing a non-unique key will result in unexpected snapshot results. dbt **will not** test the uniqueness of this key, consider [testing](/blog/primary-key-testing) the source data to ensure that this key is indeed unique.
+Providing a non-unique key will result in unexpected snapshot results. dbt **will not** test the uniqueness of this key, consider [testing](blog/primary-key-testing#how-to-test-primary-keys-with-dbt) the source data to ensure that this key is indeed unique.
 
 :::
 


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty-snapshots-testing-u-736c54-dbt-labs.vercel.app/reference/resource-configs/unique_key)

## What are you changing in this pull request and why?

We recommend testing for uniqueness of the `unique_key` prior to running a snapshot. This PR adds a [link](#how-to-test-primary-keys-with-dbt) to show precisely how to do that.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.