### PR TITLE
Note the important internal change from `argparse` to `click` in v1.5

### DIFF
--- a/website/docs/docs/dbt-versions/core-upgrade/05-upgrading-to-v1.5.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/05-upgrading-to-v1.5.md
@@ -24,7 +24,7 @@ dbt Labs is committed to providing backward compatibility for all versions 1.x, 
 
 :::info Why changes to previous behavior?
 
-This release includes significant new features, and rework to `dbt-core`'s CLI and initialization flow. As part of refactoring its internals, we made a handful of changes to runtime configuration. The net result of these changes is more consistent & practical configuration options, and a more legible codebase.
+This release includes significant new features, and rework to `dbt-core`'s CLI and initialization flow. As part of refactoring its internals from `argparse` to `click`, we made a handful of changes to runtime configuration. The net result of these changes is more consistent & practical configuration options, and a more legible codebase.
 
 **_Wherever possible, we will provide backward compatibility and deprecation warnings for at least one minor version before actually removing the old functionality._** In those cases, we still reserve the right to fully remove backwards compatibility for deprecated functionality in a future v1.x minor version of `dbt-core`.
 

--- a/website/docs/docs/dbt-versions/core-upgrade/05-upgrading-to-v1.5.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/05-upgrading-to-v1.5.md
@@ -24,7 +24,7 @@ dbt Labs is committed to providing backward compatibility for all versions 1.x, 
 
 :::info Why changes to previous behavior?
 
-This release includes significant new features, and rework to `dbt-core`'s CLI and initialization flow. As part of refactoring its internals from `argparse` to `click`, we made a handful of changes to runtime configuration. The net result of these changes is more consistent & practical configuration options, and a more legible codebase.
+This release includes significant new features, and rework to `dbt-core`'s CLI and initialization flow. As part of refactoring its internals from [`argparse`](https://docs.python.org/3/library/argparse.html) to [`click`](https://click.palletsprojects.com), we made a handful of changes to runtime configuration. The net result of these changes is more consistent & practical configuration options, and a more legible codebase.
 
 **_Wherever possible, we will provide backward compatibility and deprecation warnings for at least one minor version before actually removing the old functionality._** In those cases, we still reserve the right to fully remove backwards compatibility for deprecated functionality in a future v1.x minor version of `dbt-core`.
 

--- a/website/docs/docs/dbt-versions/core-upgrade/05-upgrading-to-v1.5.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/05-upgrading-to-v1.5.md
@@ -24,7 +24,7 @@ dbt Labs is committed to providing backward compatibility for all versions 1.x, 
 
 :::info Why changes to previous behavior?
 
-This release includes significant new features, and rework to `dbt-core`'s CLI and initialization flow. As part of refactoring its internals from [`argparse`](https://docs.python.org/3/library/argparse.html) to [`click`](https://click.palletsprojects.com), we made a handful of changes to runtime configuration. The net result of these changes is more consistent & practical configuration options, and a more legible codebase.
+This release includes significant new features, and rework to `dbt-core`'s CLI and initialization flow. As part of refactoring its internals from [`argparse`](https://docs.python.org/3/library/argparse.html) to [`click`](https://click.palletsprojects.com), we made a handful of changes to runtime configuration. The net result of these changes is more consistent and practical configuration options, and a more legible codebase.
 
 **_Wherever possible, we will provide backward compatibility and deprecation warnings for at least one minor version before actually removing the old functionality._** In those cases, we still reserve the right to fully remove backwards compatibility for deprecated functionality in a future v1.x minor version of `dbt-core`.
 


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty10-patch-2-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/upgrading-to-v1.5#behavior-changes)

## What are you changing in this pull request and why?

In v1.5, we changed the CLI internals from [`argparse` to `click`](https://github.com/dbt-labs/dbt-core/issues/8123#issuecomment-1642357545). Since this marked an important change that affected some behavior, it would be helpful to document that this change took place in v1.5.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.