### PR TITLE
Update model-notifications.md - description is not allowed as a group property

### DIFF
--- a/website/docs/docs/deploy/model-notifications.md
+++ b/website/docs/docs/deploy/model-notifications.md
@@ -36,17 +36,17 @@ version: 2
 
 groups:
   - name: finance
-    description: "Models related to the finance department"
     owner:
       # Email is required to receive model-level notifications, additional properties are also allowed.
       name: "Finance Team"
+      description: "Models related to the finance department"
       email: finance@dbtlabs.com
       favorite_food: donuts
 
   - name: marketing
-    description: "Models related to the marketing department"
     owner:
       name: "Marketing Team"
+      description: "Models related to the marketing department"
       email: marketing@dbtlabs.com
       favorite_food: jaffles
 ```


### PR DESCRIPTION
This pull request includes a small change to the `website/docs/docs/deploy/model-notifications.md` file. The change moves the `description` field from the `groups` level to the `owner` level for both the finance and marketing groups.

With the current configuration, parsing failed and returned the following error:

```
08:32:37  Running dbt...
dbt command failed
08:32:58  Encountered an error:
Parsing Error
  Invalid groups config given in .........
Additional properties are not allowed ('description' was unexpected)
```

Changes to `model-notifications.md`:

* Moved the `description` field for the finance group to the `owner` level.
* Moved the `description` field for the marketing group to the `owner` level.