### PR TITLE
The "plus" graph operator also selects the model itself

### DIFF
--- a/website/docs/reference/node-selection/graph-operators.md
+++ b/website/docs/reference/node-selection/graph-operators.md
@@ -3,7 +3,7 @@ title: "Graph operators"
 ---
 
 ### The "plus" operator
-If placed at the front of the model selector, + will select all parents of the selected model and the model itself. If placed at the end of the string, + will select all children of the selected model and the model itself.
+If placed at the front of the model selector, `+` will select all parents of the selected model and the model itself. If placed at the end of the string, `+` will select all children of the selected model and the model itself.
 
 
    ```bash

--- a/website/docs/reference/node-selection/graph-operators.md
+++ b/website/docs/reference/node-selection/graph-operators.md
@@ -3,7 +3,7 @@ title: "Graph operators"
 ---
 
 ### The "plus" operator
-If placed at the front of the model selector, `+` will select all parents of the selected model. If placed at the end of the string, `+` will select all children of the selected model.
+If placed at the front of the model selector, + will select all parents of the selected model and the model itself. If placed at the end of the string, + will select all children of the selected model and the model itself.
 
 
    ```bash

--- a/website/docs/reference/node-selection/graph-operators.md
+++ b/website/docs/reference/node-selection/graph-operators.md
@@ -9,7 +9,7 @@ If placed at the front of the model selector, `+` will select all parents of the
    ```bash
 dbt run --select "my_model+"         # select my_model and all children
 dbt run --select "+my_model"         # select my_model and all parents
-dbt run --select "+my_model+"         # select my_model, and all of its parents and children
+dbt run --select "+my_model+"        # select my_model, and all of its parents and children
   ```
 
 
@@ -22,7 +22,7 @@ to step through.
   ```bash
 dbt run --select "my_model+1"        # select my_model and its first-degree children
 dbt run --select "2+my_model"        # select my_model, its first-degree parents, and its second-degree parents ("grandparents")
-dbt run --select "3+my_model+4"        # select my_model, its parents up to the 3rd degree, and its children down to the 4th degree
+dbt run --select "3+my_model+4"      # select my_model, its parents up to the 3rd degree, and its children down to the 4th degree
   ```
 
 
@@ -32,5 +32,5 @@ The `@` operator is similar to `+`, but will also include _the parents of the ch
 <Lightbox src="/img/docs/running-a-dbt-project/command-line-interface/1643e30-Screen_Shot_2019-03-11_at_7.18.20_PM.png" title="@snowplow_web_page_context will select all of the models shown here"/>
 
 ```bash
-dbt run --models @my_model          # select my_model, its children, and the parents of its children
+dbt run --models @my_model           # select my_model, its children, and the parents of its children
 ```


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty-plus-operator-dbt-labs.vercel.app/reference/node-selection/graph-operators)

## What are you changing in this pull request and why?

resolves #3979 by updating the description of the "plus" graph operator from:

> If placed at the front of the model selector, + will select all parents of the selected model. If placed at the end of the string, + will select all children of the selected model.

to:

> If placed at the front of the model selector, + will select all parents of the selected model and the model itself. If placed at the end of the string, + will select all children of the selected model and the model itself.

as discussed in https://github.com/dbt-labs/dbt-core/issues/8340#issuecomment-1693785453.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.