### PR TITLE
Update spark-setup.md

### DIFF
--- a/website/docs/docs/core/connect-data-platform/spark-setup.md
+++ b/website/docs/docs/core/connect-data-platform/spark-setup.md
@@ -220,3 +220,6 @@ Delta-only features:
 1. Incremental model updates by `unique_key` instead of `partition_by` (see [`merge` strategy](/reference/resource-configs/spark-configs#the-merge-strategy))
 2. [Snapshots](/docs/build/snapshots)
 3. [Persisting](/reference/resource-configs/persist_docs) column-level descriptions as database comments
+
+### Default Namespace Using Thrift Connection Method
+There are metadata queries that run pre-executing any dbt workflow, these queries run on the default namespace. So if your Spark cluster for some reason doesn't have a default namespace created these queries will results in a failed workflow during run or debug even though the configutations are set correctly. 

--- a/website/docs/docs/core/connect-data-platform/spark-setup.md
+++ b/website/docs/docs/core/connect-data-platform/spark-setup.md
@@ -221,7 +221,7 @@ Delta-only features:
 2. [Snapshots](/docs/build/snapshots)
 3. [Persisting](/reference/resource-configs/persist_docs) column-level descriptions as database comments
 
-### Default namespace using Thrift connection method
+### Default namespace with Thrift connection method
 
 If your Spark cluster doesn't have a default namespace, metadata queries that run before any dbt workflow will fail, causing the entire workflow to fail, even if your configurations are correct. The metadata queries fail there's no default namespace in which to run it.
 

--- a/website/docs/docs/core/connect-data-platform/spark-setup.md
+++ b/website/docs/docs/core/connect-data-platform/spark-setup.md
@@ -48,7 +48,7 @@ $ python -m pip install "dbt-spark[session]"
 
 <p>For further info, refer to the GitHub repository: <a href={`https://github.com/${frontMatter.meta.github_repo}`}>{frontMatter.meta.github_repo}</a></p>
 
-## Connection Methods
+## Connection methods
 
 dbt-spark can connect to Spark clusters by four different methods:
 
@@ -211,7 +211,7 @@ Spark can be customized using [Application Properties](https://spark.apache.org/
 ### Usage with EMR
 To connect to Apache Spark running on an Amazon EMR cluster, you will need to run `sudo /usr/lib/spark/sbin/start-thriftserver.sh` on the master node of the cluster to start the Thrift server (see [the docs](https://aws.amazon.com/premiumsupport/knowledge-center/jdbc-connection-emr/) for more information). You will also need to connect to port 10001, which will connect to the Spark backend Thrift server; port 10000 will instead connect to a Hive backend, which will not work correctly with dbt.
 
-### Supported Functionality
+### Supported functionality
 
 Most dbt Core functionality is supported, but some features are only available
 on Delta Lake (Databricks).
@@ -221,5 +221,8 @@ Delta-only features:
 2. [Snapshots](/docs/build/snapshots)
 3. [Persisting](/reference/resource-configs/persist_docs) column-level descriptions as database comments
 
-### Default Namespace Using Thrift Connection Method
-There are metadata queries that run pre-executing any dbt workflow, these queries run on the default namespace. So if your Spark cluster for some reason doesn't have a default namespace created these queries will results in a failed workflow during run or debug even though the configutations are set correctly. 
+### Default namespace using Thrift connection method
+
+If your Spark cluster doesn't have a default namespace, metadata queries that run before any dbt workflow will fail, causing the entire workflow to fail, even if your configurations are correct. The metadata queries fail there's no default namespace in which to run it.
+
+To debug, review the debug-level logs to confirm the query dbt is running when it encounters the error: `dbt run --debug` or `logs/dbt.log`.


### PR DESCRIPTION
Updating caveats section in `/connect-data-platform/spark-setup`  to include a caveat when using thrift connection method with cluster that doesn't have a `default` namespace. 

For more context check: https://github.com/dbt-labs/dbt-spark/issues/1036 