### PR TITLE
Fix tip callout box in Redshift Quickstart guide

### DIFF
--- a/website/docs/guides/redshift-qs.md
+++ b/website/docs/guides/redshift-qs.md
@@ -21,7 +21,7 @@ In this quickstart guide, you'll learn how to use dbt Cloud with Redshift. It wi
 - Document your models
 - Schedule a job to run
 
-:::tips Videos for you
+:::tip Videos for you
 Check out [dbt Fundamentals](https://learn.getdbt.com/courses/dbt-fundamentals) for free if you're interested in course learning with videos.
 :::
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
I just noticed that the tip box wasn't rendering properly, I think it's because it's `tips` instead of `tip`.

## Checklist
- [ ] I have reviewed the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [ ] The topic I'm writing about is for specific dbt version(s) and I have versioned it according to the [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and/or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content) guidelines.
- [ ] I have added checklist item(s) to this list for anything anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-fix-redshift-qs-tip-box-dbt-labs.vercel.app/guides/redshift-qs

<!-- end-vercel-deployment-preview -->