### PR TITLE
Adjust positioning of qualified widget button positioning

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -2219,3 +2219,10 @@ table th {
   background-color: transparent;
 }
 /* End tab borders */
+
+/* Qualified chat widget button positioning when widget not opened */
+iframe#q-messenger-frame:not(.qlfd-maximized) {
+  right: 100px !important;
+  z-index: 100000 !important;
+  bottom: 6px !important;
+}


### PR DESCRIPTION
## What are you changing in this pull request and why?

[Asana task](https://app.asana.com/0/1200792801231972/1209825760963624/f)

This adjusts the Qualified chat widget button positioning to be slightly off to the left, to prevent overlap in the scenario where the Qualified and Forethought widgets are active at the same time.

I don't have an easy way to display this within the preview. But you can follow the steps below on the live site, and drop the css here into devtools to see how it affects the Qualified chat button positioning:
1. Open https://docs.getdbt.com/
2. In a separate tab in the same browser, open https://www.getdbt.com/
3. Wait for the Qualified chat widget to appear on WWW
4. This will cause the Qualified widget to appear on docs
5. Ensure the css correctly moves the Qualified chat widget button to the left of the Forethought widget