### PR TITLE
Fix whitespace and callout

### DIFF
--- a/website/docs/docs/cloud/secure/databricks-privatelink.md
+++ b/website/docs/docs/cloud/secure/databricks-privatelink.md
@@ -7,6 +7,7 @@ pagination_next: null
 ---
 
 import SetUpPages from '/snippets/_available-tiers-privatelink.md';
+import PrivateLinkSLA from '/snippets/_PrivateLink-SLA.md';
 
 <SetUpPages features={'/snippets/_available-tiers-privatelink.md'}/>
 
@@ -15,31 +16,29 @@ The following steps will walk you through the setup of a Databricks AWS PrivateL
 ## Configure AWS PrivateLink
 
 1. Locate your [Databricks instance name](https://docs.databricks.com/en/workspace/workspace-details.html#workspace-instance-names-urls-and-ids)
-  -  Example: `cust-success.cloud.databricks.com`
-2. Add the required information to the following template and submit your AWS PrivateLink request to [dbt Support](https://docs.getdbt.com/docs/dbt-support#dbt-cloud-support): 
-```
-Subject: New AWS Multi-Tenant PrivateLink Request
-- Type: Databricks
-- Databricks instance name:
-- Databricks cluster AWS Region (e.g., us-east-1, eu-west-2):
-- dbt Cloud multi-tenant environment (US, EMEA, AU):
-```
+    - Example: `cust-success.cloud.databricks.com`
 
-import PrivateLinkSLA from '/snippets/_PrivateLink-SLA.md';
+1. Add the required information to the following template and submit your AWS PrivateLink request to [dbt Support](https://docs.getdbt.com/docs/dbt-support#dbt-cloud-support): 
+    ```
+    Subject: New AWS Multi-Tenant PrivateLink Request
+    - Type: Databricks
+    - Databricks instance name:
+    - Databricks cluster AWS Region (e.g., us-east-1, eu-west-2):
+    - dbt Cloud multi-tenant environment (US, EMEA, AU):
+    ```
+    <PrivateLinkSLA />
 
-<PrivateLinkSLA />
+1. Once dbt Cloud support has notified you that setup is complete, [register the VPC endpoint in Databricks](https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html#step-3-register-privatelink-objects-and-attach-them-to-a-workspace) and attach it to the workspace:
+    - [Register your VPC endpoint](https://docs.databricks.com/en/security/network/classic/vpc-endpoints.html) &mdash; Register the VPC endpoint using the VPC endpoint ID provided by dbt Support.
+    - [Create a Private Access Settings object](https://docs.databricks.com/en/security/network/classic/private-access-settings.html) &mdash; Create a Private Access Settings (PAS) object with your desired public access settings, and setting Private Access Level to **Endpoint**. Choose the registered endpoint created in the previous step.
+    - [Create or update your workspace](https://docs.databricks.com/en/security/network/classic/privatelink.html#step-3d-create-or-update-the-workspace-front-end-back-end-or-both) &mdash; Create a workspace, or update your an existing workspace. Under **Advanced configurations → Private Link** choose the private access settings object created in the previous step.
 
-3. Once dbt Cloud support has notified you that setup is complete, [register the VPC endpoint in Databricks](https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html#step-3-register-privatelink-objects-and-attach-them-to-a-workspace) and attach it to the workspace:
-  - [Register your VPC endpoint](https://docs.databricks.com/en/security/network/classic/vpc-endpoints.html) &mdash; Register the VPC endpoint using the VPC endpoint ID provided by dbt Support.
-  - [Create a Private Access Settings object](https://docs.databricks.com/en/security/network/classic/private-access-settings.html) &mdash; Create a Private Access Settings (PAS) object with your desired public access settings, and setting Private Access Level to **Endpoint**. Choose the registered endpoint created in the previous step.
-  - [Create or update your workspace](https://docs.databricks.com/en/security/network/classic/privatelink.html#step-3d-create-or-update-the-workspace-front-end-back-end-or-both) &mdash; Create a workspace, or update your an existing workspace. Under **Advanced configurations → Private Link** choose the private access settings object created in the previous step.
+    :::warning
+    If using an existing Databricks workspace, all workloads running in the workspace need to be stopped to enable Private Link. Workloads also can't be started for another 20 minutes after making changes. From the [Databricks documentation](https://docs.databricks.com/en/security/network/classic/privatelink.html#step-3d-create-or-update-the-workspace-front-end-back-end-or-both):
 
-:::note Warning
-If using an existing Databricks workspace, all workloads running in the workspace will need to be stopped to enable Private Link! Workloads also cannot be started for another 20 minutes after making changes. From the [Databricks documentation](https://docs.databricks.com/en/security/network/classic/privatelink.html#step-3d-create-or-update-the-workspace-front-end-back-end-or-both):
+    "After creating (or updating) a workspace, wait until it’s available for using or creating clusters. The workspace status stays at status RUNNING and the VPC change happens immediately. However, you cannot use or create clusters for another 20 minutes. If you create or use clusters before this time interval elapses, clusters do not launch successfully, fail, or could cause other unexpected behavior."
 
->After creating (or updating) a workspace, wait until it’s available for using or creating clusters. The workspace status stays at status RUNNING and the VPC change happens immediately. However, you cannot use or create clusters for another 20 minutes. If you create or use clusters before this time interval elapses, clusters do not launch successfully, fail, or could cause other unexpected behavior.
-
-:::
+    :::
 
 ## Configure Azure Private Link
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

The blockquote in the callout in this section https://docs.getdbt.com/docs/cloud/secure/databricks-privatelink#configure-aws-privatelink is not showing up in light mode.

- Updated callout to be of type `warning` and used double quotes instead of blockquote to be more readable. Filed Asana ticket re: the blockquote bug https://app.asana.com/0/1200099998847559/1208117747990951/f
- Fixed whitespacing so indentations look prettier 

