### PR TITLE
Experiment-driven update - Docs navigation 

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -111,10 +111,27 @@ var siteSettings = {
       },
       items: [
         {
-          to: "/docs/introduction",
           label: "Docs",
           position: "left",
-          activeBaseRegex: "docs/(?!(dbt-cloud))",
+          items: [
+            {
+              label: "Product Docs",
+              to: "/docs/introduction",
+              activeBaseRegex: "docs/(?!(dbt-cloud))",
+            },
+            {
+              label: "API Docs",
+              to: "/docs/dbt-cloud-apis/overview",
+            },
+            {
+              label: "Best Practices",
+              to: "/best-practices",
+            },
+            {
+              label: "Release Notes",
+              to: "/docs/dbt-versions/dbt-cloud-release-notes",
+            },
+          ],
         },
         {
           to: "reference/references-overview",


### PR DESCRIPTION
## What are you changing in this pull request and why?
Replaces Docs main nav item as a dropdown with the following items.
Product Docs - https://docs.getdbt.com/docs/introduction
API Docs - https://docs.getdbt.com/docs/dbt-cloud-apis/overview
Best Practices - https://docs.getdbt.com/best-practices
Release Notes - https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes

We are making this change to reflect the positive result we saw in our recent experiment.

## Preview Link
https://docs-getdbt-com-git-exp-docs-nav-dropdown-dbt-labs.vercel.app/
