### PR TITLE
Models with introspective queries can not be unit tested

### DIFF
--- a/website/docs/docs/build/unit-tests.md
+++ b/website/docs/docs/build/unit-tests.md
@@ -24,6 +24,7 @@ Starting in dbt Core v1.8, we have introduced an additional type of test to dbt 
 - We currently only support adding unit tests to models in your _current_ project.
 - We currently _don't_ support unit testing models that use the [`materialized view`](/docs/build/materializations#materialized-view) materialization.
 - We currently _don't_ support unit testing models that use recursive SQL.
+- We currently _don't_ support unit testing models that use introspective queries.
 - If your model has multiple versions, by default the unit test will run on *all* versions of your model. Read [unit testing versioned models](/reference/resource-properties/unit-testing-versions) for more information.
 - Unit tests must be defined in a YML file in your [`models/` directory](/reference/project-configs/model-paths).
 - Table names must be aliased in order to unit test `join` logic.


### PR DESCRIPTION
## What are you changing in this pull request and why?

There's been multiple times where people have tried adding unit tests to models that use introspective queries on the given inputs (e.g. [dbt-core#10759](https://github.com/dbt-labs/dbt-core/issues/10759), [dbt-core#11121](https://github.com/dbt-labs/dbt-core/issues/11121)).

It is a known limitation that this will not work unless something like [dbt-core#8499](https://github.com/dbt-labs/dbt-core/issues/8499) is implemented.

In the meantime, we should document this limitation.

## Checklist
- [x] I have reviewed the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/docs/build/unit-tests

<!-- end-vercel-deployment-preview -->