### PR TITLE
Updates query param handling on /guides

### DIFF
--- a/website/src/components/quickstartGuideList/index.js
+++ b/website/src/components/quickstartGuideList/index.js
@@ -48,11 +48,20 @@ function QuickstartList({ quickstartData }) {
   }, [quickstartData]);
 
   const updateUrlParams = (selectedTags, selectedLevel) => {
-    const params = new URLSearchParams();
+    // Create a new URLSearchParams object from the current URL search string
+    const params = new URLSearchParams(location.search);
+
+    // Remove existing 'tags' and 'level' parameters to avoid duplicates
+    params.delete('tags');
+    params.delete('level');
+
+    // Append new 'tags' and 'level' values from the current state
     selectedTags.forEach(tag => params.append('tags', tag.value));
     selectedLevel.forEach(level => params.append('level', level.value));
+
+    // Update the URL with the new search parameters
     history.replace({ search: params.toString() });
-  };
+};
 
   // Handle all filters
   const handleDataFilter = () => {


### PR DESCRIPTION
## What are you changing in this pull request and why?
[Asana Task](https://app.asana.com/0/1202136277772113/1207686648073613/f)
This PR allows additional query params to be used on the `/guides` page. Additional query params are required for activating Mutiny preview mode. Currently we can not activate Mutiny previews on this route.

[Slack thread](https://dbt-labs.slack.com/archives/C06M99V657T/p1718991855866109) with Mutiny support for more context.

### Old Behavior
Only `tags` and `level` were allowed as query params. Any additional query param would be removed.
Access https://docs.getdbt.com/guides?mutiny=1 and see the `mutiny` param get automatically removed on page load.

### New Behavior
Additional query params can be used while keeping the `tags` and `level` params only available to be filtered on.


## Testing Steps
1. Access https://docs-getdbt-com-git-fix-params-on-guides-dbt-labs.vercel.app/guides?mutiny=1 and confirm `mutiny` param does not get removed.
2. Confirm filtering by URL param still works https://docs-getdbt-com-git-fix-params-on-guides-dbt-labs.vercel.app/guides?mutiny=1&tags=Best+practices and that the `mutiny` param does not get applied as a filter.

