### PR TITLE
Link to example of macro in a on-run hook

### DIFF
--- a/website/docs/reference/project-configs/on-run-start-on-run-end.md
+++ b/website/docs/reference/project-configs/on-run-start-on-run-end.md
@@ -20,7 +20,7 @@ on-run-end: sql-statement | [sql-statement]
 
 A SQL statement (or list of SQL statements) to be run at the start or end of the following commands: <OnRunCommands />
 
-`on-run-start` and `on-run-end` hooks can also call macros that return SQL statements
+`on-run-start` and `on-run-end` hooks can also [call macros](#call-a-macro-to-grant-privileges) that return SQL statements.
 
 ## Usage notes
 * The `on-run-end` hook has additional jinja variables available in the context — check out the [docs](/reference/dbt-jinja-functions/on-run-end-context).


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/reference/project-configs/on-run-start-on-run-end)

## What are you changing in this pull request and why?

The docs say "on-run-start and on-run-end hooks can also call macros that return SQL statements". This PR adds a link to a section that contains an example of a macro that returns a SQL statement.

## Additional context

Inspired by https://github.com/dbt-labs/dbt-core/issues/10522

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.