### PR TITLE
6715 improve documentation for dbt clean options

### DIFF
--- a/website/docs/docs/dbt-versions/core-upgrade/08-upgrading-to-v1.7.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/08-upgrading-to-v1.7.md
@@ -66,7 +66,7 @@ dbt Core v1.5 introduced model governance which we're continuing to refine.  v1.
 
 ### dbt clean
 
-Starting in v1.7, [dbt clean](website/docs/reference/commands/clean.md) will only clean paths within the current working directory. The `--no-clean-project-files-only` flag will delete all paths specified in the `clean-targets` section of `dbt_project.yml`, even if they're outside the dbt project.
+Starting in v1.7, [dbt clean](reference/commands/clean) will only clean paths within the current working directory. The `--no-clean-project-files-only` flag will delete all paths specified in the `clean-targets` section of `dbt_project.yml`, even if they're outside the dbt project.
 
 Supported flags:
 -  `--clean-project-files-only` (default) 

--- a/website/docs/docs/dbt-versions/core-upgrade/08-upgrading-to-v1.7.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/08-upgrading-to-v1.7.md
@@ -66,7 +66,7 @@ dbt Core v1.5 introduced model governance which we're continuing to refine.  v1.
 
 ### dbt clean
 
-Starting in v1.7, `dbt clean` will only clean paths within the current working directory. The `--no-clean-project-files-only` flag will delete all paths specified in the `clean-targets` section of `dbt_project.yml`, even if they're outside the dbt project.
+Starting in v1.7, [dbt clean](website/docs/reference/commands/clean.md) will only clean paths within the current working directory. The `--no-clean-project-files-only` flag will delete all paths specified in the `clean-targets` section of `dbt_project.yml`, even if they're outside the dbt project.
 
 Supported flags:
 -  `--clean-project-files-only` (default) 

--- a/website/docs/docs/dbt-versions/core-upgrade/08-upgrading-to-v1.7.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/08-upgrading-to-v1.7.md
@@ -66,7 +66,7 @@ dbt Core v1.5 introduced model governance which we're continuing to refine.  v1.
 
 ### dbt clean
 
-Starting in v1.7, [dbt clean](reference/commands/clean) will only clean paths within the current working directory. The `--no-clean-project-files-only` flag will delete all paths specified in the `clean-targets` section of `dbt_project.yml`, even if they're outside the dbt project.
+Starting in v1.7, [dbt clean](/reference/commands/clean) will only clean paths within the current working directory. The `--no-clean-project-files-only` flag will delete all paths specified in the `clean-targets` section of `dbt_project.yml`, even if they're outside the dbt project.
 
 Supported flags:
 -  `--clean-project-files-only` (default) 

--- a/website/docs/reference/commands/clean.md
+++ b/website/docs/reference/commands/clean.md
@@ -4,6 +4,30 @@ sidebar_label: "clean"
 id: "clean"
 ---
 
-`dbt clean` is a utility function that deletes all folders specified in the [`clean-targets`](/reference/project-configs/clean-targets) list specified in `dbt_project.yml`. You can use this to delete the `dbt_packages` and `target` directories.
+`dbt clean` is a utility function that deletes the paths specified within the [`clean-targets`](/reference/project-configs/clean-targets) section of the `dbt_project.yml` file. It helps to remove any unnecessary files or directories generated during the execution of other DBT commands, ensuring a clean state for the project.
 
-To avoid complex permissions issues and potentially deleting crucial aspects of the remote file system without access to fix them, this command does not work when interfacing with the RPC server that powers the dbt Cloud IDE. Instead, when working in dbt Cloud, the `dbt deps` command cleans before it installs packages automatically. The `target` folder can be manually deleted from the sidebar file tree if needed.
+**Usage**
+```
+dbt clean
+```
+
+## Supported flags
+### --clean-project-files-only (default)
+Deletes all the paths within the project directory that are specified in the `clean-targets` section.
+
+> **NOTE:** If the `clean-targets` section contains paths outside the DBT project, this command will lead to a _Runtime Error_ to indicate the same.
+
+**Usage:**
+```
+$ dbt clean --clean-project-files-only
+```
+
+### --no-clean-project-files-only
+Deletes all the paths specified in the `clean-targets` section of `dbt_project.yml`, including those outside the current DBT project.
+
+```
+$ dbt clean --no-clean-project-files-only
+```
+
+## dbt clean with remote file system
+To avoid complex permissions issues and potentially deleting crucial aspects of the remote file system without access to fix them, this command does not work when interfacing with the RPC server that powers the DBT Cloud IDE. Instead, when working in DBT Cloud, the `dbt deps` command cleans before it installs packages automatically. The `target` folder can be manually deleted from the sidebar file tree if needed.

--- a/website/docs/reference/commands/clean.md
+++ b/website/docs/reference/commands/clean.md
@@ -4,30 +4,33 @@ sidebar_label: "clean"
 id: "clean"
 ---
 
-`dbt clean` is a utility function that deletes the paths specified within the [`clean-targets`](/reference/project-configs/clean-targets) section of the `dbt_project.yml` file. It helps to remove any unnecessary files or directories generated during the execution of other DBT commands, ensuring a clean state for the project.
+`dbt clean` is a utility function that deletes the paths specified within the [`clean-targets`](/reference/project-configs/clean-targets) list in the `dbt_project.yml` file. It helps by removing unnecessary files or directories generated during the execution of other dbt commands, ensuring a clean state for the project.
 
-**Usage**
+## Example usage
 ```
 dbt clean
 ```
 
 ## Supported flags
 ### --clean-project-files-only (default)
-Deletes all the paths within the project directory that are specified in the `clean-targets` section.
+Deletes all the paths within the project directory specified in `clean-targets`.
 
-> **NOTE:** If the `clean-targets` section contains paths outside the DBT project, this command will lead to a _Runtime Error_ to indicate the same.
+:::note
+Avoid using paths outside the dbt project; otherwise, you will see an error.
+:::
+  
 
-**Usage:**
+#### Example usage
 ```
 $ dbt clean --clean-project-files-only
 ```
 
 ### --no-clean-project-files-only
-Deletes all the paths specified in the `clean-targets` section of `dbt_project.yml`, including those outside the current DBT project.
+Deletes all the paths specified in the `clean-targets` list of `dbt_project.yml`, including those outside the current dbt project.
 
 ```
 $ dbt clean --no-clean-project-files-only
 ```
 
 ## dbt clean with remote file system
-To avoid complex permissions issues and potentially deleting crucial aspects of the remote file system without access to fix them, this command does not work when interfacing with the RPC server that powers the DBT Cloud IDE. Instead, when working in DBT Cloud, the `dbt deps` command cleans before it installs packages automatically. The `target` folder can be manually deleted from the sidebar file tree if needed.
+To avoid complex permissions issues and potentially deleting crucial aspects of the remote file system without access to fix them, this command does not work when interfacing with the RPC server that powers the dbt Cloud IDE. Instead, when working in dbt Cloud, the `dbt deps` command cleans before it installs packages automatically. The `target` folder can be manually deleted from the sidebar file tree if needed.


### PR DESCRIPTION
## What are you changing in this pull request and why?
This change is for addressing the issue: #6715 

It will help understand the flags for `dbt clean` command:
-  `--clean-project-files-only` (default) 
-  `--no-clean-project-files-only`

### Checklist:
1. Enhance the documentation for `dbt clean`
2. Link the above enhanced documentation in the Upgrading to v1.7 page

**NOTE:** Requires reviewing the change in the content.

## Checklist
- I have reviewed the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- I have added checklist item(s) to this list for anything anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
