### PR TITLE
Align example command and output for interactive compile

### DIFF
--- a/website/docs/reference/commands/compile.md
+++ b/website/docs/reference/commands/compile.md
@@ -29,7 +29,7 @@ This will log the compiled SQL to the terminal, in addition to writing to the `t
 For example:
 
 ```bash
-dbt compile --select "stg_payments"
+dbt compile --select "stg_orders"                           
 dbt compile --inline "select * from {{ ref('raw_orders') }}"
 ```
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

Missed one piece in https://github.com/dbt-labs/docs.getdbt.com/pull/4825

Specifically, the example command does not align with the example output. So this PR updates the example command.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.