### PR TITLE
SL enabled for ST accounts

### DIFF
--- a/website/docs/docs/cloud-integrations/semantic-layer/excel.md
+++ b/website/docs/docs/cloud-integrations/semantic-layer/excel.md
@@ -14,7 +14,6 @@ The dbt Semantic Layer offers a seamless integration with Excel Online and Deskt
 - You need a Microsoft Excel account with access to install add-ons.
 - You have a [dbt Cloud Environment ID](/docs/use-dbt-semantic-layer/setup-sl#set-up-dbt-semantic-layer) and a [service token](/docs/dbt-cloud-apis/service-tokens) to authenticate with from a dbt Cloud account.
 - You must have a dbt Cloud Team or Enterprise [account](https://www.getdbt.com/pricing). Suitable for both Multi-tenant and Single-tenant deployment.
-  - Single-tenant accounts should contact their account representative for necessary setup and enablement.
 
 :::tip
 

--- a/website/docs/docs/cloud-integrations/semantic-layer/gsheets.md
+++ b/website/docs/docs/cloud-integrations/semantic-layer/gsheets.md
@@ -13,7 +13,6 @@ The dbt Semantic Layer offers a seamless integration with Google Sheets through 
 - You need a Google account with access to Google Sheets and the ability to install Google add-ons.
 - You have a [dbt Cloud Environment ID](/docs/use-dbt-semantic-layer/setup-sl#set-up-dbt-semantic-layer) and a [service token](/docs/dbt-cloud-apis/service-tokens) to authenticate with from a dbt Cloud account.
 - You must have a dbt Cloud Team or Enterprise [account](https://www.getdbt.com/pricing). Suitable for both Multi-tenant and Single-tenant deployment.
-  - Single-tenant accounts should contact their account representative for necessary setup and enablement.
 
 If you're using [IP restrictions](/docs/cloud/secure/ip-restrictions), ensure you've added [Google’s IP addresses](https://www.gstatic.com/ipranges/goog.txt) to your IP allowlist. Otherwise, the Google Sheets connection will fail.
 

--- a/website/docs/docs/cloud-integrations/semantic-layer/power-bi.md
+++ b/website/docs/docs/cloud-integrations/semantic-layer/power-bi.md
@@ -21,8 +21,7 @@ The dbt Semantic Layer Power BI integration is currently in private beta. To joi
 - You installed [Power BI Desktop or Power BI On-premises Data Gateway](https://learn.microsoft.com/en-us/power-bi/connect-data/service-gateway-custom-connectors).
   - Power BI Service doesn't natively support custom connectors. To use the connector in Power BI Service, you must install and configure it on an On-premises Data Gateway.
 - You need your [dbt Cloud host](/docs/use-dbt-semantic-layer/setup-sl#3-view-connection-detail), [Environment ID](/docs/use-dbt-semantic-layer/setup-sl#set-up-dbt-semantic-layer) and [service token](/docs/dbt-cloud-apis/service-tokens) to log in. This account should be set up with the dbt Semantic Layer.
-- You must have a dbt Cloud Team or Enterprise [account](https://www.getdbt.com/pricing). Suitable for both Multi-tenant and Single-tenant deployment. 
-  - Single-tenant accounts should contact their account representative for necessary setup and enablement.
+- You must have a dbt Cloud Team or Enterprise [account](https://www.getdbt.com/pricing). Suitable for both Multi-tenant and Single-tenant deployment.
 
 import SLCourses from '/snippets/_sl-course.md';
 

--- a/website/docs/docs/cloud-integrations/semantic-layer/tableau.md
+++ b/website/docs/docs/cloud-integrations/semantic-layer/tableau.md
@@ -15,7 +15,6 @@ The Tableau integration allows you to use worksheets to query the dbt Semantic L
 - Log in to Tableau Desktop (with Online or Server credentials) or a license to Tableau Server
 - You need your dbt Cloud host, [Environment ID](/docs/use-dbt-semantic-layer/setup-sl#set-up-dbt-semantic-layer) and [service token](/docs/dbt-cloud-apis/service-tokens) to log in. This account should be set up with the dbt Semantic Layer.
 - You must have a dbt Cloud Team or Enterprise [account](https://www.getdbt.com/pricing). Suitable for both Multi-tenant and Single-tenant deployment. 
-  - Single-tenant accounts should contact their account representative for necessary setup and enablement.
 
 import SLCourses from '/snippets/_sl-course.md';
 

--- a/website/docs/docs/dbt-versions/release-notes.md
+++ b/website/docs/docs/dbt-versions/release-notes.md
@@ -18,6 +18,7 @@ Release notes are grouped by month for both multi-tenant and virtual private clo
 
 ## March 2025
 
+**Enhancement**: [dbt Semantic Layer](/docs/use-dbt-semantic-layer/dbt-sl) users on single-tenant configurations no longer need to contact their account representative to enable this feature. Setup is now self-service and available across all tenant configurations.
 -**New**: New [environment variable default](/docs/build/environment-variables#dbt-cloud-context) `DBT_CLOUD_INVOCATION_CONTEXT`. 
 - **Enhancement**: Users assigned [read-only licenses](/docs/cloud/manage-access/about-user-access#licenses) are now able to view the [Deploy](/docs/deploy/deployments) section of their dbt Cloud account and click into the individual sections but not edit or otherwise make any changes. 
 

--- a/website/docs/docs/dbt-versions/release-notes.md
+++ b/website/docs/docs/dbt-versions/release-notes.md
@@ -18,7 +18,7 @@ Release notes are grouped by month for both multi-tenant and virtual private clo
 
 ## March 2025
 
-**Enhancement**: [dbt Semantic Layer](/docs/use-dbt-semantic-layer/dbt-sl) users on single-tenant configurations no longer need to contact their account representative to enable this feature. Setup is now self-service and available across all tenant configurations.
+- **Enhancement**: [dbt Semantic Layer](/docs/use-dbt-semantic-layer/dbt-sl) users on single-tenant configurations no longer need to contact their account representative to enable this feature. Setup is now self-service and available across all tenant configurations.
 -**New**: New [environment variable default](/docs/build/environment-variables#dbt-cloud-context) `DBT_CLOUD_INVOCATION_CONTEXT`. 
 - **Enhancement**: Users assigned [read-only licenses](/docs/cloud/manage-access/about-user-access#licenses) are now able to view the [Deploy](/docs/deploy/deployments) section of their dbt Cloud account and click into the individual sections but not edit or otherwise make any changes. 
 

--- a/website/docs/docs/dbt-versions/release-notes.md
+++ b/website/docs/docs/dbt-versions/release-notes.md
@@ -19,7 +19,7 @@ Release notes are grouped by month for both multi-tenant and virtual private clo
 ## March 2025
 
 - **Enhancement**: [dbt Semantic Layer](/docs/use-dbt-semantic-layer/dbt-sl) users on single-tenant configurations no longer need to contact their account representative to enable this feature. Setup is now self-service and available across all tenant configurations.
--**New**: New [environment variable default](/docs/build/environment-variables#dbt-cloud-context) `DBT_CLOUD_INVOCATION_CONTEXT`. 
+- **New**: New [environment variable default](/docs/build/environment-variables#dbt-cloud-context) `DBT_CLOUD_INVOCATION_CONTEXT`. 
 - **Enhancement**: Users assigned [read-only licenses](/docs/cloud/manage-access/about-user-access#licenses) are now able to view the [Deploy](/docs/deploy/deployments) section of their dbt Cloud account and click into the individual sections but not edit or otherwise make any changes. 
 
 #### dbt Developer day

--- a/website/docs/guides/sl-snowflake-qs.md
+++ b/website/docs/guides/sl-snowflake-qs.md
@@ -36,7 +36,7 @@ If you're on different data platforms, you can also follow this guide and will n
 
 ### Prerequisites
 
-- You need a [dbt Cloud](https://www.getdbt.com/signup/) Trial, Team, or Enterprise account for all deployments. Contact your representative for Single-tenant setup; otherwise, create an account using this guide.
+- You need a [dbt Cloud](https://www.getdbt.com/signup/) Trial, Team, or Enterprise account for all deployments. 
 - Have the correct [dbt Cloud license](/docs/cloud/manage-access/seats-and-users) and [permissions](/docs/cloud/manage-access/enterprise-permissions) based on your plan:
   <DetailsToggle alt_header="More info on license and permissions">  
   

--- a/website/snippets/_v2-sl-prerequisites.md
+++ b/website/snippets/_v2-sl-prerequisites.md
@@ -1,5 +1,5 @@
 - Have a dbt Cloud Team or Enterprise account.
-   - Available on all [tenant configurations](/docs/cloud/about-cloud/tenancy). Single-tenant accounts should contact your account representative for setup.
+   - Available on all [tenant configurations](/docs/cloud/about-cloud/tenancy).
 - Ensure your production and development environments are on a [supported dbt version](/docs/dbt-versions/upgrade-dbt-version-in-cloud).
 - Use Snowflake, BigQuery, Databricks, or Redshift.
 -  Create a successful run in the environment where you configure the Semantic Layer. 

--- a/website/snippets/_v2-sl-prerequisites.md
+++ b/website/snippets/_v2-sl-prerequisites.md
@@ -1,5 +1,4 @@
-- Have a dbt Cloud Team or Enterprise account.
-   - Available on all [tenant configurations](/docs/cloud/about-cloud/tenancy).
+- Have a dbt Cloud Team or Enterprise account. Available on all [tenant configurations](/docs/cloud/about-cloud/tenancy).
 - Ensure your production and development environments are on a [supported dbt version](/docs/dbt-versions/upgrade-dbt-version-in-cloud).
 - Use Snowflake, BigQuery, Databricks, or Redshift.
 -  Create a successful run in the environment where you configure the Semantic Layer. 


### PR DESCRIPTION
this pr removes mentions the mention for ST users needing to contact account reps to enable ST. ST is automatically enabled for all tenants

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-sl-st-dbt-labs.vercel.app/docs/cloud-integrations/semantic-layer/excel
- https://docs-getdbt-com-git-update-sl-st-dbt-labs.vercel.app/docs/cloud-integrations/semantic-layer/gsheets
- https://docs-getdbt-com-git-update-sl-st-dbt-labs.vercel.app/docs/cloud-integrations/semantic-layer/power-bi
- https://docs-getdbt-com-git-update-sl-st-dbt-labs.vercel.app/docs/cloud-integrations/semantic-layer/tableau
- https://docs-getdbt-com-git-update-sl-st-dbt-labs.vercel.app/docs/dbt-versions/release-notes
- https://docs-getdbt-com-git-update-sl-st-dbt-labs.vercel.app/guides/sl-snowflake-qs

<!-- end-vercel-deployment-preview -->