### PR TITLE
add gitlab webhook faq

### DIFF
--- a/website/docs/docs/cloud/git/connect-gitlab.md
+++ b/website/docs/docs/cloud/git/connect-gitlab.md
@@ -115,7 +115,7 @@ If your GitLab account is not connected, you’ll see "No connected account". Se
 
 Once you approve authorization, you will be redirected to dbt Cloud, and you should see your connected account. You're now ready to start developing in the dbt Cloud IDE or dbt Cloud CLI.
 
-## FAQs
+## Troubleshooting
 
 <FAQ path="Troubleshooting/gitlab-webhook"/>
 <FAQ path="Troubleshooting/error-importing-repo"/>

--- a/website/docs/docs/cloud/git/connect-gitlab.md
+++ b/website/docs/docs/cloud/git/connect-gitlab.md
@@ -10,6 +10,7 @@ Connecting your GitLab account to dbt Cloud provides convenience and another lay
 - Clone repos using HTTPS rather than SSH.
 - Carry GitLab user permissions through to dbt Cloud or dbt Cloud CLI's git actions.
 - Trigger [Continuous integration](/docs/deploy/continuous-integration) builds when merge requests are opened in GitLab.
+  - GitLab automatically registers a webhook in your GitLab repository to enable seamless integration with dbt Cloud.
 
 The steps to integrate GitLab in dbt Cloud depend on your plan. If you are on:
 - the Developer or Team plan, read these [instructions](#for-dbt-cloud-developer-and-team-tiers).
@@ -114,20 +115,10 @@ If your GitLab account is not connected, you’ll see "No connected account". Se
 
 Once you approve authorization, you will be redirected to dbt Cloud, and you should see your connected account. You're now ready to start developing in the dbt Cloud IDE or dbt Cloud CLI.
 
-
-## Troubleshooting
-
-### Errors when importing a repository on dbt Cloud project set up
-If you do not see your repository listed, double-check that:
-- Your repository is in a Gitlab group you have access to. dbt Cloud will not read repos associated with a user.
-
-If you do see your repository listed, but are unable to import the repository successfully, double-check that:
-- You are a maintainer of that repository. Only users with maintainer permissions can set up repository connections.
-
-If you imported a repository using the dbt Cloud native integration with GitLab, you should be able to see the clone strategy is using a `deploy_token`. If it's relying on an SSH key, this means the repository was not set up using the native GitLab integration, but rather using the generic git clone option. The repository must be reconnected in order to get the benefits described above.
-
 ## FAQs
 
+<FAQ path="Troubleshooting/gitlab-webhook"/>
+<FAQ path="Troubleshooting/error-importing-repo"/>
 <FAQ path="Git/gitignore"/>
 <FAQ path="Git/gitlab-authentication"/>
 <FAQ path="Git/gitlab-selfhosted"/>

--- a/website/docs/docs/deploy/ci-jobs.md
+++ b/website/docs/docs/deploy/ci-jobs.md
@@ -188,6 +188,8 @@ To validate _all_ semantic nodes in your project, add the following command to d
 
 ## Troubleshooting
 
+<FAQ path="Troubleshooting/gitlab-webhook"/>
+
 <DetailsToggle alt_header="Temporary schemas aren't dropping">
 If your temporary schemas aren't dropping after a PR merges or closes, this typically indicates one of these issues:
 - You have overridden the <code>generate_schema_name</code> macro and it isn't using <code>dbt_cloud_pr_</code> as the prefix.
@@ -200,6 +202,7 @@ To resolve this, change your macro so that the temporary PR schema name contains
 A macro is creating a schema but there are no dbt models writing to that schema. dbt Cloud doesn't drop temporary schemas that weren't written to as a result of running a dbt model.
 
 </DetailsToggle>
+
 
 <DetailsToggle alt_header="Error messages that refer to schemas from previous PRs">
 

--- a/website/docs/faqs/Troubleshooting/error-importing-repo.md
+++ b/website/docs/faqs/Troubleshooting/error-importing-repo.md
@@ -11,4 +11,4 @@ If you don't see your repository listed, double-check that:
 If you do see your repository listed, but are unable to import the repository successfully, double-check that:
 - You are a maintainer of that repository. Only users with maintainer permissions can set up repository connections.
 
-If you imported a repository using the dbt Cloud native integration with GitLab, you should be able to see the clone strategy is using a `deploy_token`. If it's relying on an SSH key, this means the repository was not set up using the native GitLab integration, but rather using the generic git clone option. The repository must be reconnected in order to get the benefits described above.
+If you imported a repository using the dbt Cloud native integration with GitLab, you should be able to see if the clone strategy is using a `deploy_token`. If it's relying on an SSH key, this means the repository was not set up using the native GitLab integration, but rather using the generic git clone option. The repository must be reconnected in order to get the benefits described above.

--- a/website/docs/faqs/Troubleshooting/error-importing-repo.md
+++ b/website/docs/faqs/Troubleshooting/error-importing-repo.md
@@ -1,0 +1,14 @@
+---
+title: Errors importing a repository on dbt Cloud project set up
+description: "Errors importing a repository on dbt Cloud project set up"
+sidebar_label: 'Errors importing a repository on dbt Cloud project set up'
+id: error-importing-repo
+---
+
+If you don't see your repository listed, double-check that:
+- Your repository is in a Gitlab group you have access to. dbt Cloud will not read repos associated with a user.
+
+If you do see your repository listed, but are unable to import the repository successfully, double-check that:
+- You are a maintainer of that repository. Only users with maintainer permissions can set up repository connections.
+
+If you imported a repository using the dbt Cloud native integration with GitLab, you should be able to see the clone strategy is using a `deploy_token`. If it's relying on an SSH key, this means the repository was not set up using the native GitLab integration, but rather using the generic git clone option. The repository must be reconnected in order to get the benefits described above.

--- a/website/docs/faqs/Troubleshooting/gitlab-webhook.md
+++ b/website/docs/faqs/Troubleshooting/gitlab-webhook.md
@@ -1,0 +1,19 @@
+---
+title: Unable to trigger a CI job with GitLab
+description: "Unable to trigger a CI job"
+sidebar_label: 'Unable to trigger a CI job'
+id: gitlab-webhook
+---
+
+When you connect dbt Cloud to a GitLab repository, GitLab automatically registers a webhook in the background, viewable under the repository settings. This webhook is also used to trigger [CI jobs](/docs/deploy/ci-jobs) when you push to the repository.
+
+If you're unable to trigger a CI job, this usually indicates that the webhook registration is missing or incorrect.
+
+To resolve this issue, navigate to the repository settings in GitLab and view webhook registrations by navigating to GitLab --> **Settings** --> **Webhooks**.
+
+Some things to check:
+
+- The webhook registration is enabled in GitLab. 
+- The webhook registration is configured with the correct URL and secret.
+
+If you're still experiencing this issue, reach out to the Support team at support@getdbt.com and we'll be happy to help!

--- a/website/docs/faqs/Troubleshooting/gitlab-webhook.md
+++ b/website/docs/faqs/Troubleshooting/gitlab-webhook.md
@@ -9,7 +9,7 @@ When you connect dbt Cloud to a GitLab repository, GitLab automatically register
 
 If you're unable to trigger a CI job, this usually indicates that the webhook registration is missing or incorrect.
 
-To resolve this issue, navigate to the repository settings in GitLab and view webhook registrations by navigating to GitLab --> **Settings** --> **Webhooks**.
+To resolve this issue, navigate to the repository settings in GitLab and view the webhook registrations by navigating to GitLab --> **Settings** --> **Webhooks**.
 
 Some things to check:
 


### PR DESCRIPTION
this PR adds the following:

- new faq page explaining that a webhook is auto-registered when connect dbt cloud to gitlab. helps with troubleshooting if user can't trigger ci job. 
- new faq page to consolidate ['troubleshooting'](https://docs.getdbt.com/docs/cloud/git/connect-gitlab#troubleshooting) and faq' section in the gitlab set up doc. 
- turned troubleshooting content into faq and removed 'troubleshooting' header.

![Screenshot 2024-12-10 at 11 42 59](https://github.com/user-attachments/assets/221acd12-4de0-4e60-b379-335c77d1440f)

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-add-gitlab-webhook-info-dbt-labs.vercel.app/docs/cloud/git/connect-gitlab
- https://docs-getdbt-com-git-add-gitlab-webhook-info-dbt-labs.vercel.app/docs/deploy/ci-jobs
- https://docs-getdbt-com-git-add-gitlab-webhook-info-dbt-labs.vercel.app/faqs/Troubleshooting/error-importing-repo
- https://docs-getdbt-com-git-add-gitlab-webhook-info-dbt-labs.vercel.app/faqs/Troubleshooting/gitlab-webhook

<!-- end-vercel-deployment-preview -->