### PR TITLE
Remove 'databricks' as having microbatch concurrency support

### DIFF
--- a/website/docs/docs/build/incremental-microbatch.md
+++ b/website/docs/docs/build/incremental-microbatch.md
@@ -312,7 +312,6 @@ To enable parallel execution, you must:
 
 - Use a supported adapter:
   - Snowflake
-  - Databricks
   - More adapters coming soon!
     - We'll be continuing to test and add concurrency support for adapters. This means that some adapters might get concurrency support _after_ the 1.9 initial release.
     

--- a/website/docs/docs/build/incremental-microbatch.md
+++ b/website/docs/docs/build/incremental-microbatch.md
@@ -310,10 +310,9 @@ For example, if you have a microbatch model with 12 batches, you can execute tho
 
 To enable parallel execution, you must:
 
-- Use a supported adapter:
-  - Snowflake
+- Use Snowflake as a supported adapter.
   - More adapters coming soon!
-    - We'll be continuing to test and add concurrency support for adapters. This means that some adapters might get concurrency support _after_ the 1.9 initial release.
+  - We'll be continuing to test and add concurrency support for adapters. This means that some adapters might get concurrency support _after_ the 1.9 release.
     
 - Meet [additional conditions](#how-parallel-batch-execution-works) described in the following section.
 


### PR DESCRIPTION


## What are you changing in this pull request and why?

We had been listing dbt-databricks as supporting microbatch concurrency. However, this was erroneous as dbt-databricks does not currently support microbatch concurrency. As such we need to correct this in the docs. This was likely my fault in the first place 🫠 

## Checklist
- [X] I have reviewed the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [ ] The topic I'm writing about is for specific dbt version(s) and I have versioned it according to the [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and/or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content) guidelines.
- [ ] I have added checklist item(s) to this list for anything anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).
<!--
PRE-RELEASE VERSION OF dbt (if so, uncomment):
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
<!-- 
ADDING OR REMOVING PAGES (if so, uncomment):
- [ ] Add/remove page in `website/sidebars.js`
- [ ] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages
-->
