### PR TITLE
Add package config info to more surface areas

### DIFF
--- a/website/docs/reference/configs-and-properties.md
+++ b/website/docs/reference/configs-and-properties.md
@@ -38,7 +38,7 @@ Note - Generic data tests work a little differently when it comes to specificity
 
 Within the project file, configurations are also applied hierarchically. The most specific config always takes precedence. In the project file, for example, configurations applied to a `marketing` subdirectory will take precedence over configurations applied to the entire `jaffle_shop` project. To apply a configuration to a model or directory of models, define the [resource path](reference/resource-configs/resource-path) as nested dictionary keys.
 
-Configurations in your root dbt project have _higher_ precedence than configurations in installed packages. This enables you to override the configurations of installed packages, providing more control at a higher level of granularity. 
+Configurations in your root dbt project have _higher_ precedence than configurations in installed packages. This enables you to override the configurations of installed packages, providing more control over your dbt runs. 
 
 
 ### Combining configs

--- a/website/docs/reference/configs-and-properties.md
+++ b/website/docs/reference/configs-and-properties.md
@@ -32,7 +32,7 @@ Depending on the resource type, configurations can be defined in the dbt project
 
 ### Config inheritance
 
-dbt prioritizes configurations in order of specificity, from most specific to least specific. This generally follows the order above: an in-file `config()` block --> properties defined in a `.yml` file --> config defined in the project file. 
+The most specific config always takes precedence. This generally follows the order above: an in-file `config()` block --> properties defined in a `.yml` file --> config defined in the project file. 
 
 Note - Generic data tests work a little differently when it comes to specificity. See [test configs](/reference/data-test-configs).
 

--- a/website/docs/reference/configs-and-properties.md
+++ b/website/docs/reference/configs-and-properties.md
@@ -36,7 +36,7 @@ dbt prioritizes configurations in order of specificity, from most specific to le
 
 Note - Generic data tests work a little differently when it comes to specificity. See [test configs](/reference/data-test-configs).
 
-Within the project file, configurations are also applied hierarchically. The most specific config always takes precedence. In the project file, for example, configurations applied to a `marketing` subdirectory will take precedence over configurations applied to the entire `jaffle_shop` project. To apply a configuration to a model, or directory of models, define the resource path as nested dictionary keys.
+Within the project file, configurations are also applied hierarchically. The most specific config always takes precedence. In the project file, for example, configurations applied to a `marketing` subdirectory will take precedence over configurations applied to the entire `jaffle_shop` project. To apply a configuration to a model, or directory of models, define the [resource path](reference/resource-configs/resource-path) as nested dictionary keys.
 
 Configurations in your dbt project have _higher_ precedence than configurations in installed packages. This enables you to override the configurations of installed packages, providing more control at a higher level of granularity. 
 

--- a/website/docs/reference/configs-and-properties.md
+++ b/website/docs/reference/configs-and-properties.md
@@ -24,7 +24,7 @@ Whereas you can use **configurations** to:
 
 ## Where can I define configs?
 
-Depending on the resource type, configurations can be defined:
+Depending on the resource type, configurations can be defined in the dbt project and also in an installed package by:
 
 1. Using a [`config()` Jinja macro](/reference/dbt-jinja-functions/config) within a `model`, `snapshot`, or `test` SQL file
 2. Using a [`config` property](/reference/resource-properties/config) in a `.yml` file
@@ -32,11 +32,14 @@ Depending on the resource type, configurations can be defined:
 
 ### Config inheritance
 
-dbt prioritizes configurations in order of specificity, from most specificity to least specificity. This generally follows the order above: an in-file `config()` block --> properties defined in a `.yml` file --> config defined in the project file. 
+dbt prioritizes configurations in order of specificity, from most specific to least specific. This generally follows the order above: an in-file `config()` block --> properties defined in a `.yml` file --> config defined in the project file. 
 
 Note - Generic data tests work a little differently when it comes to specificity. See [test configs](/reference/data-test-configs).
 
-Within the project file, configurations are also applied hierarchically. The most specific config always "wins": In the project file, configurations applied to a `marketing` subdirectory will take precedence over configurations applied to the entire `jaffle_shop` project. To apply a configuration to a model, or directory of models, define the resource path as nested dictionary keys.
+Within the project file, configurations are also applied hierarchically. The most specific config always takes precedence. In the project file, for example, configurations applied to a `marketing` subdirectory will take precedence over configurations applied to the entire `jaffle_shop` project. To apply a configuration to a model, or directory of models, define the resource path as nested dictionary keys.
+
+Configurations in your dbt project have _higher_ precedence than configurations in installed packages. This enables you to override the configurations of installed packages, providing more control at a higher level of granularity. 
+
 
 ### Combining configs
 

--- a/website/docs/reference/configs-and-properties.md
+++ b/website/docs/reference/configs-and-properties.md
@@ -36,7 +36,7 @@ dbt prioritizes configurations in order of specificity, from most specific to le
 
 Note - Generic data tests work a little differently when it comes to specificity. See [test configs](/reference/data-test-configs).
 
-Within the project file, configurations are also applied hierarchically. The most specific config always takes precedence. In the project file, for example, configurations applied to a `marketing` subdirectory will take precedence over configurations applied to the entire `jaffle_shop` project. To apply a configuration to a model, or directory of models, define the [resource path](reference/resource-configs/resource-path) as nested dictionary keys.
+Within the project file, configurations are also applied hierarchically. The most specific config always takes precedence. In the project file, for example, configurations applied to a `marketing` subdirectory will take precedence over configurations applied to the entire `jaffle_shop` project. To apply a configuration to a model or directory of models, define the [resource path](reference/resource-configs/resource-path) as nested dictionary keys.
 
 Configurations in your root dbt project have _higher_ precedence than configurations in installed packages. This enables you to override the configurations of installed packages, providing more control at a higher level of granularity. 
 

--- a/website/docs/reference/configs-and-properties.md
+++ b/website/docs/reference/configs-and-properties.md
@@ -38,7 +38,7 @@ Note - Generic data tests work a little differently when it comes to specificity
 
 Within the project file, configurations are also applied hierarchically. The most specific config always takes precedence. In the project file, for example, configurations applied to a `marketing` subdirectory will take precedence over configurations applied to the entire `jaffle_shop` project. To apply a configuration to a model, or directory of models, define the [resource path](reference/resource-configs/resource-path) as nested dictionary keys.
 
-Configurations in your dbt project have _higher_ precedence than configurations in installed packages. This enables you to override the configurations of installed packages, providing more control at a higher level of granularity. 
+Configurations in your root dbt project have _higher_ precedence than configurations in installed packages. This enables you to override the configurations of installed packages, providing more control at a higher level of granularity. 
 
 
 ### Combining configs

--- a/website/docs/reference/model-configs.md
+++ b/website/docs/reference/model-configs.md
@@ -199,7 +199,7 @@ Model configurations are applied hierarchically. You can configure models from w
 
 The most specific configuration always takes precedence. In the project file, for example, configurations applied to a `marketing` subdirectory will take precedence over configurations applied to the entire `jaffle_shop` project. To apply a configuration to a model, or directory of models, define the resource path as nested dictionary keys.
 
-Model configurations in your dbt project have _higher_ precedence than configurations in installed packages. This enables you to override the configurations of installed packages, providing more control at a higher level of granularity. 
+Model configurations in your root dbt project have _higher_ precedence than configurations in installed packages. This enables you to override the configurations of installed packages, providing more control at a higher level of granularity. 
 
 ## Example
 

--- a/website/docs/reference/model-configs.md
+++ b/website/docs/reference/model-configs.md
@@ -197,7 +197,7 @@ Model configurations are applied hierarchically. You can configure models from w
 2. Using a `config` [resource property](/reference/model-properties) in a `.yml` file.
 3. From the `dbt_project.yml` project file, under the `models:` key. In this case, the model that's nested the deepest will have the highest priority. 
 
-The most specific configuration always takes precedence. In the project file, for example,configurations applied to a `marketing` subdirectory will take precedence over configurations applied to the entire `jaffle_shop` project. To apply a configuration to a model, or directory of models, define the resource path as nested dictionary keys.
+The most specific configuration always takes precedence. In the project file, for example, configurations applied to a `marketing` subdirectory will take precedence over configurations applied to the entire `jaffle_shop` project. To apply a configuration to a model, or directory of models, define the resource path as nested dictionary keys.
 
 Model configurations in your dbt project have _higher_ precedence than configurations in installed packages. This enables you to override the configurations of installed packages, providing more control at a higher level of granularity. 
 

--- a/website/docs/reference/model-configs.md
+++ b/website/docs/reference/model-configs.md
@@ -189,14 +189,17 @@ models:
 * [Databricks configurations](/reference/resource-configs/databricks-configs)
 * [Spark configurations](/reference/resource-configs/spark-configs)
 
-## Configuring models
-Models can be configured in one of three ways:
+## Configuring models 
 
-1. Using a `config()` Jinja macro within a model
-2. Using a `config` [resource property](/reference/model-properties) in a `.yml` file
-3. From the `dbt_project.yml` file, under the `models:` key.
+Model configurations are applied hierarchically. You can configure models from within an installed package and also from within your dbt project in the following ways, listed in order of precedence: 
 
-Model configurations are applied hierarchically. The most-specific config always "wins": In the project file, configurations applied to a `marketing` subdirectory will take precedence over configurations applied to the entire `jaffle_shop` project. To apply a configuration to a model, or directory of models, define the resource path as nested dictionary keys.
+1. Using a `config()` Jinja macro within a model.
+2. Using a `config` [resource property](/reference/model-properties) in a `.yml` file.
+3. From the `dbt_project.yml` project file, under the `models:` key. In this case, the model that's nested the deepest will have the highest priority. 
+
+The most specific configuration always takes precedence. In the project file, for example,configurations applied to a `marketing` subdirectory will take precedence over configurations applied to the entire `jaffle_shop` project. To apply a configuration to a model, or directory of models, define the resource path as nested dictionary keys.
+
+Model configurations in your dbt project have _higher_ precedence than configurations in installed packages. This enables you to override the configurations of installed packages, providing more control at a higher level of granularity. 
 
 ## Example
 

--- a/website/docs/reference/model-configs.md
+++ b/website/docs/reference/model-configs.md
@@ -197,7 +197,7 @@ Model configurations are applied hierarchically. You can configure models from w
 2. Using a `config` [resource property](/reference/model-properties) in a `.yml` file.
 3. From the `dbt_project.yml` project file, under the `models:` key. In this case, the model that's nested the deepest will have the highest priority. 
 
-The most specific configuration always takes precedence. In the project file, for example, configurations applied to a `marketing` subdirectory will take precedence over configurations applied to the entire `jaffle_shop` project. To apply a configuration to a model, or directory of models, define the resource path as nested dictionary keys.
+The most specific configuration always takes precedence. In the project file, for example, configurations applied to a `marketing` subdirectory will take precedence over configurations applied to the entire `jaffle_shop` project. To apply a configuration to a model or directory of models, define the [resource path](reference/resource-configs/resource-path) as nested dictionary keys.
 
 Model configurations in your root dbt project have _higher_ precedence than configurations in installed packages. This enables you to override the configurations of installed packages, providing more control at a higher level of granularity. 
 

--- a/website/docs/reference/model-configs.md
+++ b/website/docs/reference/model-configs.md
@@ -199,7 +199,7 @@ Model configurations are applied hierarchically. You can configure models from w
 
 The most specific configuration always takes precedence. In the project file, for example, configurations applied to a `marketing` subdirectory will take precedence over configurations applied to the entire `jaffle_shop` project. To apply a configuration to a model or directory of models, define the [resource path](reference/resource-configs/resource-path) as nested dictionary keys.
 
-Model configurations in your root dbt project have _higher_ precedence than configurations in installed packages. This enables you to override the configurations of installed packages, providing more control at a higher level of granularity. 
+Model configurations in your root dbt project have _higher_ precedence than configurations in installed packages. This enables you to override the configurations of installed packages, providing more control over your dbt runs. 
 
 ## Example
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

Add info about package configs to the following pages:

- https://docs.getdbt.com/reference/model-configs
- https://docs.getdbt.com/reference/configs-and-properties

closes #3239 

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [x] For [docs versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#about-versioning), review how to [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content).
- [x] Needs review from DX
