### PR TITLE
Tweak to defer copy

### DIFF
--- a/website/docs/docs/cloud/about-cloud-develop-defer.md
+++ b/website/docs/docs/cloud/about-cloud-develop-defer.md
@@ -13,11 +13,13 @@ Both the dbt Cloud IDE and the dbt Cloud CLI enable users to natively defer to p
 
 <Lightbox src src="/img/docs/reference/defer-diagram.png" width="50%" title="Use 'defer' to modify end-of-pipeline models by pointing to production models, instead of running everything upstream." />
 
-By default, dbt follows these rules:
+When using `--defer`, dbt Cloud will follow this order of execution for resolving the `{{ ref() }}` functions.
 
-- dbt uses the production locations of parent models to resolve `{{ ref() }}` functions, based on metadata from the production environment.
-- If a development version of a deferred model exists, dbt preferentially uses the development database location when resolving the reference.
-- Passing the [`--favor-state`](/reference/node-selection/defer#favor-state) flag overrides the default behavior and _always_ resolve refs using production metadata, regardless of the presence of a development relation.
+1. If a development version of a deferred relation exists, dbt preferentially uses the development database location when resolving the reference.
+2. If a development version does not exist, dbt uses the staging locations of parent relations based on metadata from the staging environment.
+3. If a development version AND staging version do not exist, dbt uses the production locations of parent relations based on metadata from the production environment.
+
+**Note:** Passing the `--favor-state` flag will always resolve refs using production metadata, regardless of the presence of a development relation. This will effectively by pass step #1 above.
 
 For a clean slate, it's a good practice to drop the development schema at the start and end of your development cycle.
 

--- a/website/docs/docs/cloud/about-cloud-develop-defer.md
+++ b/website/docs/docs/cloud/about-cloud-develop-defer.md
@@ -19,7 +19,7 @@ When using `--defer`, dbt Cloud will follow this order of execution for resolvin
 2. If a development version does not exist, dbt uses the staging locations of parent relations based on metadata from the staging environment.
 3. If a development version AND staging version do not exist, dbt uses the production locations of parent relations based on metadata from the production environment.
 
-**Note:** Passing the `--favor-state` flag will always resolve refs using production metadata, regardless of the presence of a development relation. This will effectively by pass step #1 above.
+**Note:** Passing the `--favor-state` flag will always resolve refs using production metadata, regardless of the presence of a development relation, skipping step #1.
 
 For a clean slate, it's a good practice to drop the development schema at the start and end of your development cycle.
 

--- a/website/docs/docs/cloud/about-cloud-develop-defer.md
+++ b/website/docs/docs/cloud/about-cloud-develop-defer.md
@@ -17,7 +17,7 @@ When using `--defer`, dbt Cloud will follow this order of execution for resolvin
 
 1. If a development version of a deferred relation exists, dbt preferentially uses the development database location when resolving the reference.
 2. If a development version doesn't exist, dbt uses the staging locations of parent relations based on metadata from the staging environment.
-3. If a development version AND staging version do not exist, dbt uses the production locations of parent relations based on metadata from the production environment.
+3. If both a development and staging version doesn't exist, dbt uses the production locations of parent relations based on metadata from the production environment.
 
 **Note:** Passing the `--favor-state` flag will always resolve refs using production metadata, regardless of the presence of a development relation, skipping step #1.
 

--- a/website/docs/docs/cloud/about-cloud-develop-defer.md
+++ b/website/docs/docs/cloud/about-cloud-develop-defer.md
@@ -16,7 +16,7 @@ Both the dbt Cloud IDE and the dbt Cloud CLI enable users to natively defer to p
 When using `--defer`, dbt Cloud will follow this order of execution for resolving the `{{ ref() }}` functions.
 
 1. If a development version of a deferred relation exists, dbt preferentially uses the development database location when resolving the reference.
-2. If a development version does not exist, dbt uses the staging locations of parent relations based on metadata from the staging environment.
+2. If a development version doesn't exist, dbt uses the staging locations of parent relations based on metadata from the staging environment.
 3. If a development version AND staging version do not exist, dbt uses the production locations of parent relations based on metadata from the production environment.
 
 **Note:** Passing the `--favor-state` flag will always resolve refs using production metadata, regardless of the presence of a development relation, skipping step #1.


### PR DESCRIPTION
## What are you changing in this pull request and why?
I was working through an on demand video for learn.getdbt.com and was thinking about different ways to explain the defer command.  After reading through the docs and checking out how this works, I thought it might be helpful to contribute a rewording of the behavior here for people to follow the logic more closely.

Note: I incorrectly named the branch here 😬 

## Checklist
- [X] I have reviewed the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [X] The topic I'm writing about is for specific dbt version(s) and I have versioned it according to the [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and/or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content) guidelines.
- [X] I have added checklist item(s) to this list for anything anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
- [X] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).
- [ ] Confirm technical accuracy of the proposed changes and that they are easy to follow.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-tweak-clone-copy-dbt-labs.vercel.app/docs/cloud/about-cloud-develop-defer

<!-- end-vercel-deployment-preview -->