### PR TITLE
Document how to set Python version for snowpark

### DIFF
--- a/website/docs/docs/build/python-models.md
+++ b/website/docs/docs/build/python-models.md
@@ -621,6 +621,15 @@ In their initial launch, Python models are supported on three of the most popula
 
 **Installing packages:** Snowpark supports several popular packages via Anaconda. The complete list is at https://repo.anaconda.com/pkgs/snowflake/. Packages are installed at the time your model is being run. Different models can have different package dependencies. If you are using third-party packages, Snowflake recommends using a dedicated virtual warehouse for best performance rather than one with many concurrent users.
 
+**Python Version:** To specify a different python version, use the configuration:
+```
+def model(dbt, session):
+    dbt.config(
+        materialized = "table",
+        python_version="3.11"
+    )
+```
+
 **About "sprocs":** dbt submits Python models to run as _stored procedures_, which some people call _sprocs_ for short. By default, dbt will create a named sproc containing your model's compiled Python code, and then _call_ it to execute. Snowpark has an Open Preview feature for _temporary_ or _anonymous_ stored procedures ([docs](https://docs.snowflake.com/en/sql-reference/sql/call-with.html)), which are faster and leave a cleaner query history. You can switch this feature on for your models by configuring `use_anonymous_sproc: True`. We plan to switch this on for all dbt + Snowpark Python models starting with the release of dbt Core version 1.4.
 
 <File name='dbt_project.yml'>

--- a/website/docs/docs/build/python-models.md
+++ b/website/docs/docs/build/python-models.md
@@ -621,7 +621,7 @@ In their initial launch, Python models are supported on three of the most popula
 
 **Installing packages:** Snowpark supports several popular packages via Anaconda. The complete list is at https://repo.anaconda.com/pkgs/snowflake/. Packages are installed at the time your model is being run. Different models can have different package dependencies. If you are using third-party packages, Snowflake recommends using a dedicated virtual warehouse for best performance rather than one with many concurrent users.
 
-**Python Version:** To specify a different python version, use the configuration:
+**Python version:** To specify a different python version, use the following configuration:
 ```
 def model(dbt, session):
     dbt.config(


### PR DESCRIPTION
Discussion here (internal) https://dbt-labs.slack.com/archives/C03AV98FU5C/p1709637978840529

shows a way to override the default python version (ref: https://github.com/dbt-labs/dbt-snowflake/blob/f0cbea2a47cae7b7d6d6ce750faaafa33e0d3ced/dbt/adapters/snowflake/impl.py#L204C26-L204C49) 