### PR TITLE
add deprecation callout

### DIFF
--- a/website/docs/docs/core/connect-data-platform/fal-setup.md
+++ b/website/docs/docs/core/connect-data-platform/fal-setup.md
@@ -16,17 +16,15 @@ meta:
   config_page: '/reference/resource-configs/fal-configs'
 ---
 
-:::info Community plugin
+:::info Adapter no longer maintained
+The [`dbt-fal` adapter](https://github.com/fal-ai/dbt-fal) is no longer actively maintained. This means although the adapter is still operational, there is no further development or bug fixes planned and it may not be compatible with future versions of dbt. `dbt-fal` was test until dbt v1.5.
 
-Some core functionality may be limited. If you're interested in contributing, check out the source code for each repository listed below.
-
+Documentation for `dbt-fal` are kept for reference purposes only and will eventually be removed from the site in the future.
 :::
 
 import SetUpPages from '/snippets/_setup-pages-intro.md';
 
 <SetUpPages meta={frontMatter.meta} />
-
-
 
 ## Setting up fal with other adapter
 

--- a/website/docs/reference/resource-configs/fal-configs.md
+++ b/website/docs/reference/resource-configs/fal-configs.md
@@ -3,6 +3,12 @@ title: "fal configurations"
 id: "fal-configs"
 ---
 
+:::info Adapter no longer maintained
+The [`dbt-fal` adapter](https://github.com/fal-ai/dbt-fal) is no longer actively maintained. This means although the adapter is still operational, there is no further development or bug fixes planned and it may not be compatible with future versions of dbt. `dbt-fal` was test until dbt v1.5.
+
+Documentation for `dbt-fal` are kept for reference purposes only and will eventually be removed from the site in the future.
+:::
+
 ## Setting the `db_profile`
 
 The fal profile configuration needs the `db_profile` property set to the profile configuring your database for SQL models.


### PR DESCRIPTION
this pr adds a callout to the dbt fal adapter docs as its no longer being maintained actively. 

this pr is the first phase inspired by @kiwamizamurai 's first pr.

https://github.com/dbt-labs/docs.getdbt.com/pull/5368

this was confirmed and ok'ed by @chamini2 (maintainer)