### PR TITLE
add azure region to email template

### DIFF
--- a/website/docs/docs/cloud/secure/databricks-privatelink.md
+++ b/website/docs/docs/cloud/secure/databricks-privatelink.md
@@ -56,6 +56,7 @@ The following steps will walk you through the setup of a Databricks AWS PrivateL
     - Databricks instance name:
     - Databricks Azure resource ID:
     - dbt Cloud multi-tenant environment: EMEA
+    - Azure region: Region where your Databricks workspace is hosted (for example, WestEurope, NorthEurope)
     ```
 5. Once our Support team confirms the resources are available in the Azure portal, navigate to the Azure Databricks Workspace and browse to **Networking** > **Private Endpoint Connections**. Then, highlight the `dbt` named option and select **Approve**.
 

--- a/website/docs/docs/cloud/secure/databricks-privatelink.md
+++ b/website/docs/docs/cloud/secure/databricks-privatelink.md
@@ -56,7 +56,7 @@ The following steps will walk you through the setup of a Databricks AWS PrivateL
     - Databricks instance name:
     - Databricks Azure resource ID:
     - dbt Cloud multi-tenant environment: EMEA
-    - Azure region: Region where your Databricks workspace is hosted (for example, WestEurope, NorthEurope)
+    - Azure region: Region that hosts your Databricks workspace (like, WestEurope, NorthEurope)
     ```
 5. Once our Support team confirms the resources are available in the Azure portal, navigate to the Azure Databricks Workspace and browse to **Networking** > **Private Endpoint Connections**. Then, highlight the `dbt` named option and select **Approve**.
 


### PR DESCRIPTION
this pr adds the azure region that's needed by user when configuring azure PL for databricks

raised in [internal slack](https://dbt-labs.slack.com/archives/C02NCQ9483C/p1737475208064709)

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-mirnawong1-patch-26-dbt-labs.vercel.app/docs/cloud/secure/databricks-privatelink

<!-- end-vercel-deployment-preview -->