### PR TITLE
Update documentation on yml version defaults

### DIFF
--- a/website/docs/reference/project-configs/config-version.md
+++ b/website/docs/reference/project-configs/config-version.md
@@ -23,4 +23,4 @@ Specify your `dbt_project.yml` as using the v2 structure.
 <VersionBlock firstVersion="1.5"> This configuration is optional. </VersionBlock>
 
 ## Default
-Without this configuration, dbt will assume your `dbt_project.yml` uses the version 2 syntaz. Version 1 was deprecated in dbt v0.19.0.
+Without this configuration, dbt will assume your `dbt_project.yml` uses the version 2 syntax. Version 1 was deprecated in dbt v0.19.0.

--- a/website/docs/reference/project-configs/config-version.md
+++ b/website/docs/reference/project-configs/config-version.md
@@ -23,4 +23,4 @@ Specify your `dbt_project.yml` as using the v2 structure.
 <VersionBlock firstVersion="1.5"> This configuration is optional. </VersionBlock>
 
 ## Default
-Without this configuration, dbt will assume your `dbt_project.yml` uses the version 1 syntax, which was deprecated in dbt v0.19.0.
+Without this configuration, dbt will assume your `dbt_project.yml` uses the version 2 syntaz. Version 1 was deprecated in dbt v0.19.0.


### PR DESCRIPTION
## What are you changing in this pull request and why?
<!---
Describe your changes and why you're making them. If related to an open 
issue or a pull request on dbt Core, then link to them here! 

To learn more about the writing conventions used in the dbt Labs docs, see the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md).
-->
The [config-version documentation](https://docs.getdbt.com/reference/project-configs/config-version) is not clear about what the default value is. It states that the parameter is optional and that the old version, version 1, is not in use. This implies that the default version should be 2, but the default is explicitly stated here as version 1.
```md
## Default
Without this configuration, dbt will assume your dbt_project.yml uses the version 1 syntax, which was deprecated in dbt v0.19.0.
```

As per PR https://github.com/dbt-labs/dbt-core/pull/7060, the default version is in-fact version 2, so this documentation needs to be updated.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [x] For [docs versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#about-versioning), review how to [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content).
- [x] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
