### PR TITLE
Redshift-managed Serverless PrivateLink update

### DIFF
--- a/website/docs/docs/cloud/secure/redshift-privatelink.md
+++ b/website/docs/docs/cloud/secure/redshift-privatelink.md
@@ -53,14 +53,14 @@ dbt Cloud supports both types of endpoints, but there are a number of [considera
        ```
 
    - **Redshift Serverless**
-     ```
-     Subject: New Multi-Tenant PrivateLink Request
+       ```
+       Subject: New Multi-Tenant PrivateLink Request
        - Type: Redshift-managed - Serverless
        - Redshift workgroup name:
        - Redshift workgroup AWS account ID:
        - Redshift workgroup AWS Region (e.g., us-east-1, eu-west-2):
        - dbt Cloud multi-tenant environment (US, EMEA, AU):
-     ```
+       ```
 
 import PrivateLinkSLA from '/snippets/_PrivateLink-SLA.md';
 

--- a/website/docs/docs/cloud/secure/redshift-privatelink.md
+++ b/website/docs/docs/cloud/secure/redshift-privatelink.md
@@ -20,15 +20,15 @@ dbt Cloud supports both types of endpoints, but there are a number of [considera
 
 <CloudProviders type='Redshift' />
 
-:::note Redshift Serverless
-While Redshift Serverless does support Redshift-managed type VPC endpoints, this functionality is not currently available across AWS accounts. Due to this limitation, an Interface-type VPC endpoint service must be used for Redshift Serverless cluster PrivateLink connectivity from dbt Cloud. 
-:::
-
 ## Configuring Redshift-managed PrivateLink
 
-1. On the running Redshift cluster, select the **Properties** tab.
-
-<Lightbox src="/img/docs/dbt-cloud/redshiftprivatelink1.png" title="Redshift Properties tab"/>
+1. Locate the **Granted accounts** section of the Redshift configuration
+   - **Standard Redshift**
+        - On the running Redshift cluster, select the **Properties** tab.
+        <Lightbox src="/img/docs/dbt-cloud/redshiftprivatelink1.png" title="Redshift Properties tab"/>
+     
+   - **Redshift Serverless**
+       - On the Redshift Serverless Workgroup's configuration page.  
 
 2. In the **Granted accounts** section, click **Grant access**.
 

--- a/website/docs/docs/cloud/secure/redshift-privatelink.md
+++ b/website/docs/docs/cloud/secure/redshift-privatelink.md
@@ -42,14 +42,25 @@ dbt Cloud supports both types of endpoints, but there are a number of [considera
 
 5. Add the required information to the following template, and submit your request to [dbt Support](https://docs.getdbt.com/community/resources/getting-help#dbt-cloud-support):
 
-```
-Subject: New Multi-Tenant PrivateLink Request
-- Type: Redshift-managed
-- Redshift cluster name:
-- Redshift cluster AWS account ID:
-- Redshift cluster AWS Region (e.g., us-east-1, eu-west-2):
-- dbt Cloud multi-tenant environment (US, EMEA, AU):
-```
+   - **Standard Redshift**
+       ```
+       Subject: New Multi-Tenant PrivateLink Request
+       - Type: Redshift-managed
+       - Redshift cluster name:
+       - Redshift cluster AWS account ID:
+       - Redshift cluster AWS Region (e.g., us-east-1, eu-west-2):
+       - dbt Cloud multi-tenant environment (US, EMEA, AU):
+       ```
+
+   - **Redshift Serverless**
+     ```
+     Subject: New Multi-Tenant PrivateLink Request
+       - Type: Redshift-managed - Serverless
+       - Redshift workgroup name:
+       - Redshift workgroup AWS account ID:
+       - Redshift workgroup AWS Region (e.g., us-east-1, eu-west-2):
+       - dbt Cloud multi-tenant environment (US, EMEA, AU):
+     ```
 
 import PrivateLinkSLA from '/snippets/_PrivateLink-SLA.md';
 

--- a/website/docs/docs/cloud/secure/redshift-privatelink.md
+++ b/website/docs/docs/cloud/secure/redshift-privatelink.md
@@ -28,7 +28,7 @@ dbt Cloud supports both types of endpoints, but there are a number of [considera
         <Lightbox src="/img/docs/dbt-cloud/redshiftprivatelink1.png" title="Redshift Properties tab"/>
      
    - **Redshift Serverless**
-       - On the Redshift Serverless Workgroup's configuration page.  
+       - On the Redshift Serverless **Workgroup configuration** page.  
 
 2. In the **Granted accounts** section, click **Grant access**.
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
- Remove note about Redshift-managed serverless VPC endpoints not being supported in all AWS accounts
- Added new support template for requesting a Redshift-managed Serverless VPC endpoint

## Checklist
<!-- Ensure your PR meets the following items. Feel free to add additiona checklist items to the list if additional checks need to happen before the PR is merged, such as:
- [ ] Needs technical review
- [ ] Change base branch
- [ ] Merge on xyz date
-->
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).
<!--
PRE-RELEASE VERSION OF dbt (if so, uncomment):
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
<!-- 
ADDING OR REMOVING PAGES (if so, uncomment):
- [ ] Add/remove page in `website/sidebars.js`
- [ ] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages
-->
