### PR TITLE
Update Compatible release track

### DIFF
--- a/website/dbt-versions.js
+++ b/website/dbt-versions.js
@@ -20,6 +20,7 @@ exports.versions = [
   },
   {
     version: "1.9",
+    customDisplay: "1.9 (Compatible)",
     EOLDate: "2025-12-08",
   },
   {

--- a/website/docs/docs/dbt-versions/cloud-release-tracks.md
+++ b/website/docs/docs/dbt-versions/cloud-release-tracks.md
@@ -16,9 +16,9 @@ By moving your environments and jobs to release tracks you can get all the funct
 
 | Release track | Description | Plan Availability | API Value |
 | ------------- | ----------- | ----------------- | --------- |
-| **Latest** `<Lifecycle status="GA"/>` |  (Formerly called "Versionless") Provides a continuous release of the latest functionality in dbt Cloud, and includes early access to new features of the dbt framework before they're available in open source releases of dbt Core | All plans | `latest` (or `versionless`) |
-| **Compatible** `<Lifecycle status="preview"/>`  | Provides a monthly release aligned with the most recent open source versions of dbt Core and adapters, plus functionality exclusively available in dbt Cloud |  Team + Enterprise | `compatible` |
-| **Extended** `<Lifecycle status="preview"/>` | The previous month's "Compatible" release | Enterprise | `extended` |
+| **Latest** <Lifecycle status="GA"/> |  (Formerly called "Versionless") Provides a continuous release of the latest functionality in dbt Cloud, and includes early access to new features of the dbt framework before they're available in open source releases of dbt Core | All plans | `latest` (or `versionless`) |
+| **Compatible** <Lifecycle status="preview"/>  | Provides a monthly release aligned with the most recent open source versions of dbt Core and adapters, plus functionality exclusively available in dbt Cloud |  Team + Enterprise | `compatible` |
+| **Extended** <Lifecycle status="preview"/> | The previous month's "Compatible" release | Enterprise | `extended` |
 
 The first "Compatible" release was on December 12, 2024, after the final release of dbt Core v1.9.0. For December 2024 only, the "Extended" release is the same as "Compatible." Starting in January 2025, "Extended" will be one month behind "Compatible."
 

--- a/website/docs/docs/dbt-versions/cloud-release-tracks.md
+++ b/website/docs/docs/dbt-versions/cloud-release-tracks.md
@@ -15,10 +15,10 @@ By moving your environments and jobs to release tracks you can get all the funct
 ## Which release tracks are available?
 
 - **"Latest"** (available to all plans, formerly called "Versionless"): Provides a continuous release of the latest functionality in dbt Cloud. Includes early access to new features of the dbt framework before they're available in open source releases of dbt Core.
-- <Lifecycle status="coming soon"/> **"Compatible"** (available to Team + Enterprise): Provides a monthly release aligned with the most recent open source versions of dbt Core and adapters, plus functionality exclusively available in dbt Cloud.
-- <Lifecycle status="coming soon"/> **"Extended"** (available to Enterprise): Provides a delayed release of the previous month's "Compatible" release.
+- <Lifecycle status="preview"/> **"Compatible"** (available to Team + Enterprise): Provides a monthly release aligned with the most recent open source versions of dbt Core and adapters, plus functionality exclusively available in dbt Cloud.
+- <Lifecycle status="preview"/> **"Extended"** (available to Enterprise): The previous month's "Compatible" release.
 
-The first "Compatible" release will be in December 2024, after the final release of dbt Core v1.9.0. For December 2024 only, the "Extended" release is the same as "Compatible." Starting in January 2025, "Extended" will be one month behind "Compatible."
+The first "Compatible" release was on December 12, 2024, after the final release of dbt Core v1.9.0. For December 2024 only, the "Extended" release is the same as "Compatible." Starting in January 2025, "Extended" will be one month behind "Compatible."
 
 To configure an environment in the [dbt Cloud Admin API](/docs/dbt-cloud-apis/admin-cloud-api) or [Terraform](https://registry.terraform.io/providers/dbt-labs/dbtcloud/latest) to use a release track, set `dbt_version` to the release track name:
 - `latest` (formerly called `versionless`; the old name is still supported)
@@ -69,7 +69,7 @@ To learn more about how dbt Labs deploys stable dbt upgrades in a safe manner to
 
 If you're running dbt version 1.6 or older, please know that your version of dbt Core has reached [end-of-life (EOL)](/docs/dbt-versions/core#eol-version-support) and is no longer supported. We strongly recommend that you update to a newer version as soon as reasonably possible.
 
-dbt Labs has extended the critical support period of dbt Core v1.7 for dbt Cloud Enterprise customers to January 31, 2024. At that point, we will be asking all customers to select a Release Track for receiving ongoing updates to dbt in dbt Cloud.
+dbt Labs has extended the critical support period of dbt Core v1.7 for dbt Cloud Enterprise customers to March 2025. At that point, we will be encouraging all customers to select a Release Track for receiving ongoing updates to dbt in dbt Cloud.
 
 <Expandable alt_header="I'm using an older version of dbt in dbt Cloud. What should I do? What happens if I do nothing?" >
 
@@ -77,9 +77,7 @@ If you're running dbt version v1.6 or older, please know that your version of db
 
 dbt Labs has extended the "Critical Support" period of dbt Core v1.7 for dbt Cloud Enterprise customers while we work through the migration with those customers to Release Tracks. In the meantime, this means that v1.7 will continue to be accessible in dbt Cloud for Enteprise customers, jobs and environments on v1.7 for those customers will not be automatically migrated to "Latest," and dbt Labs will continue to fix critical bugs and security issues.
 
-dbt Cloud accounts on the Developer and Team plans will be migrated to the "Latest" release track after November 1, 2024. If you know that your project will not be compatible with the upgrade, for one of the reasons described here, or a different reason in your own testing, you should [contact dbt Cloud support](https://docs.getdbt.com/docs/dbt-support#dbt-cloud-support) to request an extension.
-
-If your account has been migrated to the "Latest" release track, and you are seeing net-new failures in your scheduled dbt jobs, you should also [contact dbt Cloud support](https://docs.getdbt.com/docs/dbt-support#dbt-cloud-support) to request an extension.
+Starting in October 2024, dbt Cloud accounts on the Developer and Team plans have been migrated off very old dbt Core versions and onto release tracks. If your account has been migrated to the "Latest" release track, and you are seeing net-new failures in your scheduled dbt jobs, please [contact dbt Cloud support](https://docs.getdbt.com/docs/dbt-support#dbt-cloud-support) to report the problem or request an extension.
 
 </Expandable>
 
@@ -134,7 +132,7 @@ In 2024, we've changed the way that new dbt functionality is made available for 
 
 Opting into a release cadence with automated upgrades is required for accessing any new functionality that we've released in 2024, and going forward.
 
-We continue to release new minor versions of dbt Core (OSS), including v1.9 which will be available later this year. When we do, it will be a subset of the functionality that's already available to dbt Cloud customers, and always after the functionality has been available in dbt Cloud.
+We continue to release new minor versions of dbt Core (OSS). We most recently released dbt Core v1.9 on December 9, 2024. These releases always include a subset of the functionality that's already available to dbt Cloud customers, and always after the functionality has been available in dbt Cloud.
 
 </Expandable>
 

--- a/website/docs/docs/dbt-versions/cloud-release-tracks.md
+++ b/website/docs/docs/dbt-versions/cloud-release-tracks.md
@@ -16,7 +16,7 @@ By moving your environments and jobs to release tracks you can get all the funct
 
 | Release track | Description | Plan availability | API value |
 | ------------- | ----------- | ----------------- | --------- |
-| **Latest** <br /> <Lifecycle status="GA"/> |  Formerly called "Versionless", provides a continuous release of the latest functionality in dbt Cloud, and includes early access to new features of the dbt framework before they're available in open source releases of dbt Core. | All plans | `latest` (or `versionless`) |
+| **Latest** <br /> <Lifecycle status="GA"/> |  Formerly called "Versionless", provides a continuous release of the latest functionality in dbt Cloud. Includes early access to new features of the dbt framework before they're available in open source releases of dbt Core. | All plans | `latest` (or `versionless`) |
 | **Compatible** <Lifecycle status="preview"/>  | Provides a monthly release aligned with the most recent open source versions of dbt Core and adapters, plus functionality exclusively available in dbt Cloud. |  Team + Enterprise | `compatible` |
 | **Extended** <Lifecycle status="preview"/> | The previous month's "Compatible" release. | Enterprise | `extended` |
 

--- a/website/docs/docs/dbt-versions/cloud-release-tracks.md
+++ b/website/docs/docs/dbt-versions/cloud-release-tracks.md
@@ -16,9 +16,9 @@ By moving your environments and jobs to release tracks you can get all the funct
 
 | Release track | Description | Plan availability | API value |
 | ------------- | ----------- | ----------------- | --------- |
-| **Latest** <br /> <Lifecycle status="GA"/> |  (Formerly called "Versionless") Provides a continuous release of the latest functionality in dbt Cloud, and includes early access to new features of the dbt framework before they're available in open source releases of dbt Core | All plans | `latest` (or `versionless`) |
-| **Compatible** <Lifecycle status="preview"/>  | Provides a monthly release aligned with the most recent open source versions of dbt Core and adapters, plus functionality exclusively available in dbt Cloud |  Team + Enterprise | `compatible` |
-| **Extended** <Lifecycle status="preview"/> | The previous month's "Compatible" release | Enterprise | `extended` |
+| **Latest** <br /> <Lifecycle status="GA"/> |  Formerly called "Versionless", provides a continuous release of the latest functionality in dbt Cloud, and includes early access to new features of the dbt framework before they're available in open source releases of dbt Core. | All plans | `latest` (or `versionless`) |
+| **Compatible** <Lifecycle status="preview"/>  | Provides a monthly release aligned with the most recent open source versions of dbt Core and adapters, plus functionality exclusively available in dbt Cloud. |  Team + Enterprise | `compatible` |
+| **Extended** <Lifecycle status="preview"/> | The previous month's "Compatible" release. | Enterprise | `extended` |
 
 The first "Compatible" release was on December 12, 2024, after the final release of dbt Core v1.9.0. For December 2024 only, the "Extended" release is the same as "Compatible." Starting in January 2025, "Extended" will be one month behind "Compatible."
 

--- a/website/docs/docs/dbt-versions/cloud-release-tracks.md
+++ b/website/docs/docs/dbt-versions/cloud-release-tracks.md
@@ -16,7 +16,7 @@ By moving your environments and jobs to release tracks you can get all the funct
 
 | Release track | Description | Plan availability | API value |
 | ------------- | ----------- | ----------------- | --------- |
-| **Latest** <Lifecycle status="GA"/> |  (Formerly called "Versionless") Provides a continuous release of the latest functionality in dbt Cloud, and includes early access to new features of the dbt framework before they're available in open source releases of dbt Core | All plans | `latest` (or `versionless`) |
+| **Latest** <br /> <Lifecycle status="GA"/> |  (Formerly called "Versionless") Provides a continuous release of the latest functionality in dbt Cloud, and includes early access to new features of the dbt framework before they're available in open source releases of dbt Core | All plans | `latest` (or `versionless`) |
 | **Compatible** <Lifecycle status="preview"/>  | Provides a monthly release aligned with the most recent open source versions of dbt Core and adapters, plus functionality exclusively available in dbt Cloud |  Team + Enterprise | `compatible` |
 | **Extended** <Lifecycle status="preview"/> | The previous month's "Compatible" release | Enterprise | `extended` |
 

--- a/website/docs/docs/dbt-versions/cloud-release-tracks.md
+++ b/website/docs/docs/dbt-versions/cloud-release-tracks.md
@@ -14,7 +14,7 @@ By moving your environments and jobs to release tracks you can get all the funct
 
 ## Which release tracks are available?
 
-| Release track | Description | Plan Availability | API Value |
+| Release track | Description | Plan availability | API value |
 | ------------- | ----------- | ----------------- | --------- |
 | **Latest** <Lifecycle status="GA"/> |  (Formerly called "Versionless") Provides a continuous release of the latest functionality in dbt Cloud, and includes early access to new features of the dbt framework before they're available in open source releases of dbt Core | All plans | `latest` (or `versionless`) |
 | **Compatible** <Lifecycle status="preview"/>  | Provides a monthly release aligned with the most recent open source versions of dbt Core and adapters, plus functionality exclusively available in dbt Cloud |  Team + Enterprise | `compatible` |

--- a/website/docs/docs/dbt-versions/cloud-release-tracks.md
+++ b/website/docs/docs/dbt-versions/cloud-release-tracks.md
@@ -69,7 +69,7 @@ To learn more about how dbt Labs deploys stable dbt upgrades in a safe manner to
 
 If you're running dbt version 1.6 or older, please know that your version of dbt Core has reached [end-of-life (EOL)](/docs/dbt-versions/core#eol-version-support) and is no longer supported. We strongly recommend that you update to a newer version as soon as reasonably possible.
 
-dbt Labs has extended the critical support period of dbt Core v1.7 for dbt Cloud Enterprise customers to March 2025. At that point, we will be encouraging all customers to select a Release Track for receiving ongoing updates to dbt in dbt Cloud.
+dbt Labs has extended the critical support period of dbt Core v1.7 for dbt Cloud Enterprise customers to March 2025. At that point, we will be encouraging all customers to select a Release Track for ongoing updates in dbt Cloud.
 
 <Expandable alt_header="I'm using an older version of dbt in dbt Cloud. What should I do? What happens if I do nothing?" >
 

--- a/website/docs/docs/dbt-versions/cloud-release-tracks.md
+++ b/website/docs/docs/dbt-versions/cloud-release-tracks.md
@@ -14,9 +14,11 @@ By moving your environments and jobs to release tracks you can get all the funct
 
 ## Which release tracks are available?
 
-- **"Latest"** (available to all plans, formerly called "Versionless"): Provides a continuous release of the latest functionality in dbt Cloud. Includes early access to new features of the dbt framework before they're available in open source releases of dbt Core.
-- <Lifecycle status="preview"/> **"Compatible"** (available to Team + Enterprise): Provides a monthly release aligned with the most recent open source versions of dbt Core and adapters, plus functionality exclusively available in dbt Cloud.
-- <Lifecycle status="preview"/> **"Extended"** (available to Enterprise): The previous month's "Compatible" release.
+| Release track | Description | Plan Availability | 
+| ------------- | ------------ | ---------- | 
+| **Latest** `<Lifecycle status="GA"/>` |  (Formerly called "Versionless") Provides a continuous release of the latest functionality in dbt Cloud, and includes early access to new features of the dbt framework before they're available in open source releases of dbt Core | All plans |
+| **Compatible** `<Lifecycle status="preview"/>`  | Provides a monthly release aligned with the most recent open source versions of dbt Core and adapters, plus functionality exclusively available in dbt Cloud |  Team + Enterprise |
+| **Extended** `<Lifecycle status="preview"/>` | The previous month's "Compatible" release | Enterprise |
 
 The first "Compatible" release was on December 12, 2024, after the final release of dbt Core v1.9.0. For December 2024 only, the "Extended" release is the same as "Compatible." Starting in January 2025, "Extended" will be one month behind "Compatible."
 

--- a/website/docs/docs/dbt-versions/cloud-release-tracks.md
+++ b/website/docs/docs/dbt-versions/cloud-release-tracks.md
@@ -14,18 +14,18 @@ By moving your environments and jobs to release tracks you can get all the funct
 
 ## Which release tracks are available?
 
-| Release track | Description | Plan Availability | 
-| ------------- | ------------ | ---------- | 
-| **Latest** `<Lifecycle status="GA"/>` |  (Formerly called "Versionless") Provides a continuous release of the latest functionality in dbt Cloud, and includes early access to new features of the dbt framework before they're available in open source releases of dbt Core | All plans |
-| **Compatible** `<Lifecycle status="preview"/>`  | Provides a monthly release aligned with the most recent open source versions of dbt Core and adapters, plus functionality exclusively available in dbt Cloud |  Team + Enterprise |
-| **Extended** `<Lifecycle status="preview"/>` | The previous month's "Compatible" release | Enterprise |
+| Release track | Description | Plan Availability | API Value |
+| ------------- | ----------- | ----------------- | --------- |
+| **Latest** `<Lifecycle status="GA"/>` |  (Formerly called "Versionless") Provides a continuous release of the latest functionality in dbt Cloud, and includes early access to new features of the dbt framework before they're available in open source releases of dbt Core | All plans | `latest` (or `versionless`) |
+| **Compatible** `<Lifecycle status="preview"/>`  | Provides a monthly release aligned with the most recent open source versions of dbt Core and adapters, plus functionality exclusively available in dbt Cloud |  Team + Enterprise | `compatible` |
+| **Extended** `<Lifecycle status="preview"/>` | The previous month's "Compatible" release | Enterprise | `extended` |
 
 The first "Compatible" release was on December 12, 2024, after the final release of dbt Core v1.9.0. For December 2024 only, the "Extended" release is the same as "Compatible." Starting in January 2025, "Extended" will be one month behind "Compatible."
 
 To configure an environment in the [dbt Cloud Admin API](/docs/dbt-cloud-apis/admin-cloud-api) or [Terraform](https://registry.terraform.io/providers/dbt-labs/dbtcloud/latest) to use a release track, set `dbt_version` to the release track name:
-- `latest` (formerly called `versionless`; the old name is still supported)
-- `compatible` (available to Team + Enterprise)
-- `extended` (available to Enterprise)
+- `latest` (or `versionless`, the old name is still supported)
+- `compatible`
+- `extended`
 
 ## Which release track should I choose?
 

--- a/website/docs/docs/dbt-versions/cloud-release-tracks.md
+++ b/website/docs/docs/dbt-versions/cloud-release-tracks.md
@@ -77,7 +77,7 @@ If you're running dbt version v1.6 or older, please know that your version of db
 
 dbt Labs has extended the "Critical Support" period of dbt Core v1.7 for dbt Cloud Enterprise customers while we work through the migration with those customers to Release Tracks. In the meantime, this means that v1.7 will continue to be accessible in dbt Cloud for Enteprise customers, jobs and environments on v1.7 for those customers will not be automatically migrated to "Latest," and dbt Labs will continue to fix critical bugs and security issues.
 
-Starting in October 2024, dbt Cloud accounts on the Developer and Team plans have been migrated off very old dbt Core versions and onto release tracks. If your account has been migrated to the "Latest" release track, and you are seeing net-new failures in your scheduled dbt jobs, please [contact dbt Cloud support](https://docs.getdbt.com/docs/dbt-support#dbt-cloud-support) to report the problem or request an extension.
+Starting in October 2024, dbt Cloud accounts on the Developer and Team plans have been migrated to release tracks from older dbt Core versions. If your account was migrated to the "Latest" release track and you notice new failures in scheduled jobs, please [contact dbt Cloud support](https://docs.getdbt.com/docs/dbt-support#dbt-cloud-support) to report the problem or request an extension.
 
 </Expandable>
 

--- a/website/docs/docs/dbt-versions/compatible-track-changelog.md
+++ b/website/docs/docs/dbt-versions/compatible-track-changelog.md
@@ -4,9 +4,9 @@ sidebar_label: "Compatible Track Changelog"
 description: "The Compatible release track updates once per month, and it includes up-to-date open source versions as of the monthly release."
 ---
 
-:::info Coming soon
+:::info Preview
 
-The "Compatible" and "Extended" release tracks will be available in Preview to eligible dbt Cloud accounts in December 2024.
+The "Compatible" and "Extended" release tracks are available in Preview. Access will be rolling out to eligible dbt Cloud accounts during the week of December 16-20, 2024.
 
 :::
 
@@ -20,8 +20,42 @@ For more information, see [release tracks](/docs/dbt-versions/cloud-release-trac
 
 ## December 2024
 
-Planned release: December 11-13
+Release date: December 12, 2024
 
-This release will include functionality from `dbt-core==1.9.0` and the most recent versions of all adapters supported in dbt Cloud. After the Compatible release is cut, we will update with:
-- exact versions of open source dbt packages
-- changelog notes concerning functionality specific to dbt Cloud
+This release includes functionality from the following versions of dbt Core OSS:
+```
+dbt-core==1.9.0
+
+# shared interfaces
+dbt-adapters==1.10.4
+dbt-common==1.14.0
+dbt-semantic-interfaces==0.7.4
+
+# adapters
+dbt-athena==1.9.0
+dbt-bigquery==1.9.0
+dbt-databricks==1.9.0
+dbt-fabric==1.8.8
+dbt-postgres==1.9.0
+dbt-redshift==1.9.0
+dbt-snowflake==1.9.0
+dbt-spark==1.9.0
+dbt-synapse==1.8.2
+dbt-teradata==1.8.2
+dbt-trino==1.8.5
+```
+
+Changelogs:
+- [dbt-core 1.9.0](https://github.com/dbt-labs/dbt-core/blob/1.9.latest/CHANGELOG.md#dbt-core-190---december-09-2024)
+- [dbt-adapters 1.10.4](https://github.com/dbt-labs/dbt-adapters/blob/main/CHANGELOG.md#dbt-adapters-1104---november-11-2024)
+- [dbt-common 1.14.0](https://github.com/dbt-labs/dbt-common/blob/main/CHANGELOG.md)
+- [dbt-bigquery 1.9.0](https://github.com/dbt-labs/dbt-bigquery/blob/1.9.latest/CHANGELOG.md#dbt-bigquery-190---december-09-2024)
+- [dbt-databricks 1.9.0](https://github.com/databricks/dbt-databricks/blob/main/CHANGELOG.md#dbt-databricks-190-december-9-2024)
+- [dbt-fabric 1.8.8](https://github.com/microsoft/dbt-fabric/blob/v1.8.latest/CHANGELOG.md)
+- [dbt-postgres 1.9.0](https://github.com/dbt-labs/dbt-postgres/blob/main/CHANGELOG.md#dbt-postgres-190---december-09-2024)
+- [dbt-redshift 1.9.0](https://github.com/dbt-labs/dbt-redshift/blob/1.9.latest/CHANGELOG.md#dbt-redshift-190---december-09-2024)
+- [dbt-snowflake 1.9.0](https://github.com/dbt-labs/dbt-snowflake/blob/1.9.latest/CHANGELOG.md#dbt-snowflake-190---december-09-2024)
+- [dbt-spark 1.9.0](https://github.com/dbt-labs/dbt-spark/blob/1.9.latest/CHANGELOG.md#dbt-spark-190---december-10-2024)
+- [dbt-synapse 1.8.2](https://github.com/microsoft/dbt-synapse/blob/v1.8.latest/CHANGELOG.md)
+- [dbt-teradata 1.8.2](https://github.com/Teradata/dbt-teradata/releases/tag/v1.8.2)
+- [dbt-trino 1.8.5](https://github.com/starburstdata/dbt-trino/blob/master/CHANGELOG.md#dbt-trino-185---december-11-2024)

--- a/website/docs/docs/dbt-versions/compatible-track-changelog.md
+++ b/website/docs/docs/dbt-versions/compatible-track-changelog.md
@@ -6,7 +6,7 @@ description: "The Compatible release track updates once per month, and it includ
 
 :::info Preview
 
-The "Compatible" and "Extended" release tracks are available in Preview. Access will be rolling out to eligible dbt Cloud accounts during the week of December 16-20, 2024.
+The "Compatible" and "Extended" [release tracks](/docs/dbt-versions/cloud-release-tracks) are available in Preview. Access will be rolling out to eligible dbt Cloud accounts during the week of December 16-20, 2024.
 
 :::
 

--- a/website/docs/docs/dbt-versions/compatible-track-changelog.md
+++ b/website/docs/docs/dbt-versions/compatible-track-changelog.md
@@ -6,7 +6,7 @@ description: "The Compatible release track updates once per month, and it includ
 
 :::info Preview
 
-The "Compatible" and "Extended" [release tracks](/docs/dbt-versions/cloud-release-tracks) are available in Preview. Access will be rolling out to eligible dbt Cloud accounts during the week of December 16-20, 2024.
+The "Compatible" and "Extended" [release tracks](/docs/dbt-versions/cloud-release-tracks) are available in Preview. Access will be rolling out to dbt Cloud accounts on eligible plans during the week of December 16-20, 2024.
 
 :::
 


### PR DESCRIPTION
Follow-up to #6471

- "Compatible" + "Extended" release tracks are now available in `Preview` to eligible dbt Cloud customers. Actual availability will be rolling out to those accounts over the course of next week (December 16-20)
- Add versions + changelogs for first "Compatible" release (December 12, 2024)

Preview links:
- https://docs-getdbt-com-git-jerco-update-compatible-rel-25951c-dbt-labs.vercel.app/docs/dbt-versions/cloud-release-tracks
- https://docs-getdbt-com-git-jerco-update-compatible-rel-25951c-dbt-labs.vercel.app/docs/dbt-versions/compatible-track-changelog