### PR TITLE
Update code example for `fail_calc`

### DIFF
--- a/website/docs/reference/resource-configs/fail_calc.md
+++ b/website/docs/reference/resource-configs/fail_calc.md
@@ -37,7 +37,7 @@ models:
         tests:
           - unique:
               config:
-                fail_calc: "sum(n_records)"
+                fail_calc: "case when count(*) > 0 then sum(n_records) else 0 end"
 ```
 
 </File>


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty10-patch-4-dbt-labs.vercel.app/reference/resource-configs/fail_calc)

## What are you changing in this pull request and why?

The current code example does not always work and may raise an error like this:

```
14:01:53  None is not of type 'integer'
14:01:53  
14:01:53  Failed validating 'type' in schema['properties']['failures']:
14:01:53      {'type': 'integer'}
14:01:53  
14:01:53  On instance['failures']:
14:01:53      None
```

As described in https://github.com/dbt-labs/dbt-core/issues/4248, it's known that:
- tests whose `fail_calc` is a sum() function raises an error when the test produces no rows at all

Well, that explains why the code example doesn't work!

Jerco described two options for dealing with this:

1. rewrite the test query, to ensure it always returns at least one row
1. rewrite the `fail_calc`, to handle the case in which no rows are returned

This PR adopts the 2nd option and updates the code example to handle the case in which no rows are returned.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [x] I've verified that the updated code example works