### PR TITLE
add related docs to custom schema/alias/db

### DIFF
--- a/website/docs/docs/build/custom-aliases.md
+++ b/website/docs/docs/build/custom-aliases.md
@@ -157,3 +157,8 @@ If these models should indeed have the same database identifier, you can work ar
 
 By default, dbt will create versioned models with the alias `<model_name>_v<v>`, where `<v>` is that version's unique identifier. You can customize this behavior just like for non-versioned models by configuring a custom `alias` or re-implementing the `generate_alias_name` macro.
 
+## Related docs
+
+- [Customize dbt models database, schema, and alias](/guides/customize-schema-alias?step=1) to learn how to customize dbt models database, schema, and alias
+- [Custom schema](/docs/build/custom-schemas) to learn how to customize dbt schema 
+- [Custom database](/docs/build/custom-databases) to learn how to customize dbt database

--- a/website/docs/docs/build/custom-databases.md
+++ b/website/docs/docs/build/custom-databases.md
@@ -103,4 +103,4 @@ When dbt opens a BigQuery connection, it will do so using the `project_id` defin
 
 - [Customize dbt models database, schema, and alias](/guides/customize-schema-alias?step=1) to learn how to customize dbt models database, schema, and alias
 - [Custom schema](/docs/build/custom-schemas) to learn how to customize dbt model schema
-- [Custom alias](/docs/build/custom-aliases) to learn how to customize dbt model alias name
+- [Custom aliases](/docs/build/custom-aliases) to learn how to customize dbt model alias name

--- a/website/docs/docs/build/custom-databases.md
+++ b/website/docs/docs/build/custom-databases.md
@@ -98,3 +98,9 @@ See docs on macro `dispatch`: ["Managing different global overrides across packa
 ### BigQuery
 
 When dbt opens a BigQuery connection, it will do so using the `project_id` defined in your active `profiles.yml` target. This `project_id` will be billed for the queries that are executed in the dbt run, even if some models are configured to be built in other projects.
+
+## Related docs
+
+- [Customize dbt models database, schema, and alias](/guides/customize-schema-alias?step=1) to learn how to customize dbt models database, schema, and alias
+- [Custom schema](/docs/build/custom-schemas) to learn how to customize dbt model schema
+- [Custom alias](/docs/build/custom-aliases) to learn how to customize dbt model alias name

--- a/website/docs/docs/build/custom-schemas.md
+++ b/website/docs/docs/build/custom-schemas.md
@@ -207,3 +207,9 @@ In the `generate_schema_name` macro examples shown in the [built-in alternative 
 If your schema names are being generated incorrectly, double-check your target name in the relevant environment.
 
 For more information, consult the [managing environments in dbt Core](/docs/core/dbt-core-environments) guide.
+
+## Related docs
+
+- [Customize dbt models database, schema, and alias](/guides/customize-schema-alias?step=1) to learn how to customize dbt models database, schema, and alias
+- [Custom database](/docs/build/custom-databases) to learn how to customize dbt model database
+- [Custom aliases](/docs/build/custom-aliases) to learn how to customize dbt model alias name


### PR DESCRIPTION
adding a ‘related docs’ section and link to the guide on the following pages:

custom schema
custom database
custom alias

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-add-related-docs-links-dbt-labs.vercel.app/docs/build/custom-aliases
- https://docs-getdbt-com-git-add-related-docs-links-dbt-labs.vercel.app/docs/build/custom-databases
- https://docs-getdbt-com-git-add-related-docs-links-dbt-labs.vercel.app/docs/build/custom-schemas

<!-- end-vercel-deployment-preview -->