### PR TITLE
Allowed and default values for `LOG_FORMAT` and `LOG_FORMAT_FILE`

### DIFF
--- a/website/docs/reference/global-configs/logs.md
+++ b/website/docs/reference/global-configs/logs.md
@@ -6,7 +6,53 @@ sidebar: "logs"
 
 ### Log Formatting
 
-The `LOG_FORMAT` config specifies how dbt's logs should be formatted. If the value of this config is `json`, dbt will output fully structured logs in <Term id="json" /> format; otherwise, it will output text-formatted logs that are sparser for the CLI and more detailed in `logs/dbt.log`. The available options for the log format are `text`, `debug`, `json`, and `default`. The default is `default`. 
+dbt outputs logs to two different locations: CLI console and the log file (whose default location is `logs/dbt.log`). When the `LOG_FORMAT` is set explicitly, it will take affect in both the console and log files.
+
+<VersionBlock lastVersion="1.4">
+
+The `LOG_FORMAT` config specifies how dbt's logs should be formatted and has three options: `json`, `text`, and `debug`.
+
+</VersionBlock>
+
+<VersionBlock firstVersion="1.5">
+
+The `LOG_FORMAT` and `LOG_FORMAT_FILE` configs specify how dbt's logs should be formatted, and they each have the same options: `json`, `text`, and `debug`.
+
+</VersionBlock>
+
+The `text` format is the default for console logs and has plain text messages prefixed with a simple timestamp:
+
+```
+23:30:16  Running with dbt=1.8.0
+23:30:17  Registered adapter: postgres=1.8.0
+```
+
+The `debug` format is the default for the log file and is the same as the `text` format but with a more detailed timestamp and also includes the invocation id, thread id, and log level of each message:
+
+```
+============================== 16:12:08.555032 | 9089bafa-4010-4f38-9b42-564ec9106e07 ==============================
+16:12:08.555032 [info ] [MainThread]: Running with dbt=1.8.0
+16:12:08.751069 [info ] [MainThread]: Registered adapter: postgres=1.8.0
+```
+
+The `json` format outputs fully structured logs in <Term id="json" /> format:
+
+```json
+{"data": {"log_version": 3, "version": "=1.8.0"}, "info": {"category": "", "code": "A001", "extra": {}, "invocation_id": "82131fa0-d2b4-4a77-9436-019834e22746", "level": "info", "msg": "Running with dbt=1.8.0", "name": "MainReportVersion", "pid": 7875, "thread": "MainThread", "ts": "2024-05-29T23:32:54.993336Z"}}
+{"data": {"adapter_name": "postgres", "adapter_version": "=1.8.0"}, "info": {"category": "", "code": "E034", "extra": {}, "invocation_id": "82131fa0-d2b4-4a77-9436-019834e22746", "level": "info", "msg": "Registered adapter: postgres=1.8.0", "name": "AdapterRegistered", "pid": 7875, "thread": "MainThread", "ts": "2024-05-29T23:32:56.437986Z"}}
+```
+
+<VersionBlock lastVersion="1.4">
+
+When the `LOG_FORMAT` is set explicitly, it will take affect in both the console and log files.
+
+</VersionBlock>
+
+<VersionBlock firstVersion="1.5">
+
+When the `LOG_FORMAT` is set explicitly, it will take affect in both the console and log files whereas the `LOG_FORMAT_FILE` only affects the log file.
+
+</VersionBlock>
 
 <File name='Usage'>
 
@@ -19,7 +65,9 @@ dbt --log-format json run
 
 <VersionBlock firstVersion="1.5">
 
-To set the `LOG_FORMAT_FILE` type output for the file without impacting the console log format, use the `log-format-file` flag. The default option is `debug`.
+To set the `LOG_FORMAT_FILE` type output for the file without impacting the console log format, use the `log-format-file` flag.
+
+</VersionBlock>
 
 
 ```text

--- a/website/docs/reference/global-configs/logs.md
+++ b/website/docs/reference/global-configs/logs.md
@@ -6,7 +6,7 @@ sidebar: "logs"
 
 ### Log Formatting
 
-dbt outputs logs to two different locations: CLI console and the log file (whose default location is `logs/dbt.log`).
+dbt outputs logs to two different locations: CLI console and the log file.
 
 <VersionBlock lastVersion="1.4">
 

--- a/website/docs/reference/global-configs/logs.md
+++ b/website/docs/reference/global-configs/logs.md
@@ -58,7 +58,6 @@ When the `LOG_FORMAT` is set explicitly, it will take affect in both the console
 
 ```text
 dbt --log-format json run
-{"code": "A001", "data": {"v": "=1.0.0"}, "invocation_id": "1193e449-4b7a-4eb1-8e8e-047a8b3b7973", "level": "info", "log_version": 1, "msg": "Running with dbt=1.0.0", "node_info": {}, "pid": 35098, "thread_name": "MainThread", "ts": "2021-12-03T10:46:59.928217Z", "type": "log_line"}
 ```
 
 </File>

--- a/website/docs/reference/global-configs/logs.md
+++ b/website/docs/reference/global-configs/logs.md
@@ -43,7 +43,7 @@ The `debug` format is the default for the log file and is the same as the `text`
 16:12:08.751069 [info ] [MainThread]: Registered adapter: postgres=1.8.0
 ```
 
-The `json` format outputs fully structured logs in <Term id="json" /> format:
+The `json` format outputs fully structured logs in the <Term id="json" /> format:
 
 ```json
 {"data": {"log_version": 3, "version": "=1.8.0"}, "info": {"category": "", "code": "A001", "extra": {}, "invocation_id": "82131fa0-d2b4-4a77-9436-019834e22746", "level": "info", "msg": "Running with dbt=1.8.0", "name": "MainReportVersion", "pid": 7875, "thread": "MainThread", "ts": "2024-05-29T23:32:54.993336Z"}}

--- a/website/docs/reference/global-configs/logs.md
+++ b/website/docs/reference/global-configs/logs.md
@@ -20,6 +20,14 @@ The `LOG_FORMAT` and `LOG_FORMAT_FILE` configs specify how dbt's logs should be 
 
 </VersionBlock>
 
+<File name='Usage'>
+
+```text
+dbt --log-format json run
+```
+
+</File>
+
 The `text` format is the default for console logs and has plain text messages prefixed with a simple timestamp:
 
 ```
@@ -54,22 +62,17 @@ When the `LOG_FORMAT` is set explicitly, it will take affect in both the console
 
 </VersionBlock>
 
-<File name='Usage'>
-
-```text
-dbt --log-format json run
-```
-
-</File>
-
 <VersionBlock firstVersion="1.5">
 
 To set the `LOG_FORMAT_FILE` type output for the file without impacting the console log format, use the `log-format-file` flag.
 
+<File name='Usage'>
 
 ```text
 dbt --log-format-file json run
 ```
+
+</File>
 
 </VersionBlock>
 

--- a/website/docs/reference/global-configs/logs.md
+++ b/website/docs/reference/global-configs/logs.md
@@ -6,7 +6,7 @@ sidebar: "logs"
 
 ### Log Formatting
 
-The `LOG_FORMAT` config specifies how dbt's logs should be formatted. If the value of this config is `json`, dbt will output fully structured logs in <Term id="json" /> format; otherwise, it will output text-formatted logs that are sparser for the CLI and more detailed in `logs/dbt.log`.
+The `LOG_FORMAT` config specifies how dbt's logs should be formatted. If the value of this config is `json`, dbt will output fully structured logs in <Term id="json" /> format; otherwise, it will output text-formatted logs that are sparser for the CLI and more detailed in `logs/dbt.log`. The available options for the log format are `text`, `debug`, `json`, and `default`. The default is `default`. 
 
 <File name='Usage'>
 
@@ -19,7 +19,7 @@ dbt --log-format json run
 
 <VersionBlock firstVersion="1.5">
 
-To set the `LOG_FORMAT_FILE` type output for the file without impacting the console log format, use the `log-format-file` flag.
+To set the `LOG_FORMAT_FILE` type output for the file without impacting the console log format, use the `log-format-file` flag. The default option is `debug`.
 
 
 ```text

--- a/website/docs/reference/global-configs/logs.md
+++ b/website/docs/reference/global-configs/logs.md
@@ -6,7 +6,7 @@ sidebar: "logs"
 
 ### Log Formatting
 
-dbt outputs logs to two different locations: CLI console and the log file (whose default location is `logs/dbt.log`). When the `LOG_FORMAT` is set explicitly, it will take affect in both the console and log files.
+dbt outputs logs to two different locations: CLI console and the log file (whose default location is `logs/dbt.log`).
 
 <VersionBlock lastVersion="1.4">
 

--- a/website/docs/reference/global-configs/logs.md
+++ b/website/docs/reference/global-configs/logs.md
@@ -67,8 +67,6 @@ dbt --log-format json run
 
 To set the `LOG_FORMAT_FILE` type output for the file without impacting the console log format, use the `log-format-file` flag.
 
-</VersionBlock>
-
 
 ```text
 dbt --log-format-file json run

--- a/website/docs/reference/global-configs/logs.md
+++ b/website/docs/reference/global-configs/logs.md
@@ -35,7 +35,7 @@ The `text` format is the default for console logs and has plain text messages pr
 23:30:17  Registered adapter: postgres=1.8.0
 ```
 
-The `debug` format is the default for the log file and is the same as the `text` format but with a more detailed timestamp and also includes the invocation id, thread id, and log level of each message:
+The `debug` format is the default for the log file and is the same as the `text` format but with a more detailed timestamp and also includes the [`invocation_id`](/reference/dbt-jinja-functions/invocation_id), [`thread_id`](/reference/dbt-jinja-functions/thread_id), and [log level](/reference/global-configs/logs#log-level) of each message:
 
 ```
 ============================== 16:12:08.555032 | 9089bafa-4010-4f38-9b42-564ec9106e07 ==============================

--- a/website/docs/reference/global-configs/logs.md
+++ b/website/docs/reference/global-configs/logs.md
@@ -60,12 +60,6 @@ When the `LOG_FORMAT` is set explicitly, it will take affect in both the console
 
 When the `LOG_FORMAT` is set explicitly, it will take affect in both the console and log files whereas the `LOG_FORMAT_FILE` only affects the log file.
 
-</VersionBlock>
-
-<VersionBlock firstVersion="1.5">
-
-To set the `LOG_FORMAT_FILE` type output for the file without impacting the console log format, use the `log-format-file` flag.
-
 <File name='Usage'>
 
 ```text


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/reference/global-configs/logs#log-formatting)

## What are you changing in this pull request and why?

resolves https://github.com/dbt-labs/docs.getdbt.com/issues/5577

Allowed and default values are in the source code [here](https://github.com/dbt-labs/dbt-core/blob/3e37d77780492499b5fcf72a99078f7843f0bd28/core/dbt/cli/params.py#L179-L180).

### TLDR

The `LOG_FORMAT` and `LOG_FORMAT_FILE` global config flags in dbt control the format of log outputs. There are three formats:

1. **`text`**
   - Outputs unstructured text with minimal metadata and second-precision timestamps in UTC.
   - Default format for console output.

   Example:
    ```
    23:30:16  Running with dbt=1.8.0
    23:30:17  Registered adapter: postgres=1.8.0
    ```

2. **`debug`**
   - Outputs unstructured text with detailed metadata including log level, thread ID, and microsecond-precision timestamps in the system's local time zone.
   - Default format for the `logs/dbt.log` file.

   Example:
    ```
    ============================== 16:12:08.555032 | 9089bafa-4010-4f38-9b42-564ec9106e07 ==============================
    16:12:08.555032 [info ] [MainThread]: Running with dbt=1.8.0
    16:12:08.751069 [info ] [MainThread]: Registered adapter: postgres=1.8.0
    ```

3. **`json`**
   - Outputs structured JSON-L format logs.


   Example:
    ```json
    {"data": {"log_version": 3, "version": "=1.8.0"}, "info": {"category": "", "code": "A001", "extra": {}, "invocation_id": "82131fa0-d2b4-4a77-9436-019834e22746", "level": "info", "msg": "Running with dbt=1.8.0", "name": "MainReportVersion", "pid": 7875, "thread": "MainThread", "ts": "2024-05-29T23:32:54.993336Z"}}
    {"data": {"adapter_name": "postgres", "adapter_version": "=1.8.0"}, "info": {"category": "", "code": "E034", "extra": {}, "invocation_id": "82131fa0-d2b4-4a77-9436-019834e22746", "level": "info", "msg": "Registered adapter: postgres=1.8.0", "name": "AdapterRegistered", "pid": 7875, "thread": "MainThread", "ts": "2024-05-29T23:32:56.437986Z"}}

    ```

**Note:** The `debug` log format should not be confused with the `debug` log level. The `log level` determines the number of log messages, while the `log format` determines the detail in each log message.

### More info

There are two different sub-classes of [`_Logger`](https://github.com/dbt-labs/dbt-common/blob/50072e70b01c988bfc7dcd777d603f8a7d7738bd/dbt_common/events/logger.py#L93):
1. [`_TextLogger`](https://github.com/dbt-labs/dbt-common/blob/50072e70b01c988bfc7dcd777d603f8a7d7738bd/dbt_common/events/logger.py#L145) (default)
2. [`_JsonLogger`](https://github.com/dbt-labs/dbt-common/blob/50072e70b01c988bfc7dcd777d603f8a7d7738bd/dbt_common/events/logger.py#L190)

`_TextLogger` has two different line formats:
1. [`DebugText`](https://github.com/dbt-labs/dbt-common/blob/50072e70b01c988bfc7dcd777d603f8a7d7738bd/dbt_common/events/logger.py#L44) (default)
    - Same as `PlainText` below except it includes a header at the beginning of each invocation (which has a timestamp and the [invocation ID](https://docs.getdbt.com/reference/dbt-jinja-functions/invocation_id)) and each message includes the [log level](https://docs.getdbt.com/reference/global-configs/logs#log-level) of the message, [thread ID](https://docs.getdbt.com/reference/dbt-jinja-functions/thread_id), and the timestamp has a microsecond precision using the Python system time zone
1. [`PlainText`](https://github.com/dbt-labs/dbt-common/blob/50072e70b01c988bfc7dcd777d603f8a7d7738bd/dbt_common/events/logger.py#L43)
    - Same as `DebugText` above except it does not include a header at the beginning of each invocation and each message does not include the [log level](https://docs.getdbt.com/reference/global-configs/logs#log-level) of the message or the [thread ID](https://docs.getdbt.com/reference/dbt-jinja-functions/thread_id). The timestamp for each message has a second precision represented in UTC.

`_JsonLogger` has a single line format:
1. [`Json`](https://github.com/dbt-labs/dbt-common/blob/50072e70b01c988bfc7dcd777d603f8a7d7738bd/dbt_common/events/logger.py#L45)

Those (3) line formats correspond to the options for the [`LOG_FORMAT` and `LOG_FORMAT_FILE`](https://docs.getdbt.com/reference/global-configs/logs#log-formatting) global config flags:
1. `debug` -> `DebugText` line format  (default for the `logs/dbt.log` file) outputs unstructured text with more metadata at the beginning of each log line and upon each dbt invocation
1. `text` -> `PlainText` line format (default for console output) outputs unstructured text with minimal metadata at the beginning of each log line and none upon each dbt invocation
1. `json` -> `Json` line format outputs structured [JSON-L](https://www.ncbi.nlm.nih.gov/datasets/docs/v2/reference-docs/file-formats/metadata-files/why-jsonl/#why-use-the-json-lines-format-for-various-data-reports)

> [!WARNING]
> The `debug` [`log_level`](https://docs.getdbt.com/reference/global-configs/logs#log-level) can easily be confused with the `debug` [`log_format`](https://docs.getdbt.com/reference/global-configs/logs#log-formatting) since they have the same name. But the `log_level` and `log_format` are independent configurations whose options can be mixed'n'matched.
> 
> Think of **log levels** as affecting the total number of log messages and the **log format** as affecting the length of each log message: the `debug` log level includes the **maximal number** of log messages whereas the `debug` log format includes more detailed information **per log message**
> 
> e.g. The `debug` log level filters out the least number of potential log messages -- none! And the `debug` log format has longer lines because it includes the most detailed debugging metadata per log message.
> 
> To avoid confusion, we would have been better off giving the `debug` log format a unique name instead (like `detailed`). A better name for the `text` log format would have been `basic`, `simple`, or `brief`.

> [!NOTE]  
> I don't know the precision reasons why the `PlainText` line format is in UTC with low-resolution while the `DebugText` with a local time zone and high resolution

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.