### PR TITLE
Wildcards require single or double quotes for `zsh` shell

### DIFF
--- a/website/docs/reference/node-selection/methods.md
+++ b/website/docs/reference/node-selection/methods.md
@@ -380,7 +380,7 @@ Supported in v1.6 or newer.
 The `semantic_model` method selects [semantic models](/docs/build/semantic-models).
 
 ```bash
-dbt list --select semantic_model:*        # list all semantic models 
+dbt list --select "semantic_model:*"        # list all semantic models 
 dbt list --select +semantic_model:orders  # list your semantic model named "orders" and all upstream resources
 ```
 

--- a/website/docs/reference/node-selection/methods.md
+++ b/website/docs/reference/node-selection/methods.md
@@ -364,7 +364,7 @@ The `version` method selects [versioned models](/docs/collaborate/govern/model-v
 ```bash
 dbt list --select "version:latest"      # only 'latest' versions
 dbt list --select "version:prerelease"  # versions newer than the 'latest' version
-dbt list --select version:old         # versions older than the 'latest' version
+dbt list --select "version:old"         # versions older than the 'latest' version
 
 dbt list --select "version:none"        # models that are *not* versioned
 ```
@@ -381,7 +381,7 @@ The `semantic_model` method selects [semantic models](/docs/build/semantic-model
 
 ```bash
 dbt list --select "semantic_model:*"        # list all semantic models 
-dbt list --select +semantic_model:orders  # list your semantic model named "orders" and all upstream resources
+dbt list --select "+semantic_model:orders"  # list your semantic model named "orders" and all upstream resources
 ```
 
 </VersionBlock>


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty10-patch-3-dbt-labs.vercel.app/reference/node-selection/methods#the-semantic_model-method)

## What are you changing in this pull request and why?

This code example doesn't work for me:
```shell
dbt list --select semantic_model:*
```

It gives the following error:
```
zsh: no matches found: semantic_model:*
```

But adding double quotes works great:
```shell
dbt list --select "semantic_model:*"
```

To keep things consistent, I also added double quotes to the two other examples that were missing them.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.