### PR TITLE
add dbt mesh to tenancy table

### DIFF
--- a/website/snippets/cloud-feature-parity.md
+++ b/website/snippets/cloud-feature-parity.md
@@ -10,7 +10,7 @@ The following table outlines which dbt Cloud features are supported on the diffe
 | dbt Mesh                      | ✅           | ✅                     | ✅                  |
 | dbt Semantic Layer            | ✅           | ✅ (Upon request)      | ❌                  |
 | Discovery API                 | ✅           | ✅                     | ✅                  |  
-| IP Restrictions               | ✅           | ✅                     | ✅                  |
+| IP restrictions               | ✅           | ✅                     | ✅                  |
 | Job scheduler                 | ✅           | ✅                     | ✅                  |
 | PrivateLink egress            | ✅ (AWS only)| ✅                     | ✅                  |
 | PrivateLink ingress           | ❌           | ✅                     | ✅                  |

--- a/website/snippets/cloud-feature-parity.md
+++ b/website/snippets/cloud-feature-parity.md
@@ -3,7 +3,7 @@ The following table outlines which dbt Cloud features are supported on the diffe
 | Feature                       | Multi-tenant | AWS single tenant     | Azure single tenant  |
 |-------------------------------|--------------|-----------------------|----------------------|
 | Audit logs                    | ✅           | ✅                     | ✅                  |  
-| Continuous Integration jobs   | ✅           | ✅                     | ✅                  |
+| Continuous integration jobs   | ✅           | ✅                     | ✅                  |
 | dbt Cloud CLI                 | ✅           | ✅                     | ✅                  |
 | dbt Cloud IDE                 | ✅           | ✅                     | ✅                  |
 | dbt Explorer                  | ✅           | ✅                     | ✅                  |

--- a/website/snippets/cloud-feature-parity.md
+++ b/website/snippets/cloud-feature-parity.md
@@ -1,16 +1,17 @@
 The following table outlines which dbt Cloud features are supported on the different SaaS options available today. For more information about feature availability, please [contact us](https://www.getdbt.com/contact/).
 
-| Feature                       | Multi-tenant | AWS single tenant     | Azure single tenant  | 
+| Feature                       | Multi-tenant | AWS single tenant     | Azure single tenant  |
 |-------------------------------|--------------|-----------------------|----------------------|
-| Job scheduler                 | ✅           | ✅                     | ✅                  |  
-| dbt Cloud IDE                 | ✅           | ✅                     | ✅                  |
-| dbt Cloud CLI                 | ✅           | ✅                     | ✅                 |
 | Audit logs                    | ✅           | ✅                     | ✅                  |  
-| Discovery API                 | ✅           | ✅                     | ✅                  | 
-| dbt Explorer                  | ✅           | ✅                     | ✅                   | 
+| Continuous Integration jobs   | ✅           | ✅                     | ✅                  |
+| dbt Cloud CLI                 | ✅           | ✅                     | ✅                  |
+| dbt Cloud IDE                 | ✅           | ✅                     | ✅                  |
+| dbt Explorer                  | ✅           | ✅                     | ✅                  |
+| dbt Mesh                      | ✅           | ✅                     | ✅                  |
+| dbt Semantic Layer            | ✅           | ✅ (Upon request)      | ❌                  |
+| Discovery API                 | ✅           | ✅                     | ✅                  |  
+| IP Restrictions               | ✅           | ✅                     | ✅                  |
+| Job scheduler                 | ✅           | ✅                     | ✅                  |
+| PrivateLink egress            | ✅ (AWS only)| ✅                     | ✅                  |
+| PrivateLink ingress           | ❌           | ✅                     | ✅                  |
 | Webhooks (Outbound)           | ✅           | ✅                     | ❌                  |
-| Continuous Integration, including CI jobs    | ✅        |     ✅     | ✅                  | 
-| dbt Semantic Layer            | ✅           | ✅ (Upon request)      | ❌                  | 
-| IP Restrictions               | ✅           | ✅                     | ✅                  | 
-| PrivateLink egress            | ✅ (AWS only)| ✅                     | ✅                  | 
-| PrivateLink ingress           | ❌           | ✅                     | ✅                  | 


### PR DESCRIPTION
this pr adds dbt mesh to the tenancy table [per notion convo](https://www.notion.so/dbtlabs/Mesh-Corp-Blog-Azzam-s-fork-3577c7390c6849cba08233c6046ebe83?pvs=4#d5970539a125474189f5eaca52b6960a) from @azzam34 and @jtcohen6  

this also structures the table alphabetically so it has an order and is easier to navigate.