### PR TITLE
remove outdated dbt example projects

### DIFF
--- a/website/docs/faqs/Project/example-projects.md
+++ b/website/docs/faqs/Project/example-projects.md
@@ -11,6 +11,7 @@ Yes!
 * **Quickstart Tutorial:** You can build your own example dbt project in the [quickstart guide](/docs/get-started-dbt)
 * **Jaffle Shop:** A demonstration project (closely related to the tutorial) for a fictional e-commerce store ([main source code](https://github.com/dbt-labs/jaffle-shop) and [source code using duckdb](https://github.com/dbt-labs/jaffle_shop_duckdb))
 * **GitLab:** Gitlab's internal dbt project is open source and is a great example of how to use dbt at scale ([source code](https://gitlab.com/gitlab-data/analytics/-/tree/master/transform/snowflake-dbt))
+* **dummy-dbt:** A containerized dbt project that populates the Sakila database in Postgres and populates dbt seeds, models, snapshots, and tests. The project can be used for testing and experimentation purposes ([source code](https://github.com/gmyrianthous/dbt-dummy))
 * **Google Analytics 4:** A demonstration project that transforms the Google Analytics 4 BigQuery exports to various models ([source code](https://github.com/stacktonic-com/stacktonic-dbt-example-project), [docs](https://stacktonic.com/article/google-analytics-big-query-and-dbt-a-dbt-example-project))
 
 If you have an example project to add to this list, suggest an edit by clicking **Edit this page** below.

--- a/website/docs/faqs/Project/example-projects.md
+++ b/website/docs/faqs/Project/example-projects.md
@@ -8,12 +8,9 @@ id: example-projects
 
 Yes!
 
-* **Quickstart Tutorial:** You can build your own example dbt project in the [quickstart guide](/guides)
-* **Jaffle Shop:** A demonstration project (closely related to the tutorial) for a fictional ecommerce store ([source code](https://github.com/dbt-labs/jaffle_shop))
-* **MRR Playbook:** A demonstration project that models subscription revenue ([source code](https://github.com/dbt-labs/mrr-playbook), [docs](https://www.getdbt.com/mrr-playbook/#!/overview))
-* **Attribution Playbook:** A demonstration project that models marketing attribution  ([source code](https://github.com/dbt-labs/attribution-playbook), [docs](https://www.getdbt.com/attribution-playbook/#!/overview))
-* **GitLab:** Gitlab's internal dbt project is open source and is a great example of how to use dbt at scale ([source code](https://gitlab.com/gitlab-data/analytics/-/tree/master/transform/snowflake-dbt), [docs](https://dbt.gitlabdata.com/))
-* **dummy-dbt:** A containerized dbt project that populates the Sakila database in Postgres and populates dbt seeds, models, snapshots, and tests. The project can be used for testing and experimentation purposes ([source code](https://github.com/gmyrianthous/dbt-dummy))
+* **Quickstart Tutorial:** You can build your own example dbt project in the [quickstart guide](/docs/get-started-dbt)
+* **Jaffle Shop:** A demonstration project (closely related to the tutorial) for a fictional e-commerce store ([main source code](https://github.com/dbt-labs/jaffle-shop) and [source code using duckdb](https://github.com/dbt-labs/jaffle_shop_duckdb))
+* **GitLab:** Gitlab's internal dbt project is open source and is a great example of how to use dbt at scale ([source code](https://gitlab.com/gitlab-data/analytics/-/tree/master/transform/snowflake-dbt))
 * **Google Analytics 4:** A demonstration project that transforms the Google Analytics 4 BigQuery exports to various models ([source code](https://github.com/stacktonic-com/stacktonic-dbt-example-project), [docs](https://stacktonic.com/article/google-analytics-big-query-and-dbt-a-dbt-example-project))
 
 If you have an example project to add to this list, suggest an edit by clicking **Edit this page** below.


### PR DESCRIPTION
this pr removes outdated example projects. the outdated projects also linked to dbt docs but was erroring out. consulted by [dx in internal slck](https://dbt-labs.slack.com/archives/C02HE19D51R/p1719506110010469)

also raised in slack: https://getdbt.slack.com/archives/CBSQTAPLG/p1719474709310489
