### PR TITLE
Add applicable `group by` clauses

### DIFF
--- a/website/blog/2023-02-01-ingestion-time-partitioning-bigquery.md
+++ b/website/blog/2023-02-01-ingestion-time-partitioning-bigquery.md
@@ -64,6 +64,7 @@ select
     campaign_id,
     NULLIF(COUNTIF(action = 'impression'), 0) impressions_count
 from {{ source('logs', 'tracking_events') }}
+group by day, campaign_id
 ```
 
 We only need to add a field to move to ingestion-time partitioning: `"time_ingestion_partitioning": true`
@@ -84,6 +85,7 @@ select
     campaign_id,
     NULLIF(COUNTIF(action = 'impression'), 0) impressions_count
 from {{ source('logs', 'tracking_events') }}
+group by day, campaign_id
 ```
 
 The resulting table schema will be:
@@ -158,6 +160,7 @@ select
     campaign_id,
     NULLIF(COUNTIF(action = 'impression'), 0) impressions_count
 from {{ source('logs', 'tracking_events') }}
+group by day, campaign_id
 ```
 
 Again we only need to add a field to move to partition copy: `"copy_partitions": true`
@@ -178,6 +181,7 @@ select
     campaign_id,
     NULLIF(COUNTIF(action = 'impression'), 0) impressions_count
 from {{ source('logs', 'tracking_events') }}
+group by day, campaign_id
 ```
 
 The configuration will be read at run time and will use the BQ driver integration to write the data using partition copy. The integration should be seamless.


### PR DESCRIPTION
## What are you changing in this pull request and why?

### Problem

I got the following error when trying to run the examples within the blog post for [BigQuery ingestion-time partitioning and partition copy with dbt](https://docs.getdbt.com/blog/bigquery-ingestion-time-partitioning-and-partition-copy-with-dbt):

```
Database Error in model a (models/a.sql)
  SELECT list expression references column day which is neither grouped nor aggregated at [15:5]
```

### Solution

Add applicable `group by` clauses so that the example queries work.

## Checklist
- [x] I have reviewed the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.