### PR TITLE
Update semantic-layer-8-refactor-a-rollup.md

### DIFF
--- a/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-8-refactor-a-rollup.md
+++ b/website/docs/best-practices/how-we-build-our-metrics/semantic-layer-8-refactor-a-rollup.md
@@ -49,26 +49,26 @@ So far we've been working in new pointing at a staging model to simplify things 
 
 ```yaml
 semantic_models:
-- name: locations
-   description: |
-   Location dimension table. The grain of the table is one row per location.
-   model: ref('stg_locations')
-   entities:
-   - name: location
-      type: primary
-      expr: location_id
-   dimensions:
-   - name: location_name
-      type: categorical
-   - name: date_trunc('day', opened_at)
-      type: time
-      type_params:
-         time_granularity: day
-   measures:
-   - name: average_tax_rate
-      description: Average tax rate.
-      expr: tax_rate
-      agg: avg
+  - name: locations
+    description: |
+      Location dimension table. The grain of the table is one row per location.
+    model: ref('stg_locations')
+    entities:
+      - name: location
+        type: primary
+        expr: location_id
+    dimensions:
+      - name: location_name
+        type: categorical
+      - name: date_trunc('day', opened_at)
+        type: time
+        type_params:
+          time_granularity: day
+    measures:
+      - name: average_tax_rate
+        description: Average tax rate.
+        expr: tax_rate
+        agg: avg
 ```
 
 ## Semantic and logical interaction


### PR DESCRIPTION
## What are you changing in this pull request and why?

Hello! Currently, the yaml in models/marts/locations.yml on the 'Refactor an existing rollup' page has incorrect indentation, so syntax highlighting is not working properly as shown in the image below. So I fixed the indentation in the yaml to have the correct syntax.

https://docs.getdbt.com/best-practices/how-we-build-our-metrics/semantic-layer-8-refactor-a-rollup#lets-make-a-revenue-metric
<img width="1306" alt="image" src="https://github.com/user-attachments/assets/bd07b41f-c8ed-46c2-9175-9c67e8cdd457">



## Checklist
<!--
Uncomment when publishing docs for a prerelease version of dbt:
- [ ] Add versioning components, as described in [Versioning Docs](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-entire-pages)
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.

<!--
- [ ] For [docs versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#about-versioning), review how to [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content).
- [ ] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
-->