### PR TITLE
Remove trailing dash on header IDs when using LifeCycle component

### DIFF
--- a/website/static/js/headerLinkCopy.js
+++ b/website/static/js/headerLinkCopy.js
@@ -1,58 +1,68 @@
 /* eslint-disable */
 
-  // Get all the headers with anchor links. 
-  // The 'click' event worked over 'popstate' because click captures page triggers, as well as back/forward button triggers
-  // Adding the 'load' event to also capture the initial page load
-  window.addEventListener("click", copyHeader);
-  window.addEventListener("load", copyHeader);
-  
-  // separating function from eventlistener to understand they are two separate things
-  function copyHeader () {
-    const headers = document.querySelectorAll("h2.anchor, h3.anchor, .expandable-anchor.anchor");
+// Get all the headers with anchor links. 
+// The 'click' event worked over 'popstate' because click captures page triggers, as well as back/forward button triggers
+// Adding the 'load' event to also capture the initial page load
+window.addEventListener("click", copyHeader);
+window.addEventListener("load", copyHeader);
 
-headers.forEach((header) => {
+// separating function from eventlistener to understand they are two separate things
+function copyHeader () {
+  const headers = document.querySelectorAll("h2.anchor, h3.anchor, .expandable-anchor.anchor");
+
+  headers.forEach((header) => {
     header.style.cursor = "pointer";
+
+    // Remove trailing `-` if exists
+    const thisId = header?.getAttribute('id')
+    if(thisId?.endsWith('-')) {
+      console.log(`Updating ID: ${thisId}`);
+      // Remove `-` from end of ID string
+      header.id = thisId?.substring(0, thisId?.length - 1)
+      console.log(`header.id after update: ${header.id}`);
+    }
+
     const clipboard = new ClipboardJS(header, {
-        text: function(trigger) {
-            const anchorLink = trigger.getAttribute("id");
-            return window.location.href.split('#')[0] + '#' + anchorLink;
-        }
+      text: function(trigger) {
+          const anchorLink = trigger.getAttribute("id");
+          return window.location.href.split('#')[0] + '#' + anchorLink;
+      }
     });
 
     clipboard.on('success', function(e) {
-        // Provide user feedback (e.g., alert or tooltip) here
-        const popup = document.createElement('div');
-        popup.classList.add('copy-popup');
-        popup.innerText = 'Link copied!';
-        document.body.appendChild(popup);
+      // Provide user feedback (e.g., alert or tooltip) here
+      const popup = document.createElement('div');
+      popup.classList.add('copy-popup');
+      popup.innerText = 'Link copied!';
+      document.body.appendChild(popup);
 
-        // Set up timeout to remove the popup after 3 seconds
-        setTimeout(() => {
-            document.body.removeChild(popup);
-        }, 3000);
+      // Set up timeout to remove the popup after 3 seconds
+      setTimeout(() => {
+          document.body.removeChild(popup);
+      }, 3000);
 
-        // Add close button ('x')
-        const closeButton = document.createElement('span');
-        closeButton.classList.add('close-button');
-        closeButton.innerHTML = ' &times;'; // '×' symbol for 'x'
-        closeButton.addEventListener('click', () => {
-            if (document.body.contains(popup)) {
-                document.body.removeChild(popup);
-            }
-        });
-        popup.appendChild(closeButton);
+      // Add close button ('x')
+      const closeButton = document.createElement('span');
+      closeButton.classList.add('close-button');
+      closeButton.innerHTML = ' &times;'; // '×' symbol for 'x'
+      closeButton.addEventListener('click', () => {
+          if (document.body.contains(popup)) {
+              document.body.removeChild(popup);
+          }
+      });
+      popup.appendChild(closeButton);
 
-        // Add and remove the 'clicked' class for styling purposes
-        e.trigger.classList.add("clicked");
-        setTimeout(() => {
-            if (document.body.contains(popup)) {
-                document.body.removeChild(popup);
-            }
-        }, 3000);
+      // Add and remove the 'clicked' class for styling purposes
+      e.trigger.classList.add("clicked");
+      setTimeout(() => {
+          if (document.body.contains(popup)) {
+              document.body.removeChild(popup);
+          }
+      }, 3000);
     });
 
     clipboard.on('error', function(e) {
         console.error("Unable to copy to clipboard: " + e.text);
     });
-});
+  });
 };

--- a/website/static/js/headerLinkCopy.js
+++ b/website/static/js/headerLinkCopy.js
@@ -14,13 +14,7 @@ function copyHeader () {
     header.style.cursor = "pointer";
 
     // Remove trailing `-` if exists
-    const thisId = header?.getAttribute('id')
-    if(thisId?.endsWith('-')) {
-      console.log(`Updating ID: ${thisId}`);
-      // Remove `-` from end of ID string
-      header.id = thisId?.substring(0, thisId?.length - 1)
-      console.log(`header.id after update: ${header.id}`);
-    }
+    header = removeTrailingDashes(header)
 
     const clipboard = new ClipboardJS(header, {
       text: function(trigger) {
@@ -66,3 +60,25 @@ function copyHeader () {
     });
   });
 };
+
+// Util function to remove trailing dashes from ID attribute on headers
+function removeTrailingDashes(header) {
+  // Create copy of header element
+  const updatedHeader = header;
+
+  // Get id attribute
+  const thisId = updatedHeader?.getAttribute("id");
+  
+  // If header's id ends with trailing dash, remove dash
+  if (thisId?.endsWith("-")) {
+    console.log(`Updating ID: ${thisId}`);
+    // Remove `-` from end of ID string
+    updatedHeader.id = thisId?.substring(0, thisId?.length - 1);
+    console.log(`Header ID after update: ${updatedHeader.id}`);
+
+    // Recursively run function to check for another trailing slash
+    removeTrailingDashes(updatedHeader);
+  }
+
+  return updatedHeader;
+}

--- a/website/static/js/headerLinkCopy.js
+++ b/website/static/js/headerLinkCopy.js
@@ -68,13 +68,11 @@ function removeTrailingDashes(header) {
 
   // Get id attribute
   const thisId = updatedHeader?.getAttribute("id");
-  
+
   // If header's id ends with trailing dash, remove dash
   if (thisId?.endsWith("-")) {
-    console.log(`Updating ID: ${thisId}`);
     // Remove `-` from end of ID string
     updatedHeader.id = thisId?.substring(0, thisId?.length - 1);
-    console.log(`Header ID after update: ${updatedHeader.id}`);
 
     // Recursively run function to check for another trailing slash
     removeTrailingDashes(updatedHeader);


### PR DESCRIPTION
[Asana task](https://app.asana.com/0/1200099998847559/1206616034730932/f)

## What are you changing in this pull request and why?

### Issue
If the `LifeCycle` component is used on a header, Docusaurus adds a trailing `-` at the end of the header id attribute. If you click to copy a header using the LifeCycle component, you will see the trailing dash included to the url in your clipboard. 

While this works, it may cause confusion when the team is sharing links to specific sections.

### Resolution
Check if header id has a trailing dash, and if so, remove trailing dash on initial load of page.

## Preview

### Checking header with single LifeCycle status

On this page on the live site, a LifeCycle component is used on the `Keep on latest version` header. This causes a trailing dash to be added to the `id` for this header element:
https://docs.getdbt.com/docs/dbt-versions/upgrade-dbt-version-in-cloud

In the preview:
- verify the trailing slash is removed from the `Keep on latest version` id attribute
- verify you can click the header to copy it, and that the trailing dash is removed
- verify other headers have correct id set and the click-to-copy function works as expected

https://docs-getdbt-com-git-remove-trailing-dash-dbt-labs.vercel.app/docs/dbt-versions/upgrade-dbt-version-in-cloud

### Checking header with multiple LifeCycle statuses set

On this page, multiple statuses are used in the `Trigger on job completion` header, causing multiple trailing dashes:
https://docs.getdbt.com/docs/deploy/deploy-jobs#trigger-on-job-completion--

Verify all trailing dashes are removed within the preview
https://docs-getdbt-com-git-remove-trailing-dash-dbt-labs.vercel.app/docs/deploy/deploy-jobs
## Notes

I have a couple console logs in the preview to verify the script is detecting and removing the trailing slashes.

## TODO Before Merge
- [ ] Remove console logs

