### PR TITLE
Example using a `{% do return(...) %}` statement in a Jinja macro

### DIFF
--- a/website/docs/reference/dbt-jinja-functions/return.md
+++ b/website/docs/reference/dbt-jinja-functions/return.md
@@ -12,7 +12,7 @@ __Args__:
 The `return` function can be used in macros to return data to the caller. The type of the data (dict, list, int, etc) will be preserved through the `return` call.  You can use the `return` function in the following ways within your macros: as an expression or as a statement.
 
 - Expression &mdash; An expression is used when the goal is to output a string from the macro.
-- Statement with a `do` tag &mdash; Use a statement with a `do` tag to execute the return function without generating an output string.
+- Statement with a `do` tag &mdash; Use a statement with a `do` tag to execute the return function without generating an output string.  This is particularly useful when you want to perform actions without necessarily inserting their results directly into the template. 
 
 In the following example, `{{ return([1,2,3]) }}` acts as an _expression_ that directly outputs a string, making it suitable for directly inserting returned values into SQL code.
 
@@ -28,7 +28,9 @@ In the following example, `{{ return([1,2,3]) }}` acts as an _expression_ that d
 
 </File>
 
-or
+Alternatively, you can use a statement with a [do](https://jinja.palletsprojects.com/en/3.0.x/extensions/#expression-statement) tag (or expression-statements) to execute the return function without generating an output string.  
+
+In the following example ,`{% do return([1,2,3]) %}` acts as a _statement_ that executes the return action but does not output a string:
 
 <File name='macros/get_data.sql'>
 

--- a/website/docs/reference/dbt-jinja-functions/return.md
+++ b/website/docs/reference/dbt-jinja-functions/return.md
@@ -46,7 +46,7 @@ select
   -- getdata() returns a list!
   {% for i in get_data() %}
     {{ i }}
-    {% if not loop.last %},{% endif %}
+    {%- if not loop.last %},{% endif -%}
   {% endfor %}
 ```
 

--- a/website/docs/reference/dbt-jinja-functions/return.md
+++ b/website/docs/reference/dbt-jinja-functions/return.md
@@ -9,7 +9,12 @@ __Args__:
 
  * `data`: The data to return to the caller
 
-The `return` function can be used in macros to return data to the caller. The type of the data (dict, list, int, etc) will be preserved through the `return` call.
+The `return` function can be used in macros to return data to the caller. The type of the data (dict, list, int, etc) will be preserved through the `return` call.  You can use the `return` function in the following ways within your macros: as an expression or as a statement.
+
+- Expression &mdash; An expression is used when the goal is to output a string from the macro.
+- Statement with a `do` tag &mdash; Use a statement with a `do` tag to execute the return function without generating an output string.
+
+In the following example, `{{ return([1,2,3]) }}` acts as an _expression_ that directly outputs a string, making it suitable for directly inserting returned values into SQL code.
 
 <File name='macros/get_data.sql'>
 

--- a/website/docs/reference/dbt-jinja-functions/return.md
+++ b/website/docs/reference/dbt-jinja-functions/return.md
@@ -11,7 +11,7 @@ __Args__:
 
 The `return` function can be used in macros to return data to the caller. The type of the data (dict, list, int, etc) will be preserved through the `return` call.  You can use the `return` function in the following ways within your macros: as an expression or as a statement.
 
-- Expression &mdash; An expression is used when the goal is to output a string from the macro.
+- Expression &mdash; Use an expression when the goal is to output a string from the macro.
 - Statement with a `do` tag &mdash; Use a statement with a `do` tag to execute the return function without generating an output string.  This is particularly useful when you want to perform actions without necessarily inserting their results directly into the template. 
 
 In the following example, `{{ return([1,2,3]) }}` acts as an _expression_ that directly outputs a string, making it suitable for directly inserting returned values into SQL code.

--- a/website/docs/reference/dbt-jinja-functions/return.md
+++ b/website/docs/reference/dbt-jinja-functions/return.md
@@ -23,6 +23,19 @@ The `return` function can be used in macros to return data to the caller. The ty
 
 </File>
 
+or
+
+<File name='macros/get_data.sql'>
+
+```sql
+{% macro get_data() %}
+
+  {% do return([1,2,3]) %}
+  
+{% endmacro %}
+```
+
+</File>
 
 
 <File name='models/my_model.sql'>


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty10-patch-2-dbt-labs.vercel.app/reference/dbt-jinja-functions/return)

## What are you changing in this pull request and why?

There's a subtle difference between these two:
- `{{ return([1,2,3]) }}` (an expression that outputs a string)
- `{% do return([1,2,3]) %}` (a statement that does not output a string)

This PR adds an example of using the `do` tag along with the [`return`](https://docs.getdbt.com/reference/dbt-jinja-functions/return) function.

### More detail

The ["do" extension](https://jinja.palletsprojects.com/en/3.0.x/extensions/#expression-statement) (AKA expression-statements) adds a simple `do` tag to the template engine that works like a variable expression but ignores the return value.

Put another way, there is a difference between _expressions_ and _statements_ in Jinja:

- **Expressions** `{{ ... }}`: Expressions are used when you want to output a string. You can use expressions to reference [variables](https://docs.getdbt.com/reference/dbt-jinja-functions/var) and call [macros](https://docs.getdbt.com/docs/build/jinja-macros#macros).
- **Statements** `{% ... %}`: Statements don't output a string. They are used for control flow, for example, to set up for loops and if statements, to [set](https://jinja.palletsprojects.com/en/3.1.x/templates/#assignments) or [modify](https://jinja.palletsprojects.com/en/3.1.x/templates/#expression-statement) variables, or to define macros.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [x] I've verified that the code example works