### PR TITLE
update incremental strategy and add overview page

### DIFF
--- a/website/docs/docs/build/incremental-strategy.md
+++ b/website/docs/docs/build/incremental-strategy.md
@@ -23,7 +23,7 @@ The [`microbatch` incremental strategy](/docs/build/incremental-microbatch) is i
 
 This table shows the support of each incremental strategy across adapters available on dbt Cloud's [Latest release track](/docs/dbt-versions/cloud-release-tracks). Some strategies may be unavailable if you're not on "Latest" and the feature hasn't been released to the "Compatible" track.  
 
-If you're interested in an adapter available only in dbt Core, check out the [adapter's individual configuration page](/reference/resource-configs/resource-configs) for more details.
+If you're interested in an adapter available in dbt Core only, check out the [adapter's individual configuration page](/reference/resource-configs/resource-configs) for more details.
 
 Click the name of the adapter in the following table for more information about supported incremental strategies:
 

--- a/website/docs/docs/build/incremental-strategy.md
+++ b/website/docs/docs/build/incremental-strategy.md
@@ -21,9 +21,11 @@ The [`microbatch` incremental strategy](/docs/build/incremental-microbatch) is i
 
 ### Supported incremental strategies by adapter
 
-This table represents the availability of each incremental strategy, based on the latest version of dbt Core and each adapter.
+This table shows the support of each incremental strategy across adapters available on dbt Cloud on the [Latest release track](/docs/dbt-versions/cloud-release-tracks). Some strategies may be unavailable if you're not on "Latest" and the feature hasn't be released to the "Compatible" track.  
 
-Click the name of the adapter in the below table for more information about supported incremental strategies.
+If you're interested in an adapter available on only dbt Core, check out the [adapter's individual configuration page](/reference/resource-configs/resource-configs).
+
+Click the name of the adapter in the following table for more information about supported incremental strategies:
 
 | Data platform adapter | `append` | `merge` | `delete+insert` | `insert_overwrite` | `microbatch`        |
 |-----------------------|:--------:|:-------:|:---------------:|:------------------:|:-------------------:|

--- a/website/docs/docs/build/incremental-strategy.md
+++ b/website/docs/docs/build/incremental-strategy.md
@@ -21,9 +21,9 @@ The [`microbatch` incremental strategy](/docs/build/incremental-microbatch) is i
 
 ### Supported incremental strategies by adapter
 
-This table shows the support of each incremental strategy across adapters available on dbt Cloud on the [Latest release track](/docs/dbt-versions/cloud-release-tracks). Some strategies may be unavailable if you're not on "Latest" and the feature hasn't be released to the "Compatible" track.  
+This table shows the support of each incremental strategy across adapters available on dbt Cloud's [Latest release track](/docs/dbt-versions/cloud-release-tracks). Some strategies may be unavailable if you're not on "Latest" and the feature hasn't been released to the "Compatible" track.  
 
-If you're interested in an adapter available on only dbt Core, check out the [adapter's individual configuration page](/reference/resource-configs/resource-configs).
+If you're interested in an adapter available only in dbt Core, check out the [adapter's individual configuration page](/reference/resource-configs/resource-configs) for more details.
 
 Click the name of the adapter in the following table for more information about supported incremental strategies:
 

--- a/website/docs/reference/resource-configs/_category.yaml
+++ b/website/docs/reference/resource-configs/_category.yaml
@@ -1,0 +1,10 @@
+# position: 2.5 # float position is supported
+label: 'Resource configs'
+collapsible: true # make the category collapsible
+collapsed: true # keep the category collapsed by default
+className: red
+link:
+  type: generated-index
+  title: Resource configs
+customProps:
+  description: Platform-specific configs are used to configure the dbt project for a specific database platform.

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "website",
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "3.7.0",

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -894,6 +894,13 @@ const sidebarSettings = {
     {
       type: "category",
       label: "Platform-specific configs",
+      link: {
+        type: "generated-index",
+        title: "Platform-specific configs",
+        description:
+          "Platform-specific configs are used to configure the dbt project for a specific database platform.",
+        slug: "/reference/resource-configs/resource-configs",
+      },
       items: [
         "reference/resource-configs/athena-configs",
         "reference/resource-configs/impala-configs",


### PR DESCRIPTION
this pr adds the following:
- updated language to clarify the incremental strategy table shows adapters avail in core and cloud for maintainability
- adds an autogenerated yaml for the resource configs page to fix the breadcrumbs and provide an overview page.


[discussed internally](https://dbt-labs.slack.com/archives/C067EUS2D7S/p1739883993636309?thread_ts=1739788547.953469&cid=C067EUS2D7S)

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-incremental-doc-dbt-labs.vercel.app/docs/build/incremental-strategy
- https://docs-getdbt-com-git-update-incremental-doc-dbt-labs.vercel.app/reference/resource-configs/resource-configs

<!-- end-vercel-deployment-preview -->