### PR TITLE
add snippet to versions and model contracts

### DIFF
--- a/website/docs/docs/collaborate/govern/model-contracts.md
+++ b/website/docs/docs/collaborate/govern/model-contracts.md
@@ -205,13 +205,11 @@ At the same time, for models with many columns, we understand that this can mean
 
 When comparing to a previous project state, dbt will look for breaking changes that could impact downstream consumers. If breaking changes are detected, dbt will present a contract error. 
 
-Breaking changes include:
-- Removing an existing column.
-- Changing the `data_type` of an existing column.
-- Removing or modifying one of the `constraints` on an existing column (dbt v1.6 or higher).
-- Removing a contracted model by deleting, renaming, or disabling it (dbt v1.9 or higher).
-  - versioned models will raise an error.
-  - unversioned models will raise a warning.
+import BreakingChanges from '/snippets/_versions-contracts.md';
+
+<BreakingChanges 
+value="Removing a contracted model by deleting, renaming, or disabling it (dbt v1.9 or higher)."
+value2="versioned models will raise an error. unversioned models will raise a warning."
+/>
 
 More details are available in the [contract reference](/reference/resource-configs/contract#detecting-breaking-changes).
-

--- a/website/docs/reference/resource-properties/versions.md
+++ b/website/docs/reference/resource-properties/versions.md
@@ -73,13 +73,13 @@ Note that the value of `defined_in` and the `alias` configuration of a model are
 
 When you use the `state:modified` selection method in Slim CI, dbt will detect changes to versioned model contracts, and raise an error if any of those changes could be breaking for downstream consumers.
 
-Breaking changes include:
-- Removing an existing column
-- Changing the `data_type` of an existing column
-- Removing or modifying one of the `constraints` on an existing column (dbt v1.6 or higher)
-- Changing unversioned, contracted models. 
-  - dbt also warns if a model has or had a contract but isn't versioned
-  
+import BreakingChanges from '/snippets/_versions-contracts.md';
+
+<BreakingChanges 
+value="Changing unversioned, contracted models."
+value2="dbt also warns if a model has or had a contract but isn't versioned."
+/>
+
 <Tabs>
 
 <TabItem value="unversioned" label="Example message for unversioned models">

--- a/website/snippets/_versions-contracts.md
+++ b/website/snippets/_versions-contracts.md
@@ -1,0 +1,7 @@
+Breaking changes include:
+
+- Removing an existing column
+- Changing the data_type of an existing column
+- Removing or modifying one of the `constraints` on an existing column (dbt v1.6 or higher)
+- {props.value}
+  - {props.value2}


### PR DESCRIPTION
the breaking changes section contains similar language. turning it into a snippet with props for scalability and efficiency.

Resolves #6198

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-add-snippet-dbt-labs.vercel.app/docs/collaborate/govern/model-contracts
- https://docs-getdbt-com-git-add-snippet-dbt-labs.vercel.app/reference/resource-properties/versions

<!-- end-vercel-deployment-preview -->