### PR TITLE
Deprecated functionality for v1.8

### DIFF
--- a/website/docs/docs/dbt-versions/core-upgrade/01-upgrading-to-v1.8.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/01-upgrading-to-v1.8.md
@@ -86,7 +86,7 @@ The ability for installed packages to override built-in materializations without
 - Using a custom materialization from an installed package does not raise a deprecation warning.
 - Using a built-in materialization package override from the root project via a wrapping materialization is still supported. For example:
 
-  ```
+  ```sql
   {% materialization view, default %}
   {{ return(my_cool_package.materialization_view_default()) }}
   {% endmaterialization %}

--- a/website/docs/docs/dbt-versions/core-upgrade/01-upgrading-to-v1.8.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/01-upgrading-to-v1.8.md
@@ -78,6 +78,20 @@ models:
 
 The [`run`](/reference/commands/run#the-`--empty`-flag) and [`build`](/reference/commands/build#the---empty-flag) commands now support the `--empty` flag for building schema-only dry runs. The `--empty` flag limits the refs and sources to zero rows. dbt will still execute the model SQL against the target data warehouse but will avoid expensive reads of input data. This validates dependencies and ensures your models will build properly.
 
+### Deprecated functionality
+
+The ability for installed packages to override built-in materializations without explicit opt-in from the user is being deprecated.
+
+- Overriding a built-in materialization from an installed package raises a deprecation warning.
+- Using a custom materialization from an installed package does not raise a deprecation warning.
+- Using a built-in materialization package override from the root project via a wrapping materialization is still supported. For example:
+
+  ```
+  {% materialization view, default %}
+  {{ return(my_cool_package.materialization_view_default()) }}
+  {% endmaterialization %}
+  ```
+
 ### Managing changes to legacy behaviors
 
 dbt Core v1.8 has introduced flags for [managing changes to legacy behaviors](/reference/global-configs/legacy-behaviors). You may opt into recently introduced changes (disabled by default), or opt out of mature changes (enabled by default), by setting `True` / `False` values, respectively, for `flags` in `dbt_project.yml`.

--- a/website/docs/docs/dbt-versions/core-upgrade/02-upgrading-to-v1.7.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/02-upgrading-to-v1.7.md
@@ -30,6 +30,7 @@ This is a relatively small behavior change, but worth calling out in case you no
 
 Beginning with v1.7, running [`dbt deps`](/reference/commands/deps) creates or updates the `package-lock.yml` file in the _project_root_ where `packages.yml` is recorded. The `package-lock.yml` file contains a record of all packages installed and, if subsequent `dbt deps` runs contain no updated packages in `dependencies.yml` or `packages.yml`, dbt-core installs from `package-lock.yml`. 
 
+
 ## New and changed features and functionality
 
 - [`dbt docs generate`](/reference/commands/cmd-docs) now supports `--select` to generate [catalog metadata](/reference/artifacts/catalog-json) for a subset of your project. Currently available for Snowflake and Postgres only, but other adapters are coming soon. 
@@ -75,6 +76,20 @@ The run_results.json now includes three attributes related to the `applied` stat
 - `compiled`: Boolean entry of the node compilation status (`False` after parsing, but `True` after compiling).
 - `compiled_code`: Rendered string of the code that was compiled (empty after parsing, but full string after compiling).
 - `relation_name`: The fully-qualified name of the object that was (or will be) created/updated within the database.
+
+### Deprecated functionality
+
+The ability for installed packages to override built-in materializations without explicit opt-in from the user is being deprecated.
+
+- Overriding a built-in materialization from an installed package raises a deprecation warning.
+- Using a custom materialization from an installed package does not raise a deprecation warning.
+- Using a built-in materialization package override from the root project via a wrapping materialization is still supported. For example:
+
+  ```
+  {% materialization view, default %}
+  {{ return(my_cool_package.materialization_view_default()) }}
+  {% endmaterialization %}
+  ```
 
 
 ### Quick hits

--- a/website/docs/docs/dbt-versions/core-upgrade/03-upgrading-to-v1.6.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/03-upgrading-to-v1.6.md
@@ -85,6 +85,20 @@ More consistency and flexibility around packages. Resources defined in a package
 [**Project dependencies**](/docs/collaborate/govern/project-dependencies): Introduces `dependencies.yml` and dependent `projects` as a feature of dbt Cloud Enterprise. Allows enforcing model access (public vs. protected/private) across project/package boundaries. Enables cross-project `ref` of public models, without requiring the installation of upstream source code.
 :::
 
+### Deprecated functionality
+
+The ability for installed packages to override built-in materializations without explicit opt-in from the user is being deprecated.
+
+- Overriding a built-in materialization from an installed package raises a deprecation warning.
+- Using a custom materialization from an installed package does not raise a deprecation warning.
+- Using a built-in materialization package override from the root project via a wrapping materialization is still supported. For example:
+
+  ```
+  {% materialization view, default %}
+  {{ return(my_cool_package.materialization_view_default()) }}
+  {% endmaterialization %}
+  ```
+
 ### Quick hits
 
 - [`state:unmodified` and `state:old`](/reference/node-selection/methods#the-state-method) for [MECE](https://en.wikipedia.org/wiki/MECE_principle) stateful selection


### PR DESCRIPTION
## What are you changing in this pull request and why?

Closes https://github.com/dbt-labs/docs.getdbt.com/issues/5320

Backported to v1.7 and v1.6

## Checklist
<!--
Uncomment when publishing docs for a prerelease version of dbt:
- [x] Add versioning components, as described in [Versioning Docs](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-entire-pages)
- [x] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [x] For [docs versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#about-versioning), review how to [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content).
- [x] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
