### PR TITLE
Move metrics key

### DIFF
--- a/website/docs/docs/build/metrics-overview.md
+++ b/website/docs/docs/build/metrics-overview.md
@@ -120,14 +120,15 @@ semantic_models:
     - name: orders
       expr: 1
       agg: sum
-  metrics:
-    - name: orders
-      type: simple
-      label: Count of Orders
-      type_params:
-        measure:
-          name: orders
-      time_granularity: month -- Optional, defaults to day
+
+metrics:
+  - name: orders
+    type: simple
+    label: Count of Orders
+    type_params:
+      measure:
+        name: orders
+    time_granularity: month -- Optional, defaults to day
 ```
 </VersionBlock>
 


### PR DESCRIPTION
This pr moves the metrics so it's not nested under semantic_models. Raised by user in community slack https://getdbt.slack.com/archives/C02CCBBBR1D/p1737248111053329

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-mirnawong1-patch-43-dbt-labs.vercel.app/docs/build/metrics-overview

<!-- end-vercel-deployment-preview -->