### PR TITLE
replace callout w component

### DIFF
--- a/website/docs/docs/build/environment-variables.md
+++ b/website/docs/docs/build/environment-variables.md
@@ -105,7 +105,6 @@ dbt Cloud has a number of pre-defined variables built in. Variables are set auto
 The following environment variable is set automatically for the dbt Cloud IDE:
 
 - `DBT_CLOUD_GIT_BRANCH` &mdash; Provides the development Git branch name in the [dbt Cloud IDE](/docs/cloud/dbt-cloud-ide/develop-in-the-cloud).
-  - Available in dbt v1.6 and later.
   - The variable changes when the branch is changed.
   - Doesn't require restarting the IDE after a branch change.
   - Currently not available in the [dbt Cloud CLI](/docs/cloud/cloud-cli-installation).

--- a/website/docs/docs/build/unit-tests.md
+++ b/website/docs/docs/build/unit-tests.md
@@ -8,6 +8,8 @@ keywords:
   - unit test, unit tests, unit testing, dag
 ---
 
+<VersionCallout version="1.9" />
+
 :::note 
 
 Unit testing functionality is available in [dbt Cloud Release Tracks](/docs/dbt-versions/cloud-release-tracks) or dbt Core v1.8+

--- a/website/docs/docs/build/unit-tests.md
+++ b/website/docs/docs/build/unit-tests.md
@@ -8,7 +8,7 @@ keywords:
   - unit test, unit tests, unit testing, dag
 ---
 
-<VersionCallout version="1.9" />
+<VersionCallout version="1.8" />
 
 :::note 
 

--- a/website/docs/docs/build/unit-tests.md
+++ b/website/docs/docs/build/unit-tests.md
@@ -11,7 +11,6 @@ keywords:
 <VersionCallout version="1.8" />
 
 
-Unit testing functionality is available in [dbt Cloud Release Tracks](/docs/dbt-versions/cloud-release-tracks) or dbt Core v1.8+
 
 :::
 

--- a/website/docs/docs/build/unit-tests.md
+++ b/website/docs/docs/build/unit-tests.md
@@ -10,7 +10,6 @@ keywords:
 
 <VersionCallout version="1.8" />
 
-:::note 
 
 Unit testing functionality is available in [dbt Cloud Release Tracks](/docs/dbt-versions/cloud-release-tracks) or dbt Core v1.8+
 

--- a/website/docs/docs/build/unit-tests.md
+++ b/website/docs/docs/build/unit-tests.md
@@ -12,7 +12,6 @@ keywords:
 
 
 
-:::
 
 Historically, dbt's test coverage was confined to [“data” tests](/docs/build/data-tests), assessing the quality of input data or resulting datasets' structure. However, these tests could only be executed _after_ building a model. 
 

--- a/website/docs/reference/global-configs/version-compatibility.md
+++ b/website/docs/reference/global-configs/version-compatibility.md
@@ -14,7 +14,7 @@ Running with dbt=1.0.0
 Found 13 models, 2 tests, 1 archives, 0 analyses, 204 macros, 2 operations....
 ```
 
-:::info dbt Cloud release tracks
+:::note dbt Cloud release tracks
 <Snippet path="_config-dbt-version-check" />
 
 :::

--- a/website/docs/reference/resource-configs/batch_size.md
+++ b/website/docs/reference/resource-configs/batch_size.md
@@ -7,7 +7,7 @@ description: "dbt uses `batch_size` to determine how large batches are when runn
 datatype: hour | day | month | year
 ---
 
-Available in the [dbt Cloud "Latest" release track](/docs/dbt-versions/cloud-release-tracks) and dbt Core v1.9 and higher.
+<VersionCallout version="1.9" />
 
 ## Definition
 

--- a/website/docs/reference/resource-configs/begin.md
+++ b/website/docs/reference/resource-configs/begin.md
@@ -7,7 +7,7 @@ description: "dbt uses `begin` to determine when a microbatch incremental model 
 datatype: string
 ---
 
-Available in the [dbt Cloud "Latest" release track](/docs/dbt-versions/cloud-release-tracks) and dbt Core v1.9 and higher.
+<VersionCallout version="1.9" />
 
 ## Definition
 

--- a/website/docs/reference/resource-configs/delimiter.md
+++ b/website/docs/reference/resource-configs/delimiter.md
@@ -4,7 +4,7 @@ datatype: <string>
 default_value: ","
 ---
 
-Supported in v1.7 and higher.
+<VersionCallout version="1.7" />
 
 ## Definition
 

--- a/website/docs/reference/resource-configs/event-time.md
+++ b/website/docs/reference/resource-configs/event-time.md
@@ -7,7 +7,7 @@ description: "dbt uses event_time to understand when an event occurred. When def
 datatype: string
 ---
 
-Available in [the dbt Cloud "Latest" release track](/docs/dbt-versions/cloud-release-tracks) and dbt Core v1.9 and higher.
+<VersionCallout version="1.9" />
 
 <Tabs>
 <TabItem value="model" label="Models">

--- a/website/docs/reference/resource-configs/hard-deletes.md
+++ b/website/docs/reference/resource-configs/hard-deletes.md
@@ -8,8 +8,7 @@ id: "hard-deletes"
 sidebar_label: "hard_deletes"
 ---
 
-Available from dbt v1.9 or with [dbt Cloud "Latest" release track](/docs/dbt-versions/cloud-release-tracks).
-
+<VersionCallout version="1.9" />
 
 <File name='snapshots/schema.yml'>
 

--- a/website/docs/reference/resource-configs/lookback.md
+++ b/website/docs/reference/resource-configs/lookback.md
@@ -7,8 +7,7 @@ description: "dbt uses `lookback` to detrmine how many 'batches' of `batch_size`
 datatype: int
 ---
 
-Available in the [dbt Cloud "Latest" release track](/docs/dbt-versions/cloud-release-tracks) and dbt Core v1.9 and higher.
-
+<VersionCallout version="1.9" />
 ## Definition
 
 Set the `lookback` to an integer greater than or equal to zero. The default value is `1`.  You can configure `lookback` for a [model](/docs/build/models) in your `dbt_project.yml` file, property YAML file, or config block.

--- a/website/docs/reference/resource-configs/snapshot_meta_column_names.md
+++ b/website/docs/reference/resource-configs/snapshot_meta_column_names.md
@@ -6,7 +6,7 @@ default_value: {"dbt_valid_from": "dbt_valid_from", "dbt_valid_to": "dbt_valid_t
 id: "snapshot_meta_column_names"
 ---
 
-Available in dbt Core v1.9+. Select v1.9 or newer from the version dropdown to view the configs. Try it now in the [dbt Cloud "Latest" release track](/docs/dbt-versions/cloud-release-tracks).
+<VersionCallout version="1.9" />
 
 <File name='snapshots/schema.yml'>
 

--- a/website/docs/reference/resource-configs/snapshot_meta_column_names.md
+++ b/website/docs/reference/resource-configs/snapshot_meta_column_names.md
@@ -6,7 +6,7 @@ default_value: {"dbt_valid_from": "dbt_valid_from", "dbt_valid_to": "dbt_valid_t
 id: "snapshot_meta_column_names"
 ---
 
-<VersionCallout version="1.8" />
+<VersionCallout version="1.9" />
 
 <File name='snapshots/schema.yml'>
 

--- a/website/docs/reference/resource-configs/snapshot_meta_column_names.md
+++ b/website/docs/reference/resource-configs/snapshot_meta_column_names.md
@@ -6,7 +6,7 @@ default_value: {"dbt_valid_from": "dbt_valid_from", "dbt_valid_to": "dbt_valid_t
 id: "snapshot_meta_column_names"
 ---
 
-<VersionCallout version="1.9" />
+<VersionCallout version="1.8" />
 
 <File name='snapshots/schema.yml'>
 

--- a/website/docs/reference/resource-properties/concurrent_batches.md
+++ b/website/docs/reference/resource-properties/concurrent_batches.md
@@ -5,11 +5,7 @@ datatype: model_name
 description: "Learn about concurrent_batches in dbt."
 ---
 
-:::note
-
-Available in dbt Core v1.9+ or the [dbt Cloud "Latest" release tracks](/docs/dbt-versions/cloud-release-tracks).
-
-:::
+<VersionCallout version="1.9" />
 
 <Tabs>
 <TabItem value="Project file">

--- a/website/docs/reference/resource-properties/unit-tests.md
+++ b/website/docs/reference/resource-properties/unit-tests.md
@@ -5,11 +5,8 @@ resource_types: [models]
 datatype: test
 ---
 
-:::note 
+<VersionCallout version="1.8" />
 
-This functionality is available in dbt Core v1.8+ and [dbt Cloud release tracks](/docs/dbt-versions/cloud-release-tracks).
-
-:::
 
 Unit tests validate your SQL modeling logic on a small set of static inputs before you materialize your full model in production. They support a test-driven development approach, improving both the efficiency of developers and reliability of code.
 

--- a/website/src/components/versionCallout/index.js
+++ b/website/src/components/versionCallout/index.js
@@ -13,7 +13,7 @@ const VersionCallout = ({ version }) => {
         Available from dbt v{version} or with the{' '}
         <a href="/docs/dbt-versions/cloud-release-tracks">
         dbt Cloud "Latest" release track
-        </a>{' '}.
+        </a>{''}.
       </span>
     </Admonition>
   </div>


### PR DESCRIPTION
replacing hardcoded callouts with the `VersionCallout` component for uniformity and scability. 

Natalie to add the component to the following pages:

- website/docs/reference/resource-configs/snapshot_meta_column_names.md
- website/docs/docs/build/unit-tests.md

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-add-version-callout-dbt-labs.vercel.app/docs/build/environment-variables
- https://docs-getdbt-com-git-add-version-callout-dbt-labs.vercel.app/docs/build/unit-tests
- https://docs-getdbt-com-git-add-version-callout-dbt-labs.vercel.app/reference/global-configs/version-compatibility
- https://docs-getdbt-com-git-add-version-callout-dbt-labs.vercel.app/reference/resource-configs/batch_size
- https://docs-getdbt-com-git-add-version-callout-dbt-labs.vercel.app/reference/resource-configs/begin
- https://docs-getdbt-com-git-add-version-callout-dbt-labs.vercel.app/reference/resource-configs/delimiter
- https://docs-getdbt-com-git-add-version-callout-dbt-labs.vercel.app/reference/resource-configs/event-time
- https://docs-getdbt-com-git-add-version-callout-dbt-labs.vercel.app/reference/resource-configs/hard-deletes
- https://docs-getdbt-com-git-add-version-callout-dbt-labs.vercel.app/reference/resource-configs/lookback
- https://docs-getdbt-com-git-add-version-callout-dbt-labs.vercel.app/reference/resource-configs/snapshot_meta_column_names
- https://docs-getdbt-com-git-add-version-callout-dbt-labs.vercel.app/reference/resource-properties/concurrent_batches
- https://docs-getdbt-com-git-add-version-callout-dbt-labs.vercel.app/reference/resource-properties/unit-tests

<!-- end-vercel-deployment-preview -->