### PR TITLE
Parallel execution support

### DIFF
--- a/website/docs/docs/build/parallel-batch-execution.md
+++ b/website/docs/docs/build/parallel-batch-execution.md
@@ -15,22 +15,18 @@ For example, if you have a microbatch model with 12 batches, you can execute tho
 
 ## Prerequisites
 
-To enable parallel execution, you must:
+To use parallel execution, you must meet the following prerequisites:
 
 - Use Snowflake as a supported adapter.
-  - More adapters coming soon!
-  - We'll be continuing to test and add concurrency support for adapters. This means that some adapters might get concurrency support _after_ the 1.9 release.
-- Meet [additional conditions](#how-parallel-batch-execution-works) described in the following section.
+  - More adapters are coming soon!
+  - We'll continue to test and add concurrency support for more adapters in the future.
+- A batch can only be run in parallel if:
+  - The batch is _not_ the first batch.
+  - The batch is _not_ the last batch.
 
 ## How parallel batch execution works
 
-A batch can only run in parallel if all of these conditions are met:
-
-- Batch is _not_ the first batch.
-- Batch is _not_ the last batch.
-- [Adapter supports](#prerequisites) parallel batches.
-
-After checking for the conditions in the previous table &mdash; and if `concurrent_batches` value isn't set, dbt will intelligently auto-detect if the model invokes the [`{{ this }}`](/reference/dbt-jinja-functions/this) Jinja function. If it references `{{ this }}`, the batches will run sequentially since  `{{ this }}` represents the database of the current model and referencing the same relation causes conflict. 
+After checking for the conditions in the [prerequisites](#prerequisites), and if `concurrent_batches` value isn't set, dbt will intelligently auto-detect if the model invokes the [`{{ this }}`](/reference/dbt-jinja-functions/this) Jinja function. If it references `{{ this }}`, the batches will run sequentially since  `{{ this }}` represents the database of the current model and referencing the same relation causes conflict. 
 
 Otherwise, if `{{ this }}` isn't detected (and other conditions are met), the batches will run in parallel, which can be overriden when you [set a value for `concurrent_batches`](/reference/resource-properties/concurrent_batches).
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

Merging the two prerequisite sections on parallel execution

[See internal thread](https://dbt-labs.slack.com/archives/C02NCQ9483C/p1741886041137309)

## Checklist
- [ ] I have reviewed the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [ ] The topic I'm writing about is for specific dbt version(s) and I have versioned it according to the [version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) and/or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content) guidelines.
- [ ] I have added checklist item(s) to this list for anything anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).
<!--
PRE-RELEASE VERSION OF dbt (if so, uncomment):
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
<!-- 
ADDING OR REMOVING PAGES (if so, uncomment):
- [ ] Add/remove page in `website/sidebars.js`
- [ ] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages
-->

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-link-parallel-dbt-labs.vercel.app/docs/build/parallel-batch-execution

<!-- end-vercel-deployment-preview -->