### PR TITLE
Update metrics-overview.md

### DIFF
--- a/website/docs/docs/build/metrics-overview.md
+++ b/website/docs/docs/build/metrics-overview.md
@@ -9,7 +9,7 @@ pagination_next: "docs/build/cumulative"
   
 After building [semantic models](/docs/build/semantic-models), it's time to start adding metrics. This page explains the different supported metric types you can add to your dbt project
 
-Metrics can be defined in the same YAML files as your semantic models, or defined in their dedicated separate YAML files located in any subdirectories within the same dbt project repository.
+Metrics must be defined in a YAML file—either within the same file as your semantic models or in a separate YAML file in a subdirectory of your dbt project. They shouldn't be defined in a `config` block on a model.
 
 The keys for metrics definitions are:
 

--- a/website/docs/docs/build/metrics-overview.md
+++ b/website/docs/docs/build/metrics-overview.md
@@ -9,7 +9,7 @@ pagination_next: "docs/build/cumulative"
   
 After building [semantic models](/docs/build/semantic-models), it's time to start adding metrics. This page explains the different supported metric types you can add to your dbt project
 
-Metrics must be defined in a YAML file—either within the same file as your semantic models or in a separate YAML file in a subdirectory of your dbt project. They shouldn't be defined in a `config` block on a model.
+Metrics must be defined in a YAML file &mdash; either within the same file as your semantic models or in a separate YAML file in a subdirectory of your dbt project. They shouldn't be defined in a `config` block on a model.
 
 The keys for metrics definitions are:
 


### PR DESCRIPTION
though the doc says metrics are yaml based, let's make it more explicit that they can't be defined via config block. 

user confusion raised in [internal slck thread](https://dbt-labs.slack.com/archives/C019QLR6EJE/p1738981129259909)

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-mirnawong1-patch-26-dbt-labs.vercel.app/docs/build/metrics-overview

<!-- end-vercel-deployment-preview -->