### PR TITLE
Updates `seeds` directory  with `data` directory for storing seed files

### DIFF
--- a/website/docs/docs/build/seeds.md
+++ b/website/docs/docs/build/seeds.md
@@ -10,7 +10,7 @@ id: "seeds"
 * [`seed` command](/reference/commands/seed)
 
 ## Overview
-Seeds are CSV files in your dbt project (typically in your `seeds` directory), that dbt can load into your <Term id="data-warehouse" /> using the `dbt seed` command.
+Seeds are CSV files in your dbt project (typically in your `data` directory), that dbt can load into your <Term id="data-warehouse" /> using the `dbt seed` command.
 
 Seeds can be referenced in downstream models the same way as referencing models — by using the [`ref` function](/reference/dbt-jinja-functions/ref).
 
@@ -29,9 +29,9 @@ personal identifiable information (PII) and passwords.
 
 ## Example
 To load a seed file in your dbt project:
-1. Add the file to your `seeds` directory, with a `.csv` file extension, e.g. `seeds/country_codes.csv`
+1. Add the file to your `data` directory, with a `.csv` file extension, e.g. `data/country_codes.csv`
 
-<File name='seeds/country_codes.csv'>
+<File name='data/country_codes.csv'>
 
 ```text
 country_code,country_name
@@ -66,7 +66,7 @@ Done. PASS=1 ERROR=0 SKIP=0 TOTAL=1
 <File name='models/orders.sql'>
 
 ```sql
--- This refers to the table created from seeds/country_codes.csv
+-- This refers to the table created from data/country_codes.csv
 select * from {{ ref('country_codes') }}
 ```
 


### PR DESCRIPTION
Seed files are now stored in the `data` directory under the project root directory. This commit makes changes to the following lines to reflect this new project setup:

- Line 13: typically in your `seeds` directory --> typically in your `data` directory

- Line 32: Add the file... `seeds` directory... e.g. `seeds/country_codes.csv` --> Add the files...`data` directory...e.g. `data/country_codes.csv`

- Line 34: File name='seeds/country_codes.csv' --> File name='data/country_codes.csv'

- Line 69: -- This refers to...seeds/country_codes.csv --> -- This refers to ...data/country_codes.csv

## What are you changing in this pull request and why?
Seed files are now stored in the `data` directory under the project root directory and no longer the seeds directory. The seeds directory no longer exists and is confusing when the seeds directory is mentioned as the location for storing seeds.

<!---
Describe your changes and why you're making them. If related to an open 
issue or a pull request on dbt Core, then link to them here! 

To learn more about the writing conventions used in the dbt Labs docs, see the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md).
-->

## Checklist
<!--
Uncomment when publishing docs for a prerelease version of dbt:
- [ ] Add versioning components, as described in [Versioning Docs](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-entire-pages)
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
- [ ] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [ ] For [docs versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#about-versioning), review how to [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content).
- [ ] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
