### PR TITLE
update callout and clarify title to blog

### DIFF
--- a/website/blog/2022-04-14-add-ci-cd-to-bitbucket.md
+++ b/website/blog/2022-04-14-add-ci-cd-to-bitbucket.md
@@ -14,7 +14,7 @@ is_featured: true
 
 
 :::info Set up CI/CD with dbt Cloud
-This blog is specifically tailored for dbt Core users. If you're using dbt Cloud and your Git provider doesn't have a native dbt Cloud integration (like BitBucket) follow the [Customizing CI/CD with custom pipelines guide](/guides/custom-cicd-pipelines?step=3) to set up CI/CD.
+This blog is specifically tailored for dbt Core users. If you're using dbt Cloud and your Git provider doesn't have a native dbt Cloud integration (like BitBucket), follow the [Customizing CI/CD with custom pipelines guide](/guides/custom-cicd-pipelines?step=3) to set up CI/CD.
 :::
 
 Continuous Integration (CI) sets the system up to test everyone’s pull request before merging. Continuous Deployment (CD) deploys each approved change to production. “Slim CI” refers to running/testing only the changed code, [thereby saving compute](https://discourse.getdbt.com/t/how-we-sped-up-our-ci-runs-by-10x-using-slim-ci/2603). In summary, CI/CD automates dbt pipeline testing and deployment.

--- a/website/blog/2022-04-14-add-ci-cd-to-bitbucket.md
+++ b/website/blog/2022-04-14-add-ci-cd-to-bitbucket.md
@@ -1,5 +1,5 @@
 ---
-title: "Slim CI/CD with Bitbucket Pipelines"
+title: "Slim CI/CD with Bitbucket Pipelines for dbt Core"
 description: "How to set up slim CI/CD outside of dbt Cloud"
 slug: slim-ci-cd-with-bitbucket-pipelines
 
@@ -11,6 +11,11 @@ hide_table_of_contents: false
 date: 2022-05-06
 is_featured: true
 ---
+
+
+:::info Set up CI/CD with dbt Cloud
+This blog is specifically tailored for dbt Core users. If you're using dbt Cloud and your Git provider doesn't have a native dbt Cloud integration (like BitBucket) follow the [Customizing CI/CD with custom pipelines guide](/guides/custom-cicd-pipelines?step=3) to set up CI/CD.
+:::
 
 Continuous Integration (CI) sets the system up to test everyone’s pull request before merging. Continuous Deployment (CD) deploys each approved change to production. “Slim CI” refers to running/testing only the changed code, [thereby saving compute](https://discourse.getdbt.com/t/how-we-sped-up-our-ci-runs-by-10x-using-slim-ci/2603). In summary, CI/CD automates dbt pipeline testing and deployment.
 


### PR DESCRIPTION
this pr updates the title so it's clear it's for dbt core users. and also adds a callout to link to a bitbucket guide for dbt cloud users. 

[internal slack thread](https://dbt-labs.slack.com/archives/C06V62247K5/p1725345980389369?thread_ts=1725334647.490049&cid=C06V62247K5)