### PR TITLE
Link all all migration guides instead of hard-pinning to v1.4 migration guide

### DIFF
--- a/website/docs/docs/core/installation-overview.md
+++ b/website/docs/docs/core/installation-overview.md
@@ -32,7 +32,7 @@ You can install dbt Core on the command line by using one of these methods:
 
 ## Upgrading dbt Core
 
-dbt provides a number of resources for understanding [general best practices](/blog/upgrade-dbt-without-fear) while upgrading your dbt project as well as detailed [migration guides](/docs/dbt-versions/core-upgrade/upgrading-to-v1.4) highlighting the changes required for each minor and major release, and [core versions](/docs/dbt-versions/core)
+dbt provides a number of resources for understanding [general best practices](/blog/upgrade-dbt-without-fear) while upgrading your dbt project as well as detailed [migration guides](/docs/dbt-versions/core-upgrade) highlighting the changes required for each [minor and major release](/docs/dbt-versions/core).
 
 - [Upgrade `pip`](/docs/core/pip-install#change-dbt-core-versions)
 


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/docs/core/installation-overview#upgrading-dbt-core)

## What are you changing in this pull request and why?

Two things:
1. Update the link to the migration guide(s)
1. Improve the sentence it appears within (remove the comma and add a period at the end)

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.