### PR TITLE
clarify metrics key location

### DIFF
--- a/website/docs/docs/build/metrics-overview.md
+++ b/website/docs/docs/build/metrics-overview.md
@@ -7,9 +7,11 @@ tags: [Metrics, Semantic Layer]
 pagination_next: "docs/build/cumulative"
 ---
   
-Once you've created your semantic models, it's time to start adding metrics. Metrics can be defined in the same YAML files as your semantic models, or split into separate YAML files into any other subdirectories (provided that these subdirectories are also within the same dbt project repo).
+After building [semantic models](/docs/build/semantic-models), it's time to start adding metrics. This page explains the different supported metric types you can add to your dbt project
 
-This article explains the different supported metric types you can add to your dbt project. The keys for metrics definitions are:
+Metrics can be defined in the same YAML files as your semantic models, or defined in their dedicated separate YAML files located in any subdirectories within the same dbt project repository.
+
+The keys for metrics definitions are:
 
 <!-- for v1.8 and higher -->
 
@@ -107,7 +109,10 @@ It's possible to define a default time granularity for metrics if it's different
 The granularity can be set using the `time_granularity` parameter on the metric, and defaults to `day`. If day is not available because the dimension is defined at a coarser granularity, it will default to the defined granularity for the dimension.
 
 ### Example
-You have a semantic model called `orders` with a time dimension called `order_time`. You want the `orders` metric to roll up to `monthly` by default; however, you want the option to look at these metrics hourly. You can set the `time_granularity` parameter on the `order_time` dimension to `hour`, and then set the `time_granularity` parameter in the metric to `month`.
+- You have a semantic model called `orders` with a time dimension called `order_time`.
+- You want the `orders` metric to roll up to `monthly` by default; however, you want the option to look at these metrics hourly.
+- You can set the `time_granularity` parameter on the `order_time` dimension to `hour`, and then set the `time_granularity` parameter in the metric to `month`.
+
 ```yaml
 semantic_models:
   ...
@@ -130,6 +135,9 @@ metrics:
         name: orders
     time_granularity: month -- Optional, defaults to day
 ```
+
+Remember that metrics can be defined in the same YAML files as your semantic models but must be defined as a separate top-level section and not nested within a `semantic_model`. Or you can define metrics in their dedicated separate YAML files located in any subdirectories within the same dbt project repository.
+
 </VersionBlock>
 
 ## Conversion metrics

--- a/website/docs/docs/build/metrics-overview.md
+++ b/website/docs/docs/build/metrics-overview.md
@@ -136,7 +136,7 @@ metrics:
     time_granularity: month -- Optional, defaults to day
 ```
 
-Remember that metrics can be defined in the same YAML files as your semantic models but must be defined as a separate top-level section and not nested within a `semantic_model`. Or you can define metrics in their dedicated separate YAML files located in any subdirectories within the same dbt project repository.
+Remember that metrics can be defined in the same YAML files as your semantic models but must be defined as a separate top-level section and not nested within the `semantic_models` key. Or you can define metrics in their dedicated separate YAML files located in any subdirectories within the same dbt project repository.
 
 </VersionBlock>
 


### PR DESCRIPTION
this pr tries to clarify that metrics can be defined in their own standalone file or with in the semantic_models file (but not nested).

this was raised in by docs and user error in [community slack](https://getdbt.slack.com/archives/C02CCBBBR1D/p1737248111053329) adn we want to make it a bit more clearer so it's less confusing.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-mirnawong1-patch-26-dbt-labs.vercel.app/docs/build/metrics-overview

<!-- end-vercel-deployment-preview -->