### PR TITLE
Missing parenthesis when mentioning the Prettier YAML formatter

### DIFF
--- a/website/docs/best-practices/how-we-style/5-how-we-style-our-yaml.md
+++ b/website/docs/best-practices/how-we-style/5-how-we-style-our-yaml.md
@@ -9,7 +9,7 @@ id: 5-how-we-style-our-yaml
 - ➡️ List items should be indented
 - 🆕 Use a new line to separate list items that are dictionaries where appropriate
 - 📏 Lines of YAML should be no longer than 80 characters.
-- 🛠️ Use the [dbt JSON schema](https://github.com/dbt-labs/dbt-jsonschema) with any compatible IDE and a YAML formatter (we recommend [Prettier](https://prettier.io/) to validate your YAML files and format them automatically.
+- 🛠️ Use the [dbt JSON schema](https://github.com/dbt-labs/dbt-jsonschema) with any compatible IDE and a YAML formatter (we recommend [Prettier](https://prettier.io/)) to validate your YAML files and format them automatically.
 
 :::info
 ☁️ As with Python and SQL, the dbt Cloud IDE comes with built-in formatting for YAML files (Markdown and JSON too!), via Prettier. Just click the `Format` button and you're in perfect style. As with the other tools, you can [also customize the formatting rules](https://docs.getdbt.com/docs/cloud/dbt-cloud-ide/lint-format#format-yaml-markdown-json) to your liking to fit your company's style guide.


### PR DESCRIPTION
## What are you changing in this pull request and why?

There is an unclosed parenthesis [here](https://docs.getdbt.com/best-practices/how-we-style/5-how-we-style-our-yaml#yaml-style-guide):

<img width="450" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/e1b0792b-594b-4549-adc9-f9dc36085ca1">


## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.