### PR TITLE
Add AlloyDB to data platforms available within dbt Cloud

### DIFF
--- a/website/docs/docs/cloud/connect-data-platform/about-connections.md
+++ b/website/docs/docs/cloud/connect-data-platform/about-connections.md
@@ -7,6 +7,7 @@ pagination_next: "docs/cloud/connect-data-platform/connect-microsoft-fabric"
 pagination_prev: null
 ---
 dbt Cloud can connect with a variety of data platform providers including: 
+- [AlloyDB](/docs/cloud/connect-data-platform/connect-redshift-postgresql-alloydb) 
 - [Amazon Redshift](/docs/cloud/connect-data-platform/connect-redshift-postgresql-alloydb) 
 - [Apache Spark](/docs/cloud/connect-data-platform/connect-apache-spark) 
 - [Databricks](/docs/cloud/connect-data-platform/connect-databricks) 


### PR DESCRIPTION
## What are you changing in this pull request and why?

AlloyDB has a link titled "Set up in dbt Cloud" [here](https://docs.getdbt.com/docs/trusted-adapters), but is not in the listing [here](https://docs.getdbt.com/docs/cloud/connect-data-platform/about-connections).

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.