### PR TITLE
Removing banners

### DIFF
--- a/website/src/theme/DocRoot/Layout/Main/index.js
+++ b/website/src/theme/DocRoot/Layout/Main/index.js
@@ -119,34 +119,6 @@ export default function DocRootLayoutMain({
           hiddenSidebarContainer && styles.docItemWrapperEnhanced
         )}
       >
-        {!pageAvailable &&
-          dbtVersion && (
-            <div className={styles.versionBanner}>
-              <Admonition
-                type="caution"
-                title={`${hasFirstAvailableVersion ? "New feature!" : lastAvailableVersion ? "Old feature" : "Note"}`}
-                icon={
-                  hasFirstAvailableVersion
-                    ? "🎉"
-                    : lastAvailableVersion
-                      ? "❗"
-                      : ""
-                }
-              >
-                <p style={{ marginTop: "5px", marginBottom: "0" }}>
-                  Unfortunately, this feature is not available in dbt Core
-                  version {dbtVersion}
-                </p>
-                {hasFirstAvailableVersion ? (
-                  <p>
-                    {" "}
-                    You should upgrade to {firstAvailableVersion} or later if
-                    you want to use this feature.
-                  </p>
-                ) : null}
-              </Admonition>
-            </div>
-          )}
         {PreData.showisPrereleaseBanner && (
           <div className={styles.versionBanner}>
             <Admonition type="caution" title="Warning">


### PR DESCRIPTION
## What are you changing in this pull request and why?

This removes two edge case banners that are no longer required.  

One banner is displayed if the user is on a page that is marked as `lastversion` in the dbt-versions file and the user changes to a higher version.

The other is if they are on a page that is marked as `firstversion` in. the dbt-versions file but the user changes to a lower, unsupported version. 

## Checklist
- [ ] I have reviewed the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [ ] The topic I'm writing about is for specific dbt version(s) and I have versioned it according to the [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and/or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content) guidelines.
- [ ] I have added checklist item(s) to this list for anything anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
<!--
PRE-RELEASE VERSION OF dbt (if so, uncomment):
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
<!-- 
ADDING OR REMOVING PAGES (if so, uncomment):
- [ ] Add/remove page in `website/sidebars.js`
- [ ] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages
-->
