### PR TITLE
Consistent parameter references and BigQuery terminology layout

### DIFF
--- a/website/docs/reference/resource-properties/schema.md
+++ b/website/docs/reference/resource-properties/schema.md
@@ -28,12 +28,14 @@ The schema name as stored in the database.
 This parameter is useful if you want to use a source name that differs from the schema name.
 
 
-#### BigQuery terminology
+:::info BigQuery Terminology
 
-If you're using BigQuery, use the _dataset_ name as the `schema:` property.
+If you're using BigQuery, use the _dataset_ name as the `schema` property.
+
+:::
 
 ## Default
-By default, dbt will use the source's `name:` parameter as the schema name.
+By default, dbt will use the source's `name` parameter as the schema name.
 
 ## Examples
 ### Use a simpler name for a source schema than the one in your database

--- a/website/docs/reference/resource-properties/schema.md
+++ b/website/docs/reference/resource-properties/schema.md
@@ -28,7 +28,7 @@ The schema name as stored in the database.
 This parameter is useful if you want to use a source name that differs from the schema name.
 
 
-:::info BigQuery Terminology
+:::info BigQuery terminology
 
 If you're using BigQuery, use the _dataset_ name as the `schema` property.
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
Format BigQuery terminology paragraph as info block (as is consistent with other pages) and refer to parameter names without `:` suffix.

## Checklist
- [x] I have reviewed the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [x] The topic I'm writing about is for specific dbt version(s) and I have versioned it according to the [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and/or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content) guidelines.
- [x] I have added checklist item(s) to this list for anything anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
<!--
PRE-RELEASE VERSION OF dbt (if so, uncomment):
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
<!-- 
ADDING OR REMOVING PAGES (if so, uncomment):
- [ ] Add/remove page in `website/sidebars.js`
- [ ] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages
-->
