### PR TITLE
adding x proj ref to overview page

### DIFF
--- a/website/docs/docs/build/metricflow-time-spine.md
+++ b/website/docs/docs/build/metricflow-time-spine.md
@@ -47,9 +47,9 @@ The example creates a time spine at a daily grain and an hourly grain. A few thi
 * You can add a time spine for each granularity you intend to use if query efficiency is more important to you than configuration time, or storage constraints. For most engines, the query performance difference should be minimal and transforming your time spine to a coarser grain at query time shouldn't add significant overhead to your queries.
 * We recommend having a time spine at the finest grain used in any of your dimensions to avoid unexpected errors. i.e., if you have dimensions at an hourly grain, you should have a time spine at an hourly grain.
 
-<VersionBlock lastVersion="1.6">
+<File name="metricflow_time_spine.sql">
 
-<File name='time_spine_daily.sql'>
+<VersionBlock lastVersion="1.6">
 
 ```sql
 {{
@@ -80,13 +80,10 @@ select * from final
 where date_day > dateadd(year, -4, current_timestamp()) 
 and date_hour < dateadd(day, 30, current_timestamp())
 ```
-</File
 
 </VersionBlock>
 
 <VersionBlock firstVersion="1.7">
-
-<File name="metricflow_time_spine.sql">
 
 ```sql
 {{
@@ -116,18 +113,15 @@ select * from final
 where date_day > dateadd(year, -4, current_timestamp()) 
 and date_hour < dateadd(day, 30, current_timestamp())
 ```
-</File>
-
 </VersionBlock>
 
-</File>
 
+Use this model if you're using BigQuery. BigQuery supports `DATE()` instead of `TO_DATE()`:
 <VersionBlock lastVersion="1.6">
 
 <File name="metricflow_time_spine.sql">
   
 ```sql
--- BigQuery supports DATE() instead of TO_DATE(). Use this model if you're using BigQuery
 {{config(materialized='table')}}
 with days as (
     {{dbt_utils.date_spine(
@@ -150,15 +144,14 @@ where date_day > dateadd(year, -4, current_timestamp())
 and date_hour < dateadd(day, 30, current_timestamp())
 ```
 </File>
-
 </VersionBlock>
 
 <VersionBlock firstVersion="1.7">
 
 <File name="metricflow_time_spine.sql">
-  
+
 ```sql
--- BigQuery supports DATE() instead of TO_DATE(). Use this model if you're using BigQuery
+
 {{config(materialized='table')}}
 with days as (
     {{dbt.date_spine(
@@ -181,8 +174,9 @@ where date_day > dateadd(year, -4, current_timestamp())
 and date_hour < dateadd(day, 30, current_timestamp())
 ```
 </File>
-
 </VersionBlock>
+
+</File>
 
 ## Hourly time spine
 <File name='time_spine_hourly.sql'>

--- a/website/docs/docs/collaborate/govern/about-model-governance.md
+++ b/website/docs/docs/collaborate/govern/about-model-governance.md
@@ -11,3 +11,5 @@ pagination_prev: null
 [**Model contracts**](model-contracts): Guarantee the shape of a model while it is building to avoid surprises or breaking changes for downstream queries. Explicitly define column names, data types, and constraints (as supported by your data platform).
 
 [**Model versions**](model-versions): When a breaking change is unavoidable, provide a smoother upgrade pathway by creating a new version of the model. These model versions share a common reference name and can reuse properties & configurations.
+
+[**Project dependencies**](project-dependencies): Use cross project dependencies to reference public models across dbt projects using the [two-argument ref](/reference/dbt-jinja-functions/ref#ref-project-specific-models), which includes the project name.

--- a/website/docs/docs/collaborate/govern/about-model-governance.md
+++ b/website/docs/docs/collaborate/govern/about-model-governance.md
@@ -12,4 +12,4 @@ pagination_prev: null
 
 [**Model versions**](model-versions): When a breaking change is unavoidable, provide a smoother upgrade pathway by creating a new version of the model. These model versions share a common reference name and can reuse properties & configurations.
 
-[**Project dependencies**](project-dependencies): Use cross project dependencies to reference public models across dbt projects using the [two-argument ref](/reference/dbt-jinja-functions/ref#ref-project-specific-models), which includes the project name.
+[**Project dependencies**](/docs/collaborate/govern/project-dependencies): Use cross project dependencies to reference public models across dbt projects using the [two-argument ref](/reference/dbt-jinja-functions/ref#ref-project-specific-models), which includes the project name.


### PR DESCRIPTION
adding a link to x proj ref to the overview page so it's consistent with the sidebar. currently, it only contains model versions/contracts/acccess, but not proj dependencies. 
![Screenshot 2024-09-02 at 15 48 00](https://github.com/user-attachments/assets/3ef12ff8-386f-4492-b787-bad5e5748c8f)


