### PR TITLE
Fix typo in exports.md resource type selector

### DIFF
--- a/website/docs/docs/use-dbt-semantic-layer/exports.md
+++ b/website/docs/docs/use-dbt-semantic-layer/exports.md
@@ -240,7 +240,7 @@ You can use exports to create a custom integration with tools such as PowerBI, a
 
 <detailsToggle alt_header="How can I select saved_queries by their resource type?">
 
-To select `saved_queries` by resource type, run `dbt build --resource-type saved_queries`.
+To select `saved_queries` by resource type, run `dbt build --resource-type saved_query`.
 
 </detailsToggle>
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

The docs state you can build saved queries using `dbt build --resource-type saved_queries`, but in dbt Cloud running dbt 1.7 this results in the error:  

```
Error: Invalid value for '--resource-types' / '--resource-type': 'saved_queries' is not one of 'metric', 'semantic_model', 'saved_query', 'source', 'analysis', 'model', 'test', 'exposure', 'snapshot', 'seed', 'default', 'all'.
```

This commit changes the docs to use the correct selector, `saved_query`


## Checklist

- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [ ] For [docs versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#about-versioning), review how to [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content).
