### PR TITLE
Fixing format error

### DIFF
--- a/website/docs/reference/commands/build.md
+++ b/website/docs/reference/commands/build.md
@@ -26,10 +26,11 @@ In DAG order, for selected resources or an entire project.
 **Flags:** The `build` task supports all the same flags as `run`, `test`, `snapshot`, and `seed`. For flags that are shared between multiple tasks (e.g. `--full-refresh`), `build` will use the same value for all selected resource types (e.g. both models and seeds will be full refreshed).
 
 <VersionBlock firstVersion="1.8">
-  
+
 ### The `--empty` flag
 
 The `build` command supports the `--empty` flag for building schema-only dry runs. The `--empty` flag limits the refs and sources to zero rows. dbt will still execute the model SQL against the target data warehouse but will avoid expensive reads of input data. This validates dependencies and ensures your models will build properly.
+
 
 ## Tests
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

Closes https://github.com/dbt-labs/docs.getdbt.com/issues/5355

This was a very strange bug @graciegoheen uncovered and I'm not sure we need to investigate further, but it's good to have this record in if it happens again. 

The header formatting wasn't working for this one particular section (see the above issue for a screenshot). I could reproduce it locally when I pulled it up (`npm`). Adding/removing spaces and changing the formatting had no impact. I deleted the section and moved the `Tests` section up, which was then impacted by the error. When I pasted the original text back, it was suddenly fine. 

Works in the preview too https://docs-getdbt-2e8g4l6nu-dbt-labs.vercel.app/reference/commands/build#the---empty-flag

## Checklist
<!--
Uncomment when publishing docs for a prerelease version of dbt:
- [ ] Add versioning components, as described in [Versioning Docs](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-entire-pages)
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
- [ ] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [ ] For [docs versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#about-versioning), review how to [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content).
- [ ] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
