### PR TITLE
Explain behavior of `config.get`

### DIFF
--- a/website/docs/reference/dbt-jinja-functions/config.md
+++ b/website/docs/reference/dbt-jinja-functions/config.md
@@ -35,7 +35,7 @@ __Args__:
 The `config.get` function is used to get configurations for a model from the end-user. Configs defined in this way are optional, and a default value can be provided.
 
 There are 3 cases:
-1. The configuration variable exists, it isn't `None`
+1. The configuration variable exists, it is not `None`
 1. The configuration variable exists, it is `None`
 1. The configuration variable doesn't exist
 

--- a/website/docs/reference/dbt-jinja-functions/config.md
+++ b/website/docs/reference/dbt-jinja-functions/config.md
@@ -35,7 +35,7 @@ __Args__:
 The `config.get` function is used to get configurations for a model from the end-user. Configs defined in this way are optional, and a default value can be provided.
 
 There are 3 cases:
-1. The configuration variable exists, it is it not `None`
+1. The configuration variable exists, it is not `None`
 1. The configuration variable exists, it it is `None`
 1. The configuration variable does not exist
 

--- a/website/docs/reference/dbt-jinja-functions/config.md
+++ b/website/docs/reference/dbt-jinja-functions/config.md
@@ -36,7 +36,7 @@ The `config.get` function is used to get configurations for a model from the end
 
 There are 3 cases:
 1. The configuration variable exists, it is not `None`
-1. The configuration variable exists, it it is `None`
+1. The configuration variable exists, it is `None`
 1. The configuration variable does not exist
 
 Example usage:

--- a/website/docs/reference/dbt-jinja-functions/config.md
+++ b/website/docs/reference/dbt-jinja-functions/config.md
@@ -35,7 +35,7 @@ __Args__:
 The `config.get` function is used to get configurations for a model from the end-user. Configs defined in this way are optional, and a default value can be provided.
 
 There are 3 cases:
-1. The configuration variable exists, it is not `None`
+1. The configuration variable exists, it isn't `None`
 1. The configuration variable exists, it is `None`
 1. The configuration variable does not exist
 

--- a/website/docs/reference/dbt-jinja-functions/config.md
+++ b/website/docs/reference/dbt-jinja-functions/config.md
@@ -34,13 +34,21 @@ __Args__:
 
 The `config.get` function is used to get configurations for a model from the end-user. Configs defined in this way are optional, and a default value can be provided.
 
+There are 3 cases:
+1. The configuration variable exists, it is it not `None`
+1. The configuration variable exists, it it is `None`
+1. The configuration variable does not exist
+
 Example usage:
 ```sql
 {% materialization incremental, default -%}
   -- Example w/ no default. unique_key will be None if the user does not provide this configuration
   {%- set unique_key = config.get('unique_key') -%}
 
-  -- Example w/ default value. Default to 'id' if 'unique_key' not provided
+  -- Example w/ alternate value. Use alternative of 'id' if 'unique_key' config is provided, but it is None
+  {%- set unique_key = config.get('unique_key') or 'id' -%}
+
+  -- Example w/ default value. Default to 'id' if the 'unique_key' config does not exist
   {%- set unique_key = config.get('unique_key', default='id') -%}
   ...
 ```

--- a/website/docs/reference/dbt-jinja-functions/config.md
+++ b/website/docs/reference/dbt-jinja-functions/config.md
@@ -37,7 +37,7 @@ The `config.get` function is used to get configurations for a model from the end
 There are 3 cases:
 1. The configuration variable exists, it isn't `None`
 1. The configuration variable exists, it is `None`
-1. The configuration variable does not exist
+1. The configuration variable doesn't exist
 
 Example usage:
 ```sql

--- a/website/docs/reference/dbt-jinja-functions/config.md
+++ b/website/docs/reference/dbt-jinja-functions/config.md
@@ -37,7 +37,7 @@ The `config.get` function is used to get configurations for a model from the end
 There are 3 cases:
 1. The configuration variable exists, it is not `None`
 1. The configuration variable exists, it is `None`
-1. The configuration variable doesn't exist
+1. The configuration variable does not exist
 
 Example usage:
 ```sql


### PR DESCRIPTION
resolves https://github.com/dbt-labs/docs.getdbt.com/issues/3969

## What are you changing in this pull request and why?

Details in https://github.com/dbt-labs/docs.getdbt.com/issues/3969

#### TLDR

The key insight is that many people expect `config.get("foo", default="bar")` to act like [`coalesce`](https://docs.snowflake.com/en/sql-reference/functions/coalesce) in SQL, but it does **not**.

There are cases where users will want to use an alternative value whenever `config.get("something")` is `None` (similar to `coalesce` in SQL). This PR documents how to do that.

## Checklist
- [x] I have reviewed the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-dbeatty10-patch-2-dbt-labs.vercel.app/reference/dbt-jinja-functions/config

<!-- end-vercel-deployment-preview -->