### PR TITLE
add optional oauth step

### DIFF
--- a/website/docs/guides/bigquery-qs.md
+++ b/website/docs/guides/bigquery-qs.md
@@ -85,13 +85,14 @@ In order to let dbt connect to your warehouse, you'll need to generate a keyfile
 3. Create a service account key for your new project from the [Service accounts page](https://console.cloud.google.com/iam-admin/serviceaccounts?walkthrough_id=iam--create-service-account-keys&start_index=1#step_index=1). For more information, refer to [Create a service account key](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating) in the Google Cloud docs. When downloading the JSON file, make sure to use a filename you can easily remember. For example, `dbt-user-creds.json`. For security reasons, dbt Labs recommends that you protect this JSON file like you would your identity credentials; for example, don't check the JSON file into your version control software.
 
 ## Connect dbt Cloud to BigQuery​
-1. Create a new project in [dbt Cloud](/docs/cloud/about-cloud/access-regions-ip-addresses). Navigate to **Account settings** (by clicking on your account name in the left side menu), and click **+ New Project**.
+1. Create a new project in [dbt Cloud](/docs/cloud/about-cloud/access-regions-ip-addresses). Navigate to **Account settings** (by clicking on your account name in the left side menu), and click **+ New project**.
 2. Enter a project name and click **Continue**.
 3. For the warehouse, click **BigQuery** then **Next** to set up your connection.
 4. Click **Upload a Service Account JSON File** in settings.
 5. Select the JSON file you downloaded in [Generate BigQuery credentials](#generate-bigquery-credentials) and dbt Cloud will fill in all the necessary fields.
-6. Click **Test Connection**. This verifies that dbt Cloud can access your BigQuery account.
-7. Click **Next** if the test succeeded. If it failed, you might need to go back and regenerate your BigQuery credentials.
+6. Optional &mdash; dbt Cloud Enterprise plans can configure developer OAuth with BigQuery, providing an additional layer of security. For more information, refer to [Set up BigQuery OAuth](/docs/cloud/manage-access/set-up-bigquery-oauth).
+7. Click **Test Connection**. This verifies that dbt Cloud can access your BigQuery account.
+8. Click **Next** if the test succeeded. If it failed, you might need to go back and regenerate your BigQuery credentials.
 
 
 ## Set up a dbt Cloud managed repository 


### PR DESCRIPTION
addresses customer feedback and adds optional oauth step + link in bq set up. 

Resolves #4898

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-add-bq-oauth-quickstart-dbt-labs.vercel.app/guides/bigquery?step=5

<!-- end-vercel-deployment-preview -->