### PR TITLE
Add script to check for Qualified cookie to hide Forethought widget

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -294,6 +294,7 @@ var siteSettings = {
     "/js/gtm.js",
     "/js/onetrust.js",
     "/js/mutiny.js",
+    "/js/hide-forethought.js",
   ],
   stylesheets: [
     "/css/fonts.css",

--- a/website/static/js/hide-forethought.js
+++ b/website/static/js/hide-forethought.js
@@ -1,26 +1,20 @@
 (function() {
-  console.log('hide forethought script running')
   // Check if QualifiedConversationStarted cookie set
   const qualifiedCookie = document.cookie
     .split("; ")
     .find((row) => row.startsWith("QualifiedConversationStarted="))
-  console.log('qualifiedCookie', qualifiedCookie)
 
   // If QualifiedConversationStarted cookie set, 
   // attempt to hide Forethought widget
   let intCount = 0
   if(qualifiedCookie) {
-    console.log('hiding forethought widget')
     // Start interval to allow time for Forethought widget element to load
     const interval = setInterval(function(){
       intCount++
       // Attempt to get forethought-chat widget element 5 times
-      console.log('count', intCount)
       if (intCount < 10) {
-        
         // Get Forethought widget by ID
         const forethoughtIframe = document.getElementById('forethought-chat')
-        console.log('forethoughtIframe', forethoughtIframe)
         if (forethoughtIframe) {
           // If element found, hide element
           forethoughtIframe.style.display = 'none';

--- a/website/static/js/hide-forethought.js
+++ b/website/static/js/hide-forethought.js
@@ -1,0 +1,36 @@
+(function() {
+  console.log('hide forethought script running')
+  // Check if QualifiedConversationStarted cookie set
+  const qualifiedCookie = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith("QualifiedConversationStarted="))
+  console.log('qualifiedCookie', qualifiedCookie)
+
+  // If QualifiedConversationStarted cookie set, 
+  // attempt to hide Forethought widget
+  let intCount = 0
+  if(qualifiedCookie) {
+    console.log('hiding forethought widget')
+    // Start interval to allow time for Forethought widget element to load
+    const interval = setInterval(function(){
+      intCount++
+      // Attempt to get forethought-chat widget element 5 times
+      console.log('count', intCount)
+      if (intCount < 10) {
+        // const forethoughtIframe = document.getElementById('forethought-chat')
+    
+        // Temp - use footer element for testing
+        const forethoughtIframe = document.querySelector('.footer')
+        console.log('forethoughtIframe', forethoughtIframe)
+        if (forethoughtIframe) {
+          // If element found, hide element
+          forethoughtIframe.style.display = 'none';
+          clearInterval(interval)
+        }
+      } else {
+        // Unable to retrieve Forethought element, stopping interval
+        clearInterval(interval)
+      }
+    }, 500) 
+  }
+})()

--- a/website/static/js/hide-forethought.js
+++ b/website/static/js/hide-forethought.js
@@ -17,10 +17,9 @@
       // Attempt to get forethought-chat widget element 5 times
       console.log('count', intCount)
       if (intCount < 10) {
-        // const forethoughtIframe = document.getElementById('forethought-chat')
-    
-        // Temp - use footer element for testing
-        const forethoughtIframe = document.querySelector('.footer')
+        
+        // Get Forethought widget by ID
+        const forethoughtIframe = document.getElementById('forethought-chat')
         console.log('forethoughtIframe', forethoughtIframe)
         if (forethoughtIframe) {
           // If element found, hide element


### PR DESCRIPTION
## What are you changing in this pull request and why?

[Asana task](https://app.asana.com/0/1200792801231972/1209653584238369)

This PR adds a script which checks for a `QualifiedConversationStarted` cookie which is set from WWW within GTM. This cookie signals that a conversation has been started within the Qualified widget.

If a conversation is active, and the user is linked to the docs site from the widget, the Qualified widget will open on Docs to continue the conversation. If the Qualified widget is open, we should hide the Forethought widget to prevent the two widgets from overlapping.

## Preview
https://docs-getdbt-com-git-hide-forethought-dbt-labs.vercel.app/

## Testing Steps

1. Open the preview above
2. Verify you see the Forethought widget in the bottom-right corner
3. In `DevTools > Application (or Storage if using Firefox)`, create a new cookie called `QualifiedConversationStarted`. The value could be anything, I'm setting it to `true`
4. With the cookie created, refresh the page and verify the Forethought widget hides. The console logs should also confirm the element was found and hidden

## TODO Before Merge
- [x] Update selector to get `forethought-chat` element by ID 
- [x] Clear console logs
