### PR TITLE
Update snapshots.md

### DIFF
--- a/website/docs/docs/build/snapshots.md
+++ b/website/docs/docs/build/snapshots.md
@@ -371,7 +371,7 @@ snapshots:
 
 In this example:
 
-- If there is any change in at least one of the specified `check_cols`, then a new row is created in the snapshot. If the provided `updated_at` column value is not null, it will be used; otherwise, the timestamp will be used.
+- If at least one of the specified `check_cols `changes, the snapshot creates a new row. If the `updated_at` column has a value (is not null), the snapshot uses it; otherwise, it defaults to the timestamp.
 - If `updated_at` isn’t set, then dbt automatically falls back to [using the current timestamp](#sample-results-for-the-check-strategy) to track changes.
 - Use this approach when your `updated_at` column isn't reliable for tracking record updates, but you still want to use it &mdash; rather than the snapshot's execution time &mdash; whenever row changes are detected.
 

--- a/website/docs/docs/build/snapshots.md
+++ b/website/docs/docs/build/snapshots.md
@@ -373,7 +373,7 @@ In this example:
 
 - If there is any change in at least one of the specified `check_cols`, then a new row is created in the snapshot. If the provided `updated_at` column value is not null, it will be used; otherwise, the timestamp will be used.
 - If `updated_at` isn’t set, then dbt automatically falls back to [using the current timestamp](#sample-results-for-the-check-strategy) to track changes.
-- Use this approach when your `updated_at` column isn't reliable for tracking record updates, but you still want to use it - rather than the snapshot's execution time - whenever row changes are detected.
+- Use this approach when your `updated_at` column isn't reliable for tracking record updates, but you still want to use it &mdash; rather than the snapshot's execution time &mdash; whenever row changes are detected.
 
 ### Hard deletes (opt-in)
 

--- a/website/docs/docs/build/snapshots.md
+++ b/website/docs/docs/build/snapshots.md
@@ -371,7 +371,7 @@ snapshots:
 
 In this example:
 
-- If there is any change in at least one of the specified `check_cols`, then a new row is created in the snapshot. If the provided `updated_at` column value is not null, it will be used; otherwise, the timestamp will be used"
+- If there is any change in at least one of the specified `check_cols`, then a new row is created in the snapshot. If the provided `updated_at` column value is not null, it will be used; otherwise, the timestamp will be used.
 - If `updated_at` isn’t set, then dbt automatically falls back to [using the current timestamp](#sample-results-for-the-check-strategy) to track changes.
 - Use this approach when your `updated_at` column isn't reliable for tracking record updates, but you still want to use it - rather than the snapshot's execution time - whenever row changes are detected.
 

--- a/website/docs/docs/build/snapshots.md
+++ b/website/docs/docs/build/snapshots.md
@@ -346,14 +346,14 @@ snapshots:
 
 </VersionBlock>
 
-####  Example usage with `check_cols: updated_at`
+####  Example usage with `updated_at`
 
-When using the `check` strategy, dbt tracks changes by comparing values in `check_cols`. You can use an `updated_at` column to detect when a row has changed.
+When using the `check` strategy, dbt tracks changes by comparing values in `check_cols`. By default, dbt uses the timestamp to update `dbt_updated_at`, `dbt_valid_from` and `dbt_valid_to` fields. Optionally you can set an `updated_at` column:
 
-- If `check_cols: updated_at` is set, dbt only tracks changes in that column.
-- If `updated_at` isn't included, dbt defaults to using the current timestamp.
+- If `updated_at` is configured, the `check` strategy uses this column instead, as with the timestamp strategy.
+- If `updated_at` value is null, dbt defaults to using the current timestamp.
 
-Check out the following example, which shows how to use the `check` strategy with `updated_at` using `check_cols`:
+Check out the following example, which shows how to use the `check` strategy with `updated_at`:
 
 ```yaml
 snapshots:
@@ -364,13 +364,16 @@ snapshots:
       unique_key: order_id
       strategy: check
       check_cols:
-        - updated_at
+        - status
+        - is_cancelled
+      updated_at: updated_at
 ```
 
 In this example:
 
-- `check_cols: updated_at` makes sure that only the `updated_at` column triggers new snapshots.
+- If there is any change in at least one of the specified `check_cols`, then a new row is created in the snapshot. If the provided `updated_at` column value is not null, it will be used; otherwise, the timestamp will be used"
 - If `updated_at` isn’t set, then dbt automatically falls back to [using the current timestamp](#sample-results-for-the-check-strategy) to track changes.
+- Use this approach when your `updated_at` column isn't reliable for tracking record updates, but you still want to use it - rather than the snapshot's execution time - whenever row changes are detected.
 
 ### Hard deletes (opt-in)
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
This PR suggests changing the example recently added to this document as the result of this [Slack thread](https://getdbt.slack.com/archives/CBSQTAPLG/p1737393637257859).

The key point of the [original question](https://discourse.getdbt.com/t/snapshot-check-strategy-with-valid-from-date/1795) is: "...there is a parent entity that has a “last updated” date that I need to use for new rows instead of the current timestamp. This column is present in the source data, although as it comes from the parent entity instead it can’t be used reliably to indicate changes in the source entity, but when there are changes then it can be used as the start date for those changes."

So we need to check some columns, without including anything related to update dates, and when a change is detected, we want to use our database update-related column instead of the timestamp corresponding to the snapshot execution.

The recently added example isn't incorrect, but doesn't capture what was discussed and solved in the thread, which is a more probable use case situation. Moreover, using a timestamp strategy with a properly defined updated_at field and a check strategy that only checks a column corresponding to the updated time is basically the same. I'd venture to say it could even be less efficient.

In addition to modifying the example, titles, and described logic, a summary of this use case was added to the clarifications section to serve as a reference.

## Checklist
- [x] I have reviewed the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [ ] The topic I'm writing about is for specific dbt version(s) and I have versioned it according to the [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and/or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content) guidelines.
- [ ] I have added checklist item(s) to this list for anything anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).
<!--
PRE-RELEASE VERSION OF dbt (if so, uncomment):
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
<!-- 
ADDING OR REMOVING PAGES (if so, uncomment):
- [ ] Add/remove page in `website/sidebars.js`
- [ ] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages
-->
