### PR TITLE
Grants caveats for Snowflake's database roles and Redshift's groups and roles

### DIFF
--- a/website/docs/reference/resource-configs/grants.md
+++ b/website/docs/reference/resource-configs/grants.md
@@ -249,7 +249,7 @@ models:
 
 <div warehouse="Redshift">
 
-* Granting to / revoking from is only fully supported for Redshift users (not groups or roles).
+* Granting to / revoking from is only fully supported for Redshift users (not [groups](https://docs.aws.amazon.com/redshift/latest/dg/r_Groups.html) or [roles](https://docs.aws.amazon.com/redshift/latest/dg/r_roles-managing.html)).
 
 </div>
 

--- a/website/docs/reference/resource-configs/grants.md
+++ b/website/docs/reference/resource-configs/grants.md
@@ -258,8 +258,6 @@ models:
 * dbt accounts for the [`copy_grants` configuration](/reference/resource-configs/snowflake-configs#copying-grants) when calculating which grants need to be added or removed.
 * Granting to / revoking from is only fully supported for Snowflake roles (not [database roles](https://docs.snowflake.com/user-guide/security-access-control-overview#types-of-roles)).
 
-https://docs.snowflake.com/en/sql-reference/sql/grant-privilege#syntax
-
 </div>
 
 </WHCode>

--- a/website/docs/reference/resource-configs/grants.md
+++ b/website/docs/reference/resource-configs/grants.md
@@ -256,6 +256,9 @@ models:
 <div warehouse="Snowflake">
 
 * dbt accounts for the [`copy_grants` configuration](/reference/resource-configs/snowflake-configs#copying-grants) when calculating which grants need to be added or removed.
+* Granting to / revoking from is only fully supported for Snowflake roles (not [database roles](https://docs.snowflake.com/user-guide/security-access-control-overview#types-of-roles)).
+
+https://docs.snowflake.com/en/sql-reference/sql/grant-privilege#syntax
 
 </div>
 


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty10-patch-4-dbt-labs.vercel.app/reference/resource-configs/grants#database-specific-requirements-and-notes)

## What are you changing in this pull request and why?

- Clarify that dbt grants do not support Snowflake's database roles [[1](https://docs.snowflake.com/user-guide/security-access-control-overview#types-of-roles), [2](https://docs.snowflake.com/en/sql-reference/sql/grant-privilege#syntax)].
- Hyperlink to Redshift's groups and roles (which also aren't supported).

## Checklist
- [x] I have reviewed the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.