### PR TITLE
add supported examples for alias

### DIFF
--- a/website/docs/reference/resource-configs/alias.md
+++ b/website/docs/reference/resource-configs/alias.md
@@ -191,7 +191,7 @@ In `tests/unique_order_id_test.sql` file:
 
 When using [`store_failures_as`](/reference/resource-configs/store_failures_as), this would return the name `analytics.finance.orders_order_id_unique_order_id_test` in the database.
 
-</File>
+
 </TabItem>
 </Tabs>
 

--- a/website/docs/reference/resource-configs/alias.md
+++ b/website/docs/reference/resource-configs/alias.md
@@ -8,9 +8,11 @@ datatype: string
 <Tabs>
 <TabItem value="model" label="Models">
 
-Specify a custom alias for a model in your `dbt_project.yml` file or config block. 
+Specify a custom alias for a model in your `dbt_project.yml` file, `models/properties.yml` file, or config block in a SQL file. 
 
-For example, if you have a model that calculates `sales_total` and want to give it a more user-friendly alias, you can alias it like this:
+For example, if you have a model that calculates `sales_total` and want to give it a more user-friendly alias, you can alias it as shown in the following examples.
+
+In the `dbt_project.yml` file, the following example sets a default `alias` for the `sales_total` model at the project level:
 
 <File name='dbt_project.yml'>
 
@@ -22,16 +24,40 @@ models:
 ```
 </File>
 
+In the `models/properties.yml` file, the following specifies an `alias` as part of the model's metadata, useful for centralized configuration:
+
+<File name='models/properties.yml'>
+
+```yml
+version: 2
+
+models:
+  - name: sales_total
+    config:
+      alias: sales_dashboard
+```
+</File>
+
+In `models/sales_total.sql` file, the following assigns the `alias` directly in the model file:
+
+<File name='models/sales_total.sql'>
+
+```sql
+{{ config(
+    alias="sales_dashboard"
+) }}
+```
+</File>
+
 This would return `analytics.finance.sales_dashboard` in the database, instead of the default `analytics.finance.sales_total`.
 
 </TabItem>
 
 <TabItem value="seeds" label="Seeds">
 
+Configure a seed's alias in your `dbt_project.yml` file or a `properties.yml` file. The following examples demonstrate how to `alias` a seed named `product_categories` to `categories_data`.
 
-Configure a seed's alias in your `dbt_project.yml` file or config block. 
-
-For example, if you have a seed that represents `product_categories` and want to alias it as `categories_data`, you would alias like this:
+In the `dbt_project.yml` file at the project level:
 
 <File name='dbt_project.yml'>
 
@@ -41,6 +67,21 @@ seeds:
     product_categories:
       +alias: categories_data
 ```
+</File>
+
+In the `seeds/properties.yml` file:
+
+<File name='seeds/properties.yml'>
+
+```yml
+version: 2
+
+seeds:
+  - name: product_categories
+    config:
+      alias: categories_data
+```
+</File>
 
 This would return the name `analytics.finance.categories_data` in the database.
 
@@ -65,7 +106,9 @@ seeds:
 
 Configure a snapshots's alias in your `dbt_project.yml` file or config block. 
 
-For example, if you have a snapshot that is named `your_snapshot` and want to alias it as `the_best_snapshot`, you would alias like this:
+The following examples demonstrate how to `alias` a snapshot named `your_snapshot` to `the_best_snapshot`.
+
+In the `dbt_project.yml` file at the project level:
 
 <File name='dbt_project.yml'>
 
@@ -75,20 +118,57 @@ snapshots:
     your_snapshot:
       +alias: the_best_snapshot
 ```
+</File>
+
+In the `snapshots/properties.yml` file:
+
+<File name='snapshots/properties.yml'>
+
+```yml
+version: 2
+
+snapshots:
+  - name: your_snapshot
+    config:
+      alias: the_best_snapshot
+```
+</File>
+
+In `snapshots/your_snapshot.sql` file:
+
+<File name='snapshots/your_snapshot.sql'>
+
+```sql
+{{ config(
+    alias="the_best_snapshot"
+) }}
+```
+</File>
 
 This would build your snapshot to `analytics.finance.the_best_snapshot` in the database.
-
-</File>
 
 </TabItem>
 
 <TabItem value="test" label="Tests">
 
-Configure a test's alias in your `schema.yml` file or config block. 
+Configure a data test's alias in your `dbt_project.yml` file, `properties.yml` file, or config block in the model file. 
 
-For example, to add a unique test to the `order_id` column and give it an alias `unique_order_id_test` to identify this specific test, you would alias like this:
+The following examples demonstrate how to `alias` a unique data test named `order_id` to `unique_order_id_test` to identify a specific data test.
 
-<File name='schema.yml'>
+In the `dbt_project.yml` file at the project level:
+
+<File name='dbt_project.yml'>
+
+```yml
+tests:
+  your_project:
+    +alias: unique_order_id_test
+```
+</File>
+
+In the `models/properties.yml` file:
+
+<File name='models/properties.yml'>
 
 ```yml
 models:
@@ -99,6 +179,18 @@ models:
           - unique:
               alias: unique_order_id_test
 ```
+</File>
+
+In `tests/unique_order_id_test.sql` file:
+
+<File name='tests/unique_order_id_test.sql'>
+
+```sql
+{{ config(
+    alias="unique_order_id_test",
+    severity="error",
+```
+</File>
 
 When using [`store_failures_as`](/reference/resource-configs/store_failures_as), this would return the name `analytics.finance.orders_order_id_unique_order_id_test` in the database.
 

--- a/website/docs/reference/resource-configs/alias.md
+++ b/website/docs/reference/resource-configs/alias.md
@@ -96,9 +96,6 @@ seeds:
       +alias: country_mappings
 
 ```
-
-</File>
-
 </File>
 </TabItem>
 

--- a/website/docs/reference/resource-configs/alias.md
+++ b/website/docs/reference/resource-configs/alias.md
@@ -24,7 +24,7 @@ models:
 ```
 </File>
 
-In the `models/properties.yml` file, the following specifies an `alias` as part of the model's metadata, useful for centralized configuration:
+The following specifies an `alias` as part of the `models/properties.yml` file metadata, useful for centralized configuration:
 
 <File name='models/properties.yml'>
 

--- a/website/docs/reference/resource-configs/alias.md
+++ b/website/docs/reference/resource-configs/alias.md
@@ -38,7 +38,7 @@ models:
 ```
 </File>
 
-In `models/sales_total.sql` file, the following assigns the `alias` directly in the model file:
+The following assigns the `alias` directly in the In `models/sales_total.sql` file:
 
 <File name='models/sales_total.sql'>
 


### PR DESCRIPTION
this pr adds additional examples for the `alias` config for the supported resources. missing examples were for dbt_projct.yml, properties.yml, and sql config block (depending on the resource)

Resolves #6512

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-mirnawong1-patch-26-dbt-labs.vercel.app/best-practices/how-we-style/5-how-we-style-our-yaml
- https://docs-getdbt-com-git-mirnawong1-patch-26-dbt-labs.vercel.app/docs/core/connect-data-platform/dremio-setup
- https://docs-getdbt-com-git-mirnawong1-patch-26-dbt-labs.vercel.app/reference/resource-configs/alias

<!-- end-vercel-deployment-preview -->