### PR TITLE
Add versionless value for admin api and terraform

### DIFF
--- a/website/docs/docs/dbt-versions/core-upgrade/01-upgrading-to-v1.8.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/01-upgrading-to-v1.8.md
@@ -21,7 +21,7 @@ dbt Cloud is going "versionless." This means you'll automatically get early acce
 
 Select ["Keep on latest version"](/docs/dbt-versions/upgrade-dbt-version-in-cloud#keep-on-latest-version) in your development, staging, and production [environments](/docs/deploy/deploy-environments) to access to everything in dbt Core v1.8 and more.
 
-For the dbt Cloud Admin API and Terraform, use the value `versionless` to configure your environment. 
+To upgrade an environment in the dbt Cloud Admin API or Terraform, set `dbt_version` to the string `versionless`.
 
 ## New and changed features and functionality
 

--- a/website/docs/docs/dbt-versions/core-upgrade/01-upgrading-to-v1.8.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/01-upgrading-to-v1.8.md
@@ -21,6 +21,8 @@ dbt Cloud is going "versionless." This means you'll automatically get early acce
 
 Select ["Keep on latest version"](/docs/dbt-versions/upgrade-dbt-version-in-cloud#keep-on-latest-version) in your development, staging, and production [environments](/docs/deploy/deploy-environments) to access to everything in dbt Core v1.8 and more.
 
+For the dbt Cloud Admin API and Terraform, use the value `versionless` to configure your environment. 
+
 ## New and changed features and functionality
 
 Features and functionality new in dbt v1.8.

--- a/website/docs/docs/dbt-versions/core-upgrade/01-upgrading-to-v1.8.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/01-upgrading-to-v1.8.md
@@ -21,7 +21,7 @@ dbt Cloud is going "versionless." This means you'll automatically get early acce
 
 Select ["Keep on latest version"](/docs/dbt-versions/upgrade-dbt-version-in-cloud#keep-on-latest-version) in your development, staging, and production [environments](/docs/deploy/deploy-environments) to access to everything in dbt Core v1.8 and more.
 
-To upgrade an environment in the dbt Cloud Admin API or Terraform, set `dbt_version` to the string `versionless`.
+To upgrade an environment in the [dbt Cloud Admin API](/docs/dbt-cloud-apis/admin-cloud-api) or [Terraform](https://registry.terraform.io/providers/dbt-labs/dbtcloud/latest), set `dbt_version` to the string `versionless`.
 
 ## New and changed features and functionality
 

--- a/website/docs/docs/dbt-versions/upgrade-dbt-version-in-cloud.md
+++ b/website/docs/docs/dbt-versions/upgrade-dbt-version-in-cloud.md
@@ -17,7 +17,7 @@ By choosing to **Keep on latest version**, you opt for a versionless experience 
 
 You can upgrade to **Keep on latest version** and the versionless experience no matter which version of dbt you currently have selected. As a best practice, dbt Labs recommends that you test the upgrade in development first; use the [Override dbt version](#override-dbt-version) setting to test _your_ project on the latest dbt version before upgrading your deployment environments and the default development environment for all your colleagues.
 
-To upgrade an environment in the dbt Cloud Admin API or Terraform, set `dbt_version` to the string `versionless`.
+To upgrade an environment in the [dbt Cloud Admin API](/docs/dbt-cloud-apis/admin-cloud-api) or [Terraform](https://registry.terraform.io/providers/dbt-labs/dbtcloud/latest), set `dbt_version` to the string `versionless`.
 
 ### Override dbt version
 

--- a/website/docs/docs/dbt-versions/upgrade-dbt-version-in-cloud.md
+++ b/website/docs/docs/dbt-versions/upgrade-dbt-version-in-cloud.md
@@ -17,7 +17,7 @@ By choosing to **Keep on latest version**, you opt for a versionless experience 
 
 You can upgrade to **Keep on latest version** and the versionless experience no matter which version of dbt you currently have selected. As a best practice, dbt Labs recommends that you test the upgrade in development first; use the [Override dbt version](#override-dbt-version) setting to test _your_ project on the latest dbt version before upgrading your deployment environments and the default development environment for all your colleagues.
 
-For the dbt Cloud Admin API and Terraform, use the value `versionless` to configure your environment. 
+To upgrade an environment in the dbt Cloud Admin API or Terraform, set `dbt_version` to the string `versionless`.
 
 ### Override dbt version
 

--- a/website/docs/docs/dbt-versions/upgrade-dbt-version-in-cloud.md
+++ b/website/docs/docs/dbt-versions/upgrade-dbt-version-in-cloud.md
@@ -17,6 +17,8 @@ By choosing to **Keep on latest version**, you opt for a versionless experience 
 
 You can upgrade to **Keep on latest version** and the versionless experience no matter which version of dbt you currently have selected. As a best practice, dbt Labs recommends that you test the upgrade in development first; use the [Override dbt version](#override-dbt-version) setting to test _your_ project on the latest dbt version before upgrading your deployment environments and the default development environment for all your colleagues.
 
+For the dbt Cloud Admin API and Terraform, use the value `versionless` to configure your environment. 
+
 ### Override dbt version
 
 Configure your project to use a different dbt Core version than what's configured in your [development environment](/docs/dbt-cloud-environments#types-of-environments). This _override_ only affects your user account, no one else's. Use this to safely test new dbt features before upgrading the dbt version for your projects. 


### PR DESCRIPTION
This pr adds clarification on which value to input for dbt_version for the admin api and terraform. Also raised in community slack. More context in [internal slack thread](https://dbt-labs.slack.com/archives/C05FWBP9X1U/p1720107316597949?thread_ts=1715782793.330549&channel=C05FWBP9X1U&message_ts=1720107316.597949)

