### PR TITLE
Update arguments.md

### DIFF
--- a/website/docs/reference/resource-properties/arguments.md
+++ b/website/docs/reference/resource-properties/arguments.md
@@ -16,7 +16,7 @@ macros:
   - name: <macro name>
     arguments:
       - name: <arg name>
-        type: <column>
+        [type](#supported-types): <string>
         description: <markdown_string>
 
 ```
@@ -51,7 +51,7 @@ macros:
   - name: <macro name>
     arguments:
       - name: <arg name>
-        type: <column>
+        type: <string>
 
 ```
 


### PR DESCRIPTION
update type to string, which is its actual supported type. also linked `type` to supported types section

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-mirnawong1-patch-27-dbt-labs.vercel.app/reference/resource-properties/arguments

<!-- end-vercel-deployment-preview -->