### PR TITLE
6715 improve documentation for dbt clean options

### DIFF
--- a/website/docs/docs/dbt-versions/core-upgrade/08-upgrading-to-v1.7.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/08-upgrading-to-v1.7.md
@@ -62,11 +62,11 @@ dbt Core v1.5 introduced model governance which we're continuing to refine.  v1.
 - **[Breaking change detection](/reference/resource-properties/versions#detecting-breaking-changes) for models with contracts enforced:** When dbt detects a breaking change to a model with an enforced contract during state comparison, it will now raise an error for versioned models and a warning for models that are not versioned.
 - **[Set `access` as a config](/reference/resource-configs/access):** You can now set a model's `access` within config blocks in the model's file or in the `dbt_project.yml` for an entire subfolder at once.
 - **[Type aliasing for model contracts](/reference/resource-configs/contract):** dbt will use each adapter's built-in type aliasing for user-provided data types—meaning you can now write `string` always, and dbt will translate to `text` on Postgres/Redshift. This is "on" by default, but you can opt-out.
-- **[Raise warning for numeric types](/reference/resource-configs/contract):** Because of issues when putting `numeric` in model contracts without considering that default values such as `numeric(38,0)` might round decimals accordingly. dbt will now warn you if it finds a numeric type without specified precision/scale.
+- **[Raise warning for numeric types](/reference/resource-configs/contract):** Because of issues when putting `numeric` in model contracts without considering that default values such as `numeric(38,0)` might round decimals accordingly. dbt will now warn you if it finds a numeric type without specified precision/scale.
 
 ### dbt clean
 
-Starting in v1.7, `dbt clean` will only clean paths within the current working directory. The `--no-clean-project-files-only` flag will delete all paths specified in the `clean-targets` section of `dbt_project.yml`, even if they're outside the dbt project.
+Starting in v1.7, [dbt clean](/reference/commands/clean) will only clean paths within the current working directory. The `--no-clean-project-files-only` flag will delete all paths specified in the `clean-targets` section of `dbt_project.yml`, even if they're outside the dbt project.
 
 Supported flags:
 -  `--clean-project-files-only` (default) 

--- a/website/docs/reference/commands/clean.md
+++ b/website/docs/reference/commands/clean.md
@@ -15,8 +15,8 @@ dbt clean
 
 This section will briefly explain the following flags:
 
-- `--clean-project-files-only` (default)
-- `--no-clean-project-files-only`
+- [`--clean-project-files-only`](#--clean-project-files-only) (default)
+- [`--no-clean-project-files-only`](#--no-clean-project-files-only)
 
 To view the list of all supported flags for the `dbt clean` command in the terminal, use the `--help` flag, which will display detailed information about the available flags you can use, including its description and usage:
 

--- a/website/docs/reference/commands/clean.md
+++ b/website/docs/reference/commands/clean.md
@@ -4,6 +4,33 @@ sidebar_label: "clean"
 id: "clean"
 ---
 
-`dbt clean` is a utility function that deletes all folders specified in the [`clean-targets`](/reference/project-configs/clean-targets) list specified in `dbt_project.yml`. You can use this to delete the `dbt_packages` and `target` directories.
+`dbt clean` is a utility function that deletes the paths specified within the [`clean-targets`](/reference/project-configs/clean-targets) list in the `dbt_project.yml` file. It helps by removing unnecessary files or directories generated during the execution of other dbt commands, ensuring a clean state for the project.
 
+## Example usage
+```
+dbt clean
+```
+
+## Supported flags
+### --clean-project-files-only (default)
+Deletes all the paths within the project directory specified in `clean-targets`.
+
+:::note
+Avoid using paths outside the dbt project; otherwise, you will see an error.
+:::
+  
+
+#### Example usage
+```
+$ dbt clean --clean-project-files-only
+```
+
+### --no-clean-project-files-only
+Deletes all the paths specified in the `clean-targets` list of `dbt_project.yml`, including those outside the current dbt project.
+
+```
+$ dbt clean --no-clean-project-files-only
+```
+
+## dbt clean with remote file system
 To avoid complex permissions issues and potentially deleting crucial aspects of the remote file system without access to fix them, this command does not work when interfacing with the RPC server that powers the dbt Cloud IDE. Instead, when working in dbt Cloud, the `dbt deps` command cleans before it installs packages automatically. The `target` folder can be manually deleted from the sidebar file tree if needed.

--- a/website/docs/reference/commands/clean.md
+++ b/website/docs/reference/commands/clean.md
@@ -16,6 +16,10 @@ To view the supported flags for the `dbt clean` command in the terminal, use the
 
 ```shell
 dbt clean --help
+```
+
+This command displays detailed information about the available flags you can use, including its description and usage.
+
 ### --clean-project-files-only (default)
 Deletes all the paths within the project directory specified in `clean-targets`.
 

--- a/website/docs/reference/commands/clean.md
+++ b/website/docs/reference/commands/clean.md
@@ -12,16 +12,20 @@ dbt clean
 ```
 
 ## Supported flags
-To view the supported flags for the `dbt clean` command in the terminal, use the `--help` flag like this:
+
+This section will briefly explain the following flags:
+
+- `--clean-project-files-only` (default)
+- `--no-clean-project-files-only`
+
+To view the list of all supported flags for the `dbt clean` command in the terminal, use the `--help` flag, which will display detailed information about the available flags you can use, including its description and usage:
 
 ```shell
 dbt clean --help
 ```
 
-This command displays detailed information about the available flags you can use, including its description and usage.
-
 ### --clean-project-files-only (default)
-Deletes all the paths within the project directory specified in `clean-targets`.
+By default, dbt deletes all the paths within the project directory specified in `clean-targets`.
 
 :::note
 Avoid using paths outside the dbt project; otherwise, you will see an error.
@@ -29,15 +33,15 @@ Avoid using paths outside the dbt project; otherwise, you will see an error.
   
 
 #### Example usage
-```
-$ dbt clean --clean-project-files-only
+```shell
+dbt clean --clean-project-files-only
 ```
 
 ### --no-clean-project-files-only
 Deletes all the paths specified in the `clean-targets` list of `dbt_project.yml`, including those outside the current dbt project.
 
-```
-$ dbt clean --no-clean-project-files-only
+```shell
+dbt clean --no-clean-project-files-only
 ```
 
 ## dbt clean with remote file system

--- a/website/docs/reference/commands/clean.md
+++ b/website/docs/reference/commands/clean.md
@@ -24,7 +24,7 @@ To view the list of all supported flags for the `dbt clean` command in the termi
 dbt clean --help
 ```
 
-### --clean-project-files-only (default)
+### --clean-project-files-only
 By default, dbt deletes all the paths within the project directory specified in `clean-targets`.
 
 :::note

--- a/website/docs/reference/commands/clean.md
+++ b/website/docs/reference/commands/clean.md
@@ -12,6 +12,10 @@ dbt clean
 ```
 
 ## Supported flags
+To view the supported flags for the `dbt clean` command in the terminal, use the `--help` flag like this:
+
+```shell
+dbt clean --help
 ### --clean-project-files-only (default)
 Deletes all the paths within the project directory specified in `clean-targets`.
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
This change is for addressing the issue: #6715 

This is a copy of the previous PR -> https://github.com/dbt-labs/docs.getdbt.com/pull/6716 (As I deleted my personal docs.getdbt.com project and the PR closed automatically)

It will help understand the flags for `dbt clean` command:
-  `--clean-project-files-only` (default) 
-  `--no-clean-project-files-only`

### Checklist:
1. Enhance the documentation for `dbt clean`
2. Link the above enhanced documentation in the Upgrading to v1.7 page

**NOTE:** Requires reviewing the change in the content.

## Checklist
- I have reviewed the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- I have added checklist item(s) to this list for anything anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
