### PR TITLE
[#5218] Fix Configuration for max_staleness should be string with explicit format, instead of integer

### DIFF
--- a/website/blog/2023-08-01-announcing-materialized-views.md
+++ b/website/blog/2023-08-01-announcing-materialized-views.md
@@ -150,7 +150,7 @@ config(
     on_configuration_change = 'apply',
     enable_refresh = True,
     refresh_interval_minutes = 30
-    max_staleness = 60,
+    max_staleness = 'INTERVAL 60 MINUTE'
 )
 }}
 ```


### PR DESCRIPTION
Resolves #5218 

## What are you changing in this pull request and why?
As stated in the issue description, while following the example code snippets in  the [Optimizing Materialized Views with dbt ](https://docs.getdbt.com/blog/announcing-materialized-views) page to setup materialized views in BigQuery, I got a database error when I defined `max_staleness=60` (as described in the blog).

When I instead changed that line of the `config` block to `max_staleness='INTERVAL 60 MINUTE'`, the model successfully materialized.

## Checklist

- [X] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [X]  Needs technical review

### Additional information

I tested with:
- `dbt-core`   v1.7.3
- `dbt-bigquery`  v1.7.1

