### PR TITLE
Platform connections: Add new data platform adapter for CrateDB

### DIFF
--- a/website/docs/docs/community-adapters.md
+++ b/website/docs/docs/community-adapters.md
@@ -7,7 +7,8 @@ Community adapters are adapter plugins contributed and maintained by members of 
 
 | Data platforms (click to view setup guide) |||
 | ------------------------------------------ | -------------------------------- | ------------------------------------- |
-| [Clickhouse](/docs/core/connect-data-platform/clickhouse-setup) | [Databend Cloud](/docs/core/connect-data-platform/databend-setup) | [Doris & SelectDB](/docs/core/connect-data-platform/doris-setup)  |
+| [Clickhouse](/docs/core/connect-data-platform/clickhouse-setup) | [CrateDB](/docs/core/connect-data-platform/cratedb-setup)
+| [Databend Cloud](/docs/core/connect-data-platform/databend-setup) | [Doris & SelectDB](/docs/core/connect-data-platform/doris-setup)  |
 | [DuckDB](/docs/core/connect-data-platform/duckdb-setup) | [Exasol Analytics](/docs/core/connect-data-platform/exasol-setup) | [Extrica](/docs/core/connect-data-platform/extrica-setup) | 
 | [Hive](/docs/core/connect-data-platform/hive-setup) | [IBM DB2](/docs/core/connect-data-platform/ibmdb2-setup) | [Impala](/docs/core/connect-data-platform/impala-setup) |
 | [Infer](/docs/core/connect-data-platform/infer-setup) | [iomete](/docs/core/connect-data-platform/iomete-setup) | [MindsDB](/docs/core/connect-data-platform/mindsdb-setup) |

--- a/website/docs/docs/core/connect-data-platform/cratedb-setup.md
+++ b/website/docs/docs/core/connect-data-platform/cratedb-setup.md
@@ -1,0 +1,62 @@
+---
+title: "CrateDB setup"
+description: "Read this guide to learn about the CrateDB data platform setup in dbt."
+id: "cratedb-setup"
+meta:
+  maintained_by: Crate.io, Inc.
+  authors: 'CrateDB maintainers'
+  github_repo: 'crate/dbt-cratedb2'
+  pypi_package: 'dbt-cratedb2'
+  min_core_version: 'v1.0.0'
+  cloud_support: Not Supported
+  min_supported_version: 'n/a'
+  slack_channel_name: 'Community Forum'
+  slack_channel_link: 'https://community.cratedb.com/'
+  platform_name: 'CrateDB'
+  config_page: '/reference/resource-configs/no-configs'
+---
+
+import SetUpPages from '/snippets/_setup-pages-intro.md';
+
+<SetUpPages meta={frontMatter.meta}/>
+
+
+[CrateDB] is compatible with PostgreSQL, so its dbt adapter strongly depends on
+dbt-postgres, documented at [PostgreSQL profile setup].
+
+CrateDB targets are configured exactly the same way, see also [PostgreSQL
+configuration], with just a few things to consider which are special to
+CrateDB. Relevant details are outlined at [using dbt with CrateDB],
+which also includes up-to-date information.
+
+
+## Profile configuration
+
+CrateDB targets should be set up using a configuration like this minimal sample
+of settings in your [`profiles.yml`] file.
+
+<File name='~/.dbt/profiles.yml'>
+
+```yaml
+cratedb_analytics:
+  target: dev
+  outputs:
+    dev:
+      type: cratedb
+      host: [clustername].aks1.westeurope.azure.cratedb.net
+      port: 5432
+      user: [username]
+      pass: [password]
+      dbname: crate         # Do not change this value. CrateDB's only catalog is `crate`.
+      schema: doc           # Define the schema name. CrateDB's default schema is `doc`.
+```
+
+</File>
+
+
+
+[CrateDB]: https://cratedb.com/database
+[PostgreSQL configuration]: https://docs.getdbt.com/reference/resource-configs/postgres-configs
+[PostgreSQL profile setup]: https://docs.getdbt.com/docs/core/connect-data-platform/postgres-setup
+[`profiles.yml`]: https://docs.getdbt.com/docs/core/connect-data-platform/profiles.yml
+[using dbt with CrateDB]: https://cratedb.com/docs/guide/integrate/dbt/

--- a/website/docs/reference/resource-configs/no-configs.md
+++ b/website/docs/reference/resource-configs/no-configs.md
@@ -1,11 +1,12 @@
 ---
-title: "No specifc configurations for this Adapter"
+title: "No specific configurations for this adapter"
 id: "no-configs"
 ---
 
 If you were guided to this page from a data platform setup article, it most likely means:
 
 - Setting up the profile is the only action the end-user needs to take on the data platform, or
-- The subsequent actions the end-user needs to take are not currently documented
+- The subsequent actions the end-user needs to take are not currently documented, or
+- Relevant information is provided on the documentation pages of the data platform vendor.
 
 If you'd like to contribute to data platform-specific configuration information, refer to [Documenting a new adapter](/guides/adapter-creation)

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -222,6 +222,7 @@ const sidebarSettings = {
                 "docs/core/connect-data-platform/athena-setup",
                 "docs/core/connect-data-platform/glue-setup",
                 "docs/core/connect-data-platform/clickhouse-setup",
+                "docs/core/connect-data-platform/cratedb-setup",
                 "docs/core/connect-data-platform/databend-setup",
                 "docs/core/connect-data-platform/decodable-setup",
                 "docs/core/connect-data-platform/doris-setup",


### PR DESCRIPTION
## About
First things first, thanks a stack for conceiving and maintaining dbt. 💯

This patch adds information about the database adapter for the [CrateDB database](https://github.com/crate/crate) to dbt's documentation. Because CrateDB is compatible with PostgreSQL, it builds heavily upon the [dbt-postgres](https://github.com/dbt-labs/dbt-postgres) adapter.

It was tremendously helpful for us to get started by gradually working through its test suite to progressively make test cases succeed on CrateDB, so we would like to explicitly send kudos to @mikealfare and all contributors.

## Preview
[CrateDB setup](https://docs-getdbt-com-git-fork-crate-workbench-cratedb-dbt-labs.vercel.app/docs/core/connect-data-platform/cratedb-setup)

## Details
**Package:** https://pypi.org/project/dbt-cratedb2/
**Repository:** https://github.com/crate/dbt-cratedb2
**Documentation:** https://cratedb.com/docs/guide/integrate/dbt/

## Checklist
ADDING OR REMOVING PAGES:
- [x] Add/remove page in `website/sidebars.js`
- [x] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages

