### PR TITLE
Add BQ timeout to list of migration gotchas

### DIFF
--- a/website/docs/docs/dbt-versions/versionless-cloud.md
+++ b/website/docs/docs/dbt-versions/versionless-cloud.md
@@ -51,10 +51,11 @@ The legacy dbt Semantic Layer was deprecated in the second half of 2023. We reco
 <Expandable alt_header="What are other known issues when upgrading from older dbt Core versions?" >
 
 If you are upgrading from a very old unsupported version of dbt Core, you may run into one of these edge cases after the upgrade to a newer version:
+- [v1.1] Customers on BigQuery should be aware that dbt Cloud sets a default [per-model timeout](/docs/core/connect-data-platform/bigquery-setup#job_execution_timeout_seconds) of 5 minutes. You may override this config in your connection details. Older versions of dbt (including v1.0) did not appropriately respect this timeout configuration.
 - [v1.3] Customers with non-dbt `.py` files defined within their project directories, such as `models/`. Since v1.3, dbt expects these files be valid [Python models](/docs/build/python-models). The customer needs to move these files out of their `models/` directory, or ignore them via `.dbtignore`
 - [v1.5] Customers who have `--m` in their job definitions, instead of `-m` or `--models`. This autocompletion (`--m[odels]` for `--models`) has never been officially documented or supported. It was an implicit behavior of argparse (CLI library used in dbt-core v1.0-1.4) that is not supported by `click` (the CLI library used in dbt-core since v1.5+).
 - [v1.5] Empty invalid `tests` config start raising a validation error](https://docs.getdbt.com/docs/dbt-versions/core-upgrade/upgrading-to-v1.5). Replace empty `tests` config with `tests: []` or remove it altogether.
-- [v1.6] Performance optimization to `load_result` means you cannot call it on the same query result multiple times (https://github.com/dbt-labs/dbt-core/pull/7371)
+- [v1.6] Performance optimization to `load_result` means you cannot call it on the same query result multiple times. Instead, save it to a local variable once, and reuse that variable (context: [dbt-core#7371](https://github.com/dbt-labs/dbt-core/pull/7371)
 
 You should [contact dbt Cloud support](https://docs.getdbt.com/docs/dbt-support#dbt-cloud-support) to request an extension, during which you will need to make those updates.
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

Customers migrating from v1.0 &rarr; v1.1+ may run into an issue with BigQuery timeouts. dbt Cloud has always set a default per-model timeout of 5 minutes (= `300` seconds), but in older versions of dbt (including v1.0) this config was inconsistently applied. The "fix" in v1.1+ means that customers will see timeouts on long-running models for the first time, even though this is the expected behavior.

Context:
- https://github.com/dbt-labs/dbt-bigquery/issues/201

Add a note about BigQuery timeouts to the list of "gotchas" for customers being migrated from v1.0 to newer versions