### PR TITLE
Add redirect for mesh structures

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -3176,6 +3176,11 @@
       "permanent": true
     },
     {
+      "source": "/best-practices/how-we-mesh/mesh-2-structures",
+      "destination": "/best-practices/how-we-mesh/mesh-3-structures",
+      "permanent": true
+    },
+    {
       "source": "/guides/advanced/adapter-development/:path*",
       "destination": "/guides/adapter-creation",
       "permanent": true


### PR DESCRIPTION
## What are you changing in this pull request and why?
Fixing missing redirect for https://docs.getdbt.com/best-practices/how-we-mesh/mesh-2-structures to https://docs.getdbt.com/best-practices/how-we-mesh/mesh-3-structures