### PR TITLE
Link to the CLI flags that are available for setting

### DIFF
--- a/website/docs/reference/global-configs/command-line-options.md
+++ b/website/docs/reference/global-configs/command-line-options.md
@@ -4,7 +4,7 @@ id: "command-line-options"
 sidebar: "Command line options"
 ---
 
-For consistency, command-line interface (CLI) flags should come right after the `dbt` prefix and its subcommands. This includes "global" flags (supported for all commands). For a list of all dbt CLI flags you can set, refer to [Available flags](/reference/global-configs/about-global-configs#available-flags). When set, CLI flags override [environment variables](https://docs.getdbt.com/reference/global-configs/environment-variable-configs) and [project flags](/reference/global-configs/project-flags).
+For consistency, command-line interface (CLI) flags should come right after the `dbt` prefix and its subcommands. This includes "global" flags (supported for all commands). For a list of all dbt CLI flags you can set, refer to [Available flags](/reference/global-configs/about-global-configs#available-flags). When set, CLI flags override [environment variables](/reference/global-configs/environment-variable-configs) and [project flags](/reference/global-configs/project-flags).
 
 Environment variables contain a `DBT_` prefix. 
 

--- a/website/docs/reference/global-configs/command-line-options.md
+++ b/website/docs/reference/global-configs/command-line-options.md
@@ -4,7 +4,7 @@ id: "command-line-options"
 sidebar: "Command line options"
 ---
 
-For consistency, command-line interface (CLI) flags should come right after the `dbt` prefix and its subcommands. This includes "global" flags (supported for all commands). When set, CLI flags override environment variables and profile configs. 
+For consistency, command-line interface (CLI) flags should come right after the `dbt` prefix and its subcommands. This includes "global" flags (supported for all commands). Reference the [table of all flags](/reference/global-configs/about-global-configs#available-flags) to see which CLI flags are available for setting. When set, CLI flags override [environment variables](https://docs.getdbt.com/reference/global-configs/environment-variable-configs) and [project flags](/reference/global-configs/project-flags).
 
 For example, instead of using:
 

--- a/website/docs/reference/global-configs/command-line-options.md
+++ b/website/docs/reference/global-configs/command-line-options.md
@@ -4,7 +4,9 @@ id: "command-line-options"
 sidebar: "Command line options"
 ---
 
-For consistency, command-line interface (CLI) flags should come right after the `dbt` prefix and its subcommands. This includes "global" flags (supported for all commands). Reference the [table of all flags](/reference/global-configs/about-global-configs#available-flags) to see which CLI flags are available for setting. When set, CLI flags override [environment variables](https://docs.getdbt.com/reference/global-configs/environment-variable-configs) and [project flags](/reference/global-configs/project-flags).
+For consistency, command-line interface (CLI) flags should come right after the `dbt` prefix and its subcommands. This includes "global" flags (supported for all commands). For a list of all dbt CLI flags you can set, refer to [Available flags](/reference/global-configs/about-global-configs#available-flags). When set, CLI flags override [environment variables](https://docs.getdbt.com/reference/global-configs/environment-variable-configs) and [project flags](/reference/global-configs/project-flags).
+
+Environment variables contain a `DBT_` prefix. 
 
 For example, instead of using:
 


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/reference/global-configs/command-line-options)

## What are you changing in this pull request and why?

The [project flags](https://docs.getdbt.com/reference/global-configs/project-flags) has a link to the [table of all flags](https://docs.getdbt.com/reference/global-configs/about-global-configs#available-flags), so it seems like the [CLI page](https://docs.getdbt.com/reference/global-configs/command-line-options) should as well.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.