### PR TITLE
fix ms teams webhook redirect typo

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -569,7 +569,7 @@
     },
     {
         "source": "/guides/orchestration/webhooks/zapier-ms-teams",
-        "destination": "/guides/zapier-ms-team",
+        "destination": "/guides/zapier-ms-teams",
         "permanent": true
     },
     {


### PR DESCRIPTION
## What are you changing in this pull request and why?
Typo in redirect reported here https://getdbt.slack.com/archives/CMZ2V0X8V/p1709194039667679?thread_ts=1659363136.028679&cid=CMZ2V0X8V

`https://docs.getdbt.com/guides/orchestration/webhooks/zapier-ms-teams` is redirecting to `https://docs.getdbt.com/guides/zapier-ms-team` instead of `https://docs.getdbt.com/guides/zapier-ms-teams` (note the s)