### PR TITLE
add plus operator example to tags doc

### DIFF
--- a/website/docs/reference/node-selection/graph-operators.md
+++ b/website/docs/reference/node-selection/graph-operators.md
@@ -5,9 +5,9 @@ title: "Graph operators"
 ### The "plus" operator
 The `+` operator expands your selection to include ancestors (upstream dependencies) or descendants (downstream dependencies) of a resource. This operator works for individual models, tags, or other resources.
 
-- `+` operator placed after a model/resource &mdash; Includes the resource itself and all its descendants (downstream dependencies).
-- `+` operator placed before a model/resource &mdash; Includes the resource itself and all its ancestors (upstream dependencies).
-- `+` operator placed on both sides of a model/resource &mdash; Includes the resource itself, all its ancestors, and all its descendants.
+- Placed after a model/resource &mdash; Includes the resource itself and all its descendants (downstream dependencies).
+- Placed before a model/resource &mdash; Includes the resource itself and all its ancestors (upstream dependencies).
+- Placed on both sides of a model/resource &mdash; Includes the resource itself, all its ancestors, and all its descendants.
 
 ```bash
 dbt run --select "my_model+"         # select my_model and all descendants

--- a/website/docs/reference/node-selection/graph-operators.md
+++ b/website/docs/reference/node-selection/graph-operators.md
@@ -3,7 +3,7 @@ title: "Graph operators"
 ---
 
 ### The "plus" operator
-The `+` operator expands your selection to include ancestors (upstream dependencies) or descendants (downstream dependencies) of a resource. This operator works for individual models, tags, or other resources.
+The `+` operator expands your selection to include ancestors (upstream dependencies) or descendants (downstream dependencies) of a resource. This operator works for individual models, tags, and other resources.
 
 - Placed after a model/resource &mdash; Includes the resource itself and all its descendants (downstream dependencies).
 - Placed before a model/resource &mdash; Includes the resource itself and all its ancestors (upstream dependencies).

--- a/website/docs/reference/node-selection/graph-operators.md
+++ b/website/docs/reference/node-selection/graph-operators.md
@@ -15,7 +15,7 @@ dbt run --select "+my_model"         # select my_model and all ancestors
 dbt run --select "+my_model+"        # select my_model, and all of its ancestors and descendants
 ```
 
-You can use it with selectors for a more specific scope in your commands. You can also combine it with [`--exclude`](/reference/node-selection/exclude) for even more finer control over what gets included in your command.
+You can use it with selectors for a more specific scope in your commands. You can also combine it with [`--exclude`](/reference/node-selection/exclude) flag for even more finer control over what gets included in your command.
 
 ### The "n-plus" operator
 

--- a/website/docs/reference/node-selection/graph-operators.md
+++ b/website/docs/reference/node-selection/graph-operators.md
@@ -3,15 +3,19 @@ title: "Graph operators"
 ---
 
 ### The "plus" operator
-If placed at the front of the model selector, `+` will select all ancestors of the selected model and the model itself. If placed at the end of the string, `+` will select all descendants of the selected model and the model itself.
+The `+` operator expands your selection to include ancestors (upstream dependencies) or descendants (downstream dependencies) of a resource. This operator works for individual models, tags, or other resources.
 
+- `+` operator placed after a model/resource &mdash; Includes the resource itself and all its descendants (downstream dependencies).
+- `+` operator placed before a model/resource &mdash; Includes the resource itself and all its ancestors (upstream dependencies).
+- `+` operator placed on both sides of a model/resource &mdash; Includes the resource itself, all its ancestors, and all its descendants.
 
-   ```bash
+```bash
 dbt run --select "my_model+"         # select my_model and all descendants
 dbt run --select "+my_model"         # select my_model and all ancestors
 dbt run --select "+my_model+"        # select my_model, and all of its ancestors and descendants
-  ```
+```
 
+You can use it with selectors for a more specific scope in your commands. You can also combine it with [`--exclude`](/reference/node-selection/exclude) for even more finer control over what gets included in your command.
 
 ### The "n-plus" operator
 

--- a/website/docs/reference/resource-configs/tags.md
+++ b/website/docs/reference/resource-configs/tags.md
@@ -121,9 +121,9 @@ These tags can be used as part of the [resource selection syntax](/reference/nod
 
 #### Using tags with the `+` operator
 You can use the [`+` operator](/reference/node-selection/graph-operators#the-plus-operator) to include upstream or downstream dependencies in your `tag` selection:
-- `dbt run --select tag:my_tag+` &mdash; Run models tagged with `my_tag` and all their downstream dependencies (children).
-- `dbt run --select +tag:my_tag` &mdash; Run models tagged with `my_tag` and all their upstream dependencies (parents).
-- `dbt run --select +model_name+` &mdash; Run a model, its upstream dependencies (parents), and its downstream dependencies (children).
+- `dbt run --select tag:my_tag+` &mdash; Run models tagged with `my_tag` and all their downstream dependencies.
+- `dbt run --select +tag:my_tag` &mdash; Run models tagged with `my_tag` and all their upstream dependencies.
+- `dbt run --select +model_name+` &mdash; Run a model, its upstream dependencies, and its downstream dependencies.
 - `dbt run --select tag:my_tag+ --exclude tag:exclude_tag` &mdash; Run model tagged with `my_tag` and their downstream dependencies and exclude models tagged with `exclude_tag`, regardless of their dependencies.
 
 ## Examples

--- a/website/docs/reference/resource-configs/tags.md
+++ b/website/docs/reference/resource-configs/tags.md
@@ -113,11 +113,17 @@ resource_type:
 Apply a tag (or list of tags) to a resource.
 
 These tags can be used as part of the [resource selection syntax](/reference/node-selection/syntax), when running the following commands:
-- `dbt run --select tag:my_tag`
-- `dbt build --select tag:my_tag`
-- `dbt seed --select tag:my_tag`
-- `dbt snapshot --select tag:my_tag`
-- `dbt test --select tag:my_tag` (indirectly runs all tests associated with the models that are tagged)
+- `dbt run --select tag:my_tag` &mdash; Run all models tagged with a specific tag.
+- `dbt build --select tag:my_tag` &mdash; Build all resources tagged with a specific tag.
+- `dbt seed --select tag:my_tag` &mdash; Seed all resources tagged with a specific tag.
+- `dbt snapshot --select tag:my_tag` &mdash; Snapshot all resources tagged with a specific tag.
+- `dbt test --select tag:my_tag` &mdash; Indirectly runs all tests associated with the models that are tagged.
+
+#### Using tags with the `+` operator
+You can use the [`+` operator](/reference/node-selection/graph-operators#the-plus-operator) to include upstream or downstream dependencies in your `tag` selection:
+- `dbt run --select tag:my_tag+` &mdash; Run models tagged with `my_tag` and all their downstream dependencies (children).
+- `dbt run --select +tag:my_tag` &mdash; Run models tagged with `my_tag` and all their upstream dependencies (parents).
+- `dbt run --select +model_name+` &mdash; Run a model, its upstream dependencies (parents), and its downstream dependencies (children).
 
 ## Examples
 ### Use tags to run parts of your project

--- a/website/docs/reference/resource-configs/tags.md
+++ b/website/docs/reference/resource-configs/tags.md
@@ -124,6 +124,7 @@ You can use the [`+` operator](/reference/node-selection/graph-operators#the-plu
 - `dbt run --select tag:my_tag+` &mdash; Run models tagged with `my_tag` and all their downstream dependencies (children).
 - `dbt run --select +tag:my_tag` &mdash; Run models tagged with `my_tag` and all their upstream dependencies (parents).
 - `dbt run --select +model_name+` &mdash; Run a model, its upstream dependencies (parents), and its downstream dependencies (children).
+- `dbt run --select tag:my_tag+ --exclude tag:exclude_tag` &mdash; Run model tagged with `my_tag` and their downstream dependencies and exclude models tagged with `exclude_tag`, regardless of their dependencies.
 
 ## Examples
 ### Use tags to run parts of your project

--- a/website/docs/reference/resource-configs/tags.md
+++ b/website/docs/reference/resource-configs/tags.md
@@ -124,7 +124,7 @@ You can use the [`+` operator](/reference/node-selection/graph-operators#the-plu
 - `dbt run --select tag:my_tag+` &mdash; Run models tagged with `my_tag` and all their downstream dependencies.
 - `dbt run --select +tag:my_tag` &mdash; Run models tagged with `my_tag` and all their upstream dependencies.
 - `dbt run --select +model_name+` &mdash; Run a model, its upstream dependencies, and its downstream dependencies.
-- `dbt run --select tag:my_tag+ --exclude tag:exclude_tag` &mdash; Run model tagged with `my_tag` and their downstream dependencies and exclude models tagged with `exclude_tag`, regardless of their dependencies.
+- `dbt run --select tag:my_tag+ --exclude tag:exclude_tag` &mdash; Run model tagged with `my_tag` and their downstream dependencies, and exclude models tagged with `exclude_tag`, regardless of their dependencies.
 
 ## Examples
 ### Use tags to run parts of your project


### PR DESCRIPTION
this pr adds an example combining tags and the plus operator in the `tags` doc and the `+ operator` doc. 

Resolves #6735

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-mirnawong1-patch-26-dbt-labs.vercel.app/reference/node-selection/graph-operators
- https://docs-getdbt-com-git-mirnawong1-patch-26-dbt-labs.vercel.app/reference/resource-configs/tags

<!-- end-vercel-deployment-preview -->