### PR TITLE
Add info for `package:this` selector

### DIFF
--- a/website/docs/reference/node-selection/methods.md
+++ b/website/docs/reference/node-selection/methods.md
@@ -143,6 +143,8 @@ selectors unambiguous.
   dbt run --select "snowplow.*"
 ```
 
+The package `this` is also a special one that would select the ndoes of the current project. With the example above, running `dbt run --select "package:this"` from the `snowplow` project would run the exact same set of models as any of the three other selectors.
+
 ### path
 The `path` method is used to select models/sources defined at or under a specific path.
 Model definitions are in SQL/Python files (not YAML), and source definitions are in YAML files.

--- a/website/docs/reference/node-selection/methods.md
+++ b/website/docs/reference/node-selection/methods.md
@@ -143,7 +143,9 @@ selectors unambiguous.
   dbt run --select "snowplow.*"
 ```
 
-The package `this` is also a special one that would select the ndoes of the current project. With the example above, running `dbt run --select "package:this"` from the `snowplow` project would run the exact same set of models as any of the three other selectors.
+Use the `this` package to select nodes from the current project. From the example, running `dbt run --select "package:this"` from the `snowplow` project runs the exact same set of models as the other three selectors.
+
+Since `this` always refers to the current project, using `package:this` ensures that you're only selecting models from the project you're working in.
 
 ### path
 The `path` method is used to select models/sources defined at or under a specific path.


### PR DESCRIPTION
## What are you changing in this pull request and why?
<!--
Describe your changes and why you're making them. If related to an open issue or a pull request on dbt Core or another repository, then link to them here! 

To learn more about the writing conventions used in the dbt Labs docs, see the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md).
-->
Adding `package:this` to the docs as `this` is a special name that can be used to select nodes from the current project.

This was implemented [here](https://github.com/dbt-labs/dbt-core/issues/6891) but was never added to the docs.

## Checklist
- [x] I have reviewed the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [x] The topic I'm writing about is for specific dbt version(s) and I have versioned it according to the [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and/or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content) guidelines.


<!-- 
ADDING OR REMOVING PAGES (if so, uncomment):
- [ ] Add/remove page in `website/sidebars.js`
- [ ] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages
-->

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-b-per-patch-1-dbt-labs.vercel.app/reference/node-selection/methods

<!-- end-vercel-deployment-preview -->