### PR TITLE
`dbt retry` will only work if dbt can parse the project and generate a manifest

### DIFF
--- a/website/docs/docs/deploy/retry-jobs.md
+++ b/website/docs/docs/deploy/retry-jobs.md
@@ -10,6 +10,7 @@ If your dbt job run completed with a status of **Error**, you can rerun it from 
 
 - You have a [dbt Cloud account](https://www.getdbt.com/signup).
 - You must be using [dbt version](/docs/dbt-versions/upgrade-dbt-version-in-cloud) 1.6 or newer.
+- dbt can successfully parse the project and generate a [manifest](/reference/artifacts/manifest-json)
 - The most recent run of the job hasn't completed successfully. The latest status of the run is **Error**.
     - The job command that failed in the run must be one that supports the [retry command](/reference/commands/retry).
 


### PR DESCRIPTION
resolves #5964

## What are you changing in this pull request and why?

Per https://github.com/dbt-labs/dbt-core/issues/10590#issuecomment-2305390153, `dbt retry` will only work if dbt can successfully parse the project and generate a [manifest](https://docs.getdbt.com/reference/artifacts/manifest-json) (i.e., a `dbt parse` should indicate if a project can be `dbt retry`'d or not).

## Checklist
- [x] I have reviewed the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-dbeatty10-patch-2-dbt-labs.vercel.app/docs/deploy/retry-jobs

<!-- end-vercel-deployment-preview -->