### PR TITLE
Corrected syntax for defining the foreign key reference model using ref()

### DIFF
--- a/website/docs/reference/resource-properties/constraints.md
+++ b/website/docs/reference/resource-properties/constraints.md
@@ -47,7 +47,7 @@ models:
         columns: [first_column, second_column, ...]
       - type: foreign_key # multi_column
         columns: [first_column, second_column, ...]
-        to: "{{ ref('other_model_name') }}"
+        to: ref('other_model_name')
         to_columns: [other_model_first_column, other_model_second_columns, ...]
       - type: check
         columns: [first_column, second_column, ...]
@@ -64,7 +64,7 @@ models:
           - type: not_null
           - type: unique
           - type: foreign_key
-            to: "{{ ref('other_model_name') }}"
+            to: ref('other_model_name')
             to_columns: other_model_column
           - type: ...
 ```


### PR DESCRIPTION
When declaring the model reference for a foreign key constraint, the code sample said to use `to: "{{ ref('other_model_name') }}"` which results in "Compilation error [...] 'ref' is undefined"

Using `to: ref('other_model_name')` parses correctly.

## What are you changing in this pull request and why?
<!--
Describe your changes and why you're making them. If related to an open issue or a pull request on dbt Core or another repository, then link to them here! 

To learn more about the writing conventions used in the dbt Labs docs, see the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md).
-->

## Checklist
- [x] I have reviewed the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.

