### PR TITLE
Remove empty FAQ in snapshots page

### DIFF
--- a/website/docs/docs/build/snapshots.md
+++ b/website/docs/docs/build/snapshots.md
@@ -593,6 +593,5 @@ Snapshot results:
 <FAQ path="Runs/snapshot-frequency" />
 <FAQ path="Snapshots/snapshot-schema-changes" />
 <FAQ path="Snapshots/snapshot-hooks" />
-<FAQ path="Snapshots/snapshot-target-schema" />
 <FAQ path="Accounts/configurable-snapshot-path" />
 <FAQ path="Snapshots/snapshot-target-is-not-a-snapshot-table" />

--- a/website/docs/reference/resource-configs/target_schema.md
+++ b/website/docs/reference/resource-configs/target_schema.md
@@ -40,9 +40,6 @@ On **BigQuery**, this is analogous to a `dataset`.
 ## Default
 This is a **required** parameter, no default is provided.
 
-## FAQs
-<FAQ path="Snapshots/snapshot-target-schema" />
-
 ## Examples
 ### Build all snapshots in a schema named `snapshots`
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
There is an empty FAQ in `this page `. I can't find the FAQ file it's referencing, that's why I'm deleting it to fix. 

<img width="990" alt="image" src="https://github.com/user-attachments/assets/058538e4-bc26-49cf-a4ac-585cdf4a2bc5">

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [x] For [docs versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#about-versioning), review how to [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content).
- [x] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
