### PR TITLE
change Databricks PL setup steps to get the correct instance identifier

### DIFF
--- a/website/docs/docs/cloud/secure/databricks-privatelink.md
+++ b/website/docs/docs/cloud/secure/databricks-privatelink.md
@@ -20,7 +20,7 @@ The following steps will walk you through the setup of a Databricks AWS PrivateL
 ```
 Subject: New Multi-Tenant PrivateLink Request
 - Type: Databricks
-- Databricks Instance Name:
+- Databricks instance name:
 - Databricks cluster AWS Region (e.g., us-east-1, eu-west-2):
 - dbt Cloud multi-tenant environment (US, EMEA, AU):
 ```

--- a/website/docs/docs/cloud/secure/databricks-privatelink.md
+++ b/website/docs/docs/cloud/secure/databricks-privatelink.md
@@ -14,7 +14,7 @@ The following steps will walk you through the setup of a Databricks AWS PrivateL
 
 ## Configure PrivateLink
 
-1. Locate your [Databricks Instance Name](https://docs.databricks.com/en/workspace/workspace-details.html#workspace-instance-names-urls-and-ids)
+1. Locate your [Databricks instance name](https://docs.databricks.com/en/workspace/workspace-details.html#workspace-instance-names-urls-and-ids)
   -  Example: `cust-success.cloud.databricks.com`
 2. Add the required information to the template below, and submit your request to [dbt Support](https://docs.getdbt.com/community/resources/getting-help#dbt-cloud-support): 
 ```

--- a/website/docs/docs/cloud/secure/databricks-privatelink.md
+++ b/website/docs/docs/cloud/secure/databricks-privatelink.md
@@ -14,12 +14,13 @@ The following steps will walk you through the setup of a Databricks AWS PrivateL
 
 ## Configure PrivateLink
 
-1. Locate your [Databricks Workspace ID](https://kb.databricks.com/en_US/administration/find-your-workspace-id#:~:text=When%20viewing%20a%20Databricks%20workspace,make%20up%20the%20workspace%20ID)
+1. Locate your [Databricks Instance Name](https://docs.databricks.com/en/workspace/workspace-details.html#workspace-instance-names-urls-and-ids)
+  -  Example: `cust-success.cloud.databricks.com`
 2. Add the required information to the template below, and submit your request to [dbt Support](https://docs.getdbt.com/community/resources/getting-help#dbt-cloud-support): 
 ```
 Subject: New Multi-Tenant PrivateLink Request
 - Type: Databricks
-- Databricks workspace name:
+- Databricks Instance Name:
 - Databricks cluster AWS Region (e.g., us-east-1, eu-west-2):
 - dbt Cloud multi-tenant environment (US, EMEA, AU):
 ```


### PR DESCRIPTION
## What are you changing in this pull request and why?

The PrivateLink setup doc for Databricks incorrectly has the customer send us their _workspace_ name instead of the _instance_ name, which is what we actually require for setup. This update changes the text to actually ask for Instance Name, changes the link to a different URL explaining how to get this, and provides an example.
