### PR TITLE
Rephrase the two criteria for resolving `ref` calls with the `--defer` flag

### DIFF
--- a/website/docs/reference/node-selection/defer.md
+++ b/website/docs/reference/node-selection/defer.md
@@ -29,11 +29,12 @@ dbt test --models [...] --defer --state path/to/artifacts
 
 </VersionBlock>
 
-When the `--defer` flag is provided, dbt will resolve `ref` calls differently depending on two criteria:
-1. Is the referenced node included in the model selection criteria of the current run?
-2. Does the referenced node exist as a database object in the current environment?
+By default, dbt uses the [`target`](/reference/dbt-jinja-functions/target) namespace to resolve `ref` calls.
 
-If the answer to both is **no**—a node is not included _and_ it does not exist as a database object in the current environment—references to it will use the other namespace instead, provided by the state manifest.
+But with `--defer`, dbt will use the state manifest instead if the following criteria are met:
+
+1. The node isn’t in the selected nodes **and**
+2. It doesn’t exist in the database (or `--favor-state` is used).
 
 Ephemeral models are never deferred, since they serve as "passthroughs" for other `ref` calls.
 
@@ -46,7 +47,7 @@ Deferral requires both `--defer` and `--state` to be set, either by passing flag
 
 #### Favor state
 
-You can optionally skip the second criterion by passing the `--favor-state` flag. If passed, dbt will favor using the node defined in your `--state` namespace, even if the node exists in the current target.
+You can optionally skip the second criterion by passing the `--favor-state` flag. If passed, dbt will favor using the node defined in your `--state` namespace, even if the node exists in the current target. Selected nodes will still resolve via the `target` namespace, regardless of the `--favor-state` flag.
 
 ### Example
 

--- a/website/docs/reference/node-selection/defer.md
+++ b/website/docs/reference/node-selection/defer.md
@@ -47,7 +47,7 @@ Deferral requires both `--defer` and `--state` to be set, either by passing flag
 
 #### Favor state
 
-If `--favor-state` is passed, dbt will favor the node definition from the `--state` directory, _unless_ that node is also included among the selected nodes.
+When `--favor-state` is passed, dbt prioritizes node definitions from the `--state directory`. However, this doesn’t apply if the node is also part of the selected nodes.
 
 ### Example
 

--- a/website/docs/reference/node-selection/defer.md
+++ b/website/docs/reference/node-selection/defer.md
@@ -47,7 +47,7 @@ Deferral requires both `--defer` and `--state` to be set, either by passing flag
 
 #### Favor state
 
-You can optionally skip the second criterion by passing the `--favor-state` flag. If passed, dbt will favor using the node defined in your `--state` namespace, even if the node exists in the current target. Selected nodes will still resolve via the `target` namespace, regardless of the `--favor-state` flag.
+If `--favor-state` is passed, dbt will favor the node definition from the `--state` directory, _unless_ that node is also included among the selected nodes.
 
 ### Example
 

--- a/website/docs/reference/node-selection/defer.md
+++ b/website/docs/reference/node-selection/defer.md
@@ -31,7 +31,7 @@ dbt test --models [...] --defer --state path/to/artifacts
 
 By default, dbt uses the [`target`](/reference/dbt-jinja-functions/target) namespace to resolve `ref` calls.
 
-But with `--defer`, dbt will use the state manifest instead if the following criteria are met:
+When `--defer` is enabled, dbt resolves ref calls using the state manifest instead, but only if:
 
 1. The node isn’t in the selected nodes **and**
 2. It doesn’t exist in the database (or `--favor-state` is used).

--- a/website/docs/reference/node-selection/defer.md
+++ b/website/docs/reference/node-selection/defer.md
@@ -33,7 +33,7 @@ By default, dbt uses the [`target`](/reference/dbt-jinja-functions/target) names
 
 When `--defer` is enabled, dbt resolves ref calls using the state manifest instead, but only if:
 
-1. The node isn’t in the selected nodes **and**
+1. The node isn’t among the selected nodes, _and_
 2. It doesn’t exist in the database (or `--favor-state` is used).
 
 Ephemeral models are never deferred, since they serve as "passthroughs" for other `ref` calls.


### PR DESCRIPTION
resolves #6332

## What are you changing in this pull request and why?

There's a **ton** more detail in #6332, but the TLDR is:
- `--defer`, `--state`, and `--favor-state` are tricky, so we want to make it as easy to understand as possible.

### 🎩
 
The proposed text is as follows:

> ### Usage
> 
> By default, dbt uses the [`target`](/reference/dbt-jinja-functions/target) namespace to resolve `ref` calls.
> 
> But with `--defer`, dbt will use the state manifest instead if the following criteria are met:
> 
> 1. The node isn’t in the selected nodes **and**
> 2. It doesn’t exist in the database (or `--favor-state` is used).
> 
> #### Favor state
> 
> If `--favor-state` is passed, dbt will favor the node definition from the `--state` directory, _unless_ that node is also included among the selected nodes.
> 

## Checklist
- [x] I have reviewed the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/reference/node-selection/defer

<!-- end-vercel-deployment-preview -->