### PR TITLE
Adjust wildcard redirect

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1452,11 +1452,6 @@
       "permanent": true
     },
     {
-      "source": "/docs/building-a-dbt-project/building-models/:path*",
-      "destination": "/reference/resource-configs/:path*",
-      "permanent": true
-    },
-    {
       "source": "/docs/dbt-cloud/dbt-cloud-api/metadata/metadata-querying",
       "destination": "/docs/dbt-cloud-apis/metadata-querying",
       "permanent": true
@@ -3403,6 +3398,11 @@
     {
       "source": "/reference/resource-properties/access",
       "destination": "/reference/resource-configs/access",
+      "permanent": true
+    },
+    {
+      "source": "/docs/building-a-dbt-project/building-models/:path*",
+      "destination": "/reference/resource-configs/:path*",
       "permanent": true
     }
   ],


### PR DESCRIPTION
## What are you changing in this pull request and why?

On the live site, the following URL does not redirect to the correct location, causing a 404:
https://docs.getdbt.com/docs/building-a-dbt-project/building-models/configuring-incremental-models#configuring-incremental-strategy 

This was due to the wildcard redirect match kicking in ([on line 1455](https://github.com/dbt-labs/docs.getdbt.com/blob/989f0dd46eec83c05e620a1009361cab1ff25649/website/vercel.json#L1455)) before the actual redirect needed ([on line 1500](https://github.com/dbt-labs/docs.getdbt.com/blob/989f0dd46eec83c05e620a1009361cab1ff25649/website/vercel.json#L1500)).

This moves the wildcard match to the end of the file, to allow any other redirects to kick in first if a match is found. With this preview, the same URL should now redirect:
https://docs-getdbt-com-git-update-redirects-dbt-labs.vercel.app/docs/building-a-dbt-project/building-models/configuring-incremental-models#configuring-incremental-strategy 
