### PR TITLE
Adding a release note for May behavior change flag

### DIFF
--- a/website/docs/docs/dbt-versions/release-notes/69-May-2024/no-spaces-in.md
+++ b/website/docs/docs/dbt-versions/release-notes/69-May-2024/no-spaces-in.md
@@ -7,6 +7,6 @@ tags: [May-2024]
 date: 2024-05-02
 ---
 
-In dbt Core 1.8, we introduced the `require_resource_names_without_spaces` flag, which is opt-in and disabled by default. If set to `True`, dbt will raise an exception if it finds a resource name containing a space in your project or an installed package. This will become the default in a future version of dbt. Read [No spaces in resource names](/reference/global-configs/legacy-behaviors#no-spaces-in-resource-names) for more information about this flag.
+In dbt Core 1.8, we introduced the `require_resource_names_without_spaces` flag, which is opt-in and disabled by default. If set to `True`, dbt will raise an exception if it finds a resource name containing a space in your project or an installed package. This will become the default in a future version of dbt. For more details about this flag, refer to [No spaces in resource names](/reference/global-configs/legacy-behaviors#no-spaces-in-resource-names).
 
 Refer to [Behavior change flags](/reference/global-configs/legacy-behaviors#behavior-change-flags) to learn more about how we use behavior change flags.

--- a/website/docs/docs/dbt-versions/release-notes/69-May-2024/no-spaces-in.md
+++ b/website/docs/docs/dbt-versions/release-notes/69-May-2024/no-spaces-in.md
@@ -2,7 +2,7 @@
 title: "Behavior change: no spaces in resource names"
 description: "May 2024: New flag that raises an exception if it finds a resource name containing spaces. Disabled by default."
 sidebar_label: "Behavior change: no spaces in resource names"
-sidebar_position: 10
+sidebar_position: 09
 tags: [May-2024]
 date: 2024-05-02
 ---

--- a/website/docs/docs/dbt-versions/release-notes/69-May-2024/no-spaces-in.md
+++ b/website/docs/docs/dbt-versions/release-notes/69-May-2024/no-spaces-in.md
@@ -1,0 +1,12 @@
+---
+title: "Behavior change: no spaces in resource names"
+description: "May 2024: New flag that raises an exception if it finds a resource name containing spaces. Disabled by default."
+sidebar_label: "Behavior change: no spaces in resource names"
+sidebar_position: 10
+tags: [May-2024]
+date: 2024-05-02
+---
+
+In dbt Core 1.8, we introduced the `require_resource_names_without_spaces` flag, which is opt-in and disabled by default. If set to `True`, dbt will raise an exception if it finds a resource name containing a space in your project or an installed package. This will become the default in a future version of dbt. Read [No spaces in resource names](/reference/global-configs/legacy-behaviors#no-spaces-in-resource-names) for more information about this flag.
+
+Refer to [Behavior change flags](/reference/global-configs/legacy-behaviors#behavior-change-flags) to learn more about how we use behavior change flags.

--- a/website/snippets/core-versions-table.md
+++ b/website/snippets/core-versions-table.md
@@ -2,7 +2,6 @@
 
 |                      dbt Core                                 | Initial release |      Support level and end date      |
 |:-------------------------------------------------------------:|:---------------:|:-------------------------------------:|
-
 | [**v1.8**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.8) | May 2024      | Release Candidate                              |
 | [**v1.7**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.7) | Nov 2, 2023   | <b>Active &mdash; Nov 1, 2024</b> | 
 | [**v1.6**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.6) | Jul 31, 2023  | Critical &mdash; Jul 30, 2024 |  


### PR DESCRIPTION
## What are you changing in this pull request and why?

* Adding a release note for May behavior change flag an RSS notice happens (this is duplicate work that's already captured in the main [2024 release note page](https://docs.getdbt.com/docs/dbt-versions/2024-release-notes))
* Fixing the table for core releases

Note that I didn't add the March or April behavior change because it won't show up in RSS feeds retroactively. 

## Checklist
<!--
Uncomment when publishing docs for a prerelease version of dbt:
- [ ] Add versioning components, as described in [Versioning Docs](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-entire-pages)
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
- [ ] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [ ] For [docs versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#about-versioning), review how to [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content).
- [ ] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."

Adding or removing pages (delete if not applicable):
- [ ] Add/remove page in `website/sidebars.js`
- [ ] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages
