### PR TITLE
clarify varchar default limit and how to exceed

### DIFF
--- a/website/docs/reference/resource-properties/constraints.md
+++ b/website/docs/reference/resource-properties/constraints.md
@@ -191,6 +191,8 @@ models:
         data_type: date
 ```
 
+Note that by default (or when specified without a length), `varchar` in Redshift limits the maximum length of the values to 256 characters. This means that any string data exceeding 256 characters will be truncated, potentially leading to loss of information. To allow more characters, use `varchar(max)`: `data_type: varchar(max)`.  
+
 </File>
 
 Expected DDL to enforce constraints:

--- a/website/docs/reference/resource-properties/constraints.md
+++ b/website/docs/reference/resource-properties/constraints.md
@@ -191,7 +191,7 @@ models:
         data_type: date
 ```
 
-Note that by default (or when specified without a length), `varchar` in Redshift limits the maximum length of the values to 256 characters. This means that any string data exceeding 256 characters will be truncated, potentially leading to loss of information. To allow more characters, use `varchar(max)`: `data_type: varchar(max)`.  
+Note that by default (or when specified without a length), `varchar` in Redshift limits the maximum length of the values to 256 characters. This means that any string data exceeding 256 characters will be truncated. To allow the maximum length, use `varchar(max)`. For example, `data_type: varchar(max)`.  
 
 </File>
 

--- a/website/docs/reference/resource-properties/constraints.md
+++ b/website/docs/reference/resource-properties/constraints.md
@@ -191,7 +191,7 @@ models:
         data_type: date
 ```
 
-Note that by default (or when specified without a length), `varchar` in Redshift limits the maximum length of the values to 256 characters. This means that any string data exceeding 256 characters will be truncated. To allow the maximum length, use `varchar(max)`. For example, `data_type: varchar(max)`.  
+Note that by default (or when specified without a length), `varchar` in Redshift limits the maximum length of the values to 256 characters. This means that any string data exceeding 256 characters might get truncated OR return a "value too long for character type" error. To allow the maximum length, use `varchar(max)`. For example, `data_type: varchar(max)`.  
 
 </File>
 

--- a/website/docs/reference/resource-properties/constraints.md
+++ b/website/docs/reference/resource-properties/constraints.md
@@ -191,7 +191,7 @@ models:
         data_type: date
 ```
 
-Note that by default (or when specified without a length), `varchar` in Redshift limits the maximum length of the values to 256 characters. This means that any string data exceeding 256 characters might get truncated OR return a "value too long for character type" error. To allow the maximum length, use `varchar(max)`. For example, `data_type: varchar(max)`.  
+Note that Redshift limits the maximum length of the `varchar` values to 256 characters by default (or when specified without a length). This means that any string data exceeding 256 characters might get truncated _or_ return a "value too long for character type" error. To allow the maximum length, use `varchar(max)`. For example, `data_type: varchar(max)`.  
 
 </File>
 


### PR DESCRIPTION
per user feedback and multiple support tickets where users were confuse, this pr adds clarification that varchar default to 256 characters. To exceed the limit, users can specify the data_type to `varchar(max)`.

slack thread here: https://dbt-labs.slack.com/archives/C02NCQ9483C/p1710248503404249

