### PR TITLE
Add links for clarity

### DIFF
--- a/website/docs/docs/build/python-models.md
+++ b/website/docs/docs/build/python-models.md
@@ -774,6 +774,7 @@ You can also install packages at cluster creation time by [defining cluster prop
 <Lightbox src="/img/docs/building-a-dbt-project/building-models/python-models/dataproc-pip-packages.png" title="Adding packages to install via pip at cluster startup"/>
 
 **Docs:**
+
 - [Dataproc overview](https://cloud.google.com/dataproc/docs/concepts/overview)
 - [Create a Dataproc cluster](https://cloud.google.com/dataproc/docs/guides/create-cluster)
 - [Create a Cloud Storage bucket](https://cloud.google.com/storage/docs/creating-buckets)

--- a/website/docs/docs/build/python-models.md
+++ b/website/docs/docs/build/python-models.md
@@ -775,6 +775,8 @@ You can also install packages at cluster creation time by [defining cluster prop
 
 **Docs:**
 - [Dataproc overview](https://cloud.google.com/dataproc/docs/concepts/overview)
+- [Create a Dataproc cluster](https://cloud.google.com/dataproc/docs/guides/create-cluster)
+- [Create a Cloud Storage bucket](https://cloud.google.com/storage/docs/creating-buckets)
 - [PySpark DataFrame syntax](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.html)
 
 </div>


### PR DESCRIPTION
## What are you changing in this pull request and why?

Add links to Google's docs on creating Dataproc cluster and creating Cloud Storage buckets to improve clarity. The BigQuery tab is pretty dense with content

per request on [slack](https://dbt-labs.slack.com/archives/C02NCQ9483C/p1719434723581339) 

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [x] For [docs versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#about-versioning), review how to [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content).
