### PR TITLE
Update the example commands for the "state" selector method

### DIFF
--- a/website/docs/reference/node-selection/methods.md
+++ b/website/docs/reference/node-selection/methods.md
@@ -222,7 +222,7 @@ The `state` method is used to select nodes by comparing them against a previous 
 
 
   ```bash
-dbt test --select "state:new "           # run all tests on new models + and new tests on old models
+dbt test --select "state:new"            # run all tests on new models + and new tests on old models
 dbt run --select "state:modified"        # run all models that have been modified
 dbt ls --select "state:modified"         # list all modified nodes (not just models)
   ```

--- a/website/docs/reference/node-selection/methods.md
+++ b/website/docs/reference/node-selection/methods.md
@@ -222,9 +222,9 @@ The `state` method is used to select nodes by comparing them against a previous 
 
 
   ```bash
-dbt test --select "state:new"            # run all tests on new models + and new tests on old models
-dbt run --select "state:modified"        # run all models that have been modified
-dbt ls --select "state:modified"         # list all modified nodes (not just models)
+dbt test --select "state:new" --state path/to/artifacts      # run all tests on new models + and new tests on old models
+dbt run --select "state:modified" --state path/to/artifacts  # run all models that have been modified
+dbt ls --select "state:modified" --state path/to/artifacts   # list all modified nodes (not just models)
   ```
 
 


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty10-patch-4-dbt-labs.vercel.app/reference/node-selection/methods#the-state-method)

## What are you changing in this pull request and why?

Two things:
1. All the examples need a `--state` flag (similar to the "result" selector method)
1. One example in particular doesn't work because of an extra space

### More detail

Here's the error I get when the `--state` flag is not included:
```
01:02:43  Encountered an error:
Runtime Error
  Got a state selector method, but no comparison manifest
```

Here's the error I get with the extra space:
```
01:11:01  The selection criterion '' does not match any nodes
```

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.