### PR TITLE
Update databricks-configs.md so that only 1.7 content shows on 1.7

### DIFF
--- a/website/docs/reference/resource-configs/databricks-configs.md
+++ b/website/docs/reference/resource-configs/databricks-configs.md
@@ -20,7 +20,7 @@ When materializing a model as `table`, you may include several optional configs 
 
 </VersionBlock>
 
-<VersionBlock firstVersion="1.6">
+<VersionBlock firstVersion="1.6" lastVersion="1.6">
 
  
 | Option              | Description                                                                                                                                                                                                        | Required?                                 | Model Support | Example                  |


### PR DESCRIPTION
## What are you changing in this pull request and why?
Minor change: 1.6 and 1.7 tables were both showing on 1.7

