### PR TITLE
Update connect-snowflake.md

### DIFF
--- a/website/docs/docs/cloud/connect-data-platform/connect-snowflake.md
+++ b/website/docs/docs/cloud/connect-data-platform/connect-snowflake.md
@@ -33,7 +33,7 @@ to authenticate dbt Cloud to run queries against Snowflake on behalf of a Snowfl
 
 **Available in:** Development environments,  Deployment environments
 
-The `Keypair` auth method uses Snowflake's [Key Pair Authentication](https://docs.snowflake.com/en/user-guide/python-connector-example.html#using-key-pair-authentication) to authenticate Development or Deployment credentials for a dbt Cloud project.
+The `Keypair` auth method uses Snowflake's [Key Pair Authentication](https://docs.snowflake.com/en/user-guide/key-pair-auth) to authenticate Development or Deployment credentials for a dbt Cloud project.
 
 1. After [generating an encrypted key pair](https://docs.snowflake.com/en/user-guide/key-pair-auth.html#configuring-key-pair-authentication), be sure to set the `rsa_public_key` for the Snowflake user to authenticate in dbt Cloud:
 


### PR DESCRIPTION
link to key-pair main docs

## What are you changing in this pull request and why?
<!---
Current link is to Python connector page which users have to search to find key pair 
It would be more helpful to link directly to the key pair user guide documenting how to create and use the key pairs.
-->