### PR TITLE
Update lint-format.md

### DIFF
--- a/website/docs/docs/cloud/dbt-cloud-ide/lint-format.md
+++ b/website/docs/docs/cloud/dbt-cloud-ide/lint-format.md
@@ -79,7 +79,14 @@ To configure your own linting rules:
 5. Restart the IDE.
 6. Test it out and happy linting!
 
-:::tip Configure dbtonic linting rules
+### Snapshot linting
+By default, dbt Cloud lints all modified `.sql` files in your project. [Snapshots](/docs/build/snapshots) can be defined in YAML _and_ `.sql` files, but their SQL isn't lintable, it can cause errors during linting.
+
+To avoid having SQLFluff try to lint snapshot files, add the snapshots directory to your `.sqlfluffignore` file (for example `snapshots/`).
+
+Note that you should explicitly exclude snapshots in your `.sqlfluffignore` file since dbt Cloud doesn't automatically ignore snapshots on the backend.
+
+### Configure dbtonic linting rules
 
 Refer to the [Jaffle shop SQLFluff config file](https://github.com/dbt-labs/jaffle-shop-template/blob/main/.sqlfluff) for dbt-specific (or dbtonic) linting rules we use for our own projects:
 
@@ -129,7 +136,6 @@ group_by_and_order_by_style = implicit
 </details>
 
 For more info on styling best practices, refer to [How we style our SQL](/best-practices/how-we-style/2-how-we-style-our-sql).
-:::
 
 <Lightbox src="/img/docs/dbt-cloud/cloud-ide/ide-sqlfluff-config.jpg" width="90%" title="Customize linting by configuring your own linting code rules, including dbtonic linting/styling."/>
 

--- a/website/docs/docs/cloud/dbt-cloud-ide/lint-format.md
+++ b/website/docs/docs/cloud/dbt-cloud-ide/lint-format.md
@@ -82,7 +82,7 @@ To configure your own linting rules:
 #### Snapshot linting
 By default, dbt Cloud lints all modified `.sql` files in your project, including snapshots. [Snapshots](/docs/build/snapshots) can be defined in YAML _and_ `.sql` files, but their SQL isn't lintable and can cause errors during linting.
 
-To avoid having SQLFluff try to lint snapshot files, add the snapshots directory to your `.sqlfluffignore` file (for example `snapshots/`).
+To prevent SQLFluff from linting snapshot files, add the snapshots directory to your `.sqlfluffignore` file (for example `snapshots/`).
 
 Note that you should explicitly exclude snapshots in your `.sqlfluffignore` file since dbt Cloud doesn't automatically ignore snapshots on the backend.
 

--- a/website/docs/docs/cloud/dbt-cloud-ide/lint-format.md
+++ b/website/docs/docs/cloud/dbt-cloud-ide/lint-format.md
@@ -79,8 +79,8 @@ To configure your own linting rules:
 5. Restart the IDE.
 6. Test it out and happy linting!
 
-### Snapshot linting
-By default, dbt Cloud lints all modified `.sql` files in your project. [Snapshots](/docs/build/snapshots) can be defined in YAML _and_ `.sql` files, but their SQL isn't lintable, it can cause errors during linting.
+#### Snapshot linting
+By default, dbt Cloud lints all modified `.sql` files in your project, including snapshots. [Snapshots](/docs/build/snapshots) can be defined in YAML _and_ `.sql` files, but their SQL isn't lintable and can cause errors during linting.
 
 To avoid having SQLFluff try to lint snapshot files, add the snapshots directory to your `.sqlfluffignore` file (for example `snapshots/`).
 

--- a/website/docs/docs/deploy/continuous-integration.md
+++ b/website/docs/docs/deploy/continuous-integration.md
@@ -31,7 +31,6 @@ import GitProvidersCI from '/snippets/_git-providers-supporting-ci.md';
 
 <GitProvidersCI />
 
-
 ## Differences between CI jobs and other deployment jobs
 
 The [dbt Cloud scheduler](/docs/deploy/job-scheduler) executes CI jobs differently from other deployment jobs in these important ways:
@@ -65,7 +64,9 @@ CI runs don't consume run slots. This guarantees a CI check will never block a p
 
 Available on [dbt Cloud release tracks](/docs/dbt-versions/cloud-release-tracks) and dbt Cloud Team or Enterprise accounts.
 
-When [enabled for your CI job](/docs/deploy/ci-jobs#set-up-ci-jobs), dbt invokes [SQLFluff](https://sqlfluff.com/) which is a modular and configurable SQL linter that warns you of complex functions, syntax, formatting, and compilation errors. By default, it lints all the changed SQL files in your project (compared to the last deferred production state). 
+When [enabled for your CI job](/docs/deploy/ci-jobs#set-up-ci-jobs), dbt invokes [SQLFluff](https://sqlfluff.com/) which is a modular and configurable SQL linter that warns you of complex functions, syntax, formatting, and compilation errors. 
+
+By default, SQL linting lints all the changed SQL files in your project (compared to the last deferred production state). Note that [snapshots](/docs/build/snapshots) can be defined in YAML _and_ `.sql` files, but its SQL isn't lintable and can cause errors during linting. To avoid having SQLFluff try to lint snapshot files, add the snapshots directory to your `.sqlfluffignore` file (for example `snapshots/`). Refer to [snapshot linting](/docs/cloud/dbt-cloud-ide/lint-format#snapshot-linting) for more information.
 
 If the linter runs into errors, you can specify whether dbt should stop running the job on error or continue running it on error. When failing jobs, it helps reduce compute costs by avoiding builds for pull requests that don't meet your SQL code quality CI check.
 

--- a/website/docs/docs/deploy/continuous-integration.md
+++ b/website/docs/docs/deploy/continuous-integration.md
@@ -66,7 +66,7 @@ Available on [dbt Cloud release tracks](/docs/dbt-versions/cloud-release-tracks)
 
 When [enabled for your CI job](/docs/deploy/ci-jobs#set-up-ci-jobs), dbt invokes [SQLFluff](https://sqlfluff.com/) which is a modular and configurable SQL linter that warns you of complex functions, syntax, formatting, and compilation errors. 
 
-By default, SQL linting lints all the changed SQL files in your project (compared to the last deferred production state). Note that [snapshots](/docs/build/snapshots) can be defined in YAML _and_ `.sql` files, but its SQL isn't lintable and can cause errors during linting. To avoid having SQLFluff try to lint snapshot files, add the snapshots directory to your `.sqlfluffignore` file (for example `snapshots/`). Refer to [snapshot linting](/docs/cloud/dbt-cloud-ide/lint-format#snapshot-linting) for more information.
+By default, SQL linting lints all the changed SQL files in your project (compared to the last deferred production state). Note that [snapshots](/docs/build/snapshots) can be defined in YAML _and_ `.sql` files, but its SQL isn't lintable and can cause errors during linting. To prevent SQLFluff from linting snapshot files, add the snapshots directory to your `.sqlfluffignore` file (for example `snapshots/`). Refer to [snapshot linting](/docs/cloud/dbt-cloud-ide/lint-format#snapshot-linting) for more information.
 
 If the linter runs into errors, you can specify whether dbt should stop running the job on error or continue running it on error. When failing jobs, it helps reduce compute costs by avoiding builds for pull requests that don't meet your SQL code quality CI check.
 


### PR DESCRIPTION
clarify that snapshots should be added to sqlfluffifgnore file so its not linted


[raised internally here](https://dbt-labs.slack.com/archives/C017GDLAF7D/p1734537434936589) to address multiple support tickets coming in

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-mirnawong1-patch-28-dbt-labs.vercel.app/docs/cloud/dbt-cloud-ide/lint-format
- https://docs-getdbt-com-git-mirnawong1-patch-28-dbt-labs.vercel.app/docs/deploy/continuous-integration

<!-- end-vercel-deployment-preview -->