### PR TITLE
Update snapshot-configs.md

### DIFF
--- a/website/docs/reference/snapshot-configs.md
+++ b/website/docs/reference/snapshot-configs.md
@@ -347,6 +347,7 @@ The following examples demonstrate how to configure snapshots using the `dbt_pro
         {{
             config(
               unique_key='id',
+              target_schema='snapshots',
               strategy='timestamp',
               updated_at='updated_at'
             )


### PR DESCRIPTION
adding target_schema, which is required value for 1.8 and lower. 

Resolves #5291

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-mirnawong1-patch-27-dbt-labs.vercel.app/reference/snapshot-configs

<!-- end-vercel-deployment-preview -->