### PR TITLE
clarify where docs serve is supported to ensure

### DIFF
--- a/website/docs/reference/commands/cmd-docs.md
+++ b/website/docs/reference/commands/cmd-docs.md
@@ -54,7 +54,7 @@ dbt docs generate --empty-catalog
 ### dbt docs serve
 This command starts a webserver on port 8080 to serve your documentation locally and opens the documentation site in your default browser. The webserver is rooted in your `target/` directory. Be sure to run `dbt docs generate` before `dbt docs serve` because the  `generate` command produces a [catalog metadata artifact](/reference/artifacts/catalog-json) that the `serve` command depends upon. You will see an error message if the catalog is missing.  
 
-Use the `dbt docs serve` command if you're developing locally in the dbt Core CLI. This command isn't meant to be used with the dbt Cloud IDE.
+Use the `dbt docs serve` command if you're developing locally with the [dbt Cloud CLI](/docs/cloud/cloud-cli-installation) or [dbt Core](/docs/core/installation-overview). The [dbt Cloud IDE](/docs/cloud/dbt-cloud-ide/develop-in-the-cloud) doesn't support this command.
 
 **Usage:**
 ```


### PR DESCRIPTION
per [slack thread](https://dbt-labs.slack.com/archives/C06FWKP5V28/p1715952639527989), this pr sets to clarify where you can use the docs serve command as users previously weren't aware. this pr tries to make it more explicit.
