### PR TITLE
exposures is missing from dbt_project.yml docs

### DIFF
--- a/website/docs/docs/build/exposures.md
+++ b/website/docs/docs/build/exposures.md
@@ -16,6 +16,8 @@ Exposures can be defined in two ways:
 
 Exposures are defined in `.yml` files nested under an `exposures:` key.
 
+The following example shows an exposure definition in a `models/<filename>.yml` file:
+
 <File name='models/<filename>.yml'>
 
 ```yaml
@@ -60,9 +62,11 @@ _Optional:_
 - **maturity**: Indicates the level of confidence or stability in the exposure. One of `high`, `medium`, or `low`. For example, you could use `high` maturity for a well-established dashboard, widely used and trusted within your organization. Use `low` maturity for a new or experimental analysis.
 
 _General properties (optional)_
-- **description**
-- **tags**
-- **meta**
+
+- [**description**](/reference/resource-properties/description)
+- [**tags**](/reference/resource-configs/tags)
+- [**meta**](/reference/resource-configs/meta)
+- [**enabled**](/reference/resource-configs/enabled) &mdash; You can set this property at the exposure level or at the project level in the [`dbt_project.yml`](/reference/dbt_project.yml) file.
 
 ### Referencing exposures
 

--- a/website/docs/reference/dbt_project.yml.md
+++ b/website/docs/reference/dbt_project.yml.md
@@ -52,6 +52,9 @@ The following example is a list of all available configurations in the `dbt_proj
   [project-id](/docs/cloud/configure-cloud-cli#configure-the-dbt-cloud-cli): project_id # Required
   [defer-env-id](/docs/cloud/about-cloud-develop-defer#defer-in-dbt-cloud-cli): environment_id # Optional
 
+[exposures](/docs/build/exposures):
+  +[enabled](/reference/resource-configs/enabled): true | false
+
 [quoting](/reference/project-configs/quoting):
   database: true | false
   schema: true | false

--- a/website/docs/reference/define-properties.md
+++ b/website/docs/reference/define-properties.md
@@ -40,6 +40,7 @@ These properties are:
 - [`quote`](/reference/resource-properties/quote)
 - [`source` properties](/reference/source-properties) (for example, `loaded_at_field`, `freshness`)
 - [`exposure` properties](/reference/exposure-properties) (for example, `type`, `maturity`)
+  - Note that while most exposure properties must be configured directly in `properties.yml` files, you can set the [`enabled`](/reference/resource-configs/enabled) config at the [project level](/reference/exposure-properties#project-level-configs) in the`dbt_project.yml` file.
 - [`macro` properties](/reference/macro-properties) (for example, `arguments`)
 
 import Example from '/snippets/_configs-properties.md'  ;

--- a/website/docs/reference/exposure-properties.md
+++ b/website/docs/reference/exposure-properties.md
@@ -13,6 +13,8 @@ import PropsCallout from '/snippets/_config-prop-callout.md';
 
 Exposures are defined in `properties.yml` files nested under an `exposures:` key. You may define `exposures` in YAML files that also define `sources` or `models`. <PropsCallout title={frontMatter.title}/>  <br /> 
 
+Note that while most exposure properties must be configured directly in these YAML files, you can set the [`enabled`](/reference/resource-configs/enabled) config at the [project level](#project-level-configs) in the`dbt_project.yml` file.
+
 
 You can name these files `whatever_you_want.yml`, and nest them arbitrarily deeply in subfolders within the `models/` directory.
 
@@ -29,6 +31,7 @@ exposures:
     type: {dashboard, notebook, analysis, ml, application}
     url: <string>
     maturity: {high, medium, low}  # Indicates level of confidence or stability in the exposure
+    [enabled](/reference/resource-configs/enabled): true | false
     [tags](/reference/resource-configs/tags): [<string>]
     [meta](/reference/resource-configs/meta): {<dictionary>}
     owner:
@@ -101,3 +104,30 @@ exposures:
 ```
 
 </File>
+
+#### Project-level configs
+
+You can define project-level configs for exposures in the `dbt_project.yml` file under the `exposures:` key using the `+` prefix:
+
+<File name="dbt_project.yml">
+
+```yml
+name: 'project_name'
+version: '1.0.0'
+config-version: 2
+
+.... rest of dbt_project.yml 
+
+exposures:
+  +enabled: true
+  +tags: ['docs']
+  +meta:
+    owner_team: analytics
+
+```
+
+</File>
+
+Note that only [`enabled`](/reference/resource-configs/enabled) is fully supported. Although `+tags` and `+meta` can appear under the config key of a compiled exposure, they don't populate the top-level `tags` or `meta` fields and as a result, tag-based [selection](/reference/resource-configs/tags#definition) or metadata extraction won't work or be available.
+
+For consistent behavior, set `tags` and `meta` directly within each exposure definition in your `.yml` files.

--- a/website/docs/reference/exposure-properties.md
+++ b/website/docs/reference/exposure-properties.md
@@ -116,7 +116,7 @@ name: 'project_name'
 version: '1.0.0'
 config-version: 2
 
-.... rest of dbt_project.yml 
+# rest of dbt_project.yml
 
 exposures:
   +enabled: true

--- a/website/docs/reference/exposure-properties.md
+++ b/website/docs/reference/exposure-properties.md
@@ -107,27 +107,17 @@ exposures:
 
 #### Project-level configs
 
-You can define project-level configs for exposures in the `dbt_project.yml` file under the `exposures:` key using the `+` prefix:
+You can define project-level configs for exposures in the `dbt_project.yml` file under the `exposures:` key using the `+` prefix. Currently, only the [`enabled` config](/reference/resource-configs/enabled) is supported:
 
 <File name="dbt_project.yml">
 
 ```yml
 name: 'project_name'
-version: '1.0.0'
-config-version: 2
 
 # rest of dbt_project.yml
 
 exposures:
   +enabled: true
-  +tags: ['docs']
-  +meta:
-    owner_team: analytics
-
 ```
 
 </File>
-
-Note that only [`enabled`](/reference/resource-configs/enabled) is fully supported. Although `+tags` and `+meta` can appear under the config key of a compiled exposure, they don't populate the top-level `tags` or `meta` fields and as a result, tag-based [selection](/reference/resource-configs/tags#definition) or metadata extraction won't work or be available.
-
-For consistent behavior, set `tags` and `meta` directly within each exposure definition in your `.yml` files.

--- a/website/docs/reference/resource-configs/tags.md
+++ b/website/docs/reference/resource-configs/tags.md
@@ -67,12 +67,12 @@ datatype: string | [string]
 
 <VersionBlock firstVersion="1.9">
 
-The following examples show how to add tags to dbt resources in YAML files. Replace `resource_type` with `models`, `snapshots`, `seeds`, or `saved_queries` as appropriate.
+The following examples show how to add tags to dbt resources in YAML files. Replace `resource_type` with `exposures`, `models`, `snapshots`, `seeds`, or `saved_queries` as appropriate.
 </VersionBlock>
 
 <VersionBlock lastVersion="1.8">
 
-The following examples show how to add tags to dbt resources in YAML files. Replace `resource_type` with `models`, `snapshots`, or `seeds` as appropriate.
+The following examples show how to add tags to dbt resources in YAML files. Replace `resource_type` with `exposures`, `models`, `snapshots`, or `seeds` as appropriate.
 </VersionBlock>
 
 <File name='resource_type/properties.yml'>


### PR DESCRIPTION
this pr adds `exposures` to the dbt_project.yml doc, focusing on `enabled` since the other configs mentioned in the issue (meta and tags) dont work as expected. [internal slack](https://dbt-labs.slack.com/archives/C017GDLAF7D/p1742823283862119)

Resolves #7079

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-exposures-dbt-labs.vercel.app/docs/build/exposures
- https://docs-getdbt-com-git-update-exposures-dbt-labs.vercel.app/reference/dbt_project.yml
- https://docs-getdbt-com-git-update-exposures-dbt-labs.vercel.app/reference/define-properties
- https://docs-getdbt-com-git-update-exposures-dbt-labs.vercel.app/reference/exposure-properties
- https://docs-getdbt-com-git-update-exposures-dbt-labs.vercel.app/reference/resource-configs/tags

<!-- end-vercel-deployment-preview -->