### PR TITLE
add info about --profile and --target flag

### DIFF
--- a/website/docs/docs/core/connect-data-platform/connection-profiles.md
+++ b/website/docs/docs/core/connect-data-platform/connection-profiles.md
@@ -87,7 +87,6 @@ You can find more information on which values to use in your targets below.
 
 Use the [debug](/reference/dbt-jinja-functions/debug-method) command to validate your warehouse connection. Run `dbt debug` from within a dbt project to test your connection.
 
-
 ## Understanding targets in profiles
 
 dbt supports multiple targets within one profile to encourage the use of separate development and production environments as discussed in [dbt Core Environments](/docs/core/dbt-core-environments).
@@ -97,6 +96,21 @@ A typical profile for an analyst using dbt locally will have a target named `dev
 You may also have a `prod` target within your profile, which creates the objects in your production schema. However, since it's often desirable to perform production runs on a schedule, we recommend deploying your dbt project to a separate machine other than your local machine. Most dbt users only have a `dev` target in their profile on their local machine.
 
 If you do have multiple targets in your profile, and want to use a target other than the default, you can do this using the `--target` option when issuing a dbt command.
+
+### Overriding profiles and targets
+
+When running dbt commands, you can specify which profile and target to use from the CLI using the `--profile` and `--target` [flags](/reference/global-configs/about-global-configs#available-flags). These flags override what’s defined in your `dbt_project.yml` as long as the specified profile and target are already defined in your `profiles.yml` file.
+
+To run your dbt project with a different profile or target than the default, you can do so using the followingCLI flags:
+- `--profile` flag &mdash; Overrides the profile set in `dbt_project.yml` by pointing to another profile defined in `profiles.yml`.
+- `--target` flag &mdash; Specifies the target within that profile to use (as defined in `profiles.yml`)
+
+These flags help when you're working with multiple profiles and targets and want to override defaults without changing your files.
+
+```bash
+dbt run --profile my-profile-name --target dev
+```
+In this example, the `dbt run` command will use the `my-profile-name` profile and the `dev` target.
 
 ## Understanding warehouse credentials
 

--- a/website/docs/docs/core/connect-data-platform/connection-profiles.md
+++ b/website/docs/docs/core/connect-data-platform/connection-profiles.md
@@ -103,7 +103,7 @@ When running dbt commands, you can specify which profile and target to use from 
 
 To run your dbt project with a different profile or target than the default, you can do so using the followingCLI flags:
 - `--profile` flag &mdash; Overrides the profile set in `dbt_project.yml` by pointing to another profile defined in `profiles.yml`.
-- `--target` flag &mdash; Specifies the target within that profile to use (as defined in `profiles.yml`)
+- `--target` flag &mdash; Specifies the target within that profile to use (as defined in `profiles.yml`).
 
 These flags help when you're working with multiple profiles and targets and want to override defaults without changing your files.
 

--- a/website/docs/reference/global-configs/about-global-configs.md
+++ b/website/docs/reference/global-configs/about-global-configs.md
@@ -78,7 +78,7 @@ Because the values of `flags` can differ across invocations, we strongly advise 
 | [populate_cache](/reference/global-configs/cache) | boolean | True | ✅ | `DBT_POPULATE_CACHE` | `--populate-cache`, `--no-populate-cache` | ✅ |
 | [print](/reference/global-configs/print-output#suppress-print-messages-in-stdout) | boolean | True | ❌ | `DBT_PRINT` | `--print` | ❌ |
 | [printer_width](/reference/global-configs/print-output#printer-width) | int | 80 | ✅ | `DBT_PRINTER_WIDTH` | `--printer-width` | ❌ |
-| [profile](/docs/core/connect-data-platform/connection-profiles#about-profiles) | string | None | ✅ (as top-level key) | `DBT_PROFILE`  | `--profile` | ❌ |
+| [profile](/docs/core/connect-data-platform/connection-profiles#about-profiles) | string | None | ✅ (as top-level key) | `DBT_PROFILE`  | [`--profile`](/docs/core/connect-data-platform/connection-profiles#overriding-profiles-and-targets) | ❌ |
 | [profiles_dir](/docs/core/connect-data-platform/connection-profiles#about-profiles) | path | None (current dir, then HOME dir) | ❌ | `DBT_PROFILES_DIR` | `--profiles-dir` | ❌ |
 | [project_dir](/reference/dbt_project.yml) | path |  | ❌ | `DBT_PROJECT_DIR` | `--project-dir` | ❌ |
 | [quiet](/reference/global-configs/logs#suppress-non-error-logs-in-output) | boolean | False | ❌ | `DBT_QUIET` | `--quiet` | ✅ |
@@ -89,7 +89,7 @@ Because the values of `flags` can differ across invocations, we strongly advise 
 | [static_parser](/reference/global-configs/parsing#static-parser) | boolean | True | ✅ | `DBT_STATIC_PARSER` | `--static-parser`, `--no-static-parser` | ❌ |
 | [store_failures](/reference/resource-configs/store_failures) | boolean | False | ✅ (as resource config) | `DBT_STORE_FAILURES` | `--store-failures`, `--no-store-failures` | ✅ |
 | [target_path](/reference/global-configs/json-artifacts) | path | None (uses `target/`) | ❌ | `DBT_TARGET_PATH` | `--target-path` | ❌ |
-| [target](/docs/core/connect-data-platform/connection-profiles#about-profiles) | string | None | ❌ | `DBT_TARGET` | `--target` | ❌ |
+| [target](/docs/core/connect-data-platform/connection-profiles#about-profiles) | string | None | ❌ | `DBT_TARGET` | [`--target`](/docs/core/connect-data-platform/connection-profiles#overriding-profiles-and-targets) | ❌ |
 | [use_colors_file](/reference/global-configs/logs#color) | boolean | True | ✅ | `DBT_USE_COLORS_FILE` | `--use-colors-file`, `--no-use-colors-file` | ❌ |
 | [use_colors](/reference/global-configs/print-output#print-color) | boolean | True | ✅ | `DBT_USE_COLORS` | `--use-colors`, `--no-use-colors` | ❌ |
 | [use_experimental_parser](/reference/global-configs/parsing#experimental-parser) | boolean | False | ✅ | `DBT_USE_EXPERIMENTAL_PARSER` | `--use-experimental-parser`, `--no-use-experimental-parser` | ❌ |

--- a/website/docs/reference/project-configs/profile.md
+++ b/website/docs/reference/project-configs/profile.md
@@ -13,7 +13,7 @@ profile: string
 ## Definition
 The profile your dbt project should use to connect to your <Term id="data-warehouse" />.
 * If you are developing in dbt Cloud: This configuration is not applicable
-* If you are developing locally: This configuration is required, unless a command-line option (i.e. `--profile`) is supplied.
+* If you are developing locally: This configuration is required, unless a command-line option like [`--profile`](/docs/core/connect-data-platform/connection-profiles#overriding-profiles-and-targets) is supplied. The `--profile` flag overrides the profile set in `dbt_project.yml`.
 
 ## Related guides
 * [Connecting to your warehouse using the command line](/docs/core/connect-data-platform/connection-profiles#connecting-to-your-warehouse-using-the-command-line)


### PR DESCRIPTION
this PR adds some info in the dbt core profiles doc to explain how the --profile and --target flags work. this also will make these keywords searchable.

Resolves #7132

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-profile-and-target-dbt-labs.vercel.app/docs/core/connect-data-platform/connection-profiles
- https://docs-getdbt-com-git-profile-and-target-dbt-labs.vercel.app/reference/global-configs/about-global-configs
- https://docs-getdbt-com-git-profile-and-target-dbt-labs.vercel.app/reference/project-configs/profile

<!-- end-vercel-deployment-preview -->