### PR TITLE
Fix incorrect `create_metric_display_name` reference in measure params

### DIFF
--- a/website/snippets/_sl-measures-parameters.md
+++ b/website/snippets/_sl-measures-parameters.md
@@ -7,5 +7,5 @@
 | [`non_additive_dimension`](/docs/build/measures#non-additive-dimensions) | Non-additive dimensions can be specified for measures that cannot be aggregated over certain dimensions, such as bank account balances, to avoid producing incorrect results. | Optional |
 | `agg_params` | Specific aggregation properties, such as a percentile. | Optional | 
 | `agg_time_dimension` | The time field. Defaults to the default agg time dimension for the semantic model.  | Optional | 1.6 and higher |
-| `label` | String that defines the display value in downstream tools. Accepts plain text, spaces, and quotes (such as orders_total or "orders_total"). | Optional | 1.7 and higher |
-| `create_metric` | Create a `simple` metric from a measure by setting `create_metric: True`. The `label` and `description` attributes will be automatically propagated to the created metric. Available in dbt version 1.7 or higher. | Optional |
+| `label` | String that defines the display value in downstream tools. Accepts plain text, spaces, and quotes (such as orders_total or "orders_total"). Available in dbt version 1.7 or higher. | Optional 
+| `create_metric` | Create a `simple` metric from a measure by setting `create_metric: True`. The `label` and `description` attributes will be automatically propagated to the created metric. . | Optional |

--- a/website/snippets/_sl-measures-parameters.md
+++ b/website/snippets/_sl-measures-parameters.md
@@ -7,4 +7,5 @@
 | [`non_additive_dimension`](/docs/build/measures#non-additive-dimensions) | Non-additive dimensions can be specified for measures that cannot be aggregated over certain dimensions, such as bank account balances, to avoid producing incorrect results. | Optional |
 | `agg_params` | Specific aggregation properties, such as a percentile. | Optional | 
 | `agg_time_dimension` | The time field. Defaults to the default agg time dimension for the semantic model.  | Optional | 1.6 and higher |
-| `create_metric` | Create a `simple` metric from a measure by setting `create_metric: True`. Specify its display name with `create_metric_display_name`. Available in dbt version 1.7 or higher. | Optional |
+| `label` | String that defines the display value in downstream tools. Accepts plain text, spaces, and quotes (such as orders_total or "orders_total"). | Optional | 1.7 and higher |
+| `create_metric` | Create a `simple` metric from a measure by setting `create_metric: True`. The `label` and `description` attributes will be automatically propagated to the created metric. Available in dbt version 1.7 or higher. | Optional |

--- a/website/snippets/_sl-measures-parameters.md
+++ b/website/snippets/_sl-measures-parameters.md
@@ -8,4 +8,4 @@
 | `agg_params` | Specific aggregation properties, such as a percentile. | Optional | 
 | `agg_time_dimension` | The time field. Defaults to the default agg time dimension for the semantic model.  | Optional | 1.6 and higher |
 | `label` | String that defines the display value in downstream tools. Accepts plain text, spaces, and quotes (such as orders_total or "orders_total"). Available in dbt version 1.7 or higher. | Optional 
-| `create_metric` | Create a `simple` metric from a measure by setting `create_metric: True`. The `label` and `description` attributes will be automatically propagated to the created metric. . | Optional |
+| `create_metric` | Create a `simple` metric from a measure by setting `create_metric: True`. The `label` and `description` attributes will be automatically propagated to the created metric. Available in dbt version 1.7 or higher. | Optional |


### PR DESCRIPTION
## What are you changing in this pull request and why?

The measure parameters snippet contains an outdated reference to a construct named `create_metric_display_name`, which was part of the original draft spec but never got built.

Instead, we decided to call `display_name` `label`, and to automatically propagate `label` and `description` from the underlying measure to the metric we generate when `create_metric` is set to true. This update reflects that behavior.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.