### PR TITLE
Adjust lightbox css to center-align images

### DIFF
--- a/website/src/components/lightbox/styles.module.css
+++ b/website/src/components/lightbox/styles.module.css
@@ -8,9 +8,12 @@
 :local(.docImage) {
   filter: drop-shadow(4px 4px 6px #aaaaaa33);
   margin: 10px auto;
-  padding-right: 10px;
   display: block;
-  max-width: 80%;
+}
+
+.docImage img {
+  margin: 10px auto; 
+  display: block;
 }
 
 :local(.collapsed) {
@@ -18,10 +21,10 @@
   padding: 0 5px;
 }
 
-.leftAlignLightbox {
+.docImage.leftAlignLightbox img {
   margin: 10px 0;
 }
-.rightAlignLightbox {
+.docImage.rightAlignLightbox img {
   margin: 10px 0 10px auto;
 }
 


### PR DESCRIPTION
[Asana task](https://app.asana.com/0/1200792801231972/1207068979458977/f)

## What are you changing in this pull request and why?

Fixes issue where Lightbox images are not center-aligning by default if not 100% width.

## Previews

The Example of tabs in sidebar image should now be center-aligned by default:
https://docs-getdbt-com-git-adjust-images-dbt-labs.vercel.app/docs/collaborate/explore-projects#browse-with-the-sidebar