### PR TITLE
Update links to changelogs in migration guides

### DIFF
--- a/website/docs/docs/dbt-versions/core-upgrade/01-upgrading-to-v1.8.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/01-upgrading-to-v1.8.md
@@ -7,7 +7,7 @@ displayed_sidebar: "docs"
  
 ## Resources
 
-- Changelog (coming soon)
+- [Changelog](https://github.com/dbt-labs/dbt-core/blob/1.8.latest/CHANGELOG.md)
 - [dbt Core CLI Installation guide](/docs/core/installation-overview)
 - [Cloud upgrade guide](/docs/dbt-versions/upgrade-dbt-version-in-cloud)
 

--- a/website/docs/docs/dbt-versions/core-upgrade/02-upgrading-to-v1.7.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/02-upgrading-to-v1.7.md
@@ -7,7 +7,7 @@ displayed_sidebar: "docs"
 
 ## Resources
 
-- [Changelog](https://github.com/dbt-labs/dbt-core/blob/8aaed0e29f9560bc53d9d3e88325a9597318e375/CHANGELOG.md)
+- [Changelog](https://github.com/dbt-labs/dbt-core/blob/1.7.latest/CHANGELOG.md)
 - [dbt Core CLI Installation guide](/docs/core/installation-overview)
 - [Cloud upgrade guide](/docs/dbt-versions/upgrade-dbt-version-in-cloud)
 - [Release schedule](https://github.com/dbt-labs/dbt-core/issues/8260)


### PR DESCRIPTION
## What are you changing in this pull request and why?

Add and update links to changelogs for v1.8 and v1.7 migration guides.

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.