### PR TITLE
Remove link to customizing the name of a model's database identifier using the `alias` model config

### DIFF
--- a/website/docs/docs/build/unit-tests.md
+++ b/website/docs/docs/build/unit-tests.md
@@ -26,7 +26,7 @@ Starting in dbt Core v1.8, we have introduced an additional type of test to dbt 
 - We currently _don't_ support unit testing models that use recursive SQL.
 - If your model has multiple versions, by default the unit test will run on *all* versions of your model. Read [unit testing versioned models](/reference/resource-properties/unit-testing-versions) for more information.
 - Unit tests must be defined in a YML file in your [`models/` directory](/reference/project-configs/model-paths).
-- Table names must be [aliased](/docs/build/custom-aliases) in order to unit test `join` logic.
+- Table names must be aliased in order to unit test `join` logic.
 - Include all [`ref`](/reference/dbt-jinja-functions/ref) or [`source`](/reference/dbt-jinja-functions/source) model references in the unit test configuration as `input`s to avoid "node not found" errors during compilation.
 
 #### Adapter-specific caveats


### PR DESCRIPTION
## What are you changing in this pull request and why?

There was a misunderstanding during implementation of https://github.com/dbt-labs/docs.getdbt.com/pull/5460 that lead to a hyperlink that is about something totally different.

i.e., https://github.com/dbt-labs/docs.getdbt.com/issues/5418 was referring to something like this:

```sql
select *
from {{ ref('stg_orders') }}  -- Look Ma, no relation alias!
left join {{ ref('stg_candies')}}  -- Look Pa, no relation alias here either!
    on stg_orders.candy_id = stg_candies.candy_id  -- Oopsie, the join condition here IS using relation aliases 💥
```

But the `alias` **dbt model config** is something totally different!

The `alias` config is used to give the model's an identifier in the database that differs from the model's name in dbt.

## Checklist
- [x] I have reviewed the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/docs/build/unit-tests

<!-- end-vercel-deployment-preview -->