### PR TITLE
updates to core/cloud guide

### DIFF
--- a/website/docs/guides/core-cloud-2.md
+++ b/website/docs/guides/core-cloud-2.md
@@ -20,6 +20,19 @@ import CoretoCloudTable from '/snippets/_core-to-cloud-guide-table.md';
 
 <CoretoCloudTable/>
 
+<Expandable alt_header="What is dbt Cloud and dbt Core?">
+
+   - dbt Cloud is the fastest and most reliable way to deploy dbt. It enables you to develop, test, deploy, and explore data products using a single, fully managed service. It also supports:
+     - Development experiences tailored to multiple personas ([dbt Cloud IDE](/docs/cloud/dbt-cloud-ide/develop-in-the-cloud) or [dbt Cloud CLI](/docs/cloud/cloud-cli-installation))
+     - Out-of-the-box [CI/CD workflows](/docs/deploy/ci-jobs)
+     - The [dbt Semantic Layer](/docs/use-dbt-semantic-layer/dbt-sl) for consistent metrics
+     - Domain ownership of data with multi-project [dbt Mesh](/best-practices/how-we-mesh/mesh-1-intro) setups
+     - [dbt Explorer](/docs/collaborate/explore-projects) for easier data discovery and understanding
+
+   Learn more about [dbt Cloud features](/docs/cloud/about-cloud/dbt-cloud-features).
+- dbt Core is an open-source tool that enables data teams to define and execute data transformations in a cloud data warehouse following analytics engineering best practices. While this can work well for ‘single players’ and small technical teams, all development happens on a command-line interface, and production deployments must be self-hosted and maintained. This requires significant, costly work that adds up over time to maintain and scale.
+
+</Expandable>
 
 ## What you'll learn
 Today thousands of companies, with data teams ranging in size from 2 to 2,000, rely on dbt Cloud to accelerate data work, increase collaboration, and win the trust of the business. Understanding what you'll need to do in order to move between dbt Cloud and your current Core deployment will help you strategize and plan for your move.

--- a/website/docs/guides/core-cloud-2.md
+++ b/website/docs/guides/core-cloud-2.md
@@ -20,6 +20,7 @@ import CoretoCloudTable from '/snippets/_core-to-cloud-guide-table.md';
 
 <CoretoCloudTable/>
 
+
 ## What you'll learn
 Today thousands of companies, with data teams ranging in size from 2 to 2,000, rely on dbt Cloud to accelerate data work, increase collaboration, and win the trust of the business. Understanding what you'll need to do in order to move between dbt Cloud and your current Core deployment will help you strategize and plan for your move.
 

--- a/website/docs/guides/core-to-cloud-1.md
+++ b/website/docs/guides/core-to-cloud-1.md
@@ -24,17 +24,19 @@ import CoretoCloudTable from '/snippets/_core-to-cloud-guide-table.md';
 
 <CoretoCloudTable/>
 
+<Expandable alt_header="What is dbt Cloud and dbt Core?">
 
-dbt Cloud is the fastest and most reliable way to deploy dbt. It enables you to develop, test, deploy, and explore data products using a single, fully managed service. It also supports:
-- Development experiences tailored to multiple personas ([dbt Cloud IDE](/docs/cloud/dbt-cloud-ide/develop-in-the-cloud) or [dbt Cloud CLI](/docs/cloud/cloud-cli-installation))
-- Out-of-the-box [CI/CD workflows](/docs/deploy/ci-jobs)
-- The [dbt Semantic Layer](/docs/use-dbt-semantic-layer/dbt-sl) for consistent metrics
-- Domain ownership of data with multi-project [dbt Mesh](/best-practices/how-we-mesh/mesh-1-intro) setups
-- [dbt Explorer](/docs/collaborate/explore-projects) for easier data discovery and understanding
+   - dbt Cloud is the fastest and most reliable way to deploy dbt. It enables you to develop, test, deploy, and explore data products using a single, fully managed service. It also supports:
+     - Development experiences tailored to multiple personas ([dbt Cloud IDE](/docs/cloud/dbt-cloud-ide/develop-in-the-cloud) or [dbt Cloud CLI](/docs/cloud/cloud-cli-installation))
+     - Out-of-the-box [CI/CD workflows](/docs/deploy/ci-jobs)
+     - The [dbt Semantic Layer](/docs/use-dbt-semantic-layer/dbt-sl) for consistent metrics
+     - Domain ownership of data with multi-project [dbt Mesh](/best-practices/how-we-mesh/mesh-1-intro) setups
+     - [dbt Explorer](/docs/collaborate/explore-projects) for easier data discovery and understanding
 
-Learn more about [dbt Cloud features](/docs/cloud/about-cloud/dbt-cloud-features).
+   Learn more about [dbt Cloud features](/docs/cloud/about-cloud/dbt-cloud-features).
+- dbt Core is an open-source tool that enables data teams to define and execute data transformations in a cloud data warehouse following analytics engineering best practices. While this can work well for ‘single players’ and small technical teams, all development happens on a command-line interface, and production deployments must be self-hosted and maintained. This requires significant, costly work that adds up over time to maintain and scale.
 
-dbt Core is an open-source tool that enables data teams to define and execute data transformations in a cloud data warehouse following analytics engineering best practices. While this can work well for ‘single players’ and small technical teams, all development happens on a command-line interface, and production deployments must be self-hosted and maintained. This requires significant, costly work that adds up over time to maintain and scale.
+</Expandable>
 
 ## What you'll learn
 
@@ -57,7 +59,7 @@ This guide outlines the steps you need to take to move from dbt Core to dbt Clou
 ## Prerequisites
 
 - You have an existing dbt Core project connected to a Git repository and data platform supported in [dbt Cloud](/docs/cloud/connect-data-platform/about-connections).
-- A [supported version](/docs/dbt-versions/core) of dbt or select [**Versionless**](/docs/dbt-versions/upgrade-dbt-version-in-cloud#versionless) of dbt. <Lifecycle status="Preview"/>
+- A [supported version](/docs/dbt-versions/core) of dbt or select [**Versionless**](/docs/dbt-versions/upgrade-dbt-version-in-cloud#versionless) of dbt. 
 - You have a dbt Cloud account. **[Don't have one? Start your free trial today](https://www.getdbt.com/signup)**!
 
 ## Account setup
@@ -84,8 +86,10 @@ This section outlines the considerations and methods to connect your data platfo
 
 1. In dbt Cloud, set up your [data platform connections](/docs/cloud/connect-data-platform/about-connections) and [environment variables](/docs/build/environment-variables). dbt Cloud can connect with a variety of data platform providers including:
    - [AlloyDB](/docs/cloud/connect-data-platform/connect-redshift-postgresql-alloydb) 
+   - [Amazon Athena](/docs/cloud/connect-data-platform/connect-amazon-athena) (beta)
    - [Amazon Redshift](/docs/cloud/connect-data-platform/connect-redshift-postgresql-alloydb) 
    - [Apache Spark](/docs/cloud/connect-data-platform/connect-apache-spark) 
+   - [Azure Synapse Analytics](/docs/cloud/connect-data-platform/connect-azure-synapse-analytics)
    - [Databricks](/docs/cloud/connect-data-platform/connect-databricks) 
    - [Google BigQuery](/docs/cloud/connect-data-platform/connect-bigquery)
    - [Microsoft Fabric](/docs/cloud/connect-data-platform/connect-microsoft-fabric)
@@ -229,6 +233,8 @@ Explore these additional configurations to optimize your dbt Cloud orchestration
 ### CI/CD setup
 
 Building a custom solution to efficiently check code upon pull requests is complicated. With dbt Cloud, you can enable [continuous integration / continuous deployment (CI/CD)](/docs/deploy/continuous-integration) and configure dbt Cloud to run your dbt projects in a temporary schema when new commits are pushed to open pull requests.
+
+<Lightbox src="/img/docs/dbt-cloud/using-dbt-cloud/ci-workflow.png" width="90%" title="Workflow of continuous integration in dbt Cloud"/>
 
 This build-on-PR functionality is a great way to catch bugs before deploying to production, and an essential tool for data practitioners.
 

--- a/website/snippets/_core-to-cloud-guide-table.md
+++ b/website/snippets/_core-to-cloud-guide-table.md
@@ -3,3 +3,14 @@
 | [Move from dbt Core to dbt Cloud: What you need to know](/guides/core-cloud-2) | Understand the considerations and methods needed in your move from dbt Core to dbt Cloud. | Team leads <br /> Admins |
 | [Move from dbt Core to dbt Cloud: Get started](/guides/core-to-cloud-1?step=1) | Learn the steps needed to move from dbt Core to dbt Cloud. | Developers <br /> Data engineers <br /> Data analysts |
 | [Move from dbt Core to dbt Cloud: Optimization tips](/guides/core-to-cloud-3) | Learn how to optimize your dbt Cloud experience with common scenarios and useful tips. | Everyone |
+
+### Why move to dbt Cloud?
+If your team is using dbt Core today, you could be reading this guide because:
+
+- You’ve realized the burden of maintaining that deployment.
+- The person who set it up has since left.
+- You’re interested in what dbt Cloud could do to better manage the complexity of your dbt deployment, democratize access to more contributors, or improve security and governance practices.
+
+Moving from dbt Core to dbt Cloud simplifies workflows by providing a fully managed environment that improves collaboration, security, and orchestration. With dbt Cloud, you gain access to features like cross-team collaboration ([dbt Mesh](/best-practices/how-we-mesh/mesh-1-intro)), version management, streamlined CI/CD, [dbt Explorer](/docs/collaborate/explore-projects) for comprehensive insights, and more &mdash; making it easier to manage complex dbt deployments and scale your data workflows efficiently. 
+
+It's ideal for teams looking to reduce the burden of maintaining their own infrastructure while enhancing governance and productivity.


### PR DESCRIPTION
this pr updates the core / cloud guide based on great feedback from Victoria Perez Mola.

- it removes any 'preview' language for versionless
- adds a 'why move to dbt cloud' section
- consolidates the dbt cloud and dbt core info into an expandable toggle 
- adds a ci diagram to visually convey how ci works