### PR TITLE
dbt Cloud release tracks - GA

### DIFF
--- a/website/docs/docs/dbt-versions/cloud-release-tracks.md
+++ b/website/docs/docs/dbt-versions/cloud-release-tracks.md
@@ -16,7 +16,7 @@ By moving your environments and jobs to release tracks you can get all the funct
 
 | Release track | Description | Plan availability | API value |
 | ------------- | ----------- | ----------------- | --------- |
-| **Latest** |  Formerly called "Versionless", provides a continuous release of the latest functionality in dbt Cloud.<br /><br />Includes early access to new features of the dbt framework before they're available in open source releases of dbt Core. | All plans | `latest` (or `versionless`) |
+| **Latest** | Formerly called "Versionless", provides a continuous release of the latest functionality in dbt Cloud.<br /><br />Includes early access to new features of the dbt framework before they're available in open source releases of dbt Core. | All plans | `latest` (or `versionless`) |
 | **Compatible** | Provides a monthly release aligned with the most recent open source versions of dbt Core and adapters, plus functionality exclusively available in dbt Cloud.<br /><br />See [Compatible track changelog](/docs/dbt-versions/compatible-track-changelog) for more information. |  Team + Enterprise | `compatible` |
 | **Extended** | The previous month's "Compatible" release. | Enterprise | `extended` |
 

--- a/website/docs/docs/dbt-versions/cloud-release-tracks.md
+++ b/website/docs/docs/dbt-versions/cloud-release-tracks.md
@@ -16,11 +16,9 @@ By moving your environments and jobs to release tracks you can get all the funct
 
 | Release track | Description | Plan availability | API value |
 | ------------- | ----------- | ----------------- | --------- |
-| **Latest** <br /> <Lifecycle status="GA"/> |  Formerly called "Versionless", provides a continuous release of the latest functionality in dbt Cloud.<br /><br />Includes early access to new features of the dbt framework before they're available in open source releases of dbt Core. | All plans | `latest` (or `versionless`) |
-| **Compatible** <Lifecycle status="preview"/>  | Provides a monthly release aligned with the most recent open source versions of dbt Core and adapters, plus functionality exclusively available in dbt Cloud.<br /><br />See [Compatible track changelog](/docs/dbt-versions/compatible-track-changelog) for more information. |  Team + Enterprise | `compatible` |
-| **Extended** <Lifecycle status="preview"/> | The previous month's "Compatible" release. | Enterprise | `extended` |
-
-The first "Compatible" release was on December 12, 2024, after the final release of dbt Core v1.9.0. For December 2024 only, the "Extended" release is the same as "Compatible." Starting in January 2025, "Extended" will be one month behind "Compatible."
+| **Latest** |  Formerly called "Versionless", provides a continuous release of the latest functionality in dbt Cloud.<br /><br />Includes early access to new features of the dbt framework before they're available in open source releases of dbt Core. | All plans | `latest` (or `versionless`) |
+| **Compatible** | Provides a monthly release aligned with the most recent open source versions of dbt Core and adapters, plus functionality exclusively available in dbt Cloud.<br /><br />See [Compatible track changelog](/docs/dbt-versions/compatible-track-changelog) for more information. |  Team + Enterprise | `compatible` |
+| **Extended** | The previous month's "Compatible" release. | Enterprise | `extended` |
 
 To configure an environment in the [dbt Cloud Admin API](/docs/dbt-cloud-apis/admin-cloud-api) or [Terraform](https://registry.terraform.io/providers/dbt-labs/dbtcloud/latest) to use a release track, set `dbt_version` to the release track name:
 - `latest` (or `versionless`, the old name is still supported)

--- a/website/docs/docs/dbt-versions/compatible-track-changelog.md
+++ b/website/docs/docs/dbt-versions/compatible-track-changelog.md
@@ -4,17 +4,9 @@ sidebar_label: "Compatible Track Changelog"
 description: "The Compatible release track updates once per month, and it includes up-to-date open source versions as of the monthly release."
 ---
 
-:::info Preview
-
-The "Compatible" and "Extended" [release tracks](/docs/dbt-versions/cloud-release-tracks) are available in Preview. Access will be rolling out to dbt Cloud accounts on eligible plans during the week of December 16-20, 2024.
-
-:::
-
 Select the "Compatible" and "Extended" release tracks if you need a less-frequent release cadence, the ability to test new dbt releases before they go live in production, and/or ongoing compatibility with the latest open source releases of dbt Core.
 
 Each monthly "Compatible" release includes functionality matching up-to-date open source versions of dbt Core and adapters at the time of release.
-
-Starting in January 2025, each monthly "Extended" release will match the previous month's "Compatible" release.
 
 For more information, see [release tracks](/docs/dbt-versions/cloud-release-tracks).
 

--- a/website/docs/docs/dbt-versions/release-notes.md
+++ b/website/docs/docs/dbt-versions/release-notes.md
@@ -18,6 +18,7 @@ Release notes are grouped by month for both multi-tenant and virtual private clo
 
 ## March 2025
 
+- **New**: dbt Cloud release tracks are Generally Available. Depending on their plan, customers may select among the Latest, Compatible, or Extended tracks to manage the update cadences for development and deployment environments.
 - **New:** The dbt Cloud-native integration with Azure DevOps now supports [Entra ID service principals](/docs/cloud/git/setup-service-principal). Unlike a services user, which represents a real user object in Entra ID, the service principal is a secure identity associated with your dbt Cloud app to access resources in Azure unattended. Please [migrate your service user](/docs/cloud/git/setup-service-principal#migrate-to-service-principal) to a service principal for Azure DevOps  as soon as possible.
 
 ## February 2025

--- a/website/docs/docs/dbt-versions/release-notes.md
+++ b/website/docs/docs/dbt-versions/release-notes.md
@@ -18,7 +18,7 @@ Release notes are grouped by month for both multi-tenant and virtual private clo
 
 ## March 2025
 
-- **New**: dbt Cloud release tracks are Generally Available. Depending on their plan, customers may select among the Latest, Compatible, or Extended tracks to manage the update cadences for development and deployment environments.
+- **New**: [dbt Cloud release tracks](/docs/dbt-versions/cloud-release-tracks) are Generally Available. Depending on their plan, customers may select among the Latest, Compatible, or Extended tracks to manage the update cadences for development and deployment environments.
 - **New:** The dbt Cloud-native integration with Azure DevOps now supports [Entra ID service principals](/docs/cloud/git/setup-service-principal). Unlike a services user, which represents a real user object in Entra ID, the service principal is a secure identity associated with your dbt Cloud app to access resources in Azure unattended. Please [migrate your service user](/docs/cloud/git/setup-service-principal#migrate-to-service-principal) to a service principal for Azure DevOps  as soon as possible.
 
 ## February 2025

--- a/website/snippets/core-versions-table.md
+++ b/website/snippets/core-versions-table.md
@@ -18,4 +18,4 @@ All functionality in dbt Core since the v1.7 release is available in [dbt Cloud 
 
 <sup>1</sup> Release tracks are required for the Developer and Teams plans on dbt Cloud. Accounts using older dbt versions will be migrated to the "Latest" release track.
 
-For customers of dbt Cloud: dbt Labs strongly recommends migrating any environments that are still running on older unsupported versions to either release tracks or dbt v1.7. Throughout 2025, dbt Labs is removing the oldest dbt Core versions from availability in dbt Cloud, starting with v1.0-1.2.
+For customers of dbt Cloud: dbt Labs strongly recommends migrating environments on older and unsupported versions to [release tracks](/docs/dbt-versions/cloud-release-tracks) or a supported version. In 2025, dbt Labs will remove the oldest dbt Core versions from availability in dbt Cloud, starting with v1.0 -- v1.2.

--- a/website/snippets/core-versions-table.md
+++ b/website/snippets/core-versions-table.md
@@ -18,4 +18,4 @@ All functionality in dbt Core since the v1.7 release is available in [dbt Cloud 
 
 <sup>1</sup> Release tracks are required for the Developer and Teams plans on dbt Cloud. Accounts using older dbt versions will be migrated to the "Latest" release track.
 
-For customers of dbt Cloud Enterprise, dbt v1.7 will continue to be available as an option until dbt Labs announces that "Compatible" and "Extended" release tracks are Generally Available, planned for March 2025. (They are currently available to all eligible accounts in Preview.) In the meantime, dbt Labs strongly recommends migrating any environments that are still running on older unsupported versions to either release tracks or dbt v1.7.
+For customers of dbt Cloud: dbt Labs strongly recommends migrating any environments that are still running on older unsupported versions to either release tracks or dbt v1.7. Throughout 2025, dbt Labs is removing the oldest dbt Core versions from availability in dbt Cloud, starting with v1.0-1.2.


### PR DESCRIPTION
## What are you changing in this pull request and why?

- Remove "Preview" callouts
- Remove one-time note about Compatible/Extended tracks in December/January
- Add release note

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-jerco-release-track-ga-dbt-labs.vercel.app/docs/dbt-versions/cloud-release-tracks
- https://docs-getdbt-com-git-jerco-release-track-ga-dbt-labs.vercel.app/docs/dbt-versions/compatible-track-changelog
- https://docs-getdbt-com-git-jerco-release-track-ga-dbt-labs.vercel.app/docs/dbt-versions/release-notes

<!-- end-vercel-deployment-preview -->