### PR TITLE
Link to graph operators

### DIFF
--- a/website/docs/reference/node-selection/syntax.md
+++ b/website/docs/reference/node-selection/syntax.md
@@ -29,7 +29,7 @@ To follow [POSIX standards](https://pubs.opengroup.org/onlinepubs/9699919799/bas
 
 ### How does selection work?
 
-1. dbt gathers all the resources that are matched by one or more of the `--select` criteria, in the order of selection methods (e.g. `tag:`), then graph operators (e.g. `+`), then finally set operators ([unions](/reference/node-selection/set-operators#unions), [intersections](/reference/node-selection/set-operators#intersections), [exclusions](/reference/node-selection/exclude)).
+1. dbt gathers all the resources that are matched by one or more of the `--select` criteria, in the order of [selection methods](/reference/node-selection/methods) (e.g. `tag:`), then [graph operators](/reference/node-selection/graph-operators) (e.g. `+`), then finally set operators ([unions](/reference/node-selection/set-operators#unions), [intersections](/reference/node-selection/set-operators#intersections), [exclusions](/reference/node-selection/exclude)).
 
 2. The selected resources may be models, sources, seeds, snapshots, tests. (Tests can also be selected "indirectly" via their parents; see [test selection examples](/reference/node-selection/test-selection-examples) for details.)
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

On the [Syntax overview](https://docs.getdbt.com/reference/node-selection/syntax) page  , linked to the [Graph operators](https://docs.getdbt.com/reference/node-selection/graph-operators) page which includes explanation of `+` and `+n` as well as other operators so people can dive deeper if they want. 

The overview page had links to [unions](https://docs.getdbt.com/reference/node-selection/set-operators#unions), [exclusions](https://docs.getdbt.com/reference/node-selection/set-operators#unions), etc so followed already-existing pattern. 

Also, linked to other node-selection pages for completeness. 

closes #2287 


## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.

