### PR TITLE
`conversion` is a valid metric `type`

### DIFF
--- a/website/docs/docs/build/metrics-overview.md
+++ b/website/docs/docs/build/metrics-overview.md
@@ -19,7 +19,7 @@ The keys for metrics definitions are:
 | --------- | ----------- | ---- |
 | `name` | Provide the reference name for the metric. This name must be unique amongst all metrics.   | Required |
 | `description` | Describe your metric.   | Optional |
-| `type` | Define the type of metric, which can be `simple`, `ratio`, `cumulative`, or `derived`.  | Required |
+| `type` | Define the type of metric, which can be `simple`, `ratio`, `cumulative`, `conversion`, or `derived`.  | Required |
 | `type_params` | Additional parameters used to configure metrics. `type_params` are different for each metric type. | Required |
 | `config` | Provide the specific configurations for your metric.   | Optional |
 | `config:meta` | Use the [`meta` config](/reference/resource-configs/meta) to set metadata for a resource.  | Optional |

--- a/website/docs/docs/build/metrics-overview.md
+++ b/website/docs/docs/build/metrics-overview.md
@@ -19,7 +19,7 @@ The keys for metrics definitions are:
 | --------- | ----------- | ---- |
 | `name` | Provide the reference name for the metric. This name must be unique amongst all metrics.   | Required |
 | `description` | Describe your metric.   | Optional |
-| `type` | Define the type of metric, which can be `simple`, `ratio`, `cumulative`, `conversion`, or `derived`.  | Required |
+| `type` | Define the type of metric, which can be `conversion`, `cumulative`, `derived`, `ratio`, or `simple`. | Required |
 | `type_params` | Additional parameters used to configure metrics. `type_params` are different for each metric type. | Required |
 | `config` | Provide the specific configurations for your metric.   | Optional |
 | `config:meta` | Use the [`meta` config](/reference/resource-configs/meta) to set metadata for a resource.  | Optional |


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty10-patch-3-dbt-labs.vercel.app/docs/build/metrics-overview)

## What are you changing in this pull request and why?
Since [`conversion`](https://docs.getdbt.com/docs/build/conversion) is a valid `type`, we should add it as an option in the docs.

> [!NOTE]  
> I'm not sure if version blocks apply here, because I don't know if the `conversion` has always existed or if it was added after other types.

This is the section of the page being updated:

<img width="450" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/6d05ac54-a4b1-4679-a5a5-96c02243c460">


## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.