### PR TITLE
Fix description for code example for `--resource-type` flag

### DIFF
--- a/website/docs/reference/global-configs/resource-type.md
+++ b/website/docs/reference/global-configs/resource-type.md
@@ -60,7 +60,7 @@ The available resource types are:
 
 ## Example
 
-Instead of targeting specific resources, use the `--resource-flag` or `--exclude-resource-type` flags to target all resources of a certain type: `dbt build --resource-type RESOURCE_TYPE` replacing `RESOURCE_TYPE` with the resource type you want to exclude.
+Instead of targeting specific resources, use the `--resource-flag` or `--exclude-resource-type` flags to target all resources of a certain type: `dbt build --resource-type RESOURCE_TYPE` replacing `RESOURCE_TYPE` with the resource type you want to include.
 
 - For example, use the following command to include _all_ snapshots from your dbt build process:
 


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty10-patch-2-dbt-labs.vercel.app/reference/global-configs/resource-type)

## What are you changing in this pull request and why?

One description was exactly backwards from what the example was showing.

## Checklist
- [x] I have reviewed the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.