### PR TITLE
Fix config names for `pre_hook` and `post_hook`

### DIFF
--- a/website/docs/reference/model-configs.md
+++ b/website/docs/reference/model-configs.md
@@ -136,8 +136,8 @@ models:
     config:
       [enabled](/reference/resource-configs/enabled): true | false
       [tags](/reference/resource-configs/tags): <string> | [<string>]
-      [pre-hook](/reference/resource-configs/pre-hook-post-hook): <sql-statement> | [<sql-statement>]
-      [post-hook](/reference/resource-configs/pre-hook-post-hook): <sql-statement> | [<sql-statement>]
+      [pre_hook](/reference/resource-configs/pre-hook-post-hook): <sql-statement> | [<sql-statement>]
+      [post_hook](/reference/resource-configs/pre-hook-post-hook): <sql-statement> | [<sql-statement>]
       [database](/reference/resource-configs/database): <string>
       [schema](/reference/resource-properties/schema): <string>
       [alias](/reference/resource-configs/alias): <string>


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty10-patch-3-dbt-labs.vercel.app/reference/model-configs#general-configurations) > "Property file" tab

## What are you changing in this pull request and why?

Fix config names for `pre_hook` and `post_hook` (since `pre-hook` and `post-hook` only work within `dbt_project.yml` files.

## 🎩 

<img width="503" alt="image" src="https://github.com/user-attachments/assets/da5ff68a-9c90-4bb2-8bb6-26a9ec62bdc9">


## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.