### PR TITLE
Update metricflow-time-spine.md

### DIFF
--- a/website/docs/docs/build/metricflow-time-spine.md
+++ b/website/docs/docs/build/metricflow-time-spine.md
@@ -18,11 +18,14 @@ MetricFlow requires you to define a time-spine table as a model-level configurat
 To see the generated SQL for the metric and dimension types that use time-spine joins, refer to the respective documentation or add the `compile=True` flag when querying the Semantic Layer to return the compiled SQL.
 
 ## Configuring time-spine in YAML
+
+- The time spine is a special model that tells dbt and MetricFlow how to use specific columns by defining their properties.
+- The [`models` key](/reference/model-properties) for the time spine must be in your `models/` directory.
 - You only need to configure time-spine models that the Semantic Layer should recognize.
 - At a minimum, define a time-spine table for a daily grain.
 - You can optionally define a time-spine table for a different granularity, like hourly.
 - Note that if you don’t have a date or calendar model in your project, you'll need to create one.
-- The [`models` key](/reference/model-properties) in the time spine configuration must be placed in your `models/` directory.
+
 - If you're looking to specify the grain of a time dimension so that MetricFlow can transform the underlying column to the required granularity, refer to the [Time granularity documentation](/docs/build/dimensions?dimension=time_gran)
 
 If you already have a date dimension or time-spine table in your dbt project, you can point MetricFlow to this table by updating the `model` configuration to use this table in the Semantic Layer. This is a model-level configuration that tells dbt to use the model for time range joins in the Semantic Layer. 

--- a/website/docs/docs/build/metricflow-time-spine.md
+++ b/website/docs/docs/build/metricflow-time-spine.md
@@ -21,7 +21,8 @@ To see the generated SQL for the metric and dimension types that use time-spine 
 - You only need to configure time-spine models that the Semantic Layer should recognize.
 - At a minimum, define a time-spine table for a daily grain.
 - You can optionally define a time-spine table for a different granularity, like hourly.
-- Note that if you don’t have a date or calendar model in your project, you'll need to create one. 
+- Note that if you don’t have a date or calendar model in your project, you'll need to create one.
+- The [`models` key](/reference/model-properties) in the time spine configuration must be placed in your `models/` directory.
 - If you're looking to specify the grain of a time dimension so that MetricFlow can transform the underlying column to the required granularity, refer to the [Time granularity documentation](/docs/build/dimensions?dimension=time_gran)
 
 If you already have a date dimension or time-spine table in your dbt project, you can point MetricFlow to this table by updating the `model` configuration to use this table in the Semantic Layer. This is a model-level configuration that tells dbt to use the model for time range joins in the Semantic Layer. 
@@ -40,7 +41,7 @@ If you don’t have a date dimension table, you can still create one by using th
 <File name="models/_models.yml">
   
 ```yaml
-models:
+[models:](/reference/model-properties)
   - name: time_spine_hourly
     time_spine:
       standard_granularity_column: date_hour # column for the standard grain of your table
@@ -56,7 +57,7 @@ models:
 ```
 </File>
 
-For an example project, refer to our [Jaffle shop](https://github.com/dbt-labs/jaffle-sl-template/blob/main/models/marts/_models.yml) example.
+For an example project, refer to our [Jaffle shop](https://github.com/dbt-labs/jaffle-sl-template/blob/main/models/marts/_models.yml) example. Note that the [`models` key](/reference/model-properties) in the time spine configuration must be placed in your `models/` directory.
 
 Now, break down the configuration above. It's pointing to a model called `time_spine_daily`. It sets the time spine configurations under the `time_spine` key. The `standard_granularity_column` is the lowest grain of the table, in this case, it's hourly. It needs to reference a column defined under the columns key, in this case, `date_hour`. Use the `standard_granularity_column` as the join key for the time spine table when joining tables in MetricFlow. Here, the granularity of the `standard_granularity_column` is set at the column level, in this case, `hour`.
 

--- a/website/docs/reference/model-properties.md
+++ b/website/docs/reference/model-properties.md
@@ -2,9 +2,9 @@
 title: Model properties
 ---
 
-Models properties can be declared in `.yml` files in your `models/` directory (as defined by the [`model-paths` config](/reference/project-configs/model-paths)).
+Models properties can be declared in `.yml` files in your `models/` directory (as defined by the [`model-paths` config](/reference/project-configs/model-paths)). 
 
-You can name these files `whatever_you_want.yml`, and nest them arbitrarily deeply in subfolders within the `models/` directory.
+You can name these files `whatever_you_want.yml`, and nest them arbitrarily deeply in subfolders within the `models/` directory. The [MetricFlow time spine](/docs/build/metricflow-time-spine) is a model property that tells dbt and MetricFlow how to use specific columns by defining their properties.
 
 <File name='models/<filename>.yml'>
 
@@ -74,7 +74,3 @@ models:
 
 </File>
 
-<!---
-FAQs
-- Do I need to declare every column for it to render in documentation?
---->


### PR DESCRIPTION
clarify that the time spine models key must be placed in the `models/` directory. this pr also links to the (/reference/model-properties) page.

[slack thread](https://dbt-labs.slack.com/archives/C02NCQ9483C/p1727731703755399)
