### PR TITLE
Relocate "test" heading for defer docs

### DIFF
--- a/website/docs/reference/node-selection/defer.md
+++ b/website/docs/reference/node-selection/defer.md
@@ -71,8 +71,6 @@ group by 1
 
 I want to test my changes. Nothing exists in my development schema, `dev_alice`.
 
-### test
-
 </File>
 
 <Tabs
@@ -138,6 +136,8 @@ Because `model_a` is unselected, dbt will check to see if `dev_alice.model_a` ex
 
 </TabItem>
 </Tabs>
+
+### test
 
 I also have a `relationships` test that establishes referential integrity between `model_a` and `model_b`:
 


### PR DESCRIPTION
[Preview](https://docs-getdbt-com-git-dbeatty10-patch-2-dbt-labs.vercel.app/reference/node-selection/defer#example)

## What are you changing in this pull request and why?

The code example for the executed code for `dbt run` is within the "test" heading when it seems like it should be under the "run" heading.

## 🎩 

### Before

<img width="350" alt="image" src="https://github.com/user-attachments/assets/f3de2ed1-b0a8-449b-84e7-2875e6e891e2">

### After

<img width="350" alt="image" src="https://github.com/user-attachments/assets/31b69aa6-98a6-4e76-aca7-03cdfbadb789">

## Checklist
- [x] I have reviewed the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.