### PR TITLE
Change where clause in unique_key example

### DIFF
--- a/website/docs/docs/build/incremental-models.md
+++ b/website/docs/docs/build/incremental-models.md
@@ -142,7 +142,7 @@ from {{ ref('app_data_events') }}
 
   -- this filter will only be applied on an incremental run
   -- (uses >= to include records arriving later on the same day as the last run of this model)
-  where date_day >= (select coalesce(max(event_time), '1900-01-01') from {{ this }})
+  where date_day >= (select coalesce(max(date_day), '1900-01-01') from {{ this }})
 
 {% endif %}
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
The max statement in the where clause for the unique_key example referred to event_time, but event_time isn't in the select statement. So this should be updated to max(date_day).

## Checklist
<!--
Uncomment when publishing docs for a prerelease version of dbt:
- [ ] Add versioning components, as described in [Versioning Docs](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-entire-pages)
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
- [X ] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [ X] For [docs versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#about-versioning), review how to [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content).
- [X ] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
