### PR TITLE
Clarify model contracts are not supported for other resource types

### DIFF
--- a/website/docs/docs/collaborate/govern/model-contracts.md
+++ b/website/docs/docs/collaborate/govern/model-contracts.md
@@ -38,7 +38,7 @@ At present, model contracts are supported for:
 Model contracts are _not_ supported for:
 - Python models.
 - `ephemeral`-materialized SQL models.
-- Other resource types (sources, seeds, snapshots, ...)
+- Other resource types, such as `sources`, `seeds`, `snapshots`, and so on.
 
 
 ## How to define a contract

--- a/website/docs/docs/collaborate/govern/model-contracts.md
+++ b/website/docs/docs/collaborate/govern/model-contracts.md
@@ -38,6 +38,7 @@ At present, model contracts are supported for:
 Model contracts are _not_ supported for:
 - Python models.
 - `ephemeral`-materialized SQL models.
+- Other resource types (sources, seeds, snapshots, ...)
 
 
 ## How to define a contract


### PR DESCRIPTION
## What are you changing in this pull request and why?

Clarify that model contracts are only supported for models, not for other resource types.

Context:
- https://github.com/dbt-labs/dbt-core/issues/9542