### PR TITLE
SL supports postgres

### DIFF
--- a/website/docs/docs/dbt-versions/release-notes.md
+++ b/website/docs/docs/dbt-versions/release-notes.md
@@ -18,6 +18,7 @@ Release notes are grouped by month for both multi-tenant and virtual private clo
 
 ## March 2025
 
+- **New**: The dbt Semantic Layer now supports Postgres as a data platform. For more details on how to set up the dbt Semantic Layer for Postgres, see [Set up the dbt Semantic Layer](/docs/use-dbt-semantic-layer/setup-sl).
 -**New**: New [environment variable default](/docs/build/environment-variables#dbt-cloud-context) `DBT_CLOUD_INVOCATION_CONTEXT`. 
 - **Enhancement**: Users assigned [read-only licenses](/docs/cloud/manage-access/about-user-access#licenses) are now able to view the [Deploy](/docs/deploy/deployments) section of their dbt Cloud account and click into the individual sections but not edit or otherwise make any changes. 
 

--- a/website/docs/docs/dbt-versions/release-notes.md
+++ b/website/docs/docs/dbt-versions/release-notes.md
@@ -19,7 +19,7 @@ Release notes are grouped by month for both multi-tenant and virtual private clo
 ## March 2025
 
 - **New**: The dbt Semantic Layer now supports Postgres as a data platform. For more details on how to set up the dbt Semantic Layer for Postgres, see [Set up the dbt Semantic Layer](/docs/use-dbt-semantic-layer/setup-sl).
--**New**: New [environment variable default](/docs/build/environment-variables#dbt-cloud-context) `DBT_CLOUD_INVOCATION_CONTEXT`. 
+- **New**: New [environment variable default](/docs/build/environment-variables#dbt-cloud-context) `DBT_CLOUD_INVOCATION_CONTEXT`. 
 - **Enhancement**: Users assigned [read-only licenses](/docs/cloud/manage-access/about-user-access#licenses) are now able to view the [Deploy](/docs/deploy/deployments) section of their dbt Cloud account and click into the individual sections but not edit or otherwise make any changes. 
 
 #### dbt Developer day

--- a/website/docs/docs/use-dbt-semantic-layer/exports.md
+++ b/website/docs/docs/use-dbt-semantic-layer/exports.md
@@ -15,7 +15,7 @@ Essentially, exports are like any other table in your data platform &mdash; they
 ## Prerequisites
 
 - You have a dbt Cloud account on a [Team or Enterprise](https://www.getdbt.com/pricing/) plan. 
-- You use one of the following data platforms: Snowflake, BigQuery, Databricks, or Redshift.
+- You use one of the following data platforms: Snowflake, BigQuery, Databricks, Redshift, or Postgres.
 - You are on [dbt version](/docs/dbt-versions/upgrade-dbt-version-in-cloud) 1.7 or newer.
 - You have the dbt Semantic Layer [configured](/docs/use-dbt-semantic-layer/setup-sl) in your dbt project.
 - You have a dbt Cloud environment with the [job scheduler](/docs/deploy/job-scheduler) enabled.

--- a/website/snippets/_v2-sl-prerequisites.md
+++ b/website/snippets/_v2-sl-prerequisites.md
@@ -1,7 +1,7 @@
 - Have a dbt Cloud Team or Enterprise account.
    - Available on all [tenant configurations](/docs/cloud/about-cloud/tenancy). Single-tenant accounts should contact your account representative for setup.
 - Ensure your production and development environments are on a [supported dbt version](/docs/dbt-versions/upgrade-dbt-version-in-cloud).
-- Use Snowflake, BigQuery, Databricks, or Redshift.
+- Use Snowflake, BigQuery, Databricks, Redshift, or Postgres.
 -  Create a successful run in the environment where you configure the Semantic Layer. 
    - **Note:** Semantic Layer supports querying in Deployment environments; development querying is coming soon.
 - Understand [MetricFlow's](/docs/build/about-metricflow) key concepts powering the dbt Semantic Layer.  


### PR DESCRIPTION
this pr confirms that SL supports postgres now

see [internal slack](https://dbt-labs.slack.com/archives/C03KHQRQUBX/p1742317619503189)

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-sl-postgres-dbt-labs.vercel.app/docs/dbt-versions/release-notes
- https://docs-getdbt-com-git-update-sl-postgres-dbt-labs.vercel.app/docs/use-dbt-semantic-layer/exports

<!-- end-vercel-deployment-preview -->