### PR TITLE
Add reference to VPCE ID network policies for SF OAuth docs

### DIFF
--- a/website/docs/docs/cloud/manage-access/set-up-snowflake-oauth.md
+++ b/website/docs/docs/cloud/manage-access/set-up-snowflake-oauth.md
@@ -103,7 +103,7 @@ This error might be because of a configuration issue in the Snowflake OAuth flow
 * In the Snowflake OAuth flow, `role` in the profile config is not optional, as it does not inherit from the project connection config. So each user must supply their role, regardless of whether it is provided in the project connection.
 
 #### Server error 500
-If you experience a 500 server error when redirected from Snowflake to dbt Cloud, double-check that you have allow listed [dbt Cloud's IP addresses](/docs/cloud/about-cloud/access-regions-ip-addresses), or [VPC Endpoint ID when connecting over PrivateLink](/docs/cloud/secure/snowflake-privatelink#configuring-network-policies), on a Snowflake account level.
+If you experience a 500 server error when redirected from Snowflake to dbt Cloud, double-check that you have allow-listed [dbt Cloud's IP addresses](/docs/cloud/about-cloud/access-regions-ip-addresses), or [VPC Endpoint ID (for PrivateLink connections)](/docs/cloud/secure/snowflake-privatelink#configuring-network-policies), on a Snowflake account level.
 
 Enterprise customers who have single-tenant deployments will have a different range of IP addresses (network CIDR ranges) to allow list.
 

--- a/website/docs/docs/cloud/manage-access/set-up-snowflake-oauth.md
+++ b/website/docs/docs/cloud/manage-access/set-up-snowflake-oauth.md
@@ -103,7 +103,7 @@ This error might be because of a configuration issue in the Snowflake OAuth flow
 * In the Snowflake OAuth flow, `role` in the profile config is not optional, as it does not inherit from the project connection config. So each user must supply their role, regardless of whether it is provided in the project connection.
 
 #### Server error 500
-If you experience a 500 server error when redirected from Snowflake to dbt Cloud, double-check that you have allow listed [dbt Cloud's IP addresses](/docs/cloud/about-cloud/access-regions-ip-addresses), or [VPC Endpoint ID when connecting over PrivateLink](https://docs.getdbt.com/docs/cloud/secure/snowflake-privatelink#configuring-network-policies), on a Snowflake account level.
+If you experience a 500 server error when redirected from Snowflake to dbt Cloud, double-check that you have allow listed [dbt Cloud's IP addresses](/docs/cloud/about-cloud/access-regions-ip-addresses), or [VPC Endpoint ID when connecting over PrivateLink](/docs/cloud/secure/snowflake-privatelink#configuring-network-policies), on a Snowflake account level.
 
 Enterprise customers who have single-tenant deployments will have a different range of IP addresses (network CIDR ranges) to allow list.
 

--- a/website/docs/docs/cloud/manage-access/set-up-snowflake-oauth.md
+++ b/website/docs/docs/cloud/manage-access/set-up-snowflake-oauth.md
@@ -103,7 +103,7 @@ This error might be because of a configuration issue in the Snowflake OAuth flow
 * In the Snowflake OAuth flow, `role` in the profile config is not optional, as it does not inherit from the project connection config. So each user must supply their role, regardless of whether it is provided in the project connection.
 
 #### Server error 500
-If you experience a 500 server error when redirected from Snowflake to dbt Cloud, double-check that you have allow listed [dbt Cloud's IP addresses](/docs/cloud/about-cloud/access-regions-ip-addresses) on a Snowflake account level.
+If you experience a 500 server error when redirected from Snowflake to dbt Cloud, double-check that you have allow listed [dbt Cloud's IP addresses](/docs/cloud/about-cloud/access-regions-ip-addresses), or [VPC Endpoint ID when connecting over PrivateLink](https://docs.getdbt.com/docs/cloud/secure/snowflake-privatelink#configuring-network-policies), on a Snowflake account level.
 
 Enterprise customers who have single-tenant deployments will have a different range of IP addresses (network CIDR ranges) to allow list.
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

The Snowflake OAuth docs contain a section detailing what may cause a 500 error which suggests checking that they have added our IP addresses to their Snowflake Network Policy. We've recently added guidance to the PrivateLink docs to also be able to allowlist by VPCE ID in their Network Policy when connecting over PrivateLink. 

This method is not currently mentioned in this Snowflake OAuth troubleshooting section, but it is relevant, so we're adding a mention and a link to the previously added docs.