### PR TITLE
Fix heading and links for `loaded_at_field`

### DIFF
--- a/website/docs/reference/resource-properties/freshness.md
+++ b/website/docs/reference/resource-properties/freshness.md
@@ -85,7 +85,7 @@ This is useful when all of the tables in a source have the same `loaded_at_field
 (Required)
 </VersionBlock>
 
-<br/>A column name (or expression) that returns a timestamp indicating freshness.<br/>
+<br/><br/>A column name (or expression) that returns a timestamp indicating freshness.<br/>
 If using a date field, you may have to cast it to a timestamp:
 ```yml
 loaded_at_field: "completed_date::timestamp"

--- a/website/docs/reference/resource-properties/freshness.md
+++ b/website/docs/reference/resource-properties/freshness.md
@@ -62,8 +62,6 @@ To exclude a source from freshness calculations, you have two options:
 - Don't add a `freshness:` block.
 - Explicitly set `freshness: null`.
 
-## loaded_at_field
-(Optional on adapters that support pulling freshness from warehouse metadata tables, required otherwise.)
 </VersionBlock>
 
 <VersionBlock lastVersion="1.6">
@@ -75,10 +73,18 @@ Freshness blocks are applied hierarchically:
 - A `freshness` and `loaded_at_field` property added to a source _table_ will override any properties applied to the source.
 
 This is useful when all of the tables in a source have the same `loaded_at_field`, as is often the case.
+</VersionBlock>
 
 ## loaded_at_field
+
+<VersionBlock firstVersion="1.7">
+(Optional on adapters that support pulling freshness from warehouse metadata tables, required otherwise.)
+</VersionBlock>
+
+<VersionBlock lastVersion="1.6">
 (Required)
 </VersionBlock>
+
 A column name (or expression) that returns a timestamp indicating freshness.
 
 If using a date field, you may have to cast it to a timestamp:

--- a/website/docs/reference/resource-properties/freshness.md
+++ b/website/docs/reference/resource-properties/freshness.md
@@ -86,7 +86,6 @@ This is useful when all of the tables in a source have the same `loaded_at_field
 </VersionBlock>
 
 A column name (or expression) that returns a timestamp indicating freshness.
-
 If using a date field, you may have to cast it to a timestamp:
 ```yml
 loaded_at_field: "completed_date::timestamp"

--- a/website/docs/reference/resource-properties/freshness.md
+++ b/website/docs/reference/resource-properties/freshness.md
@@ -86,6 +86,7 @@ This is useful when all of the tables in a source have the same `loaded_at_field
 </VersionBlock>
 
 <br/><br/>A column name (or expression) that returns a timestamp indicating freshness.
+
 If using a date field, you may have to cast it to a timestamp:
 ```yml
 loaded_at_field: "completed_date::timestamp"

--- a/website/docs/reference/resource-properties/freshness.md
+++ b/website/docs/reference/resource-properties/freshness.md
@@ -85,7 +85,7 @@ This is useful when all of the tables in a source have the same `loaded_at_field
 (Required)
 </VersionBlock>
 
-A column name (or expression) that returns a timestamp indicating freshness.
+<br/>A column name (or expression) that returns a timestamp indicating freshness.<br/>
 If using a date field, you may have to cast it to a timestamp:
 ```yml
 loaded_at_field: "completed_date::timestamp"

--- a/website/docs/reference/resource-properties/freshness.md
+++ b/website/docs/reference/resource-properties/freshness.md
@@ -85,7 +85,7 @@ This is useful when all of the tables in a source have the same `loaded_at_field
 (Required)
 </VersionBlock>
 
-<br/><br/>A column name (or expression) that returns a timestamp indicating freshness.<br/>
+<br/><br/>A column name (or expression) that returns a timestamp indicating freshness.
 If using a date field, you may have to cast it to a timestamp:
 ```yml
 loaded_at_field: "completed_date::timestamp"


### PR DESCRIPTION
[Preview 1.6](https://docs-getdbt-com-git-dbeatty10-patch-3-dbt-labs.vercel.app//reference/resource-properties/freshness?version=1.6#definition)
[Preview 1.7](https://docs-getdbt-com-git-dbeatty10-patch-3-dbt-labs.vercel.app//reference/resource-properties/freshness?version=1.7#definition)

## What are you changing in this pull request and why?

The changes in this PR fix the following two issues:

1. There are two links on the sidebar for `loaded_at_field`:

    <img width="135" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/91566e5f-539c-44d0-a5e2-2a28ad146bc4">

2. Another issue is that links to the `#loaded_at_field` anchor tag won't always go where you intend, depending on the version the user has selected. I believe this has the same root cause as the first issue.

## 🎩 

### After

<img width="114" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/70dcdffc-ad76-4eaf-984a-424c6a26eff0">

### 1.6 before

<img width="500" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/6775234b-0427-41ae-a1f6-3c471b97b74b">

### 1.6 after

<img width="498" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/56706b79-bd37-4141-99d4-6b2a30dadddd">

### 1.7 before

<img width="499" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/84a377db-8cdf-4d32-9c8e-dbba92549c52">

### 1.7 after

<img width="499" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/8567a4df-3577-4429-b4ed-f229e578a66b">

## Checklist

- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [x] For [docs versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#about-versioning), review how to [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content).