### PR TITLE
add dbt cloud status link

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -211,6 +211,7 @@ var siteSettings = {
           ></script>
 
           <div class='footer__items'>
+            <a href='https://status.getdbt.com//'>dbt Cloud Status</a>
             <a href='https://www.getdbt.com/terms-of-use/'>Terms of Service</a>
             <a href='https://www.getdbt.com/cloud/privacy-policy/'>Privacy Policy</a>
             <a href='https://www.getdbt.com/security/'>Security</a>


### PR DESCRIPTION
this pr adds a link to the dbt cloud status page in the documentation footer for users in case they need it. added it to the footer because:

more accessible – users who need it can find it without distracting from the main content.
SEO-neutral – footer doesn't dilute page relevance and is a very common placement for status pages.