### PR TITLE
Beware custom `fail_calc` in tests that have the potential to return no rows at all

### DIFF
--- a/website/docs/reference/resource-configs/fail_calc.md
+++ b/website/docs/reference/resource-configs/fail_calc.md
@@ -14,7 +14,7 @@ For instance, you can configure a `unique` test to return `sum(n_records)` inste
 :::tip Tip
 Beware using functions like `sum()` for `fail_calc` in any test that has the potential to return no rows at all.
 
-Such a test would break (neither pass nor fail), and return the following error: 
+If no rows are returned, the test won't pass or fail but will return the following error: 
 
 ```
 None is not of type 'integer'

--- a/website/docs/reference/resource-configs/fail_calc.md
+++ b/website/docs/reference/resource-configs/fail_calc.md
@@ -11,6 +11,29 @@ Most tests do not use the `fail_calc` config, preferring to return a count of fa
 
 For instance, you can configure a `unique` test to return `sum(n_records)` instead of `count(*)` as the failure calculation: that is, the number of rows in the model containing a duplicated column value, rather than the number of distinct column values that are duplicated.
 
+:::tip Tip
+Beware using functions like `sum()` for `fail_calc` in any test that has the potential to return no rows at all.
+
+Such a test would break (neither pass nor fail), and return the following error: 
+
+```
+None is not of type 'integer'
+
+Failed validating 'type' in schema['properties']['failures']:
+    {'type': 'integer'}
+
+On instance['failures']:
+    None
+```
+
+This scenario can be handled with a case statement that returns `0` when there are no rows:
+
+```yaml
+fail_calc: "case when count(*) > 0 then sum(n_records) else 0 end"
+```
+
+:::
+
 <Tabs
   defaultValue="specific"
   values={[

--- a/website/docs/reference/resource-configs/fail_calc.md
+++ b/website/docs/reference/resource-configs/fail_calc.md
@@ -26,7 +26,7 @@ On instance['failures']:
     None
 ```
 
-This scenario can be handled with a case statement that returns `0` when there are no rows:
+To avoid this issue, use a case statement to ensure that `0` is returned when no rows exist:
 
 ```yaml
 fail_calc: "case when count(*) > 0 then sum(n_records) else 0 end"


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/reference/resource-configs/fail_calc)

## What are you changing in this pull request and why?

Follow-up to #5221

resolves #918

See also: https://github.com/dbt-labs/dbt-core/issues/4248

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.