### PR TITLE
Link to anonymous usage stats page

### DIFF
--- a/website/docs/reference/parsing.md
+++ b/website/docs/reference/parsing.md
@@ -67,4 +67,4 @@ For now, the static parser only works with models, and models whose Jinja is lim
 
 ## Experimental parser
 
-We plan to make iterative improvements to static parsing in future versions, and to use random sampling (via anonymous usage tracking) to verify that it yields correct results. You can opt into the latest "experimental" version of the static parser using the [`USE_EXPERIMENTAL_PARSER` global config](/reference/global-configs/parsing).
+We plan to make iterative improvements to static parsing in future versions, and to use random sampling (via [anonymous usage tracking](/reference/global-configs/usage-stats)) to verify that it yields correct results. You can opt into the latest "experimental" version of the static parser using the [`USE_EXPERIMENTAL_PARSER` global config](/reference/global-configs/parsing).


### PR DESCRIPTION
## What are you changing in this pull request and why?

It's handy to link to the [anonymous usage stats](https://docs.getdbt.com/reference/global-configs/usage-stats) page from [here](https://docs.getdbt.com/reference/parsing#experimental-parser).

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.