### PR TITLE
Move 'delete job/env' content to dedicated environment pages 

### DIFF
--- a/website/docs/docs/dbt-cloud-environments.md
+++ b/website/docs/docs/dbt-cloud-environments.md
@@ -25,7 +25,6 @@ import CloudEnvInfo from '/snippets/_cloud-environments-info.md';
 
 <CloudEnvInfo setup={'/snippets/_cloud-environments-info.md'} />
 
-
 ## Create a development environment
 
 To create a new dbt Cloud development environment:
@@ -48,5 +47,10 @@ Deployment environments in dbt Cloud are necessary to execute scheduled jobs and
 
 Even though you can have many environments, only one of them can be the "main" deployment environment. This would be considered your "production" environment and represents your project's "source of truth", meaning it's where your most reliable and final data transformations live.
 
-
 To learn more about dbt Cloud deployment environments and how to configure them, refer to the [Deployment environments](/docs/deploy/deploy-environments) page. For our best practices guide, read [dbt Cloud environment best practices](/guides/set-up-ci) for more info.
+
+## Delete an environment
+
+import DeleteEnvironment from '/snippets/_delete-environment.md';
+
+<DeleteEnvironment />

--- a/website/docs/docs/deploy/deploy-environments.md
+++ b/website/docs/docs/deploy/deploy-environments.md
@@ -250,6 +250,12 @@ Use [extended attributes](/docs/dbt-cloud-environments#extended-attributes) to o
 
 </WHCode>
 
+## Delete an environment
+
+import DeleteEnvironment from '/snippets/_delete-environment.md';
+
+<DeleteEnvironment />
+
 ## Related docs
 
 - [dbt Cloud environment best practices](/guides/set-up-ci)

--- a/website/docs/docs/deploy/deploy-jobs.md
+++ b/website/docs/docs/deploy/deploy-jobs.md
@@ -128,6 +128,12 @@ To _chain_ deploy jobs together:
 
 If another job triggers your job to run, you can find a link to the upstream job in the [run details section](/docs/deploy/run-visibility#job-run-details).
 
+## Delete a job
+
+import DeleteJob from '/snippets/_delete-job.md';
+
+<DeleteJob/>
+
 ## Related docs
 
 - [Artifacts](/docs/deploy/artifacts)

--- a/website/docs/faqs/Environments/delete-environment-job.md
+++ b/website/docs/faqs/Environments/delete-environment-job.md
@@ -8,38 +8,14 @@ id: delete-environment-job
 
 To delete an environment or job in dbt Cloud, you must have a `developer` [license](/docs/cloud/manage-access/seats-and-users) and have the necessary [access permissions](/docs/cloud/manage-access/about-user-access). 
 
-## Delete a job
+### Delete a job
 
-To delete a job or multiple jobs in dbt Cloud:
+import DeleteJob from '/snippets/_delete-job.md';
 
-1. Click **Deploy** on the navigation header.
-2. Click **Jobs** and select the job(s) you want to delete. 
-3. Click **Settings** on the top right of the page and then click **Edit**.
-4. Scroll to the bottom of the page and click **Delete** to delete the job. <br />
+<DeleteJob/>
 
-<figure>
-<Lightbox src="/img/docs/dbt-cloud/cloud-configuring-dbt-cloud/delete-job.png" width="100%" title="Delete a job"/>
-<figcaption align = "center">Delete a job</figcaption>
-</figure>
+### Delete an environment
 
-5. Confirm your action in the **Confirm Delete** pop-up by clicking **Confirm Delete** in the bottom right to delete the job immediately. This action cannot be undone. However, you can create a new job with the same information if the deletion was made in error. 
+import DeleteEnvironment from '/snippets/_delete-environment.md';
 
-Refresh the page, and the deleted job should now be gone. If you want to delete multiple jobs, you'll need to perform these steps for each job. 
-
-## Delete an environment
-
-Deleting an environment automatically deletes its associated job(s). If you want to keep those jobs, move them to a different environment first. To delete an environment in dbt Cloud:
-
-1. Click **Deploy** on the navigation header and then click **Environments** 
-2. Select the Environment you want to delete. 
-3. Click **Settings** on the top right of the page and then click **Edit**.
-4. Scroll to the bottom of the page and click **Delete** to delete the environment. <br />
-
-<Lightbox src="/img/docs/dbt-cloud/cloud-configuring-dbt-cloud/delete-environment.png" width="100%" title="Delete an environment"/>
-
-5. Confirm your action in the **Confirm Delete** pop-up by clicking **Confirm Delete** in the bottom right to delete the environment immediately. This action cannot be undone. However, you can create a new environment with the same information if the deletion was made in error. <br /><br />
-
-
-Refresh your page, and the deleted environment should now be gone. If you want to delete multiple environments, you'll need to perform these steps to delete each one. 
-
-If you're having any issues, feel free to [contact us](mailto:support@getdbt.com) for additional help.
+<DeleteEnvironment/>

--- a/website/snippets/_delete-environment.md
+++ b/website/snippets/_delete-environment.md
@@ -1,0 +1,15 @@
+Deleting an environment automatically deletes its associated job(s). If you want to keep those jobs, move them to a different environment first. 
+
+Follow these steps to delete an environment in dbt Cloud:
+
+1. Click **Deploy** on the navigation header and then click **Environments**
+2. Select the environment you want to delete. 
+3. Click **Settings** on the top right of the page and then click **Edit**.
+4. Scroll to the bottom of the page and click **Delete** to delete the environment.
+
+<Lightbox src="/img/docs/dbt-cloud/cloud-configuring-dbt-cloud/delete-environment.png" width="90%" title="Delete an environment"/>
+
+5. Confirm your action in the pop-up by clicking **Confirm delete** in the bottom right to delete the environment immediately. This action cannot be undone. However, you can create a new environment with the same information if the deletion was made in error.
+6. Refresh your page and the deleted environment should now be gone. To delete multiple environments, you'll need to perform these steps to delete each one.
+
+If you're having any issues, feel free to [contact us](mailto:support@getdbt.com) for additional help.

--- a/website/snippets/_delete-job.md
+++ b/website/snippets/_delete-job.md
@@ -1,0 +1,15 @@
+To delete a job or multiple jobs in dbt Cloud:
+
+1. Click **Deploy** on the navigation header.
+2. Click **Jobs** and select the job you want to delete. 
+3. Click **Settings** on the top right of the page and then click **Edit**.
+4. Scroll to the bottom of the page and click **Delete** to delete the job. <br />
+
+<figure>
+<Lightbox src="/img/docs/dbt-cloud/cloud-configuring-dbt-cloud/delete-job.png" width="100%" title="Delete a job"/>
+</figure>
+
+5. Confirm your action in the pop-up by clicking **Confirm delete** in the bottom right to delete the job immediately. This action cannot be undone. However, you can create a new job with the same information if the deletion was made in error. 
+6. Refresh the page, and the deleted job should now be gone. If you want to delete multiple jobs, you'll need to perform these steps for each job.
+
+If you're having any issues, feel free to [contact us](mailto:support@getdbt.com) for additional help.


### PR DESCRIPTION
use existing FAQ to add a 'delete a job' or 'delete an env' header in related jobs/env pages.  

created a snippet to house 'delete a job or env' and reuse content in related pages, as well as the faq.

- https://docs.getdbt.com/docs/environments-in-dbt
- https://docs.getdbt.com/docs/environments-in-dbt
- https://docs.getdbt.com/docs/environments-in-dbt

Resolves #3924

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-delete-job-environment-dbt-labs.vercel.app/docs/dbt-cloud-environments
- https://docs-getdbt-com-git-delete-job-environment-dbt-labs.vercel.app/docs/deploy/deploy-environments
- https://docs-getdbt-com-git-delete-job-environment-dbt-labs.vercel.app/docs/deploy/deploy-jobs
- https://docs-getdbt-com-git-delete-job-environment-dbt-labs.vercel.app/faqs/Environments/delete-environment-job

<!-- end-vercel-deployment-preview -->