### PR TITLE
Add checks for sorting versions

### DIFF
--- a/website/src/utils/available-in-current-version.js
+++ b/website/src/utils/available-in-current-version.js
@@ -5,6 +5,16 @@ export const availableInCurrentVersion = (
   firstVersion = "0", 
   lastVersion = undefined
 ) => {
+  // If `firstVersion` prop set on VersionBlock component without a value,
+  // it defaults to boolean `true`. This overrides to ensure `firstVersion` is string.
+  if(typeof firstVersion === "boolean") {
+    firstVersion = "0"
+  }
+  // Do the same to ensure `lastVersion` cannot be a boolean
+  if (typeof lastVersion === "boolean") {
+    lastVersion = undefined;
+  }
+
   // Get versions sorted from earliest to latest
   const sortedVersions = sortVersions([
     currentVersion,

--- a/website/src/utils/sort-versions.js
+++ b/website/src/utils/sort-versions.js
@@ -11,6 +11,9 @@ export const sortVersions = (versionsArr) => {
     // A positive value indicates that a should come after b.
     // Zero or NaN indicates that a and b are considered equal.
 
+    // Ensure compare items are strings which can be split
+    if(!a?.length || !b?.length) return null
+
     // Split versions into arrays by decimal
     // split into max 3 length array (major, minor, patch versions)
     const aSegments = a?.split(".", 3);


### PR DESCRIPTION
## What are you changing in this pull request and why?

On the live site, the following page is crashing: https://docs.getdbt.com/docs/use-dbt-semantic-layer/exports

The error is: `e.split is not a function`

This is occurring due to a check not being available when the `firstVersion` prop is set on the `VersionBlock` component without a version value: `<VersionBlock firstVersion lastVersion="1.7">`. This causes the `firstVersion` to be `true`. The new `sortVersions` method then tries to use `.split`, which is not available for booleans.

This PR adds two additional checks to ensure the `firstVersion` (and `lastVersion`) are converted to the proper types before `.split` is run when sorting the versions.

## Previews

Verify the page no longer crashes, and verify the `VersionBlock` components correctly show/hide content based on the selected version ([page markdown here](https://github.com/dbt-labs/docs.getdbt.com/blob/current/website/docs/docs/use-dbt-semantic-layer/exports.md)):
https://docs-getdbt-com-git-fix-page-crash-dbt-labs.vercel.app/docs/use-dbt-semantic-layer/exports
