### PR TITLE
Updates databricks-configs.md to correct reference to `time_zone_value` in documentation example code

### DIFF
--- a/website/docs/reference/resource-configs/databricks-configs.md
+++ b/website/docs/reference/resource-configs/databricks-configs.md
@@ -1031,7 +1031,7 @@ The following table summarizes our configuration support:
     partition_by='id',
     schedule = {
         'cron': '0 0 * * * ? *',
-        'time_zone': 'Etc/UTC'
+        'time_zone_value': 'Etc/UTC'
     },
     tblproperties={
         'key': 'value'


### PR DESCRIPTION
Corrects reference to `time_zone_value` in documentation example code

