### PR TITLE
add python version for snowpark

### DIFF
--- a/website/docs/faqs/Core/install-python-compatibility.md
+++ b/website/docs/faqs/Core/install-python-compatibility.md
@@ -13,4 +13,4 @@ Use this table to match dbt-core versions with their compatible Python versions.
 
 Adapter plugins and their dependencies are not always compatible with the latest version of Python. For example, dbt-snowflake v0.19 is not compatible with Python 3.9, but dbt-snowflake versions 0.20+ are.
 
-Note that this shouldn't be confused with [dbt Python models](/docs/build/python-models#specific-data-platforms). If you're using a data platform that supports Snowpark, use the `python_version` configuration to run a Snowpark model with [Python versions](https://docs.snowflake.com/en/developer-guide/snowpark/python/setup) 3.9, 3.10, or 3.11.
+Note that this shouldn't be confused with [dbt Python models](/docs/build/python-models#specific-data-platforms). If you're using a data platform that supports Snowpark, use the `python_version` config to run a Snowpark model with [Python versions](https://docs.snowflake.com/en/developer-guide/snowpark/python/setup) 3.9, 3.10, or 3.11.

--- a/website/docs/faqs/Core/install-python-compatibility.md
+++ b/website/docs/faqs/Core/install-python-compatibility.md
@@ -13,4 +13,4 @@ Use this table to match dbt-core versions with their compatible Python versions.
 
 Adapter plugins and their dependencies are not always compatible with the latest version of Python. For example, dbt-snowflake v0.19 is not compatible with Python 3.9, but dbt-snowflake versions 0.20+ are.
 
-This isn't to be confused with building [dbt Python models](/docs/build/python-models#specific-data-platforms). If you're using a data platform that supports Snowpark, you can use the `python_version` config to run a Snowpark model with [Python versions](https://docs.snowflake.com/en/developer-guide/snowpark/python/setup) 3.9, 3.10, or 3.11.
+Note that this shouldn't be confused with [dbt Python models](/docs/build/python-models#specific-data-platforms). For dbt Python models, if you're using a data platform that supports Snowpark, use the `python_version` config to run a Snowpark model with [Python versions](https://docs.snowflake.com/en/developer-guide/snowpark/python/setup) 3.9, 3.10, or 3.11.

--- a/website/docs/faqs/Core/install-python-compatibility.md
+++ b/website/docs/faqs/Core/install-python-compatibility.md
@@ -13,5 +13,4 @@ Use this table to match dbt-core versions with their compatible Python versions.
 
 Adapter plugins and their dependencies are not always compatible with the latest version of Python. For example, dbt-snowflake v0.19 is not compatible with Python 3.9, but dbt-snowflake versions 0.20+ are.
 
-### Python models
-If you are building [dbt Python models](/docs/build/python-models#specific-data-platforms), you can use the `python_version` config to run a Snowpark model with [Python versions](https://docs.snowflake.com/en/developer-guide/snowpark/python/setup) 3.9, 3.10, or 3.11.
+This isn't to be confused with building [dbt Python models](/docs/build/python-models#specific-data-platforms). If you're using a data platform that supports Snowpark, you can use the `python_version` config to run a Snowpark model with [Python versions](https://docs.snowflake.com/en/developer-guide/snowpark/python/setup) 3.9, 3.10, or 3.11.

--- a/website/docs/faqs/Core/install-python-compatibility.md
+++ b/website/docs/faqs/Core/install-python-compatibility.md
@@ -13,4 +13,4 @@ Use this table to match dbt-core versions with their compatible Python versions.
 
 Adapter plugins and their dependencies are not always compatible with the latest version of Python. For example, dbt-snowflake v0.19 is not compatible with Python 3.9, but dbt-snowflake versions 0.20+ are.
 
-Note that this shouldn't be confused with [dbt Python models](/docs/build/python-models#specific-data-platforms). For dbt Python models, if you're using a data platform that supports Snowpark, use the `python_version` config to run a Snowpark model with [Python versions](https://docs.snowflake.com/en/developer-guide/snowpark/python/setup) 3.9, 3.10, or 3.11.
+Note that this shouldn't be confused with [dbt Python models](/docs/build/python-models#specific-data-platforms). If you're using a data platform that supports Snowpark, use the `python_version` configuration to run a Snowpark model with [Python versions](https://docs.snowflake.com/en/developer-guide/snowpark/python/setup) 3.9, 3.10, or 3.11.


### PR DESCRIPTION
this pr specifies Python version for Python models on Snowpark (Snowflake) in the python models page and python compatibility faq.

Resolves #5016

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-add-python-veresion-dbt-labs.vercel.app/faqs/Core/install-python-compatibility

<!-- end-vercel-deployment-preview -->