### PR TITLE
remove owner parameter

### DIFF
--- a/website/docs/docs/build/about-metricflow.md
+++ b/website/docs/docs/build/about-metricflow.md
@@ -37,7 +37,7 @@ MetricFlow abides by these principles:
 - **Simplicity with gradual complexity:** Approach MetricFlow using familiar data modeling concepts.
 - **Performance and efficiency**: Optimize performance while supporting centralized data engineering and distributed logic ownership.
 
-### Semantic graph 
+### Semantic graph
 
 We're introducing a new concept: a "semantic graph". It's the relationship between semantic models and YAML configurations that creates a data landscape for building metrics. You can think of it like a map, where tables are like locations, and the connections between them (edges) are like roads. Although it's under the hood, the semantic graph is a subset of the <Term id="dag" />, and you can see the semantic models as nodes on the DAG.
 

--- a/website/docs/docs/build/cumulative-metrics.md
+++ b/website/docs/docs/build/cumulative-metrics.md
@@ -246,6 +246,7 @@ group by
 limit 100;
 
 ```
+
 ## Limitations
 
 If you specify a `window` in your cumulative metric definition, you must include `metric_time` as a dimension in the SQL query. This is because the accumulation window is based on metric time. For example,
@@ -264,4 +265,3 @@ group by
 
 ## Related docs
 - [Fill null values for simple, derived, or ratio metrics](/docs/build/fill-nulls-advanced)
-

--- a/website/docs/docs/build/derived-metrics.md
+++ b/website/docs/docs/build/derived-metrics.md
@@ -151,7 +151,7 @@ When you run the query  `dbt sl query --metrics d7_booking_change --group-by met
 | Total  | 7252 | 2017-07-01 |
 
 4. Lastly, calculate the derived metric and return the final result set:
-   
+
 ```bash
 bookings - bookings_7_days_ago would be compile as 7438 - 7252 = 186. 
 ```

--- a/website/docs/docs/build/entities.md
+++ b/website/docs/docs/build/entities.md
@@ -18,7 +18,6 @@ There are four entity types: primary, foreign, unique, or natural.
 You can also use entities as dimensions, which allows you to aggregate a metric to the granularity of that entity.
 :::
 
-
 ## Entity types
 
 MetricFlow's join logic depends on the entity `type` you use, and it also determines how to join semantic models. Refer to [Joins](/docs/build/join-logic) for more info on how to construct joins.

--- a/website/docs/docs/build/metrics-overview.md
+++ b/website/docs/docs/build/metrics-overview.md
@@ -120,8 +120,6 @@ metrics:
 # Cumulative metrics aggregate a measure over a given window. The window is considered infinite if no window parameter is passed (accumulate the measure over all of time)
 metrics:
   - name: wau_rolling_7
-    owners:
-      - support@getdbt.com
     type: cumulative
     label: Weekly active users
     type_params:
@@ -178,8 +176,6 @@ metrics:
 ```yaml
 metrics:
   - name: cancellation_rate
-    owners:
-      - support@getdbt.com
     type: ratio
     label: Cancellation rate
     type_params:
@@ -188,8 +184,6 @@ metrics:
     filter: |   
       {{ Dimension('customer__country') }} = 'MX'
   - name: enterprise_cancellation_rate
-    owners:
-      - support@getdbt.com
     type: ratio
     type_params:
       numerator:

--- a/website/docs/docs/build/ratio-metrics.md
+++ b/website/docs/docs/build/ratio-metrics.md
@@ -113,8 +113,6 @@ Users can define constraints on input metrics for a ratio metric by applying a f
 metrics:
   - name: frequent_purchaser_ratio
     description: Fraction of active users who qualify as frequent purchasers
-    owners:
-      - support@getdbt.com
     type: ratio
     type_params:
       numerator:


### PR DESCRIPTION
removing the `owners` field in metrics docs since it's been removed in 1.6.

Resolves #5442