### PR TITLE
Better description in slack unfurls for full_refersh config

### DIFF
--- a/website/docs/reference/resource-configs/full_refresh.md
+++ b/website/docs/reference/resource-configs/full_refresh.md
@@ -1,6 +1,6 @@
 ---
 resource_types: [models, seeds]
-description: "Full_Refresh - Read this in-depth guide to learn about configurations in dbt."
+description: "Setting the full_refresh config to false prevents a model or seed from being rebuilt, even when the `--full-refresh` flag is included in an invocation."
 datatype: boolean
 ---
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
I pasted https://docs.getdbt.com/reference/resource-configs/full_refresh into Slack and it unfurled saying to read the guide:

<img width="590" alt="image" src="https://github.com/user-attachments/assets/4c9322df-00f1-4cac-865b-7c38d983c9ce">

Updating the text to instead provide information about the config. There's a bunch of these spread across the docs site but I'm cleaning up as I find them instead of doing a widespread fix. 
