### PR TITLE
Add clarity around merge job usage

### DIFF
--- a/website/docs/docs/deploy/merge-jobs.md
+++ b/website/docs/docs/deploy/merge-jobs.md
@@ -34,6 +34,12 @@ By using CD in dbt Cloud, you can take advantage of deferral to build only the e
     - **Threads** &mdash; By default, it’s set to 4 [threads](/docs/core/connect-data-platform/connection-profiles#understanding-threads). Increase the thread count to increase model execution concurrency.
     - **Run source freshness** &mdash; Enable this option to invoke the `dbt source freshness` command before running this job. Refer to [Source freshness](/docs/deploy/source-freshness) for more details.
 
+## Utilizing your merge job
+
+1. To get your merge job to run as expected, you'll first need to generate a manifest for dbt to defer future runs to. In order to do this, you'll want to navigate into job settings and change the job command from `dbt run --select state:modified+` to `dbt compile`. Click "Save" and then trigger a run manually.
+2. Once the run has completed, go back into job settings and change the job command back to `dbt build --select state:modified+`. You can now trigger this job to run on a PR merge.
+
+
 ## Example 
 
 <Lightbox src="/img/docs/dbt-cloud/using-dbt-cloud/example-create-merge-job.png" width="90%" title="Example of creating a merge job"/>

--- a/website/docs/docs/deploy/merge-jobs.md
+++ b/website/docs/docs/deploy/merge-jobs.md
@@ -22,7 +22,7 @@ By using CD in dbt Cloud, you can take advantage of deferral to build only the e
     - **Job name** &mdash; Specify the name for the merge job.
     - **Description** &mdash; Provide a descripion about the job. 
     - **Environment** &mdash; By default, it’s set to the environment you created the job from.
-1. In the **Git trigger** section, the **Run on merge** option is enabled by default. Every time a PR merges (to the main branch) in your Git repo, this job will get triggered to run. 
+1. In the **Git trigger** section, the **Run on merge** option is enabled by default. Every time a PR merges (to the base branch configured in the environment) in your Git repo, this job will get triggered to run. 
 1. Options in the **Execution settings** section:
     - **Commands** &mdash; By default, it includes the `dbt build --select state:modified+` command. This informs dbt Cloud to build only new or changed models and their downstream dependents. Importantly, state comparison can only happen when there is a deferred environment selected to compare state to. Click **Add command** to add more [commands](/docs/deploy/job-commands) that you want to be invoked when this job runs.
     - **Compare changes against an environment (Deferral)** &mdash; By default, it's set to the environment you created the job from. This option allows dbt Cloud to check the state of the code in the PR against the code running in the deferred environment, so as to only check the modified code, instead of building the full table or the entire DAG.


### PR DESCRIPTION
## What are you changing in this pull request and why?

The first commit is to make it clearer that merge jobs can be triggered by merges to custom branches (not only the main branch).

The second commit adds a section to clarify that customers must first run `dbt compile` on their merge job in order to generate a manifest for future runs to defer to. 

## Checklist
<!--
Uncomment when publishing docs for a prerelease version of dbt:
- [ ] Add versioning components, as described in [Versioning Docs](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-entire-pages)
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
- [X] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [ ] For [docs versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#about-versioning), review how to [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content).
- [ ] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
