### PR TITLE
Fix URL to docs for log and target paths

### DIFF
--- a/website/docs/reference/global-configs/yaml-configurations.md
+++ b/website/docs/reference/global-configs/yaml-configurations.md
@@ -19,6 +19,6 @@ config:
 
 <VersionBlock firstVersion="1.2">
 
-The exception: Some global configurations are actually set in `dbt_project.yml`, instead of `profiles.yml`, because they control where dbt places logs and artifacts. Those file paths are always relative to the location of `dbt_project.yml`. For more details, see ["Log and target paths"](/reference/global-configs/logs#log-and-target-paths).
+The exception: Some global configurations are actually set in `dbt_project.yml`, instead of `profiles.yml`, because they control where dbt places logs and artifacts. Those file paths are always relative to the location of `dbt_project.yml`. For more details, refer to [Log and target paths](/reference/global-configs/logs#log-and-target-paths).
 
 </VersionBlock>

--- a/website/docs/reference/global-configs/yaml-configurations.md
+++ b/website/docs/reference/global-configs/yaml-configurations.md
@@ -19,6 +19,6 @@ config:
 
 <VersionBlock firstVersion="1.2">
 
-The exception: Some global configurations are actually set in `dbt_project.yml`, instead of `profiles.yml`, because they control where dbt places logs and artifacts. Those file paths are always relative to the location of `dbt_project.yml`. For more details, see ["Log and target paths"](#log-and-target-paths) below.
+The exception: Some global configurations are actually set in `dbt_project.yml`, instead of `profiles.yml`, because they control where dbt places logs and artifacts. Those file paths are always relative to the location of `dbt_project.yml`. For more details, see ["Log and target paths"](/reference/global-configs/logs#log-and-target-paths).
 
 </VersionBlock>


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty-log-and-target-paths-url-dbt-labs.vercel.app/reference/global-configs/yaml-configurations)

## What are you changing in this pull request and why?

Found an anchor link to sub-section that was moved to its own page. This PR fixes the link to go to the new location.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.