### PR TITLE
model name casing needs to match

### DIFF
--- a/website/docs/docs/build/sql-models.md
+++ b/website/docs/docs/build/sql-models.md
@@ -23,7 +23,7 @@ dbt's Python capabilities are an extension of its capabilities with SQL models. 
 
 A SQL model is a `select` statement. Models are defined in `.sql` files (typically in your `models` directory):
 - Each `.sql` file contains one model / `select` statement
-- The model name is inherited from the filename.
+- The model name is inherited from the filename and must match the _filename_ of a model &mdash including case sensitivity. Any mismatched casing can prevent dbt from applying configurations correctly and may affect metadata in [dbt Explorer](/docs/collaborate/explore-projects).
 - We strongly recommend using underscores for model names, not dots. For example, use `models/my_model.sql` instead of `models/my.model.sql`.
 - Models can be nested in subdirectories within the `models` directory.
 

--- a/website/docs/docs/build/sql-models.md
+++ b/website/docs/docs/build/sql-models.md
@@ -23,7 +23,7 @@ dbt's Python capabilities are an extension of its capabilities with SQL models. 
 
 A SQL model is a `select` statement. Models are defined in `.sql` files (typically in your `models` directory):
 - Each `.sql` file contains one model / `select` statement
-- The model name is inherited from the filename and must match the _filename_ of a model &mdash including case sensitivity. Any mismatched casing can prevent dbt from applying configurations correctly and may affect metadata in [dbt Explorer](/docs/collaborate/explore-projects).
+- The model name is inherited from the filename and must match the _filename_ of a model &mdash; including case sensitivity. Any mismatched casing can prevent dbt from applying configurations correctly and may affect metadata in [dbt Explorer](/docs/collaborate/explore-projects).
 - We strongly recommend using underscores for model names, not dots. For example, use `models/my_model.sql` instead of `models/my.model.sql`.
 - Models can be nested in subdirectories within the `models` directory.
 

--- a/website/docs/reference/model-configs.md
+++ b/website/docs/reference/model-configs.md
@@ -74,7 +74,7 @@ models:
 version: 2
 
 models:
-  - name: [<model-name>] # Must match the filename of a model &mdash including case sensitivity.
+  - name: [<model-name>] #  Must match the filename of a model -- including case sensitivity.
     config:
       [materialized](/reference/resource-configs/materialized): <materialization_name>
       [sql_header](/reference/resource-configs/sql_header): <string>
@@ -90,7 +90,7 @@ models:
 version: 2
 
 models:
-  - name: [<model-name>] # Must match the filename of a model &mdash including case sensitivity.
+  - name: [<model-name>] #  Must match the filename of a model -- including case sensitivity.
     config:
       [materialized](/reference/resource-configs/materialized): <materialization_name>
       [sql_header](/reference/resource-configs/sql_header): <string>
@@ -226,7 +226,7 @@ models:
 version: 2
 
 models:
-  - name: [<model-name>] # Must match the filename of a model &mdash including case sensitivity.
+  - name: [<model-name>] # Must match the filename of a model -- including case sensitivity.
     config:
       [enabled](/reference/resource-configs/enabled): true | false
       [tags](/reference/resource-configs/tags): <string> | [<string>]
@@ -249,7 +249,7 @@ models:
 version: 2
 
 models:
-  - name: [<model-name>] # Must match the filename of a model &mdash including case sensitivity.
+  - name: [<model-name>] #  Must match the filename of a model -- including case sensitivity.
     config:
       [enabled](/reference/resource-configs/enabled): true | false
       [tags](/reference/resource-configs/tags): <string> | [<string>]

--- a/website/docs/reference/model-configs.md
+++ b/website/docs/reference/model-configs.md
@@ -74,7 +74,7 @@ models:
 version: 2
 
 models:
-  - name: [<model-name>]
+  - name: [<model-name>] # Must match the filename of a model &mdash including case sensitivity.
     config:
       [materialized](/reference/resource-configs/materialized): <materialization_name>
       [sql_header](/reference/resource-configs/sql_header): <string>
@@ -90,7 +90,7 @@ models:
 version: 2
 
 models:
-  - name: [<model-name>]
+  - name: [<model-name>] # Must match the filename of a model &mdash including case sensitivity.
     config:
       [materialized](/reference/resource-configs/materialized): <materialization_name>
       [sql_header](/reference/resource-configs/sql_header): <string>
@@ -226,7 +226,7 @@ models:
 version: 2
 
 models:
-  - name: [<model-name>]
+  - name: [<model-name>] # Must match the filename of a model &mdash including case sensitivity.
     config:
       [enabled](/reference/resource-configs/enabled): true | false
       [tags](/reference/resource-configs/tags): <string> | [<string>]
@@ -249,7 +249,7 @@ models:
 version: 2
 
 models:
-  - name: [<model-name>]
+  - name: [<model-name>] # Must match the filename of a model &mdash including case sensitivity.
     config:
       [enabled](/reference/resource-configs/enabled): true | false
       [tags](/reference/resource-configs/tags): <string> | [<string>]
@@ -339,6 +339,7 @@ Model configurations are applied hierarchically. You can configure models from w
 1. Using a `config()` Jinja macro within a model.
 2. Using a `config` [resource property](/reference/model-properties) in a `.yml` file.
 3. From the `dbt_project.yml` project file, under the `models:` key. In this case, the model that's nested the deepest will have the highest priority. 
+  - Note, the model name configuration must match the _filename_ of a model &mdash including case sensitivity. Any mismatched casing can prevent dbt from applying configurations correctly and may affect metadata in [dbt Explorer](/docs/collaborate/explore-projects).
 
 The most specific configuration always takes precedence. In the project file, for example, configurations applied to a `marketing` subdirectory will take precedence over configurations applied to the entire `jaffle_shop` project. To apply a configuration to a model or directory of models, define the [resource path](/reference/resource-configs/resource-path) as nested dictionary keys.
 

--- a/website/docs/reference/model-configs.md
+++ b/website/docs/reference/model-configs.md
@@ -339,7 +339,7 @@ Model configurations are applied hierarchically. You can configure models from w
 1. Using a `config()` Jinja macro within a model.
 2. Using a `config` [resource property](/reference/model-properties) in a `.yml` file.
 3. From the `dbt_project.yml` project file, under the `models:` key. In this case, the model that's nested the deepest will have the highest priority. 
-  - Note, the model name configuration must match the _filename_ of a model &mdash including case sensitivity. Any mismatched casing can prevent dbt from applying configurations correctly and may affect metadata in [dbt Explorer](/docs/collaborate/explore-projects).
+  - Note, the model name configuration must match the _filename_ of a model &mdash; including case sensitivity. Any mismatched casing can prevent dbt from applying configurations correctly and may affect metadata in [dbt Explorer](/docs/collaborate/explore-projects).
 
 The most specific configuration always takes precedence. In the project file, for example, configurations applied to a `marketing` subdirectory will take precedence over configurations applied to the entire `jaffle_shop` project. To apply a configuration to a model or directory of models, define the [resource path](/reference/resource-configs/resource-path) as nested dictionary keys.
 

--- a/website/docs/reference/model-properties.md
+++ b/website/docs/reference/model-properties.md
@@ -12,7 +12,8 @@ You can name these files `whatever_you_want.yml`, and nest them arbitrarily deep
 version: 2
 
 models:
-  - [name](/reference/resource-properties/model_name): <model name> # Must match the filename of a model &mdash including case sensitivity.
+  # Model name must match the filename of a model -- including case sensitivity
+  - [name](/reference/resource-properties/model_name): model_name 
     [description](/reference/resource-properties/description): <markdown_string>
     [docs](/reference/resource-configs/docs):
       show: true | false

--- a/website/docs/reference/model-properties.md
+++ b/website/docs/reference/model-properties.md
@@ -12,7 +12,7 @@ You can name these files `whatever_you_want.yml`, and nest them arbitrarily deep
 version: 2
 
 models:
-  - [name](/reference/resource-properties/model_name): <model name>
+  - [name](/reference/resource-properties/model_name): <model name> # Must match the filename of a model &mdash including case sensitivity.
     [description](/reference/resource-properties/description): <markdown_string>
     [docs](/reference/resource-configs/docs):
       show: true | false

--- a/website/docs/reference/resource-properties/model_name.md
+++ b/website/docs/reference/resource-properties/model_name.md
@@ -16,7 +16,7 @@ models:
 </File>
 
 ## Definition
-The name of the model you are declaring properties for. Must match the _filename_ of a model &mdash including case sensitivity. Any mismatched casing can prevent dbt from applying configurations correctly and may affect metadata in dbt Explorer.
+The name of the model you are declaring properties for. Must match the _filename_ of a model &mdash; including case sensitivity. Any mismatched casing can prevent dbt from applying configurations correctly and may affect metadata in dbt Explorer.
 
 ## Default
 

--- a/website/docs/reference/resource-properties/model_name.md
+++ b/website/docs/reference/resource-properties/model_name.md
@@ -16,7 +16,7 @@ models:
 </File>
 
 ## Definition
-The name of the model you are declaring properties for. Must match the _filename_ of a model.
+The name of the model you are declaring properties for. Must match the _filename_ of a model &mdash including case sensitivity. Any mismatched casing can prevent dbt from applying configurations correctly and may affect metadata in dbt Explorer.
 
 ## Default
 

--- a/website/snippets/_configs-properties.md
+++ b/website/snippets/_configs-properties.md
@@ -37,7 +37,7 @@ sources:
 
 
 models:
-  - name: stg_jaffle_shop__customers
+  - name: stg_jaffle_shop__customers # Must match the filename of a model &mdash including case sensitivity.
     config:
       tags: ['pii']
     columns:

--- a/website/snippets/_configs-properties.md
+++ b/website/snippets/_configs-properties.md
@@ -37,7 +37,7 @@ sources:
 
 
 models:
-  - name: stg_jaffle_shop__customers # Must match the filename of a model &mdash including case sensitivity.
+  - name: stg_jaffle_shop__customers #  Must match the filename of a model -- including case sensitivity.
     config:
       tags: ['pii']
     columns:


### PR DESCRIPTION
this pr makes it more explicit that the model `name` key in a yaml config needs to match, including case sensitivity. 

raised by support [internally](https://dbt-labs.slack.com/archives/C02NCQ9483C/p1743070181241999) due to user confusion

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-case-sensitive-model-name-dbt-labs.vercel.app/docs/build/sql-models
- https://docs-getdbt-com-git-case-sensitive-model-name-dbt-labs.vercel.app/reference/model-configs
- https://docs-getdbt-com-git-case-sensitive-model-name-dbt-labs.vercel.app/reference/model-properties
- https://docs-getdbt-com-git-case-sensitive-model-name-dbt-labs.vercel.app/reference/resource-properties/model_name

<!-- end-vercel-deployment-preview -->