### PR TITLE
adds config to example

### DIFF
--- a/website/docs/docs/build/metrics-overview.md
+++ b/website/docs/docs/build/metrics-overview.md
@@ -21,8 +21,7 @@ The keys for metrics definitions are:
 | `description` | Describe your metric.   | Optional |
 | `type` | Define the type of metric, which can be `conversion`, `cumulative`, `derived`, `ratio`, or `simple`. | Required |
 | `type_params` | Additional parameters used to configure metrics. `type_params` are different for each metric type. | Required |
-| `config` | Provide the specific configurations for your metric.   | Optional |
-| `config:meta` | Use the [`meta` config](/reference/resource-configs/meta) to set metadata for a resource.  | Optional |
+| `config` | Use the [`config`](/reference/resource-properties/config) property to specify configurations for your metric. Supports [`meta`](/reference/resource-configs/meta), [`group`](/reference/resource-configs/group), and [`enabled`](/reference/resource-configs/enabled) configurations.  | Optional |
 | `label` | The display name for your metric. This value will be shown in downstream tools.   | Required |
 | `filter` | You can optionally add a filter string to any metric type, applying filters to dimensions, entities, or time dimensions during metric computation. Consider it as your WHERE clause.   | Optional |
 

--- a/website/docs/docs/build/semantic-models.md
+++ b/website/docs/docs/build/semantic-models.md
@@ -38,6 +38,7 @@ Here we describe the Semantic model components with examples:
 | [Dimensions](#dimensions) | Different ways to group or slice data for a metric, they can be `time` or `categorical` | Required |
 | [Measures](#measures) | Aggregations applied to columns in your data model. They can be the final metric or used as building blocks for more complex metrics | Optional |
 | Label | The display name for your semantic model `node`, `dimension`, `entity`, and/or `measures` | Optional |
+| `config` | Use the [`config`](/reference/resource-properties/config) property to specify configurations for your metric. Supports [`meta`](/reference/resource-configs/meta), [`group`](/reference/resource-configs/group), and [`enabled`](/reference/resource-configs/enabled) configs.  | Optional |
 
 ## Semantic models components
 
@@ -119,28 +120,30 @@ semantic_models:
 
 <VersionBlock firstVersion="1.7">
 
-Semantic models support configs in either the schema file or at the project level. 
+Semantic models support [`meta`](/reference/resource-configs/meta), [`group`](/reference/resource-configs/group), and [`enabled`](/reference/resource-configs/enabled) [`config`](/reference/resource-properties/config) property in either the schema file or at the project level:
 
-Semantic model config in `models/semantic.yml`:
-```yml
-semantic_models:
-  - name: orders
-    config:
-      enabled: true | false
-      group: some_group
-      meta:
+- Semantic model config in `models/semantic.yml`:
+
+  ```yml
+  semantic_models:
+    - name: orders
+      config:
+        enabled: true | false
+        group: some_group
+        meta:
+          some_key: some_value
+  ```
+
+- Semantic model config in `dbt_project.yml`:
+
+  ```yml
+  semantic-models:
+    my_project_name:
+      +enabled: true | false
+      +group: some_group
+      +meta:
         some_key: some_value
-```
-
-Semantic model config in `dbt_project.yml`:
-```yml
-semantic-models:
-  my_project_name:
-    +enabled: true | false
-    +group: some_group
-    +meta:
-      some_key: some_value
-```
+  ```
 
 </VersionBlock>
 

--- a/website/docs/reference/resource-configs/group.md
+++ b/website/docs/reference/resource-configs/group.md
@@ -16,7 +16,7 @@ id: "group"
   ]
 }>
 <TabItem value="models">
-
+ 
 <VersionBlock lastVersion="1.4">
 
 Support for grouping models was added in dbt Core v1.5
@@ -255,7 +255,8 @@ version: 2
 
 metrics:
   - name: [METRIC_NAME]
-    group: GROUP_NAME
+    config:
+      group: GROUP_NAME
 
 ```
 
@@ -294,7 +295,8 @@ semantic-models:
 
 semantic_models:
   - name: SEMANTIC_MODEL_NAME
-    group: GROUP_NAME
+    config:
+      group: GROUP_NAME
 
 
 ```


### PR DESCRIPTION
this pr adds the missing `config` field to the `metrics` gobal config example. it also adds more guidance in the metrics docs so users know there are add'l configs they can use and links to those appropriate configs. 

also adds the missing config field to the semantic model exmaple

[see slack](https://dbt-labs.slack.com/archives/C04MEJT5VPY/p1714087824714039)