### PR TITLE
Update dbt_valid_to_current.md

### DIFF
--- a/website/docs/reference/resource-configs/dbt_valid_to_current.md
+++ b/website/docs/reference/resource-configs/dbt_valid_to_current.md
@@ -12,8 +12,9 @@ id: "dbt_valid_to_current"
 
 ```yaml
 snapshots:
-  my_project:
-    +dbt_valid_to_current: "to_date('9999-12-31')"
+  - name: my_snapshot
+    config:
+      dbt_valid_to_current: "string"
 
 ```
 
@@ -27,7 +28,7 @@ snapshots:
         unique_key='id',
         strategy='timestamp',
         updated_at='updated_at',
-        dbt_valid_to_current='to_date('9999-12-31')'
+        dbt_valid_to_current='string'
     )
 }}
 ```
@@ -39,7 +40,7 @@ snapshots:
 ```yml
 snapshots:
   [<resource-path>](/reference/resource-configs/resource-path):
-    +dbt_valid_to_current: "to_date('9999-12-31')"
+    +dbt_valid_to_current: "string"
 ```
 
 </File>


### PR DESCRIPTION
fix wrong example in schema.yml file. missing `config`

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-mirnawong1-patch-28-dbt-labs.vercel.app/reference/resource-configs/dbt_valid_to_current

<!-- end-vercel-deployment-preview -->