### PR TITLE
Add manifest v12 for dbt Core v1.8

### DIFF
--- a/website/snippets/_manifest-versions.md
+++ b/website/snippets/_manifest-versions.md
@@ -1,6 +1,7 @@
 
 | dbt Core version | Manifest version                                              |
 |------------------|---------------------------------------------------------------|
+| v1.8             | [v12](https://schemas.getdbt.com/dbt/manifest/v12/index.html)  |
 | v1.7             | [v11](https://schemas.getdbt.com/dbt/manifest/v11/index.html)  |
 | v1.6             | [v10](https://schemas.getdbt.com/dbt/manifest/v10/index.html) |
 | v1.5             | [v9](https://schemas.getdbt.com/dbt/manifest/v9/index.html)   |


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/reference/artifacts/manifest-json)

## What are you changing in this pull request and why?

resolves https://github.com/dbt-labs/docs.getdbt.com/issues/5525

dbt Core v1.8 is using manifest v12.

dbt Cloud KoLV (Keep on Latest Version) is also using manifest v12 currently.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.