### PR TITLE
remove props from gsheet doc

### DIFF
--- a/website/docs/docs/cloud-integrations/semantic-layer/gsheets.md
+++ b/website/docs/docs/cloud-integrations/semantic-layer/gsheets.md
@@ -50,28 +50,24 @@ queryBuilder="/img/docs/dbt-cloud/semantic-layer/gsheets-query-builder.jpg"
 
 ## Using saved selections
 
-<p><span>Saved selections allow you to save the inputs you've created in the {props.type} <strong>Query Builder</strong> and easily access them again so you don't have to continuously build common queries from scratch. To create a saved selection:</span></p>
+Saved selections allow you to save inputs in the **Query Builder** to easily access them again so you don't have to continuously build common queries from scratch. To create a saved selection:
 
-<ol>
-  <li>Run a <span>query in the {props.type} <strong>Query Builder</strong>.</span></li>
-  <li>Save the selection by selecting the arrow next to the <strong>Query</strong> button and then select <strong>Query & Save Selection</strong>.</li>
-  <li>The application saves these selections, allowing you to view and edit them from the hamburger menu under <strong>Saved Selections</strong>.</li>
-</ol>
+- Run a query in the **Query Builder**.
+- Save the selection by selecting the arrow next to the **Query** button and then select **Query & Save Selection**.
+- The application saves these selections, allowing you to view and edit them from the hamburger menu under **Saved Selections**.
 
 <Lightbox src="/img/docs/dbt-cloud/semantic-layer/gsheets-query-builder.jpg" width="25%" title="Query and save selections in the Query Builder using the arrow next to the Query button." />
 
-<p>You can also make these selections private or public:</p>
+You can also make these selections private or public:
 
-<ul>
-  <li><strong>Public selections</strong> mean your inputs are available in the menu to everyone on the sheet.</li>
-  <li><strong>Private selections</strong> mean your inputs are only visible to you. Note that anyone added to the sheet can still see the data from these private selections, but they won't be able to interact with the selection in the menu or benefit from the automatic refresh.</li>
-</ul>
+- **Public selections** mean your inputs are available in the menu to everyone on the sheet.
+- **Private selections** mean your inputs are only visible to you. Note that anyone added to the sheet can still see the data from these private selections, but they won't be able to interact with the selection in the menu or benefit from the automatic refresh.
 
 ### Refreshing selections
 
-<p>Set your saved selections to automatically refresh every time you load the addon. You can do this by selecting <strong>Refresh on Load</strong> when creating the saved selection. When you access the addon and have saved selections that should refresh, you'll see "Loading..." in the cells that are refreshing.</p>
+Set your saved selections to automatically refresh every time you load the addon. You can do this by selecting **Refresh on Load** when creating the saved selection. When you access the addon and have saved selections that should refresh, you'll see "Loading..." in the cells that are refreshing.
 
-<p>Public saved selections will refresh for anyone who edits the sheet while private selections will only update for the user who created it.</p>
+Public saved selections will refresh for anyone who edits the sheet while private selections will only update for the user who created it.
 
 :::tip What's the difference between saved selections and saved queries?
 
@@ -81,17 +77,12 @@ queryBuilder="/img/docs/dbt-cloud/semantic-layer/gsheets-query-builder.jpg"
 
 ## Using saved queries
 
-<p>Access <a href="/docs/build/saved-queries">saved queries</a>, powered by MetricFlow, in {props.type} to quickly get results from pre-defined sets of data. To access the saved queries in {props.type}:</p>
+Access <a href="/docs/build/saved-queries">saved queries</a>, powered by MetricFlow, to quickly get results from pre-defined sets of data. To access the saved queries in your integration:
 
-<ol>
-  <li>Open the hamburger menu in {props.type}.</li>
-  <li>Navigate to <strong>Saved Queries</strong> to access the ones available to you.</li>
-  <li>You can also select <strong>Build Selection</strong>, which allows you to explore the existing query. This won't change the original query defined in the code.
-    <ul>
-      <li>If you use a <code>WHERE</code> filter in a saved query, {props.type} displays the advanced syntax for this filter.</li>
-    </ul>
-  </li>
-</ol>
+- Open the hamburger menu in Google Sheets.
+- Navigate to **Saved Queries** to access the ones available to you.
+- You can also select **Build Selection**, which allows you to explore the existing query. This won't change the original query defined in the code.
+  - If you use a `where` filter in a saved query, Google Sheets displays the advanced syntax for this filter.
 
 **Limited use policy disclosure**
 

--- a/website/docs/docs/cloud-integrations/semantic-layer/gsheets.md
+++ b/website/docs/docs/cloud-integrations/semantic-layer/gsheets.md
@@ -82,7 +82,7 @@ Access <a href="/docs/build/saved-queries">saved queries</a>, powered by MetricF
 - Open the hamburger menu in Google Sheets.
 - Navigate to **Saved Queries** to access the ones available to you.
 - You can also select **Build Selection**, which allows you to explore the existing query. This won't change the original query defined in the code.
-  - If you use a `where` filter in a saved query, Google Sheets displays the advanced syntax for this filter.
+  - If you use a [`where` filter](/docs/build/saved-queries#where-clause) in a saved query, Google Sheets displays the advanced syntax for this filter.
 
 **Limited use policy disclosure**
 


### PR DESCRIPTION
remove props property from markdown as this was originally added when combining the excel/gsheets content but is no longer needed. flagged by @JKarlavige  in [internal slack](https://dbt-labs.slack.com/archives/C02NCQ9483C/p1721344801910479)