### PR TITLE
Caution new feature delay for cautious orgs on Extended

### DIFF
--- a/website/docs/docs/dbt-versions/cloud-release-tracks.md
+++ b/website/docs/docs/dbt-versions/cloud-release-tracks.md
@@ -46,7 +46,7 @@ Choose the "Compatible" and "Extended" release tracks if you need a less-frequen
 - Prioritize "bake in" time for new features & fixes
 - Configure development & test environments to use the "Compatible" release track
 - Configure pre-production & production environments to use the "Extended" release track
-- Understand that new features will not be available until they are first released in dbt Core OSS + Compatible track
+- Understand that new features will not be available until _a month after_ they are first released in dbt Core OSS and the Compatible track. Developers (on "Compatible") will get access to new features before they can leverage those capabilities in production (on "Extended"), and must be mindful of the additional delay.
 
 **Virtual Private dbt or Single Tenant**
 - Changes to all release tracks roll out as part of dbt Cloud instance upgrades once per week


### PR DESCRIPTION
## What are you changing in this pull request and why?

@b-per:
> I can very much see people trying to use the new 1.10 features in Dev and get it failing in CI without understanding why.
> I think it would be good to have some info on [this page](https://docs.getdbt.com/docs/dbt-versions/cloud-release-tracks). Maybe just under “Cautious - Enterprise, Business Critical”, calling out that the first month after a minor release we just can’t use the new features across all projects.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-jerco-caution-extended-dev-delay-dbt-labs.vercel.app/docs/dbt-versions/cloud-release-tracks

<!-- end-vercel-deployment-preview -->