### PR TITLE
Generalize hyperlink description to "Fill null values for metrics"

### DIFF
--- a/website/docs/docs/build/conversion-metrics.md
+++ b/website/docs/docs/build/conversion-metrics.md
@@ -372,4 +372,4 @@ on
 </Tabs>
 
 ## Related docs
-- [Fill null values for simple, derived, or ratio metrics](/docs/build/fill-nulls-advanced)
+- [Fill null values for metrics](/docs/build/fill-nulls-advanced)


### PR DESCRIPTION
## What are you changing in this pull request and why?

At the bottom of this page, the hyperlink description lists a **subset** of the valid metric types:

<img width="300" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/4c3f722f-d115-4063-a9b3-67817abf9b1d">

But on other pages, it uses a more **general** description:

<img width="180" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/8775cd34-92e3-44f1-b33c-fd4461e9c46c">

So this PR aligns on the more general description.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.