### PR TITLE
update unit test versioned models link

### DIFF
--- a/website/docs/docs/build/unit-tests.md
+++ b/website/docs/docs/build/unit-tests.md
@@ -24,7 +24,7 @@ With dbt Core v1.8 and dbt Cloud environments that opt to "Keep on latest versio
 - We currently only support adding unit tests to models in your _current_ project.
 - We currently *don't* support unit testing models that use recursive SQL.
 - You must specify all fields in a BigQuery STRUCT in a unit test. You cannot use only a subset of fields in a STRUCT.
-- If your model has multiple versions, by default the unit test will run on *all* versions of your model. Read [unit testing versioned models](#unit-testing-versioned-models) for more information.
+- If your model has multiple versions, by default the unit test will run on *all* versions of your model. Read [unit testing versioned models](/reference/resource-properties/unit-testing-versions) for more information.
 - Unit tests must be defined in a YML file in your `models/` directory.
 - Table names must be [aliased](/docs/build/custom-aliases) in order to unit test `join` logic.
 - Redshift customers need to be aware of a [limitation when building unit tests](/reference/resource-configs/redshift-configs#unit-test-limitations) that requires a workaround. 

--- a/website/docs/reference/resource-properties/unit-tests.md
+++ b/website/docs/reference/resource-properties/unit-tests.md
@@ -20,7 +20,7 @@ To run only your unit tests, use the command:
 
 - We currently only support unit testing SQL models.
 - We currently only support adding unit tests to models in your _current_ project.
-- If your model has multiple versions, by default the unit test will run on *all* versions of your model. Read [unit testing versioned models](#unit-testing-versioned-models) for more information.
+- If your model has multiple versions, by default the unit test will run on *all* versions of your model. Read [unit testing versioned models](/reference/resource-properties/unit-testing-versions) for more information.
 - Unit tests must be defined in a YML file in your `models/` directory.
 - If you want to unit test a model that depends on an ephemeral model, you must use `format: sql` for that input.
 

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -3,6 +3,11 @@
   "trailingSlash": false,
   "redirects": [
     {
+      "source": "/reference/resource-properties/unit-tests#unit-testing-versioned-models",
+      "destination": "/reference/resource-properties/unit-testing-versions",
+      "permanent": true
+    },
+    {
       "source": "/docs/deploy/deploy-environments#partial-parsing",
       "destination": "/docs/dbt-cloud-environments#partial-parsing",
       "permanent": true


### PR DESCRIPTION
this pr updates the link to the correct unit test versioned models link. previously it was linking to a non existent anchor link: `Read [unit testing versioned models](#unit-testing-versioned-models) for more information)` and not going anywhere. 

this pr sets to add a redirect as well so the dbt learn course links to the correct place and we avoid user confusion. 

raised in slack by @b-per: https://dbt-labs.slack.com/archives/C02NCQ9483C/p1717152369804939