### PR TITLE
Small fix for wording for `on_configuration_change`

### DIFF
--- a/website/docs/reference/resource-configs/on_configuration_change.md
+++ b/website/docs/reference/resource-configs/on_configuration_change.md
@@ -10,7 +10,7 @@ This functionality is currently only supported for [materialized views](/docs/bu
 
 The `on_configuration_change` config has three settings:
 - `apply` (default) &mdash; Attempt to update the existing database object if possible, avoiding a complete rebuild.
-  - *Note:* If any individual configuration change requires a full refresh, a full refresh be performed in lieu of individual alter statements.
+  - *Note:* If any individual configuration change requires a full refresh, a full refresh is performed in lieu of individual alter statements.
 - `continue` &mdash; Allow runs to continue while also providing a warning that the object was left untouched.
   - *Note:* This could result in downstream failures as those models may depend on these unimplemented changes.
 - `fail` &mdash; Force the entire run to fail if a change is detected.


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty10-patch-4-dbt-labs.vercel.app/reference/resource-configs/on_configuration_change)

## What are you changing in this pull request and why?

The sentence is misworded, and this is an attempt to fix it.

This PR needs someone on the Adapters team to review for technical correctness.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.