### PR TITLE
Provide a truncated version of the blog post for the main page that lists all blog entries

### DIFF
--- a/website/blog/2024-05-02-semantic-layer-llm.md
+++ b/website/blog/2024-05-02-semantic-layer-llm.md
@@ -22,6 +22,8 @@ Clearly, this technology is not going away. There are already countless number o
 
 <LoomVideo id='3b5cc878ef53488583691c390159007d?t=0' />
 
+<!--truncate-->
+
 ## Why Build This
 
 So, why build this and what makes it different?

--- a/website/blog/2024-05-02-semantic-layer-llm.md
+++ b/website/blog/2024-05-02-semantic-layer-llm.md
@@ -16,13 +16,13 @@ is_featured: true
 
 As a solutions architect at dbt Labs, my role is to help our customers and prospects understand how to best utilize the dbt Cloud platform to solve their unique data challenges.  That uniqueness presents itself in different ways - organizational maturity, data stack, team size and composition, technical capability, use case, or some combination of those.  With all those differences though, there has been one common thread throughout most of my engagements:  Generative AI and Large Language Models (LLMs).  Data teams are either 1) proactively thinking about applications for it in the context of their work or 2) being pushed to think about it by their stakeholders.  It has become the elephant in every single (zoom) room I find myself in.
 
+<!--truncate-->
+
 <Lightbox src="/img/blog/2024-05-02-semantic-layer-llm/gen-ai-everywhere.png" width="85%" title="Gen AI Everywhere!" />
 
 Clearly, this technology is not going away. There are already countless number of use cases and applications already showing very real improvements to efficiency, productivity, and creativity. Inspired by the common problem faced by data teams I'm talking to, I built a [Streamlit app](https://dbt-semantic-layer.streamlit.app/) which uses Snowflake Cortex and the dbt Semantic Layer to answer free-text questions accurately and consistently. You can preview examples of the questions it's able to answer below:
 
 <LoomVideo id='3b5cc878ef53488583691c390159007d?t=0' />
-
-<!--truncate-->
 
 ## Why Build This
 

--- a/website/blog/2024-05-22-latest-dbt-stability-improvement-innovation.md
+++ b/website/blog/2024-05-22-latest-dbt-stability-improvement-innovation.md
@@ -20,7 +20,9 @@ But no more. Today, we're ready to announce the general availability of a new op
 
 For customers, this means less maintenance overhead, faster access to bug fixes and features, and more time to focus on what matters most: building trusted data products. This will be our stable foundation for improvement and innovation in dbt Cloud. 
 
-But we wanted to go a step beyond just making this option available to you. In this blog post, we aim to shed a little light on the extensive work we've done to ensure that using "Keep on latest version" is a stable, reliable experience for the thousands of customers who rely daily on dbt Cloud. 
+But we wanted to go a step beyond just making this option available to you. In this blog post, we aim to shed a little light on the extensive work we've done to ensure that using "Keep on latest version" is a stable, reliable experience for the thousands of customers who rely daily on dbt Cloud.
+
+<!--truncate-->
 
 ## How we safely deploy dbt upgrades to Cloud
 

--- a/website/blog/2024-05-22-latest-dbt-stability-improvement-innovation.md
+++ b/website/blog/2024-05-22-latest-dbt-stability-improvement-innovation.md
@@ -18,11 +18,11 @@ However, this came at a cost. While bumping a project's dbt version *appeared* a
 
 But no more. Today, we're ready to announce the general availability of a new option in dbt Cloud: [**"Keep on latest version."**](https://docs.getdbt.com/docs/dbt-versions/upgrade-dbt-version-in-cloud#keep-on-latest-version)
 
+<!--truncate-->
+
 For customers, this means less maintenance overhead, faster access to bug fixes and features, and more time to focus on what matters most: building trusted data products. This will be our stable foundation for improvement and innovation in dbt Cloud. 
 
 But we wanted to go a step beyond just making this option available to you. In this blog post, we aim to shed a little light on the extensive work we've done to ensure that using "Keep on latest version" is a stable, reliable experience for the thousands of customers who rely daily on dbt Cloud.
-
-<!--truncate-->
 
 ## How we safely deploy dbt upgrades to Cloud
 


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty-truncate-dev-blog-posts-dbt-labs.vercel.app/blog)

## What are you changing in this pull request and why?

Here is the main page that lists all blog posts:
https://docs.getdbt.com/blog

It is supposed to have just the first section of each post so that all of them can be scrolled through, like this:

<img width="405" alt="image" src="https://github.com/dbt-labs/docs.getdbt.com/assets/44704949/378d4ab0-9289-4b61-8dfb-6d888fec58a2">


But the two most recent entries are missing this tag that delineates the shortened version from the full version:

```html
<!--truncate-->
```

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.