### PR TITLE
Table aliases needed to unit test joins

### DIFF
--- a/website/docs/docs/build/unit-tests.md
+++ b/website/docs/docs/build/unit-tests.md
@@ -20,7 +20,7 @@ Now, we are introducing a new type of test to dbt - unit tests. In software prog
 - You must specify all fields in a BigQuery STRUCT in a unit test. You cannot use only a subset of fields in a STRUCT.
 - If your model has multiple versions, by default the unit test will run on *all* versions of your model. Read [unit testing versioned models](#unit-testing-versioned-models) for more information.
 - Unit tests must be defined in a YML file in your `models/` directory.
-- Table names must be aliased to unit test `join` logic.
+- Table names must be [aliased](/docs/build/custom-aliases) to unit test `join` logic.
 
 Read the [reference doc](/reference/resource-properties/unit-tests) for more details about formatting your unit tests.
 

--- a/website/docs/docs/build/unit-tests.md
+++ b/website/docs/docs/build/unit-tests.md
@@ -20,6 +20,7 @@ Now, we are introducing a new type of test to dbt - unit tests. In software prog
 - You must specify all fields in a BigQuery STRUCT in a unit test. You cannot use only a subset of fields in a STRUCT.
 - If your model has multiple versions, by default the unit test will run on *all* versions of your model. Read [unit testing versioned models](#unit-testing-versioned-models) for more information.
 - Unit tests must be defined in a YML file in your `models/` directory.
+- Table names must be aliased to unit test `join` logic.
 
 Read the [reference doc](/reference/resource-properties/unit-tests) for more details about formatting your unit tests.
 
@@ -291,6 +292,9 @@ unit_tests:
       rows:
         - {id: 1, first_name: emily}
 ```
+
+## Known limitations 
+
 
 ## Additional resources
 

--- a/website/docs/docs/build/unit-tests.md
+++ b/website/docs/docs/build/unit-tests.md
@@ -20,7 +20,7 @@ Now, we are introducing a new type of test to dbt - unit tests. In software prog
 - You must specify all fields in a BigQuery STRUCT in a unit test. You cannot use only a subset of fields in a STRUCT.
 - If your model has multiple versions, by default the unit test will run on *all* versions of your model. Read [unit testing versioned models](#unit-testing-versioned-models) for more information.
 - Unit tests must be defined in a YML file in your `models/` directory.
-- Table names must be [aliased](/docs/build/custom-aliases) to unit test `join` logic.
+- Table names must be [aliased](/docs/build/custom-aliases) in order to unit test `join` logic.
 
 Read the [reference doc](/reference/resource-properties/unit-tests) for more details about formatting your unit tests.
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

To unit test `join` logic, need to use table aliases. 

closes #5418 

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [x] For [docs versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#about-versioning), review how to [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content).
- [ ] Needs review from PM

