### PR TITLE
Fix one of the code examples for `dbt_valid_to_current`

### DIFF
--- a/website/docs/reference/resource-configs/dbt_valid_to_current.md
+++ b/website/docs/reference/resource-configs/dbt_valid_to_current.md
@@ -61,7 +61,7 @@ Any new records inserted _after_ applying the `dbt_valid_to_current` configurati
 
 ### Considerations
 
-- **Date expressions** &mdash; Provide a hardcoded date expression compatible with your data platform, such as to_date`('9999-12-31')`. Note that syntax may vary by warehouse (for example, `to_date('YYYY-MM-DD'`) or `date(YYYY, MM, DD)`).
+- **Date expressions** &mdash; Provide a hardcoded date expression compatible with your data platform, such as `to_date('9999-12-31')`. Note that syntax may vary by warehouse (for example, `to_date('YYYY-MM-DD'`) or `date(YYYY, MM, DD)`).
 
 - **Jinja limitation** &mdash; `dbt_valid_to_current` only accepts static SQL expressions. Jinja expressions (like `{{ var('my_future_date') }}`) are not supported.
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
Here is the section that is being fixed:

<img width="449" alt="image" src="https://github.com/user-attachments/assets/4ebc4570-c141-4426-9d6e-e32889aad4d8" />

i.e., updating this:
to_date`('9999-12-31')`

To be this instead:
`to_date('9999-12-31')`

## Additional context

Noticed while responding to https://github.com/duckdb/dbt-duckdb/pull/529/files#r2021742447

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.