### PR TITLE
add semantic models and saved queries to about dbt projects page

### DIFF
--- a/website/docs/docs/build/projects.md
+++ b/website/docs/docs/build/projects.md
@@ -22,6 +22,8 @@ At a minimum, all a project needs is the `dbt_project.yml` project configuration
 | [metrics](/docs/build/build-metrics-intro) | A way for you to define metrics for your project. |
 | [groups](/docs/build/groups) | Groups enable collaborative node organization in restricted collections. |
 | [analysis](/docs/build/analyses) | A way to organize analytical SQL queries in your project such as the general ledger from your QuickBooks. |
+| [semantic models](/docs/build/semantic-models) | Semantic models define the foundational data relationships in [MetricFlow](/docs/build/about-metricflow) and the [dbt Semantic Layer](/docs/use-dbt-semantic-layer/dbt-sl), enabling you to query metrics using a semantic graph. |
+| [saved queries](/docs/build/saved-queries) | Saved queries organize reusable queries by grouping metrics, dimensions, and filters into nodes visible in the dbt DAG. |
 
 When building out the structure of your project, you should consider these impacts on your organization's workflow:
 


### PR DESCRIPTION
this pr adds semantic models and saved queries to the 'about dbt projects' page, which lists all the resources supported int eh dbt_project.yml

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-mirnawong1-patch-26-dbt-labs.vercel.app/docs/build/projects

<!-- end-vercel-deployment-preview -->