### PR TITLE
Update example for prerelease versions to use semantic versioning syntax

### DIFF
--- a/website/docs/docs/build/packages.md
+++ b/website/docs/docs/build/packages.md
@@ -96,12 +96,12 @@ By default, `dbt deps` will not include prerelease versions when resolving packa
 - Explicitly specifying a prerelease version in your `version` criteria
 - Setting `install-prerelease` to `true`, and providing a compatible version range
 
-Both of the following configurations would successfully install `0.4.5a2` of `dbt_artifacts`:
+Both of the following configurations would successfully install `0.4.5-a2` of `dbt_artifacts`:
 
 ```yaml
 packages:
   - package: brooklyn-data/dbt_artifacts
-    version: 0.4.5a2
+    version: 0.4.5-a2
 ```
 
 ```yaml

--- a/website/docs/docs/build/packages.md
+++ b/website/docs/docs/build/packages.md
@@ -96,7 +96,7 @@ By default, `dbt deps` will not include prerelease versions when resolving packa
 - Explicitly specifying a prerelease version in your `version` criteria
 - Setting `install-prerelease` to `true`, and providing a compatible version range
 
-Both of the following configurations would successfully install `0.4.5-a2` of `dbt_artifacts`:
+For example, both of the following configurations would successfully install `0.4.5-a2` for the [`dbt_artifacts` package](https://hub.getdbt.com/brooklyn-data/dbt_artifacts/latest/):
 
 ```yaml
 packages:


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty10-patch-2-dbt-labs.vercel.app/docs/build/packages#prerelease-versions)

## What are you changing in this pull request and why?

https://github.com/dbt-labs/hubcap/issues/315 describes the difference between prerelease versions in SemVer 2.0 ("semantic versioning") and PEP 440 (used in the Python packaging ecosystem).

While the current example technically does work, it would more clearly align with SemVer 2.0 if we update the example.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.