### PR TITLE
Update v1.7 EOL for dbt Cloud Enterprise customers

### DIFF
--- a/website/snippets/core-versions-table.md
+++ b/website/snippets/core-versions-table.md
@@ -3,7 +3,7 @@
 |                      dbt Core                                 | Initial release |      Support level and end date      |
 |:-------------------------------------------------------------:|:---------------:|:-------------------------------------:|
 | [**v1.8**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.8) | May 9 2024    | <b>Active Support &mdash; May 8, 2025</b>                    |
-| [**v1.7**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.7) | Nov 2, 2023   | dbt Core and dbt Cloud Developer/Team customers: Critical Support until Nov 1, 2024\  
+| [**v1.7**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.7) | Nov 2, 2023   | dbt Core and dbt Cloud Developer/Team customers: Critical Support until Nov 1, 2024 <span><br /></span>
 dbt Cloud Enterprise customers: Critical Support until further notice <sup>1</sup> | 
 | [**v1.6**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.6) | Jul 31, 2023  | End of Life ⚠️ |  
 | [**v1.5**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.5) | Apr 27, 2023  | End of Life ⚠️ |

--- a/website/snippets/core-versions-table.md
+++ b/website/snippets/core-versions-table.md
@@ -3,8 +3,7 @@
 |                      dbt Core                                 | Initial release |      Support level and end date      |
 |:-------------------------------------------------------------:|:---------------:|:-------------------------------------:|
 | [**v1.8**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.8) | May 9 2024    | <b>Active Support &mdash; May 8, 2025</b>                    |
-| [**v1.7**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.7) | Nov 2, 2023   | dbt Core and dbt Cloud Developer/Team customers: Critical Support until Nov 1, 2024 <span><br /></span>
-dbt Cloud Enterprise customers: Critical Support until further notice <sup>1</sup> | 
+| [**v1.7**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.7) | Nov 2, 2023   | <div align="left">**dbt Core and dbt Cloud Developer & Team customers:** Critical Support until Nov 1, 2024 <br /> **dbt Cloud Enterprise customers:** Critical Support until further notice <sup>1</sup></div> | 
 | [**v1.6**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.6) | Jul 31, 2023  | End of Life ⚠️ |  
 | [**v1.5**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.5) | Apr 27, 2023  | End of Life ⚠️ |
 | [**v1.4**](/docs/dbt-versions/core-upgrade/Older%20versions/upgrading-to-v1.4) | Jan 25, 2023  | End of Life ⚠️ | 

--- a/website/snippets/core-versions-table.md
+++ b/website/snippets/core-versions-table.md
@@ -2,15 +2,19 @@
 
 |                      dbt Core                                 | Initial release |      Support level and end date      |
 |:-------------------------------------------------------------:|:---------------:|:-------------------------------------:|
-| [**v1.8**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.8) | May 9 2024    | <b>Active &mdash; May 8, 2025</b>                    |
-| [**v1.7**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.7) | Nov 2, 2023   | Critical &mdash; Nov 1, 2024 | 
-| [**v1.6**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.6) | Jul 31, 2023  | End of Life* ⚠️ |  
-| [**v1.5**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.5) | Apr 27, 2023  | End of Life* ⚠️ |
-| [**v1.4**](/docs/dbt-versions/core-upgrade/Older%20versions/upgrading-to-v1.4) | Jan 25, 2023  | End of Life* ⚠️ | 
-| [**v1.3**](/docs/dbt-versions/core-upgrade/Older%20versions/upgrading-to-v1.3) | Oct 12, 2022  | End of Life* ⚠️ |
-| [**v1.2**](/docs/dbt-versions/core-upgrade/Older%20versions/upgrading-to-v1.2) | Jul 26, 2022  | End of Life* ⚠️ | 
-| [**v1.1**](/docs/dbt-versions/core-upgrade/Older%20versions/upgrading-to-v1.1) | Apr 28, 2022  | End of Life* ⚠️ |
-| [**v1.0**](/docs/dbt-versions/core-upgrade/Older%20versions/upgrading-to-v1.0) | Dec 3, 2021   | End of Life* ⚠️ | 
+| [**v1.8**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.8) | May 9 2024    | <b>Active Support &mdash; May 8, 2025</b>                    |
+| [**v1.7**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.7) | Nov 2, 2023   | Critical Support &mdash; EXTENDED for customers of dbt Cloud Enterprise<sup>1</sup> | 
+| [**v1.6**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.6) | Jul 31, 2023  | End of Life ⚠️ |  
+| [**v1.5**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.5) | Apr 27, 2023  | End of Life ⚠️ |
+| [**v1.4**](/docs/dbt-versions/core-upgrade/Older%20versions/upgrading-to-v1.4) | Jan 25, 2023  | End of Life ⚠️ | 
+| [**v1.3**](/docs/dbt-versions/core-upgrade/Older%20versions/upgrading-to-v1.3) | Oct 12, 2022  | End of Life ⚠️ |
+| [**v1.2**](/docs/dbt-versions/core-upgrade/Older%20versions/upgrading-to-v1.2) | Jul 26, 2022  | End of Life ⚠️ | 
+| [**v1.1**](/docs/dbt-versions/core-upgrade/Older%20versions/upgrading-to-v1.1) | Apr 28, 2022  | End of Life ⚠️ |
+| [**v1.0**](/docs/dbt-versions/core-upgrade/Older%20versions/upgrading-to-v1.0) | Dec 3, 2021   | End of Life ⚠️ | 
 |  **v0.X** ⛔️                                               | (Various dates) | Deprecated ⛔️  | Deprecated ⛔️     | 
 
-_*All versions of dbt Core since v1.0 are available in dbt Cloud until further notice. Versions that are EOL do not receive any fixes. For the best support, we recommend upgrading to a version released within the past 12 months._
+All functionality in dbt Core since the v1.7 release is available in dbt Cloud, early and continuously, by selecting ["Versionless"](https://docs.getdbt.com/docs/dbt-versions/versionless-cloud).
+
+Starting in November 2024, "Versionless" will be required for the Developer and Teams plans on dbt Cloud. After that point, accounts on older versions will be migrated to "Versionless."
+
+For customers of dbt Cloud Enterprise, dbt v1.7 will continue to be available as an option while dbt Labs rolls out a mechanism for "extended" upgrades. In the meantime, dbt Labs strongly recommends migrating any environments that are still running on older unsupported versions to "Versionless" dbt or dbt v1.7.

--- a/website/snippets/core-versions-table.md
+++ b/website/snippets/core-versions-table.md
@@ -3,7 +3,8 @@
 |                      dbt Core                                 | Initial release |      Support level and end date      |
 |:-------------------------------------------------------------:|:---------------:|:-------------------------------------:|
 | [**v1.8**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.8) | May 9 2024    | <b>Active Support &mdash; May 8, 2025</b>                    |
-| [**v1.7**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.7) | Nov 2, 2023   | Critical Support &mdash; EXTENDED for customers of dbt Cloud Enterprise<sup>1</sup> | 
+| [**v1.7**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.7) | Nov 2, 2023   | dbt Core and dbt Cloud Developer/Team customers: Critical Support until Nov 1, 2024 <br/>
+dbt Cloud Enterprise customers: Critical Support until further notice <sup>1</sup> | 
 | [**v1.6**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.6) | Jul 31, 2023  | End of Life ⚠️ |  
 | [**v1.5**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.5) | Apr 27, 2023  | End of Life ⚠️ |
 | [**v1.4**](/docs/dbt-versions/core-upgrade/Older%20versions/upgrading-to-v1.4) | Jan 25, 2023  | End of Life ⚠️ | 
@@ -15,6 +16,6 @@
 
 All functionality in dbt Core since the v1.7 release is available in dbt Cloud, early and continuously, by selecting ["Versionless"](https://docs.getdbt.com/docs/dbt-versions/versionless-cloud).
 
-Starting in November 2024, "Versionless" will be required for the Developer and Teams plans on dbt Cloud. After that point, accounts on older versions will be migrated to "Versionless."
+<sup>1</sup> Starting in November 2024, "Versionless" will be required for the Developer and Teams plans on dbt Cloud. After that point, accounts on older versions will be migrated to "Versionless."
 
 For customers of dbt Cloud Enterprise, dbt v1.7 will continue to be available as an option while dbt Labs rolls out a mechanism for "extended" upgrades. In the meantime, dbt Labs strongly recommends migrating any environments that are still running on older unsupported versions to "Versionless" dbt or dbt v1.7.

--- a/website/snippets/core-versions-table.md
+++ b/website/snippets/core-versions-table.md
@@ -3,7 +3,7 @@
 |                      dbt Core                                 | Initial release |      Support level and end date      |
 |:-------------------------------------------------------------:|:---------------:|:-------------------------------------:|
 | [**v1.8**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.8) | May 9 2024    | <b>Active Support &mdash; May 8, 2025</b>                    |
-| [**v1.7**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.7) | Nov 2, 2023   | dbt Core and dbt Cloud Developer/Team customers: Critical Support until Nov 1, 2024 <br/>
+| [**v1.7**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.7) | Nov 2, 2023   | dbt Core and dbt Cloud Developer/Team customers: Critical Support until Nov 1, 2024\  
 dbt Cloud Enterprise customers: Critical Support until further notice <sup>1</sup> | 
 | [**v1.6**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.6) | Jul 31, 2023  | End of Life ⚠️ |  
 | [**v1.5**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.5) | Apr 27, 2023  | End of Life ⚠️ |


### PR DESCRIPTION
## What are you changing in this pull request and why?

We are extending the "Critical Support" period for dbt Core v1.7 in dbt Cloud, for Enterprise customers of dbt Cloud, while we are in the process of implementing a mechanism for "Extended" upgrades. (We are finalizing details, more information & documentation coming soon!)

As we have communicated via email, we are planning to migrate self-service dbt Cloud accounts (Developer & Teams) to "Versionless" over the next 6 weeks.

Next week, I will look into updating this within the dbt Cloud version dropdown UI.