### PR TITLE
Updated doc to be more to date with v1.9

### DIFF
--- a/website/docs/reference/resource-properties/versions.md
+++ b/website/docs/reference/resource-properties/versions.md
@@ -79,6 +79,9 @@ Breaking changes include:
 - Removing or modifying one of the `constraints` on an existing column (dbt v1.6 or higher)
 - Changing unversioned, contracted models. 
   - dbt also warns if a model has or had a contract but isn't versioned
+- Removing a contracted model constitutes a breaking change. A model is considered 'removed' if it is deleted, renamed, or disabled:
+  - When you remove a versioned model, you will receive an error.
+  - When you remove an unversioned contract, you will receive a warning.
   
 <Tabs>
 

--- a/website/docs/reference/resource-properties/versions.md
+++ b/website/docs/reference/resource-properties/versions.md
@@ -79,7 +79,7 @@ Breaking changes include:
 - Removing or modifying one of the `constraints` on an existing column (dbt v1.6 or higher)
 - Changing unversioned, contracted models. 
   - dbt also warns if a model has or had a contract but isn't versioned
-- Removing a contracted model constitutes a breaking change. A model is considered 'removed' if it is deleted, renamed, or disabled:
+- Removing a contracted model is a breaking change. A model is considered 'removed' if it's deleted, renamed, or disabled (using the `config: enabled`):
   - When you remove a versioned model, you will receive an error.
   - When you remove an unversioned contract, you will receive a warning.
   


### PR DESCRIPTION
I've created this pull request following a suggestion from Leona here: https://dbt-labs.slack.com/archives/C02NCQ9483C/p1727101696314629 so that doc / section is up to date with v1.9 

## What are you changing in this pull request and why?
<!--
Describe your changes and why you're making them. If related to an open issue or a pull request on dbt Core or another repository, then link to them here! 

To learn more about the writing conventions used in the dbt Labs docs, see the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md).
-->

## Checklist
- [X] I have reviewed the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [X] The topic I'm writing about is for specific dbt version(s) and I have versioned it according to the [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and/or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content) guidelines.
- [ ] I have added checklist item(s) to this list for anything anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
<!--
PRE-RELEASE VERSION OF dbt (if so, uncomment):
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
<!-- 
ADDING OR REMOVING PAGES (if so, uncomment):
- [ ] Add/remove page in `website/sidebars.js`
- [ ] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages
-->
