### PR TITLE
The `USE_EXPERIMENTAL_PARSER` global config is not currently in use

### DIFF
--- a/website/docs/reference/parsing.md
+++ b/website/docs/reference/parsing.md
@@ -6,7 +6,7 @@ description: "Read this guide to understand the project parsing configuration in
 ## Related documentation
 - The `dbt parse` [command](/reference/commands/parse)
 - Partial parsing [profile config](/docs/core/connect-data-platform/profiles.yml#partial_parse) and [CLI flags](/reference/global-configs/parsing)
-- Experimental parser [CLI flag](/reference/global-configs/parsing)
+- Parsing [CLI flags](/reference/global-configs/parsing)
 
 ## What is parsing?
 
@@ -15,7 +15,7 @@ At the start of every dbt invocation, dbt reads all the files in your project, e
 Parsing projects can be slow, especially as projects get bigger—hundreds of models, thousands of files—which is frustrating in development. There are a handful of ways to optimize dbt performance today:
 - LibYAML bindings for PyYAML
 - Partial parsing, which avoids re-parsing unchanged files between invocations
-- An experimental parser, which extracts information from simple models much more quickly
+- A static parser, which extracts information from simple models much more quickly
 - [RPC server](/reference/commands/rpc), which keeps a manifest in memory, and re-parses the project at server startup/hangup
 
 These optimizations can be used in combination to reduce parse time from minutes to seconds. At the same time, each has some known limitations, so they are disabled by default.
@@ -59,11 +59,11 @@ If you ever get into a bad state, you can disable partial parsing and trigger a 
 
 ## Static parser
 
-At parse time, dbt needs to extract the contents of `ref()`, `source()`, and `config()` from all models in the project. Traditionally, dbt has extracted those values by rendering the Jinja in every model file, which can be slow. In v0.20, we introduced a new way to statically analyze model files, leveraging [`tree-sitter`](https://github.com/tree-sitter/tree-sitter), which we're calling an "experimental parser". You can see the code for an initial Jinja2 grammar [here](https://github.com/dbt-labs/tree-sitter-jinja2).
+At parse time, dbt needs to extract the contents of `ref()`, `source()`, and `config()` from all models in the project. Traditionally, dbt has extracted those values by rendering the Jinja in every model file, which can be slow. In v0.20, we introduced a new way to statically analyze model files, leveraging [`tree-sitter`](https://github.com/tree-sitter/tree-sitter). You can see the code for an initial Jinja2 grammar [here](https://github.com/dbt-labs/tree-sitter-jinja2).
 
-Starting in v1.0, the experimental parser is **on** by default. We believe it can offer *some* speedup to 95% of projects. You may optionally turn it off using the [`STATIC_PARSER` global config](/reference/global-configs/parsing).
+Starting in v1.0, the static parser is **on** by default. We believe it can offer *some* speedup to 95% of projects. You may optionally turn it off using the [`STATIC_PARSER` global config](/reference/global-configs/parsing).
 
-For now, the static parser only works with models, and models whose Jinja is limited to those three special macros (`ref`, `source`, `config`). The experimental parser is at least 3x faster than a full Jinja render. Based on testing with data from dbt Cloud, we believe the current grammar can statically parse 60% of models in the wild. So for the average project, we'd hope to see a 40% speedup in the model parser.
+For now, the static parser only works with models, and models whose Jinja is limited to those three special macros (`ref`, `source`, `config`). The static parser is at least 3x faster than a full Jinja render. Based on testing with data from dbt Cloud, we believe the current grammar can statically parse 60% of models in the wild. So for the average project, we'd hope to see a 40% speedup in the model parser.
 
 ## Experimental parser
 

--- a/website/docs/reference/parsing.md
+++ b/website/docs/reference/parsing.md
@@ -67,4 +67,4 @@ For now, the static parser only works with models, and models whose Jinja is lim
 
 ## Experimental parser
 
-We plan to make iterative improvements to static parsing in future versions, and to use random sampling (via anonymous usage tracking) to verify that it yields correct results. You can opt into the latest "experimental" version of the static parser using the [`USE_EXPERIMENTAL_PARSER` global config](/reference/global-configs/parsing).
+Not currently in use.


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty10-patch-2-dbt-labs.vercel.app/reference/parsing)

resolves #4990

## What are you changing in this pull request and why?

1. Make updates as requested [here](https://github.com/dbt-labs/dbt-core/discussions/9535).
1. Align with https://github.com/dbt-labs/docs.getdbt.com/commit/5a66d8c6e5e35279fc7a94286d0da48529805774.

## More info

In v0.20, we introduced an "experimental" static parser. It statically analyzes model files and is faster at parsing nodes that don't need a full Jinja render. Starting in v1.0, this parser is **on** by default, and is no longer experimental. It can still be toggled on/off via the [`STATIC_PARSER` global config](https://docs.getdbt.com/reference/global-configs/parsing#static-parser).

From https://github.com/dbt-labs/dbt-core/discussions/9535#discussioncomment-8395906:
> We haven't made any "experimental" updates since 2021 (in the leadup to dbt-core v1.0). But we've kept the flag around for the _next_ time we want to try some more-radical changes, and need a way to:
> - (a) let folks opt in/out
> - (b) compare timing/outputs

Put another way, the `--use-experimental-parser` / `--no-use-experimental-parser` flags still exist (along with `DBT_USE_EXPERIMENTAL_PARSER` environment variable), but they don't have any effect currently; they may again in the future.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.