### PR TITLE
remove beta for microbatch

### DIFF
--- a/website/docs/docs/build/incremental-microbatch.md
+++ b/website/docs/docs/build/incremental-microbatch.md
@@ -6,13 +6,11 @@ id: "incremental-microbatch"
 
 :::info
 
-Available in beta for [dbt Cloud "Latest"](/docs/dbt-versions/cloud-release-tracks) and dbt Core v1.9 or higher.
+Available for [dbt Cloud "Latest"](/docs/dbt-versions/cloud-release-tracks) and dbt Core v1.9 or higher.
 
 If you use a custom microbatch macro, set a [distinct behavior flag](/reference/global-configs/behavior-changes#custom-microbatch-strategy) in your `dbt_project.yml` to enable batched execution. If you don't have a custom microbatch macro, you don't need to set this flag as dbt will handle microbatching automatically for any model using the [microbatch strategy](#how-microbatch-compares-to-other-incremental-strategies).
 
-Read and participate in the discussion: [dbt-core#10672](https://github.com/dbt-labs/dbt-core/discussions/10672)
-
-Refer to [Supported incremental strategies by adapter](/docs/build/incremental-strategy#supported-incremental-strategies-by-adapter) for a list of supported adapters. 
+Read and participate in the discussion: [dbt-core#10672](https://github.com/dbt-labs/dbt-core/discussions/10672). Refer to [Supported incremental strategies by adapter](/docs/build/incremental-strategy#supported-incremental-strategies-by-adapter) for a list of supported adapters. 
 
 :::
 

--- a/website/docs/docs/build/incremental-microbatch.md
+++ b/website/docs/docs/build/incremental-microbatch.md
@@ -4,11 +4,9 @@ description: "Learn about the 'microbatch' strategy for incremental models."
 id: "incremental-microbatch"
 ---
 
-# About microbatch incremental models <Lifecycle status="beta" />
+:::info
 
-:::info Microbatch
-
-The new `microbatch` strategy is available in beta for [dbt Cloud "Latest"](/docs/dbt-versions/cloud-release-tracks) and dbt Core v1.9. 
+Available in beta for [dbt Cloud "Latest"](/docs/dbt-versions/cloud-release-tracks) and dbt Core v1.9 or higher.
 
 If you use a custom microbatch macro, set a [distinct behavior flag](/reference/global-configs/behavior-changes#custom-microbatch-strategy) in your `dbt_project.yml` to enable batched execution. If you don't have a custom microbatch macro, you don't need to set this flag as dbt will handle microbatching automatically for any model using the [microbatch strategy](#how-microbatch-compares-to-other-incremental-strategies).
 

--- a/website/docs/docs/build/incremental-models-overview.md
+++ b/website/docs/docs/build/incremental-models-overview.md
@@ -42,5 +42,5 @@ Transaction management, a process used in certain data platforms, ensures that a
 ## Related docs
 - [Incremental models](/docs/build/incremental-models) to learn how to configure incremental models in dbt.
 - [Incremental strategies](/docs/build/incremental-strategy) to understand how dbt implements incremental models on different databases.
-- [Microbatch](/docs/build/incremental-strategy) <Lifecycle status="beta" /> to understand a new incremental strategy intended for efficient and resilient processing of very large time-series datasets.
+- [Microbatch](/docs/build/incremental-strategy) to understand a new incremental strategy intended for efficient and resilient processing of very large time-series datasets.
 - [Materializations best practices](/best-practices/materializations/1-guide-overview) to learn about the best practices for using materializations in dbt.

--- a/website/docs/docs/build/incremental-strategy.md
+++ b/website/docs/docs/build/incremental-strategy.md
@@ -13,7 +13,7 @@ There are various strategies to implement the concept of incremental materializa
 
 An optional `incremental_strategy` config is provided in some adapters that controls the code that dbt uses to build incremental models.
 
-:::info Microbatch <Lifecycle status="beta" />
+:::info Microbatch
 
 The [`microbatch` incremental strategy](/docs/build/incremental-microbatch) is intended for large time-series datasets. dbt will process the incremental model in multiple queries (or "batches") based on a configured `event_time` column. Depending on the volume and nature of your data, this can be more efficient and resilient than using a single query for adding new data.
 
@@ -25,7 +25,7 @@ This table represents the availability of each incremental strategy, based on th
 
 Click the name of the adapter in the below table for more information about supported incremental strategies.
 
-| Data platform adapter | `append` | `merge` | `delete+insert` | `insert_overwrite` | `microbatch` <Lifecycle status="beta"/> |
+| Data platform adapter | `append` | `merge` | `delete+insert` | `insert_overwrite` | `microbatch`        |
 |-----------------------|:--------:|:-------:|:---------------:|:------------------:|:-------------------:|
 | [dbt-postgres](/reference/resource-configs/postgres-configs#incremental-materialization-strategies) |     ✅    |    ✅   |        ✅        |                    |      ✅            |
 | [dbt-redshift](/reference/resource-configs/redshift-configs#incremental-materialization-strategies) |     ✅    |    ✅   |        ✅        |                    |      ✅        |
@@ -200,7 +200,7 @@ Before diving into [custom strategies](#custom-strategies), it's important to un
 | `delete+insert`        | `get_incremental_delete_insert_sql`    |
 | `merge`                | `get_incremental_merge_sql`            |
 | `insert_overwrite`     | `get_incremental_insert_overwrite_sql` |
-| `microbatch`  <Lifecycle status="beta"/>         | `get_incremental_microbatch_sql`       |
+| `microbatch`           | `get_incremental_microbatch_sql`       |
 
 
 For example, a built-in strategy for the `append` can be defined and used with the following files:


### PR DESCRIPTION
microbatch went ga and this pr removes any beta pill/mention from the microbatch incremental models docs

[refer to internal slack](https://dbt-labs.slack.com/archives/CSSHB76QL/p1738873368330369)

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-microbatch-ga-dbt-labs.vercel.app/docs/build/incremental-microbatch
- https://docs-getdbt-com-git-microbatch-ga-dbt-labs.vercel.app/docs/build/incremental-models-overview
- https://docs-getdbt-com-git-microbatch-ga-dbt-labs.vercel.app/docs/build/incremental-strategy

<!-- end-vercel-deployment-preview -->