### PR TITLE
Note that dbt parse doesn't put compiled code in its manifest

### DIFF
--- a/website/docs/reference/commands/parse.md
+++ b/website/docs/reference/commands/parse.md
@@ -9,7 +9,7 @@ The `dbt parse` command parses and validates the contents of your dbt project. I
 
 It will also produce an artifact with detailed timing information, which is useful to understand parsing times for large projects. Refer to [Project parsing](/reference/parsing) for more information.
 
-Starting in v1.5, `dbt parse` will write or return a [manifest](/reference/artifacts/manifest-json), enabling you to introspect dbt's understanding of all the resources in your project.
+Starting in v1.5, `dbt parse` will write or return a [manifest](/reference/artifacts/manifest-json), enabling you to introspect dbt's understanding of all the resources in your project. Since `dbt parse` doesn't connect to your warehouse, [this manifest will not contain any compiled code](/faqs/Warehouse/db-connection-dbt-compile).
 
 By default, the dbt Cloud IDE will attempt a "partial" parse, which means it'll only check changes since the last parse (new or updated parts of your project when you make changes). Since the dbt Cloud IDE automatically parses in the background whenever you save your work, manually running `dbt parse` yourself is likely to be fast because it's just looking at recent changes.
 


### PR DESCRIPTION
I was confused about the difference between dbt parse and dbt compile, because since 1.4 they both create a manifest. Turns out that dbt parse doesn't include compiled code, so I added that caveat. 

## Checklist
- [x] I have reviewed the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-joellabes-patch-4-dbt-labs.vercel.app/reference/commands/parse

<!-- end-vercel-deployment-preview -->