### PR TITLE
Remove trailing slashes from toc links

### DIFF
--- a/website/src/theme/DocItem/Layout/index.js
+++ b/website/src/theme/DocItem/Layout/index.js
@@ -27,6 +27,7 @@ import {ThemeClassNames} from '@docusaurus/theme-common';
 import VersionContext from '../../../stores/VersionContext'
 import getElements from '../../../utils/get-html-elements';
 import useHashLink from '../../../utils/use-hash-link';
+import removeTrailingDashes from '../../../utils/remove-trailing-slashes';
 
 /**
  * Decide if the toc should be rendered, on mobile or desktop viewports
@@ -50,7 +51,7 @@ function useDocTOC() {
     );
 
     // Headings to remove from TOC
-    const headingsToFilter = await getElements(
+    const headingsToFilter = document.querySelectorAll(
       ".tabs-container h2, .tabs-container h3, .expandable-anchor h2, .expandable-anchor h3"
     );
     
@@ -84,9 +85,13 @@ function useDocTOC() {
             level = null;
           }
 
+          // Remove trailing slashes from TOC item
+          // Trailing slashes come from the LifeCycle pill use on headers
+          const updatedHeading = removeTrailingDashes(heading)
+
           return {
-            value: heading.innerHTML,
-            id: heading.id,
+            value: updatedHeading.innerHTML,
+            id: updatedHeading.id,
             level: level && level,
           };
         };

--- a/website/src/utils/remove-trailing-slashes.js
+++ b/website/src/utils/remove-trailing-slashes.js
@@ -1,0 +1,19 @@
+// Util function to remove trailing dashes from ID attribute on headers
+export default function removeTrailingDashes(header) {
+  // Create copy of header element
+  const updatedHeader = header;
+
+  // Get id attribute
+  const thisId = updatedHeader?.getAttribute("id");
+
+  // If header's id ends with trailing dash, remove dash
+  if (thisId?.endsWith("-")) {
+    // Remove `-` from end of ID string
+    updatedHeader.id = thisId?.substring(0, thisId?.length - 1);
+
+    // Recursively run function to check for another trailing slash
+    removeTrailingDashes(updatedHeader);
+  }
+
+  return updatedHeader;
+}


### PR DESCRIPTION
[Asana task](https://app.asana.com/0/1200099998847559/1206920798931157/f)

## What are you changing in this pull request and why?

Trailing slashes are being applied to TOC items which use the LifeCycle component. This update removes the trailing slashes from the TOC links to correctly match the ID of the headers on the page.

## Preview

- Verify the `Trigger on job completion` TOC link does not have trailing slashes when clicked, and brings the user to the correct spot on the page:
https://docs-getdbt-com-git-fix-click-to-copy-dbt-labs.vercel.app/docs/deploy/deploy-jobs
