### PR TITLE
fix: to_columns must be an array

### DIFF
--- a/website/docs/reference/resource-properties/constraints.md
+++ b/website/docs/reference/resource-properties/constraints.md
@@ -65,7 +65,7 @@ models:
           - type: unique
           - type: foreign_key
             to: ref('other_model_name')
-            to_columns: other_model_column
+            to_columns: [other_model_column]
           - type: ...
 ```
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
when providing a single column as a string, instead of an array, the compiled sql ends up like this:
```
some_id bigint not null references "database"."schema"."table" (e, x, t, e, r, n, a, l, _, i, d),
```

adjust the example to show an array with a single element instead.

## Checklist
- [x] I have reviewed the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [x] I have added checklist item(s) to this list for anything anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
