### PR TITLE
Update setup-azure-service-principal.md

### DIFF
--- a/website/docs/docs/cloud/git/setup-azure-service-principal.md
+++ b/website/docs/docs/cloud/git/setup-azure-service-principal.md
@@ -144,7 +144,7 @@ To confirm whether your existing app already has a service principal:
 1. In the Azure account, navigate to **Microsoft Entra ID** -> **Manage** -> **App registrations**.
 2. Click on the application for the service user integration with dbt Cloud. 
 3. Verify whether a name populates the **Managed application in local directory** field. 
-    - If a name exists, continue to the next step from the [add a role to your service principal](#add-a-role-to-service-principal) and follow the remaining instructions.
+    - If a name exists, follow the steps in Microsoft's [Assign a role to the application](https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal#assign-a-role-to-the-application) documentation, then continue with the remaining instructions in this section.
     - If no name exists, go to the next section, [Create the service principal](#create-the-service-principal).
 4. Follow the instructions to [add permissions](#add-permissions-to-your-service-principal) to your service principal.
 5. Follow the instructions to [connect DevOps to your app](#connect-azure-devops-to-your-new-app).

--- a/website/docs/docs/cloud/git/setup-azure-service-principal.md
+++ b/website/docs/docs/cloud/git/setup-azure-service-principal.md
@@ -144,8 +144,8 @@ To confirm whether your existing app already has a service principal:
 1. In the Azure account, navigate to **Microsoft Entra ID** -> **Manage** -> **App registrations**.
 2. Click on the application for the service user integration with dbt Cloud. 
 3. Verify whether a name populates the **Managed application in local directory** field. 
-    - If a name exists, follow the steps in Microsoft's [Assign a role to the application](https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal#assign-a-role-to-the-application) documentation, then continue with the remaining instructions in this section.
-    - If no name exists, go to the next section, [Create the service principal](#create-the-service-principal).
+    - If a name exists: Assign a role to the service principal by following the steps in Microsoft's [Assign a role to the application](https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal#assign-a-role-to-the-application) documentation. Then, continue with the remaining instructions in this section.
+    - If no name exists: Go to the next section, [Create the service principal](#create-the-service-principal).
 4. Follow the instructions to [add permissions](#add-permissions-to-your-service-principal) to your service principal.
 5. Follow the instructions to [connect DevOps to your app](#connect-azure-devops-to-your-new-app).
 6. In your dbt Cloud account:


### PR DESCRIPTION
this confusion was raised by a user in support, [check out internal thread](https://dbt-labs.slack.com/archives/C02NCQ9483C/p1740567697331619)

this pr replaces a broken link regarding [Verify the service principal](https://docs.getdbt.com/docs/cloud/git/setup-service-principal#verify-the-service-principal)  doc.

the sub step under 'verify the service principal' links to an empty/broken link:
> If a name exists, continue to the next step from the [add a role to your service principal](https://docs.getdbt.com/docs/cloud/git/setup-service-principal#add-a-role-to-service-principal) and follow the remaining instructions.

the sentence links to a section that was [removed](https://github.com/dbt-labs/docs.getdbt.com/blob/05c91b287ff1a6b771090e3777ee125a57ff3884/website/docs/docs/cloud/git/setup-azure-service-principal.md?plain=1) and should link to the microsoft page as it was intended. 

also clarified that the next path forward after providing the microsoft link.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-mirnawong1-patch-26-dbt-labs.vercel.app/docs/cloud/git/setup-azure-service-principal

<!-- end-vercel-deployment-preview -->