### PR TITLE
update repo links  to reflect repo move

### DIFF
--- a/website/docs/docs/core/connect-data-platform/bigquery-setup.md
+++ b/website/docs/docs/core/connect-data-platform/bigquery-setup.md
@@ -4,7 +4,7 @@ description: "Read this guide to learn about the BigQuery warehouse setup in dbt
 meta:
   maintained_by: dbt Labs
   authors: 'core dbt maintainers'
-  github_repo: 'dbt-labs/dbt-bigquery'
+  github_repo: 'dbt-labs/dbt-adapters'
   pypi_package: 'dbt-bigquery'
   min_core_version: 'v0.10.0'
   cloud_support: Supported

--- a/website/docs/docs/core/connect-data-platform/postgres-setup.md
+++ b/website/docs/docs/core/connect-data-platform/postgres-setup.md
@@ -5,7 +5,7 @@ id: "postgres-setup"
 meta:
   maintained_by: dbt Labs
   authors: 'core dbt maintainers'
-  github_repo: 'dbt-labs/dbt-postgres'
+  github_repo: 'dbt-labs/dbt-adapters'
   pypi_package: 'dbt-postgres'
   min_core_version: 'v0.4.0'
   cloud_support: Supported

--- a/website/docs/docs/core/connect-data-platform/redshift-setup.md
+++ b/website/docs/docs/core/connect-data-platform/redshift-setup.md
@@ -5,7 +5,7 @@ id: "redshift-setup"
 meta:
   maintained_by: dbt Labs
   authors: 'core dbt maintainers'
-  github_repo: 'dbt-labs/dbt-redshift'
+  github_repo: 'dbt-labs/dbt-adapters'
   pypi_package: 'dbt-redshift'
   min_core_version: 'v0.10.0'
   cloud_support: Supported

--- a/website/docs/docs/core/connect-data-platform/snowflake-setup.md
+++ b/website/docs/docs/core/connect-data-platform/snowflake-setup.md
@@ -5,7 +5,7 @@ id: "snowflake-setup"
 meta:
   maintained_by: dbt Labs
   authors: 'core dbt maintainers'
-  github_repo: 'dbt-labs/dbt-snowflake'
+  github_repo: 'dbt-labs/dbt-adapters'
   pypi_package: 'dbt-snowflake'
   min_core_version: 'v0.8.0'
   cloud_support: Supported

--- a/website/docs/docs/core/connect-data-platform/spark-setup.md
+++ b/website/docs/docs/core/connect-data-platform/spark-setup.md
@@ -5,7 +5,7 @@ id: "spark-setup"
 meta:
   maintained_by: dbt Labs
   authors: 'core dbt maintainers'
-  github_repo: 'dbt-labs/dbt-spark'
+  github_repo: 'dbt-labs/dbt-adapters'
   pypi_package: 'dbt-spark'
   min_core_version: 'v0.15.0'
   cloud_support: Supported


### PR DESCRIPTION
following on from https://github.com/dbt-labs/docs.getdbt.com/pull/6994, this pr changes the repo link to the maintained dbt-labs/dbt-adapters instead of the dbt-labs/repo-name for first party adapters

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-repos-dbt-labs.vercel.app/docs/core/connect-data-platform/bigquery-setup
- https://docs-getdbt-com-git-update-repos-dbt-labs.vercel.app/docs/core/connect-data-platform/postgres-setup
- https://docs-getdbt-com-git-update-repos-dbt-labs.vercel.app/docs/core/connect-data-platform/redshift-setup
- https://docs-getdbt-com-git-update-repos-dbt-labs.vercel.app/docs/core/connect-data-platform/snowflake-setup
- https://docs-getdbt-com-git-update-repos-dbt-labs.vercel.app/docs/core/connect-data-platform/spark-setup

<!-- end-vercel-deployment-preview -->