### PR TITLE
agg_time_dimenson required if the model contains measures

### DIFF
--- a/website/docs/docs/build/semantic-models.md
+++ b/website/docs/docs/build/semantic-models.md
@@ -49,7 +49,7 @@ semantic_models:
     description: same as always               ## Optional
     model: ref('some_model')                  ## Required
     defaults:                                 ## Required
-      agg_time_dimension: dimension_name    ## Required if the model contains dimensions
+      agg_time_dimension: dimension_name    ## Required if the model contains measures
     entities:                                 ## Required
        - see more information in entities
     measures:                                 ## Optional


### PR DESCRIPTION
## What are you changing in this pull request and why?
Docs we're incorrect - agg_time_dimenson is required if the model contains measures, not dimensions. 