### PR TITLE
Hide toc headers

### DIFF
--- a/website/docs/docs/cloud/cloud-cli-installation.md
+++ b/website/docs/docs/cloud/cloud-cli-installation.md
@@ -6,6 +6,24 @@ description: "Instructions for installing and configuring dbt Cloud CLI"
 pagination_next: "docs/cloud/configure-cloud-cli"
 ---
 
+<expandable alt_header="Test expandable with header">
+
+## Has h2 heading
+
+demo content
+
+### Has h3 heading
+
+demo content
+
+</expandable>
+
+<expandable alt_header="Test expandable without header">
+
+content
+
+</expandable>
+
 import CloudCLIFlag from '/snippets/_cloud-cli-flag.md';
 
 <CloudCLIFlag/>

--- a/website/docs/docs/cloud/cloud-cli-installation.md
+++ b/website/docs/docs/cloud/cloud-cli-installation.md
@@ -6,24 +6,6 @@ description: "Instructions for installing and configuring dbt Cloud CLI"
 pagination_next: "docs/cloud/configure-cloud-cli"
 ---
 
-<expandable alt_header="Test expandable with header">
-
-## Has h2 heading
-
-demo content
-
-### Has h3 heading
-
-demo content
-
-</expandable>
-
-<expandable alt_header="Test expandable without header">
-
-content
-
-</expandable>
-
 import CloudCLIFlag from '/snippets/_cloud-cli-flag.md';
 
 <CloudCLIFlag/>

--- a/website/src/theme/DocItem/Layout/index.js
+++ b/website/src/theme/DocItem/Layout/index.js
@@ -51,7 +51,7 @@ function useDocTOC() {
 
     // Headings to remove from TOC
     const headingsToFilter = await getElements(
-      ".tabs-container h2, .tabs-container h3"
+      ".tabs-container h2, .tabs-container h3, .expandable-anchor h2, .expandable-anchor h3"
     );
     
     // if headings exist on page

--- a/website/src/theme/DocItem/Layout/index.js
+++ b/website/src/theme/DocItem/Layout/index.js
@@ -53,7 +53,6 @@ function useDocTOC() {
     const headingsToFilter = await getElements(
       ".tabs-container h2, .tabs-container h3"
     );
-    console.log("headingsToFilter", headingsToFilter);
     
     // if headings exist on page
     // compare against toc

--- a/website/src/theme/DocItem/Layout/index.js
+++ b/website/src/theme/DocItem/Layout/index.js
@@ -45,19 +45,32 @@ function useDocTOC() {
 
   async function fetchElements() {
     // get html elements
-    const headings = await getElements(".markdown h1, .markdown h2, .markdown h3, .markdown h4, .markdown h5, .markdown h6")
+    const headings = await getElements(
+      ".markdown h1, .markdown h2, .markdown h3, .markdown h4, .markdown h5, .markdown h6"
+    );
 
+    // Headings to remove from TOC
+    const headingsToFilter = await getElements(
+      ".tabs-container h2, .tabs-container h3"
+    );
+    console.log("headingsToFilter", headingsToFilter);
     
     // if headings exist on page
     // compare against toc
     if(toc && headings && headings.length) {
       // make new TOC object 
       let updated = Array.from(headings).reduce((acc, item) => {
+        // Filter out TOC items from tabs
+        const shouldFilter = Array?.from(headingsToFilter)?.find(
+          (thisHeading) => thisHeading?.id === item?.id
+        );
+        if (shouldFilter) {
+          return acc;
+        }
+
         // If heading id and toc item id match found
         // include in updated toc
-        let found = toc.find(heading =>
-          heading.id.includes(item.id)
-        )
+        let found = toc.find((heading) => heading.id.includes(item.id));
         // If toc item is not in headings
         // do not include in toc
         // This means heading is versioned
@@ -65,29 +78,31 @@ function useDocTOC() {
         let makeToc = (heading) => {
           let level;
           if (heading.nodeName === "H2") {
-            level = 2
+            level = 2;
           } else if (heading.nodeName === "H3") {
-            level = 3
+            level = 3;
           } else {
-            level = null
+            level = null;
           }
 
           return {
             value: heading.innerHTML,
             id: heading.id,
-            level: level && level
-          }
-        }
+            level: level && level,
+          };
+        };
 
+        // If heading is in current version
+        // include in updated toc
         if (found) {
-          acc.push(makeToc(item))
+          acc.push(makeToc(item));
         } else if (!found) {
-          acc.push(makeToc(item))
+          acc.push(makeToc(item));
         } else {
-          null
+          null;
         }
 
-        return acc
+        return acc;
       }, [])
 
       // If updated toc different than current


### PR DESCRIPTION
[Asana task](https://app.asana.com/0/1200099998847559/1205976870784519/f)

## What are you changing in this pull request and why?

If h2 or h3 headers exist within the Tabs or Expandable components, they appear in the TOC. However they are unable to link to the section in the page from the TOC as they are hidden elements initially.

This filters out TOC headers which are nested in Tabs or Expandable components. 

## Previews

This page has tabs and a demo `expandable` component at the top of the page. Verify the headers within these sections are removed from the TOC:
https://docs-getdbt-com-git-hide-toc-headers-dbt-labs.vercel.app/docs/cloud/cloud-cli-installation

This page has h2 & h3 headings, verify they remain on the page:
https://docs-getdbt-com-git-hide-toc-headers-dbt-labs.vercel.app/docs/cloud/about-cloud/architecture

## Checklist
- [x] Remove demo Expandable content from cloud-cli-installation page
