### PR TITLE
update schema config

### DIFF
--- a/website/docs/reference/resource-configs/schema.md
+++ b/website/docs/reference/resource-configs/schema.md
@@ -108,7 +108,9 @@ This would result in the test results being stored in the `test_results` schema.
 Refer to [Usage](#usage) for more examples.
 
 ## Definition
-Optionally specify a custom schema for a [model](/docs/build/sql-models) or [seed](/docs/build/seeds). (To specify a schema for a [snapshot](/docs/build/snapshots), use the [`target_schema` config](/reference/resource-configs/target_schema)).
+Optionally specify a custom schema for a [model](/docs/build/sql-models), [seed](/docs/build/seeds), [snapshot](/docs/build/snapshots), [saved query](/docs/build/saved-queries), or [test](/docs/build/data-tests). 
+
+For users on dbt Cloud v1.8 or earlier, use the [`target_schema` config](/reference/resource-configs/target_schema) to specify a custom schema for a snapshot.
 
 When dbt creates a relation (<Term id="table" />/<Term id="view" />) in a database, it creates it as: `{{ database }}.{{ schema }}.{{ identifier }}`, e.g. `analytics.finance.payments`
 


### PR DESCRIPTION
this pr updates the doc to correctly reflect what the schema config supports (models, seeds, snapshots, saved queries, and tests). previously it only mentioned it supported models and seeds

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-schema-doc-dbt-labs.vercel.app/reference/resource-configs/schema

<!-- end-vercel-deployment-preview -->