### PR TITLE
Update mssql-setup.md

### DIFF
--- a/website/docs/docs/core/connect-data-platform/mssql-setup.md
+++ b/website/docs/docs/core/connect-data-platform/mssql-setup.md
@@ -243,7 +243,7 @@ your_profile_name:
       port: 1433
       database: exampledb
       schema: schema_name
-      authentication: MSI
+      authentication: ActiveDirectoryMsi
 ```
 
 </File>
@@ -457,6 +457,6 @@ Valid values for `authentication`:
 * `ActiveDirectoryIntegrated`: Active Directory authentication using the current user's credentials
 * `ServicePrincipal`: Azure Active Directory authentication using a service principal
 * `CLI`: Azure Active Directory authentication using the account you're logged in with in the Azure CLI
-* `MSI`: Azure Active Directory authentication using a managed identity available on the system
+* `ActiveDirectoryMsi`: Azure Active Directory authentication using a managed identity available on the system
 * `environment`: Azure Active Directory authentication using environment variables as documented [here](https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.environmentcredential?view=azure-python)
 * `auto`: Azure Active Directory authentication trying the previous authentication methods until it finds one that works


### PR DESCRIPTION
MSI->ActiveDirectoryMsi

## What are you changing in this pull request and why?
I am submitting this PR as I was able to authenticate using the managed identity after modifying the authentication method from "authentication: MSI" to "authentication: ActiveDirectoryMsi".

The logs have been recorded and are displayed as follows:

```
$ pip show dbt-sqlserver
Name: dbt-sqlserver
Version: 1.7.2
Summary: A Microsoft SQL Server adapter plugin for dbt
Home-page: https://github.com/dbt-msft/dbt-sqlserver
Author: Mikael Ene, Anders Swanson, Sam Debruyn, Cor Zuurmond
Author-email:
License: MIT
Location: /home/azureuser/.local/lib/python3.8/site-packages
Requires: azure-identity, dbt-core, dbt-fabric, pyodbc
Required-by:
```

```
$ dbt debug
10:46:43  Running with dbt=1.7.8
10:46:43  dbt version: 1.7.8
10:46:43  python version: 3.8.10
10:46:43  python path: /usr/bin/python3
10:46:43  os info: Linux-5.15.0-1034-azure-x86_64-with-glibc2.29
10:46:43  Using profiles dir at /home/azureuser/.dbt
10:46:43  Using profiles.yml file at /home/azureuser/.dbt/profiles.yml
10:46:43  Using dbt_project.yml file at /xxx/test_dbt/dbt_project.yml
10:46:43  adapter type: sqlserver
10:46:43  adapter version: 1.7.2
10:46:43  Configuration:
10:46:43    profiles.yml file [OK found and valid]
10:46:43    dbt_project.yml file [OK found and valid]
10:46:43  Required dependencies:
10:46:43   - git [OK found]

10:46:43  Connection:
10:46:43    server: sqldb-tdp-server-dev-003.database.windows.net
10:46:43    database: sqldb-tdp-dev-003
10:46:43    schema: dbo
10:46:43    UID: None
10:46:43    client_id: None
10:46:43    authentication: MSI
10:46:43    encrypt: True
10:46:43    trust_cert: False
10:46:43    retries: 1
10:46:43    login_timeout: 0
10:46:43    query_timeout: 0
10:46:43    port: 1433
10:46:43  Registered adapter: sqlserver=1.7.2
10:46:44    Connection test: [ERROR]

10:46:44  1 check failed:
10:46:44  dbt was unable to connect to the specified database.
The database returned the following error:

  >Database Error
  ('28000', "[28000] [Microsoft][ODBC Driver 18 for SQL Server][SQL Server]Login failed for user ''. (18456) (SQLDriverConnect)")

Check your database credentials and try again. For more information, visit:
https://docs.getdbt.com/docs/configure-your-profile
````

```
$ dbt debug
11:12:18  Running with dbt=1.7.8
11:12:18  dbt version: 1.7.8
11:12:18  python version: 3.8.10
11:12:18  python path: /usr/bin/python3
11:12:18  os info: Linux-5.15.0-1034-azure-x86_64-with-glibc2.29
11:12:18  Using profiles dir at /home/azureuser/.dbt
11:12:18  Using profiles.yml file at /home/azureuser/.dbt/profiles.yml
11:12:18  Using dbt_project.yml file at /xxx/test_dbt/dbt_project.yml
11:12:18  adapter type: sqlserver
11:12:18  adapter version: 1.7.2
11:12:19  Configuration:
11:12:19    profiles.yml file [OK found and valid]
11:12:19    dbt_project.yml file [OK found and valid]
11:12:19  Required dependencies:
11:12:19   - git [OK found]

11:12:19  Connection:
11:12:19    server: sqldb-tdp-server-dev-003.database.windows.net
11:12:19    database: sqldb-tdp-dev-003
11:12:19    schema: dbo
11:12:19    UID: None
11:12:19    client_id: None
11:12:19    authentication: ActiveDirectoryMsi
11:12:19    encrypt: True
11:12:19    trust_cert: False
11:12:19    retries: 1
11:12:19    login_timeout: 0
11:12:19    query_timeout: 0
11:12:19    port: 1433
11:12:19  Registered adapter: sqlserver=1.7.2
11:12:19    Connection test: [OK connection ok]

11:12:19  All checks passed!
```


## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.