### PR TITLE
Update environment-permissions-setup.md

### DIFF
--- a/website/docs/docs/cloud/manage-access/environment-permissions-setup.md
+++ b/website/docs/docs/cloud/manage-access/environment-permissions-setup.md
@@ -15,7 +15,7 @@ Environment-level permissions are not the same as account-level [role-based acce
 
 In your dbt Cloud account:
 
-1. Click your account name, above your profile icon on the left side panel, then select **Account settings**.
+1. Click your account name, above your profile icon on the left side panel. Then select **Account settings**.
 2. Select **Groups & Licenses**. We recommend deleting the default `Owner`, `Member`, and `Everyone` groups and replacing them with your organizational groups to avoid granting users unnecessary elevated privileges.
 
 <Lightbox src="/img/docs/dbt-cloud/groups-and-licenses.png" width="80%" title="Groups & Licenses page in dbt Cloud with the default groups highlighted."/>

--- a/website/docs/docs/cloud/manage-access/environment-permissions-setup.md
+++ b/website/docs/docs/cloud/manage-access/environment-permissions-setup.md
@@ -15,21 +15,22 @@ Environment-level permissions are not the same as account-level [role-based acce
 
 In your dbt Cloud account:
 
-1. Click your account name, above your profile icon on the left side panel, then select **Account settings**. From there, select **Groups & Licenses**. While you can edit existing groups, we recommend not altering the default `Everyone`, `Member`, and `Owner` groups.
+1. Click your account name, above your profile icon on the left side panel, then select **Account settings**.
+2. From there, select **Groups & Licenses**. We recommend deleting the default `Owner`, `Member`, and `Everyone` groups before deploying and replacing them with your organizational groups. 
 
 <Lightbox src="/img/docs/dbt-cloud/groups-and-licenses.png" width="80%" title="Groups & Licenses page in dbt Cloud with the default groups highlighted."/>
 
-2. Create a new or open an existing group. If it's a new group, give it a name, then scroll down to **Access & permissions**. Click **Add**.
+3. Create a new or open an existing group. If it's a new group, give it a name, then scroll down to **Access & permissions**. Click **Add**.
 
 <Lightbox src="/img/docs/dbt-cloud/add-permissions.png" width="80%" title="The Access & permissions section with the Add button highlighted."/>
 
-3. Select the **Permission set** for the group. Only the following permissions sets can have environment-level permissions configured:
+4. Select the **Permission set** for the group. Only the following permissions sets can have environment-level permissions configured:
 
-- Database admin
-- Git admin
-- Team admin
-- Analyst
-- Developer
+  - Database admin
+  - Git admin
+  - Team admin
+  - Analyst
+  - Developer
 
 Other permission sets are restricted because they have access to everything (for example, Account admin), or limitations prevent them from having write access to environments (for example, Account viewer).
 
@@ -37,11 +38,11 @@ If you select a permission set that is not supported, the environment permission
 
 <Lightbox src="/img/docs/dbt-cloud/no-option.png" width="80%" title="The view of the permissions box if there is no option for environment permissions."/>
 
-4. Select the **Environment** for group access. The default is **All environments**, but you can select multiple. If none are selected, the group will have read-only access.
+5. Select the **Environment** for group access. The default is **All environments**, but you can select multiple. If none are selected, the group will have read-only access.
 
 <Lightbox src="/img/docs/dbt-cloud/environment-options.png" width="80%" title="A list of available environments with the Staging and General boxes selected."/>
 
-5. Save the Group settings. You're now setup and ready to assign users!
+6. Save the Group settings. You're now setup and ready to assign users!
 
 ## User experience
 

--- a/website/docs/docs/cloud/manage-access/environment-permissions-setup.md
+++ b/website/docs/docs/cloud/manage-access/environment-permissions-setup.md
@@ -16,7 +16,7 @@ Environment-level permissions are not the same as account-level [role-based acce
 In your dbt Cloud account:
 
 1. Click your account name, above your profile icon on the left side panel, then select **Account settings**.
-2. Select **Groups & Licenses**. We recommend deleting the default `Owner`, `Member`, and `Everyone` groups before deploying and replacing them with your organizational groups to avoid granting users unnecessary elevated privileges.
+2. Select **Groups & Licenses**. We recommend deleting the default `Owner`, `Member`, and `Everyone` groups and replacing them with your organizational groups to avoid granting users unnecessary elevated privileges.
 
 <Lightbox src="/img/docs/dbt-cloud/groups-and-licenses.png" width="80%" title="Groups & Licenses page in dbt Cloud with the default groups highlighted."/>
 

--- a/website/docs/docs/cloud/manage-access/environment-permissions-setup.md
+++ b/website/docs/docs/cloud/manage-access/environment-permissions-setup.md
@@ -16,7 +16,7 @@ Environment-level permissions are not the same as account-level [role-based acce
 In your dbt Cloud account:
 
 1. Click your account name, above your profile icon on the left side panel. Then select **Account settings**.
-2. Select **Groups & Licenses**. We recommend deleting the default `Owner`, `Member`, and `Everyone` groups and replacing them with your organizational groups to avoid granting users unnecessary elevated privileges.
+2. Select **Groups & Licenses**. We recommend deleting the default `Owner`, `Member`, and `Everyone` groups and, instead, assigning users to your organizational groups to avoid granting them unnecessary elevated privileges.
 
 <Lightbox src="/img/docs/dbt-cloud/groups-and-licenses.png" width="80%" title="Groups & Licenses page in dbt Cloud with the default groups highlighted."/>
 

--- a/website/docs/docs/cloud/manage-access/environment-permissions-setup.md
+++ b/website/docs/docs/cloud/manage-access/environment-permissions-setup.md
@@ -16,7 +16,7 @@ Environment-level permissions are not the same as account-level [role-based acce
 In your dbt Cloud account:
 
 1. Click your account name, above your profile icon on the left side panel, then select **Account settings**.
-2. From there, select **Groups & Licenses**. We recommend deleting the default `Owner`, `Member`, and `Everyone` groups before deploying and replacing them with your organizational groups. 
+2. Select **Groups & Licenses**. We recommend deleting the default `Owner`, `Member`, and `Everyone` groups before deploying and replacing them with your organizational groups to avoid granting users unnecessary elevated privileges.
 
 <Lightbox src="/img/docs/dbt-cloud/groups-and-licenses.png" width="80%" title="Groups & Licenses page in dbt Cloud with the default groups highlighted."/>
 


### PR DESCRIPTION
this pr clarifies contradictory information about deleting the default everyone, owner, and member groups. 

discussed [in internal slack](https://dbt-labs.slack.com/archives/C02N953LRDF/p1740739553476449) and is now inline with what we say [here](https://docs.getdbt.com/docs/cloud/manage-access/about-user-access#groups)

further discussion needed between @matthewshaver and enterprise team to clarify the user experience

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-mirnawong1-patch-26-dbt-labs.vercel.app/docs/cloud/manage-access/environment-permissions-setup

<!-- end-vercel-deployment-preview -->