### PR TITLE
clarify bq qs step after config block change 

### DIFF
--- a/website/snippets/quickstarts/change-way-model-materialized.md
+++ b/website/snippets/quickstarts/change-way-model-materialized.md
@@ -54,10 +54,9 @@ By default, everything gets created as a view. You can override that at the dire
 
     </File>
 
-4. Enter the `dbt run` command. Your model, `customers` should now build as a view.
-5. Enter the `dbt run --full-refresh` command for this to take effect in your warehouse.
+4. Enter the `dbt run --full-refresh` command for this to take effect in your warehouse.
 
-#### FAQs
+### FAQs
 
 <FAQ path="Models/available-materializations" />
 <FAQ path="Project/which-materialization" />

--- a/website/snippets/quickstarts/change-way-model-materialized.md
+++ b/website/snippets/quickstarts/change-way-model-materialized.md
@@ -54,7 +54,9 @@ By default, everything gets created as a view. You can override that at the dire
 
     </File>
 
-4. Enter the `dbt run --full-refresh` command for this to take effect in your warehouse.
+4. Enter the `dbt run` command. Your model, customers should now build as a view. 
+   - BigQuery users should run `dbt run --full-refresh` (mentioned in step 5) to ensure the materialization changes are fully applied
+5. Enter the `dbt run --full-refresh` command for this to take effect in your warehouse.
 
 ### FAQs
 

--- a/website/snippets/quickstarts/change-way-model-materialized.md
+++ b/website/snippets/quickstarts/change-way-model-materialized.md
@@ -55,7 +55,7 @@ By default, everything gets created as a view. You can override that at the dire
     </File>
 
 4. Enter the `dbt run` command. Your model, customers should now build as a view. 
-   - BigQuery users should run `dbt run --full-refresh` (mentioned in step 5) to ensure the materialization changes are fully applied
+   - BigQuery users need to run `dbt run --full-refresh` instead of `dbt run` to full apply materialization changes.
 5. Enter the `dbt run --full-refresh` command for this to take effect in your warehouse.
 
 ### FAQs

--- a/website/snippets/quickstarts/change-way-model-materialized.md
+++ b/website/snippets/quickstarts/change-way-model-materialized.md
@@ -54,7 +54,7 @@ By default, everything gets created as a view. You can override that at the dire
 
     </File>
 
-4. Enter the `dbt run` command. Your model, customers should now build as a view. 
+4. Enter the `dbt run` command. Your model, `customers`, should now build as a view. 
    - BigQuery users need to run `dbt run --full-refresh` instead of `dbt run` to full apply materialization changes.
 5. Enter the `dbt run --full-refresh` command for this to take effect in your warehouse.
 


### PR DESCRIPTION
this pr updates the quickstart snippet (for bigquery specifically) per user feedback [here](https://dbt-labs.slack.com/archives/C02NCQ9483C/p1707955900758119). dbt run isn't needed after adding a model config block for materialization. instead, users shoudl run dbt run --full-refresh for the change to take place.