### PR TITLE
Use a more direct link for the `metric` resource type

### DIFF
--- a/website/docs/reference/global-configs/resource-type.md
+++ b/website/docs/reference/global-configs/resource-type.md
@@ -18,7 +18,7 @@ The available resource types are:
 
 - [`analysis`](/docs/build/analyses)
 - [`exposure`](/docs/build/exposures)
-- [`metric`](/docs/build/build-metrics-intro)
+- [`metric`](/docs/build/metrics-overview)
 - [`model`](/docs/build/models)
 - [`seed`](/docs/build/seeds)
 - [`snapshot`](/docs/build/snapshots)


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty10-patch-2-dbt-labs.vercel.app/reference/global-configs/resource-type)

## What are you changing in this pull request and why?

During a [separate PR review](https://github.com/dbt-labs/docs.getdbt.com/pull/5641#pullrequestreview-2113129317), @mirnawong1 noticed a more direct link for metrics.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.