### PR TITLE
v1.7 is no longer the latest version

### DIFF
--- a/website/docs/docs/dbt-versions/core-upgrade/02-upgrading-to-v1.7.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/02-upgrading-to-v1.7.md
@@ -1,5 +1,5 @@
 ---
-title: "Upgrading to v1.7 (latest)"
+title: "Upgrading to v1.7"
 id: upgrading-to-v1.7
 description: New features and changes in dbt Core v1.7
 displayed_sidebar: "docs"


### PR DESCRIPTION
v1.7 is no longer the latest. Long live v1.8.

## What are you changing in this pull request and why?
With the release of v1.8, v1.7 is no longer the latest version.

![image](https://github.com/dbt-labs/docs.getdbt.com/assets/74567580/0a133230-3edd-497d-b4c2-5ae4a8b74345)


## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [x] For [docs versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#about-versioning), review how to [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content).