### PR TITLE
The "saved_query" selector method

### DIFF
--- a/website/docs/reference/node-selection/methods.md
+++ b/website/docs/reference/node-selection/methods.md
@@ -395,8 +395,8 @@ Supported in v1.7 or newer.
 The `semantic_model` method selects [semantic models](/docs/build/saved-queries).
 
 ```bash
-dbt list --select saved_query:*                    # list all saved queries 
-dbt list --select +saved_query:orders_saved_query  # list your saved query named "orders_saved_query" and all upstream resources
+dbt list --select "saved_query:*"                    # list all saved queries 
+dbt list --select "+saved_query:orders_saved_query"  # list your saved query named "orders_saved_query" and all upstream resources
 ```
 
 </VersionBlock>

--- a/website/docs/reference/node-selection/methods.md
+++ b/website/docs/reference/node-selection/methods.md
@@ -385,3 +385,18 @@ dbt list --select +semantic_model:orders  # list your semantic model named "orde
 ```
 
 </VersionBlock>
+
+### The "saved_query" method
+<VersionBlock lastVersion="1.6">
+Supported in v1.7 or newer.
+</VersionBlock>
+<VersionBlock firstVersion="1.7">
+
+The `semantic_model` method selects [semantic models](/docs/build/saved-queries).
+
+```bash
+dbt list --select saved_query:*                    # list all saved queries 
+dbt list --select +saved_query:orders_saved_query  # list your saved query named "orders_saved_query" and all upstream resources
+```
+
+</VersionBlock>

--- a/website/docs/reference/node-selection/methods.md
+++ b/website/docs/reference/node-selection/methods.md
@@ -392,7 +392,7 @@ Supported in v1.7 or newer.
 </VersionBlock>
 <VersionBlock firstVersion="1.7">
 
-The `semantic_model` method selects [semantic models](/docs/build/saved-queries).
+The `saved_query` method selects [saved queries](/docs/build/saved-queries).
 
 ```bash
 dbt list --select "saved_query:*"                    # list all saved queries 


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/reference/node-selection/methods#the-saved_query-method)

## What are you changing in this pull request and why?

The "saved_query" selector method was [added in v1.7](https://github.com/dbt-labs/dbt-core/blob/1.7.latest/CHANGELOG.md#dbt-core-170---november-02-2023) by https://github.com/dbt-labs/dbt-core/issues/8594 / https://github.com/dbt-labs/dbt-core/pull/8798.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [x] I have verified all new code examples work as described