### PR TITLE
Suggest >= consistently in incremental models

### DIFF
--- a/website/docs/docs/build/incremental-models.md
+++ b/website/docs/docs/build/incremental-models.md
@@ -57,8 +57,8 @@ from raw_app_data.events
 {% if is_incremental() %}
 
   -- this filter will only be applied on an incremental run
-  -- (uses > to include records whose timestamp occurred since the last run of this model)
-  where event_time > (select max(event_time) from {{ this }})
+  -- (uses >= to include records whose timestamp occurred since the last run of this model)
+  where event_time >= (select max(event_time) from {{ this }})
 
 {% endif %}
 ```
@@ -434,7 +434,7 @@ with large_source_table as (
 
     select * from {{ ref('large_source_table') }}
     {% if is_incremental() %}
-        where session_start > dateadd(day, -3, current_date)
+        where session_start >= dateadd(day, -3, current_date)
     {% endif %}
 
 ),


### PR DESCRIPTION
## What are you changing in this pull request and why?

The current docs sometimes suggest to use `>` and sometimes `>=` when comparing last-update date(times) in incremental models. Using `>` could probably lead to gaps in the dataset in certain cases, but even if not, then still safer to always suggest using `>=` in the documentation.

## Checklist

N/A
