### PR TITLE
Fix term tags that can't be within code blocks

### DIFF
--- a/website/docs/reference/dbt-jinja-functions/adapter.md
+++ b/website/docs/reference/dbt-jinja-functions/adapter.md
@@ -57,7 +57,7 @@ Useful for detecting new columns in a source <Term id="table" />.
 
 
 {% for col in adapter.get_missing_columns(target_relation, this) %}
-  alter <Term id="table" /> {{this}} add column "{{col.name}}" {{col.data_type}};
+  alter table {{this}} add column "{{col.name}}" {{col.data_type}};
 {% endfor %}
 ```
 
@@ -304,9 +304,9 @@ This method is deprecated and will be removed in a future release. Please use [g
 __Args__:
 
  * `schema`: The schema to test
- * `<Term id="table" />`: The relation to look for
+ * `table`: The relation to look for
 
-Returns true if a relation named like `<Term id="table" />` exists in schema `schema`, false otherwise.
+Returns true if a relation named like `table` exists in schema `schema`, false otherwise.
 
 <File name='models/example.sql'>
 


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty10-patch-4-dbt-labs.vercel.app/reference/dbt-jinja-functions/adapter)

## What are you changing in this pull request and why?

This PR is a fix for the following issue introduced in https://github.com/dbt-labs/docs.getdbt.com/pull/1335 which broke code examples like this:

<img width="500" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/5086d17d-7171-4bef-9fdf-436d0a4a1045">

And also introduced other malformed text:

<img width="400" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/dae31c51-457c-455f-a638-4ad6f78dcecb">

### Anything else?

That PR updated a lot of pages other than this one, and I didn't check any of the others.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.