### PR TITLE
Revise dates for legacy behaviours

### DIFF
--- a/website/docs/reference/global-configs/legacy-behaviors.md
+++ b/website/docs/reference/global-configs/legacy-behaviors.md
@@ -37,7 +37,7 @@ When we use dbt Cloud in the following table, we're referring to accounts that h
 
 | Flag                                                            | dbt Cloud: Intro | dbt Cloud: Maturity | dbt Core: Intro | dbt Core: Maturity | 
 |-----------------------------------------------------------------|------------------|---------------------|-----------------|--------------------|
-| require_explicit_package_overrides_for_builtin_materializations | 2024.04.141      | 2024.06.191         | 1.6.14, 1.7.14  | 1.8.0             |
+| require_explicit_package_overrides_for_builtin_materializations | 2024.04.141      | 2024.06.192         | 1.6.14, 1.7.14  | 1.8.0             |
 | require_resource_names_without_spaces                           | 2024.05.146      | TBD*                | 1.8.0           | 1.9.0             |
 | source_freshness_run_project_hooks                              | 2024.03.61       | TBD*                | 1.8.0           | 1.9.0             |
 

--- a/website/docs/reference/global-configs/legacy-behaviors.md
+++ b/website/docs/reference/global-configs/legacy-behaviors.md
@@ -38,10 +38,12 @@ When we use dbt Cloud in the following table, we're referring to accounts that h
 | Flag                                                            | dbt Cloud: Intro | dbt Cloud: Maturity | dbt Core: Intro | dbt Core: Maturity | 
 |-----------------------------------------------------------------|------------------|---------------------|-----------------|--------------------|
 | require_explicit_package_overrides_for_builtin_materializations | 2024.04.141      | 2024.06.191         | 1.6.14, 1.7.14  | 1.8.0             |
-| require_resource_names_without_spaces                           | 2024.05.146      | TBD                 | 1.8.0           | 1.9.0             |
-| source_freshness_run_project_hooks                              | 2024.03.61       | TBD                 | 1.8.0           | 1.9.0             |
+| require_resource_names_without_spaces                           | 2024.05.146      | TBD*                | 1.8.0           | 1.9.0             |
+| source_freshness_run_project_hooks                              | 2024.03.61       | TBD*                | 1.8.0           | 1.9.0             |
 
-
+*Note that TBD means the exact date/release for these flags in dbt Cloud hasn't been determined yet. Affected users will receive emails ahead of the maturity date. In the meantime, if you see deprecation warnings, you can either:
+- Migrate your project and enable the new behavior by setting the flag to `True` to stop seeing the warnings.
+- Or, set the flag to `False` to keep seeing warnings without changing behavior until the default changes later this year.
 
 ###  Package override for built-in materialization 
 

--- a/website/docs/reference/global-configs/legacy-behaviors.md
+++ b/website/docs/reference/global-configs/legacy-behaviors.md
@@ -37,9 +37,9 @@ When we use dbt Cloud in the following table, we're referring to accounts that h
 
 | Flag                                                            | dbt Cloud: Intro | dbt Cloud: Maturity | dbt Core: Intro | dbt Core: Maturity | 
 |-----------------------------------------------------------------|------------------|---------------------|-----------------|--------------------|
-| require_explicit_package_overrides_for_builtin_materializations | 2024.04.141      | 2024.05.TBD         | 1.6.14, 1.7.14    | 1.8.0             |
-| require_resource_names_without_spaces                           | 2024.05.TBD      | 2024.06.TBD         | 1.8.0           | 1.9.0             |
-| source_freshness_run_project_hooks                              | 2024.03.61       | 2024.06.TBD         | 1.8.0           | 1.9.0             |
+| require_explicit_package_overrides_for_builtin_materializations | 2024.04.141      | 2024.06.191         | 1.6.14, 1.7.14  | 1.8.0             |
+| require_resource_names_without_spaces                           | 2024.05.146      | TBD                 | 1.8.0           | 1.9.0             |
+| source_freshness_run_project_hooks                              | 2024.03.61       | TBD                 | 1.8.0           | 1.9.0             |
 
 
 

--- a/website/docs/reference/global-configs/legacy-behaviors.md
+++ b/website/docs/reference/global-configs/legacy-behaviors.md
@@ -41,9 +41,9 @@ When we use dbt Cloud in the following table, we're referring to accounts that h
 | require_resource_names_without_spaces                           | 2024.05.146      | TBD*                | 1.8.0           | 1.9.0             |
 | source_freshness_run_project_hooks                              | 2024.03.61       | TBD*                | 1.8.0           | 1.9.0             |
 
-*Note that TBD means the exact date/release for these flags in dbt Cloud hasn't been determined yet. Affected users will receive emails ahead of the maturity date. In the meantime, if you see deprecation warnings, you can either:
-- Migrate your project and enable the new behavior by setting the flag to `True` to stop seeing the warnings.
-- Or, set the flag to `False` to keep seeing warnings without changing behavior until the default changes later this year.
+When the dbt Cloud Maturity is "TBD," it means we have not yet determined the exact date when these flags' default values will change. Affected users will see deprecation warnings in the meantime, and they will receive emails providing advance warning ahead of the maturity date. In the meantime, if you are seeing a deprecation warning, you can either:
+- Migrate your project to support the new behavior, and then set the flag to `True` to stop seeing the warnings.
+- Set the flag to `False`. You will continue to see warnings, and you will retain the legacy behavior even after the maturity date (when the default value changes).
 
 ###  Package override for built-in materialization 
 


### PR DESCRIPTION
A few corrections for legacy behavior dates / releases:
- `require_explicit_package_overrides_for_builtin_materializations` is reaching "maturity" (default changing from `False` to `True`) today (release 2024.06.191), which will be rolling out gradually to dbt Cloud customers over the coming days
- `require_resource_names_without_spaces` was introduced in `2024.05.146`
- The "maturity" dates in dbt Cloud for `require_explicit_package_overrides_for_builtin_materializations` and `require_resource_names_without_spaces` are still TBD. Most likely, this will be **after** the final release of dbt Core (OSS) v1.9 later this year.