### PR TITLE
Analyses support the group config since v1.5

### DIFF
--- a/website/docs/reference/resource-configs/group.md
+++ b/website/docs/reference/resource-configs/group.md
@@ -190,6 +190,8 @@ select ...
 
 <TabItem value="analyses">
 
+<VersionBlock firstVersion="1.5">
+
 <File name='analyses/<filename>.yml'>
 
 ```yml
@@ -201,6 +203,8 @@ analyses:
 ```
 
 </File>
+
+</VersionBlock>
 
 </TabItem>
 


### PR DESCRIPTION
resolves #4416

[Preview](https://docs-getdbt-com-git-dbeatty10-patch-2-dbt-labs.vercel.app/reference/resource-configs/group) (click the "Analyses" tab)

## What are you changing in this pull request and why?

Add a block for analyses to indicate the first version that the `group` was possible (v1.5).

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.