### PR TITLE
remove outdated callout for discovery api docs

### DIFF
--- a/website/docs/docs/dbt-cloud-apis/discovery-api.md
+++ b/website/docs/docs/dbt-cloud-apis/discovery-api.md
@@ -11,20 +11,16 @@ You can access the Discovery API through [ad hoc queries](/docs/dbt-cloud-apis/d
 
 <Lightbox src="/img/docs/dbt-cloud/discovery-api/discovery-api-figure.png" width="80%" title="A rich ecosystem for integration "/>
 
-
 You can query the dbt Cloud metadata:
 
 - At the [environment](/docs/environments-in-dbt) level for both the latest state (use the `environment` endpoint) and historical run results (use `modelByEnvironment`) of a dbt Cloud project in production.
 - At the job level for results on a specific dbt Cloud job run for a given resource type, like `models` or `test`.
 
-:::tip Public Preview
-The Discovery API is currently available in Public Preview for dbt Cloud accounts on a Team or Enterprise plan. It’s available to all multi-tenant and to only select single-tenant accounts (please ask your account team to confirm). Preview features are stable and can be considered for production deployments, but there might still be some planned additions and modifications to product behavior before moving to General Availability. For details, refer to [dbt Product lifecycles](/docs/dbt-versions/product-lifecycles).
-
-:::
+<Snippet path="metadata-api-prerequisites" />
 
 ## What you can use the Discovery API for
 
-Click the tabs below to learn more about the API's use cases, the analysis you can do, and the results you can achieve by integrating with it.
+Click the following tabs to learn more about the API's use cases, the analysis you can do, and the results you can achieve by integrating with it.
 
 To use the API directly or integrate your tool with it, refer to [Uses case and examples](/docs/dbt-cloud-apis/discovery-use-cases-and-examples) for detailed information.
 

--- a/website/docs/docs/dbt-cloud-apis/discovery-querying.md
+++ b/website/docs/docs/dbt-cloud-apis/discovery-querying.md
@@ -27,7 +27,6 @@ Once you've created a token, you can use it in the Authorization header of reque
 
 3. For specific query points, refer to the [schema documentation](/docs/dbt-cloud-apis/discovery-schema-job).
 
-
 ## Run queries using HTTP requests
 
 You can run queries by sending a `POST` request to the Discovery API, making sure to replace:

--- a/website/docs/docs/dbt-cloud-apis/schema-discovery-environment.mdx
+++ b/website/docs/docs/dbt-cloud-apis/schema-discovery-environment.mdx
@@ -6,8 +6,6 @@ id: "discovery-schema-environment"
 
 import { QueryArgsTable, SchemaTable } from "./schema";
 
-<Snippet path="discovery-public-preview-banner" />
-
 The environment object allows you to query information about a particular model based on `environmentId`.
 
 The [Example queries](#example-queries) illustrate a few fields you can query with this `environment` object. Refer to [Fields](#fields) to view the entire schema, which provides all possible fields you can query.

--- a/website/snippets/discovery-public-preview-banner.md
+++ b/website/snippets/discovery-public-preview-banner.md
@@ -1,3 +1,0 @@
-:::info Public Preview
-This feature is currently in Public Preview and subject to change. If you want to provide feedback, please [contact us](mailto:metadata@dbtlabs.com).
-:::

--- a/website/snippets/metadata-api-prerequisites.md
+++ b/website/snippets/metadata-api-prerequisites.md
@@ -2,4 +2,4 @@
 
 - dbt Cloud [multi-tenant](/docs/cloud/about-cloud/tenancy#multi-tenant) or [single tenant](/docs/cloud/about-cloud/tenancy#single-tenant) account
 - You must be on a [Team or Enterprise plan](https://www.getdbt.com/pricing/)
-- Your projects must be on dbt version 1.0 or higher. Refer to [Upgrade dbt version in Cloud](/docs/dbt-versions/upgrade-dbt-version-in-cloud) to upgrade.
+- Your projects must be on dbt version 1.0 or later. Refer to [Upgrade dbt version in Cloud](/docs/dbt-versions/upgrade-dbt-version-in-cloud) to upgrade.

--- a/website/snippets/metadata-api-prerequisites.md
+++ b/website/snippets/metadata-api-prerequisites.md
@@ -2,5 +2,4 @@
 
 - dbt Cloud [multi-tenant](/docs/cloud/about-cloud/tenancy#multi-tenant) or [single tenant](/docs/cloud/about-cloud/tenancy#single-tenant) account
 - You must be on a [Team or Enterprise plan](https://www.getdbt.com/pricing/)
-- Your projects must be on dbt version 1.0 or higher. Refer to [Version migration guides](/docs/dbt-versions/core-upgrade) to upgrade
-
+- Your projects must be on dbt version 1.0 or higher. Refer to [Upgrade dbt version in Cloud](/docs/dbt-versions/upgrade-dbt-version-in-cloud) to upgrade.


### PR DESCRIPTION
this pr removes outdated callouts for the discovery api documentation, deletes a snippet, updates language to be more accessible, and also adds prerequisites to clarify ST and MT availabiity. 

Confirmed with PM and removed public preview snippet  cc @cafzal 