### PR TITLE
Clarify current support level for contracts for materialized views

### DIFF
--- a/website/docs/docs/collaborate/govern/model-contracts.md
+++ b/website/docs/docs/collaborate/govern/model-contracts.md
@@ -28,7 +28,8 @@ At present, model contracts are supported for:
 
 Model contracts are _not_ supported for:
 - Python models.
-- `ephemeral`-materialized SQL models.
+- `materialized view` or `ephemeral`-materialized SQL models.
+- Custom materializations (unless added by the author).
 - Models with recursive <Term id="cte" />'s in BigQuery.
 - Other resource types, such as `sources`, `seeds`, `snapshots`, and so on.
 


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/docs/collaborate/govern/model-contracts#where-are-contracts-supported)

## What are you changing in this pull request and why?
- It isn't clear if materialized views have support for model contracts or not.
- Also not clear if custom materializations automatically include support for model contracts or not.

Context: https://github.com/dbt-labs/dbt-adapters/issues/726 (`dynamic table` is the Snowflake equivalent of `materialized view` in other data platforms)

## Checklist
- [x] I have reviewed the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.