### PR TITLE
Add links to the model term page

### DIFF
--- a/website/docs/terms/model.md
+++ b/website/docs/terms/model.md
@@ -6,4 +6,11 @@ displayText: model
 hoverSnippet: A model is an essential building block of the DAG
 ---
 
-A model is an essential building block of the DAG that lives in a single file and contains logic that transforms data. This logic can be expressed as a SQL `select` statement or a Python dataframe operation. Models can be materialized in the warehouse in different ways &mdash; most of these materializations require models to be built in the warehouse. 
+A model is an essential building block of the DAG that lives in a single file and contains logic that transforms data. This logic can be expressed as a SQL `select` statement or a Python dataframe operation. Models can be materialized in the warehouse in different ways &mdash; most of these [materializations](/terms/materialization) require models to be built in the warehouse. 
+
+For more information, see:
+
+* [About dbt Models](/docs/build/models)
+* [Quickstart Guides](/guides?tags=Quickstart)
+* Reference > [Model properties](/reference/model-properties)
+* Reference > [Materializations](/reference/resource-configs/materialized)

--- a/website/docs/terms/model.md
+++ b/website/docs/terms/model.md
@@ -6,11 +6,11 @@ displayText: model
 hoverSnippet: A model is an essential building block of the DAG
 ---
 
-A model is an essential building block of the DAG that lives in a single file and contains logic that transforms data. This logic can be expressed as a SQL `select` statement or a Python dataframe operation. Models can be materialized in the warehouse in different ways &mdash; most of these [materializations](/terms/materialization) require models to be built in the warehouse. 
+A model is an essential building block of the DAG that lives in a single file and contains logic that transforms data. This logic can be expressed as a SQL `select` statement or a Python dataframe operation. Models can be materialized in the warehouse in different ways &mdash; most of these [materialization](/terms/materialization) require models to be built in the warehouse. 
 
-For more information, see:
+For more information, refer to:
 
-* [About dbt Models](/docs/build/models)
-* [Quickstart Guides](/guides?tags=Quickstart)
-* Reference > [Model properties](/reference/model-properties)
-* Reference > [Materializations](/reference/resource-configs/materialized)
+* [About dbt models](/docs/build/models)
+* [Quickstart guides](/guides?tags=Quickstart)
+* [Model properties](/reference/model-properties)
+* [Materializations](/reference/resource-configs/materialized)


### PR DESCRIPTION
## What are you changing in this pull request and why?
The "Model" term page in the glossary is pretty short and doesn't help lead anyone to next steps. I'm proposing adding these links to help newer contributors. Because there are so many search results for the word "model" this may be more important on this page than most Term pages.

## Checklist
- [unable, link doesn't work, will file separate issue ] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [x] For [docs versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#about-versioning), review how to [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content).
- [x] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."

