### PR TITLE
Referenced node in defer

### DIFF
--- a/website/docs/reference/node-selection/defer.md
+++ b/website/docs/reference/node-selection/defer.md
@@ -31,7 +31,7 @@ dbt test --models [...] --defer --state path/to/artifacts
 
 When the `--defer` flag is provided, dbt will resolve `ref` calls differently depending on two criteria:
 1. Is the referenced node included in the model selection criteria of the current run?
-2. Does the reference node exist as a database object in the current environment?
+2. Does the referenced node exist as a database object in the current environment?
 
 If the answer to both is **no**—a node is not included _and_ it does not exist as a database object in the current environment—references to it will use the other namespace instead, provided by the state manifest.
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

The docs [here](https://docs.getdbt.com/reference/node-selection/defer#usage) currently say:

> 1. Is the referenced node included in the model selection criteria of the current run?
> 2. Does the reference node exist as a database object in the current environment?

Since it seems like both items should have the same language, I'm guessing the latter was intended to say "reference**d** node".

## Checklist
- [x] I have reviewed the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.