### PR TITLE
fix average aggregation type in measure snippet

### DIFF
--- a/website/snippets/_sl-measures-parameters.md
+++ b/website/snippets/_sl-measures-parameters.md
@@ -2,7 +2,7 @@
 | --- | --- | --- | 
 | [`name`](/docs/build/measures#name) | Provide a name for the measure, which must be unique and can't be repeated across all semantic models in your dbt project. | Required | 
 | [`description`](/docs/build/measures#description) | Describes the calculated measure. | Optional | 
-| [`agg`](/docs/build/measures#aggregation) | dbt supports the following aggregations: `sum`, `max`, `min`, `avg`, `median`, `count_distinct`, `percentile`, and `sum_boolean`. | Required |
+| [`agg`](/docs/build/measures#aggregation) | dbt supports the following aggregations: `sum`, `max`, `min`, `average`, `median`, `count_distinct`, `percentile`, and `sum_boolean`. | Required |
 | [`expr`](/docs/build/measures#expr) | Either reference an existing column in the table or use a SQL expression to create or derive a new one. | Optional | 
 | [`non_additive_dimension`](/docs/build/measures#non-additive-dimensions) | Non-additive dimensions can be specified for measures that cannot be aggregated over certain dimensions, such as bank account balances, to avoid producing incorrect results. | Optional |
 | `agg_params` | Specific aggregation properties, such as a percentile. | Optional | 


### PR DESCRIPTION
## What are you changing in this pull request and why?
This PR updates the measure aggregation snippet to from "avg" --> "average". Avg is not a correct aggregation type. 
