### PR TITLE
clarify warn-error in prod

### DIFF
--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -18,7 +18,7 @@ This means that if a new warning is introduced in a future version of dbt Core, 
 
 Instead of using the `--warn-error` flag to promote _all_ warnings to errors, you can use [`--warn-error-options`](#use---warn-error-options-for-targeted-warnings) flag to promote _specific_ warnings to errors, including:
 
-- Test warnings with the `--warn-error-options '{"error": ["LogTestResults"]}'` flag.
+- [Test warnings](/reference/resource-configs/severity) with the `--warn-error-options '{"error": ["LogTestResults"]}'` flag.
 - Jinja [exception warnings](/reference/dbt-jinja-functions/exceptions#warn) with `--warn-error-options '{"error": ["JinjaLogWarning"]}'`.
 - No nodes selected with `--warn-error-options '{"error": ["NoNodesForSelectionCriteria"]}'`.
 - Adapter deprecation warnings with `--warn-error-options '{"error": ["AdapterDeprecationWarning"]}'`.

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -74,7 +74,7 @@ In some cases, you may want to convert _all_ warnings to errors. However, when y
   - Downloading the JSON output logs from a run and searching for the warning.
 - The `error` parameter can be set to `"all"` or `"*"` to treat all warnings as exceptions (errors), or to a list of specific warning names to treat as exceptions. This behavior is the same as using the `--warn-error` flag.
   
-  When `error` is set to `"all"` or `"*"`, the optional `warn` parameter can be set to exclude specific warnings from being treated as exceptions &mdash.
+  When `error` is set to `"all"` or `"*"`, the optional `warn` parameter can be set to exclude specific warnings from being treated as exceptions.
 - Use the `silence` parameter to ignore warnings. To silence certain warnings you want to ignore, you can specify them in the `silence` parameter. This is useful in large projects where certain warnings aren't critical and can be ignored to keep the noise low and logs clean.
 
 </VersionBlock>

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -19,7 +19,7 @@ This means that if a new warning is introduced in a future version of dbt Core, 
 Instead of using the `--warn-error` flag to promote _all_ warnings to errors, you can use [`--warn-error-options`](#use---warn-error-options-for-targeted-warnings) flag to promote _specific_ warnings to errors, including:
 
 - Test warnings with the `--warn-error-options '{"error": ["LogTestResults"]}'` flag.
-- Jinja-level warnings with the `--warn-error-options '{"error": ["JinjaLogWarning"]}'` flag or [`exceptions.warn`](/reference/dbt-jinja-functions/exceptions#warn).
+- Jinja [exception warnings](/reference/dbt-jinja-functions/exceptions#warn) with `--warn-error-options '{"error": ["JinjaLogWarning"]}'`.
 - No nodes selected with `--warn-error-options '{"error": ["NoNodesForSelectionCriteria"]}'`.
 - Adapter deprecation warnings with `--warn-error-options '{"error": ["AdapterDeprecationWarning"]}'`.
 

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -117,9 +117,7 @@ In the following example, we're silencing the [`NoNodesForSelectionCriteria` war
   <File name='dbt_project.yml'>
 
   ```yaml
-  name: "my_dbt_project"
-  tests:
-    +enabled: True
+...
   flags:
     warn_error_options:
       error: # Previously called "include"

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -87,7 +87,7 @@ You can configure warnings as errors or which warnings to silence, by warn error
 
 - Promote all warnings to errors using `{"include": "all"}` or `--warn-error` flag.
 - Promote some warnings to errors using `include` with `--warn-error-options` flag.
-- Exclude warnings from being treated as errors using `exclude` with `--warn-error-options` flag
+- Exclude warnings from being treated as errors using `exclude` with `--warn-error-options` flag.
 
 In the following example, we're promoting all warnings to errors except for the [`NoNodesForSelectionCriteria` warning](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/events/types.py#L1227) in the `profiles.yml` file by adding it to the `exclude` parameter:
 

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -28,7 +28,7 @@ Instead of using the `--warn-error` flag to promote _all_ warnings to errors, yo
 <VersionBlock lastVersion="1.7">
 
 :::caution Proceed with caution in production environments
-Using the `--warn-error` flag or `warn_error_options: include: "all"` will treat _all_ current and future warnings as errors.
+Using the `--warn-error` flag or `--warn-error-options '{"include": "all"}'` will treat _all_ current and future warnings as errors.
 
 This means that if a new warning is introduced in a future version of dbt Core, your production job may start failing unexpectedly. We recommend proceeding with caution when doing this in production environments, and explicitly listing only the warnings you want to treat as errors in production.
 :::

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -6,7 +6,7 @@ toc_max_heading_level: 2
 intro_text: "dbt's warnings can be converted to errors using --warn-error flag or WARN_ERROR config, with granular control through options."
 ---
 
-Enabling `WARN_ERROR` config or setting the `--warn-error` flag will convert dbt warnings into errors. Any time dbt would normally warn, it will instead raise an error. Examples include `--select` criteria that selects no resources, deprecations, configurations with no associated models, invalid test configurations, or tests and freshness checks that are configured to return warnings.
+Enabling `WARN_ERROR` config or setting the `--warn-error` flag will convert _all_ dbt warnings into errors. Any time dbt would normally warn, it will instead raise an error. Examples include `--select` criteria that selects no resources, deprecations, configurations with no associated models, invalid test configurations, or tests and freshness checks that are configured to return warnings.
 
  You would commonly use the `--warn-error` flag to promote test warnings from `severity: warn` to errors, but it actually affects all warning types, including:
 * Test warnings (for example, `LogTestResults`)

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -49,7 +49,7 @@ This means that if a new warning is introduced in a future version of dbt Core, 
 
 - Use the `silence` parameter to ignore warnings through project flags, without needing to re-specify the silence list every time. For example, to silence deprecation warnings or certain warnings you want to ignore across your project, you can specify them in the `silence` parameter. This is useful in large projects where certain warnings aren't critical and can be ignored to keep the noise low and logs clean.
 
-  In the following example, we're silencing the [`NoNodesForSelectionCriteria` warning](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/events/types.py#L1227) in the `dbt_project.yml` file:
+  In the following example, we're ignoring the [`NoNodesForSelectionCriteria` warning](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/events/types.py#L1227) in the `dbt_project.yml` file by adding it to the `silence` parameter:
 
   <File name='dbt_project.yml'>
 

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -8,7 +8,7 @@ intro_text: "dbt's warnings can be converted to errors using --warn-error flag o
 
 Enabling `WARN_ERROR` config or setting the `--warn-error` flag will convert _all_ dbt warnings into errors. Any time dbt would normally warn, it will instead raise an error. Examples include `--select` criteria that selects no resources, deprecations, configurations with no associated models, invalid test configurations, or tests and freshness checks that are configured to return warnings.
 
- You would commonly use the `--warn-error` flag to promote test warnings from `severity: warn` to errors, but it actually affects all warning types, including:
+Instead of using the `--warn-error` flag to promote _all_ warnings to errors, you can use [`--warn-error-options`](#using-warn_error_options-for-targeted-warnings) flag to promote **specific** warnings to errors, including:
 * Test warnings (for example, `LogTestResults`)
 * Jinja-level warnings (for example, `exceptions.warn`, or `JinjaLogWarning`)
 * Selection issues (for example, `NoNodesForSelectionCriteria`)

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -28,7 +28,7 @@ Instead of using the `--warn-error` flag to promote _all_ warnings to errors, yo
 <VersionBlock lastVersion="1.7">
 
 :::caution Proceed with caution in production environments
-Using the `--warn-error` flag or `warn_error_options: include: "all"` will treat _all_ current and future warnings as errors.
+Using the `--warn-error` flag or `--warn-error-options '{"include": "all"}'` will treat _all_ current and future warnings as errors.
 
 This means that if a new warning is introduced in a future version of dbt Core, your production job may start failing unexpectedly. We recommend proceeding with caution when doing this in production environments, and explicitly listing only the warnings you want to treat as errors in production.
 :::
@@ -38,7 +38,7 @@ Instead of using the `--warn-error` flag to promote _all_ warnings to errors, yo
 - Test warnings with the `--warn-error-options '{"include": ["LogTestResults"]}'` flag.
 - Jinja-level warnings with the `--warn-error-options '{"include": ["JinjaLogWarning"]}'` flag or [`exceptions.warn`](/reference/dbt-jinja-functions/exceptions#warn).
 - Selection issues with the `--warn-error-options '{"include": ["NoNodesForSelectionCriteria"]}'` flag.
-- Adapter deprecation warnings with the `--warn-error-options include": ["AdapterDeprecationWarning"]}'` flag.
+- Adapter deprecation warnings with the `--warn-error-options '{"include": ["AdapterDeprecationWarning"]}'` flag.
 
 </VersionBlock>
 
@@ -71,7 +71,7 @@ In some cases, you may want to convert _all_ warnings to errors. However, when y
 
 - Warnings that should be treated as errors can be specified through `error` parameter. Warning names can be found in:
   - [dbt-core's types.py file](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/events/types.py), where each class name that inherits from `WarnLevel` corresponds to a warning name (e.g. `AdapterDeprecationWarning`, `NoNodesForSelectionCriteria`).
-  - Downloading the JSON output logs from a run and searching for the warning.
+  - Using the `--log-format json` flag.
 - The `error` parameter can be set to `"all"` or `"*"` to treat all warnings as errors (this behavior is the same as using the `--warn-error` flag), or to a list of specific warning names to treat as exceptions.
   
   When `error` is set to `"all"` or `"*"`, the optional `warn` parameter can be set to exclude specific warnings from being treated as exceptions.
@@ -86,10 +86,10 @@ You can configure warnings as errors or which warnings to silence, by warn error
 <VersionBlock lastVersion="1.7"> 
 
 - Promote all warnings to errors using `{"include": "all"}` or `--warn-error` flag.
-- Promote some warnings to errors using `include`.
-- Exclude warnings from being treated as errors using `exclude`.
+- Promote some warnings to errors using `include` with `--warn-error-options` flag.
+- Exclude warnings from being treated as errors using `exclude` with `--warn-error-options` flag
 
-In the following example, we're ignoring the [`NoNodesForSelectionCriteria` warning](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/events/types.py#L1227) in the `profiles.yml` file by adding it to the `exclude` parameter:
+In the following example, we're promoting all warnings to errors except for the [`NoNodesForSelectionCriteria` warning](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/events/types.py#L1227) in the `profiles.yml` file by adding it to the `exclude` parameter:
 
   <File name='profiles.yml'>
 
@@ -109,8 +109,8 @@ In the following example, we're ignoring the [`NoNodesForSelectionCriteria` warn
 You can choose to:
 
 - Promote all warnings to errors using `{"error": "all"}` or `--warn-error` flag.
-- Promote some warnings to errors using `error` and optionally exclude others from being treated as errors with `warn`. `warn` tells dbt to continue treating the warnings as warnings.
-- Ignore warnings using `silence`.
+- Promote some warnings to errors using `error` and optionally exclude others from being treated as errors with `warn` with `--warn-error-options` flag. `warn` tells dbt to continue treating the warnings as warnings.
+- Ignore warnings using `silence` with `--warn-error-options` flag.
 
 In the following example, we're silencing the [`NoNodesForSelectionCriteria` warning](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/events/types.py#L1227) in the `dbt_project.yml` file by adding it to the `silence` parameter:
 
@@ -192,16 +192,17 @@ Values for `error`, `warn`, and/or `silence` should be passed on as arrays. For 
 
 <VersionBlock firstVersion="1.8">
 
-The following example shows how to silence or ignore warnings using the `silence` parameter in the `profiles.yml` file:
-  <File name='profiles.yml'>
+The following example shows how to promote all warnings to errors, except for the `NoNodesForSelectionCriteria` warning using the `silence` and `warn` parameters in the `dbt_project.yml` file:
+  <File name='dbt_project.yml'>
 
   ```yaml
-  config:
+  ....
+  flags:
     warn_error_options:
-      error: # Previously called "include"
-      warn: # Previously called "exclude"
+      error: all # Previously called "include"
+      warn:      # Previously called "exclude"
         - NoNodesForSelectionCriteria
-      silence: # Silence or ignore warnings
+      silence:   # To silence or ignore warnings
         - NoNodesForSelectionCriteria
   ```
 

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -69,7 +69,7 @@ In some cases, you may want to convert _all_ warnings to errors. However, when y
 
 <VersionBlock firstVersion="1.8">
 
-- Warnings that should be treated as errors can be specified through `error` and/or `warn` parameters. Warning names can be found in:
+- Warnings that should be treated as errors can be specified through `error` parameter. Warning names can be found in:
   - [dbt-core's types.py file](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/events/types.py), where each class name that inherits from `WarnLevel` corresponds to a warning name (e.g. `AdapterDeprecationWarning`, `NoNodesForSelectionCriteria`).
   - Downloading the JSON output logs from a run and searching for the warning.
 - The `error` parameter can be set to `"all"` or `"*"` to treat all warnings as exceptions (errors), or to a list of specific warning names to treat as exceptions. This behavior is the same as using the `--warn-error` flag.

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -48,10 +48,11 @@ In some cases, you may want to convert _all_ warnings to errors. However, when y
 
 <VersionBlock lastVersion="1.7">
 
-- Warnings that should be treated as errors can be specified through `include` and/or `exclude` parameters. Warning names can be found in:
+Warnings that should be treated as errors can be specified through `include` and/or `exclude` parameters. Warning names can be found in:
   - [dbt-core's types.py file](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/events/types.py), where each class name that inherits from `WarnLevel` corresponds to a warning name (e.g. `AdapterDeprecationWarning`, `NoNodesForSelectionCriteria`) 
   - Using the `--log-format json` flag.
-- The `include` parameter can be set to "all" or "*" to treat all warnings as exceptions, or to a list of specific warning names to treat as exceptions. When include is set to "all" or "*", the optional `exclude` parameter can be set to exclude specific warnings from being treated as exceptions.
+
+The `include` parameter can be set to "all" or "*" to treat all warnings as exceptions, or to a list of specific warning names to treat as exceptions. When include is set to "all" or "*", the optional `exclude` parameter can be set to exclude specific warnings from being treated as exceptions.
 
 Here's how you can use [`--warn-error-options`](#use---warn-error-options-for-targeted-warnings) flag to promote _specific_ warnings to errors:
 
@@ -64,12 +65,12 @@ Here's how you can use [`--warn-error-options`](#use---warn-error-options-for-ta
 
 <VersionBlock firstVersion="1.8">
 
-- Warnings that should be treated as errors can be specified through `error` parameter. Warning names can be found in:
+Warnings that should be treated as errors can be specified through `error` parameter. Warning names can be found in:
   - [dbt-core's types.py file](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/events/types.py), where each class name that inherits from `WarnLevel` corresponds to a warning name (e.g. `AdapterDeprecationWarning`, `NoNodesForSelectionCriteria`).
   - Using the `--log-format json` flag.
-- The `error` parameter can be set to `"all"` or `"*"` to treat all warnings as errors (this behavior is the same as using the `--warn-error` flag), or to a list of specific warning names to treat as exceptions.
-  
-  When `error` is set to `"all"` or `"*"`, the optional `warn` parameter can be set to exclude specific warnings from being treated as exceptions.
+
+The `error` parameter can be set to `"all"` or `"*"` to treat all warnings as errors (this behavior is the same as using the `--warn-error` flag), or to a list of specific warning names to treat as exceptions.
+- When `error` is set to `"all"` or `"*"`, the optional `warn` parameter can be set to exclude specific warnings from being treated as exceptions.
 - Use the `silence` parameter to ignore warnings. To silence certain warnings you want to ignore, you can specify them in the `silence` parameter. This is useful in large projects where certain warnings aren't critical and can be ignored to keep the noise low and logs clean.
 
 Here's how you can use [`--warn-error-options`](#use---warn-error-options-for-targeted-warnings) flag to promote _specific_ warnings to errors:

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -72,7 +72,7 @@ In some cases, you may want to convert _all_ warnings to errors. However, when y
 - Warnings that should be treated as errors can be specified through `error` parameter. Warning names can be found in:
   - [dbt-core's types.py file](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/events/types.py), where each class name that inherits from `WarnLevel` corresponds to a warning name (e.g. `AdapterDeprecationWarning`, `NoNodesForSelectionCriteria`).
   - Downloading the JSON output logs from a run and searching for the warning.
-- The `error` parameter can be set to `"all"` or `"*"` to treat all warnings as exceptions (errors), or to a list of specific warning names to treat as exceptions. This behavior is the same as using the `--warn-error` flag.
+- The `error` parameter can be set to `"all"` or `"*"` to treat all warnings as errors (this behavior is the same as using the `--warn-error` flag), or to a list of specific warning names to treat as exceptions.
   
   When `error` is set to `"all"` or `"*"`, the optional `warn` parameter can be set to exclude specific warnings from being treated as exceptions.
 - Use the `silence` parameter to ignore warnings. To silence certain warnings you want to ignore, you can specify them in the `silence` parameter. This is useful in large projects where certain warnings aren't critical and can be ignored to keep the noise low and logs clean.

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -15,6 +15,7 @@ dbt --warn-error run
 
 </File>
 
+## About warning options
 
 Converting any warnings to errors may suit your needs perfectly, but there may be some warnings you just don't care about, and some you care about a lot. The `WARN_ERROR_OPTIONS` config gives you more granular control over _exactly which types of warnings_ are treated as errors. 
 
@@ -24,6 +25,14 @@ Warnings that should be treated as errors can be specified through `include` and
 
 The `include` parameter can be set to `"all"` or `"*"` to treat all warnings as exceptions, or to a list of specific warning names to treat as exceptions. When `include` is set to `"all"` or `"*"`, the optional `exclude` parameter can be set to exclude specific warnings from being treated as exceptions.
 
+:::caution Proceed with caution in production environments
+
+Using  `"include": "all"` in older versions will treat _all_ current and future warnings as errors.
+
+This means that if a new warning is introduced in a future version of dbt Core, your production job may start failing unexpectedly. We recommend explicitly listing only the warnings you want to treat as errors in production.
+
+:::
+
 </VersionBlock>
 
 <VersionBlock firstVersion="1.8">
@@ -31,6 +40,13 @@ The `include` parameter can be set to `"all"` or `"*"` to treat all warnings as 
 - Warnings that should be treated as errors can be specified through `error` and/or `warn` parameters. Warning names can be found in [dbt-core's types.py file](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/events/types.py), where each class name that inherits from `WarnLevel` corresponds to a warning name (e.g. `AdapterDeprecationWarning`, `NoNodesForSelectionCriteria`).
 
 - The `error` parameter can be set to `"all"` or `"*"` to treat all warnings as exceptions, or to a list of specific warning names to treat as exceptions. When `error` is set to `"all"` or `"*"`, the optional `warn` parameter can be set to exclude specific warnings from being treated as exceptions.
+  :::caution Proceed with caution in production environments
+
+  Using `warn_error_options: error: "all"` will treat _all_ current and future warnings as errors.
+
+  This means that if a new warning is introduced in a future version of dbt Core, your production job may start failing unexpectedly. We recommend explicitly listing only the warnings you want to treat as errors in production.
+
+  :::
 
 - Use the `silence` parameter to ignore warnings through project flags, without needing to re-specify the silence list every time. For example, to silence deprecation warnings or certain warnings you want to ignore across your project, you can specify them in the `silence` parameter. This is useful in large projects where certain warnings aren't critical and can be ignored to keep the noise low and logs clean.
 
@@ -53,15 +69,72 @@ flags:
 
 </VersionBlock>
 
+## Configure warnings as errors
+
+You can configure warnings as errors, which can be set through CLI flags, environment variables, or configuration files like `dbt_project.yml` or `profiles.yml`.
+
+You can choose to:
+
+- Promote all warnings to errors (using `{"error": "all"}` or `--warn-error`)
+- Promote some warnings to errors using `error`, `warn`, and `silence`
 
 :::info `WARN_ERROR` and `WARN_ERROR_OPTIONS` are mutually exclusive
 `WARN_ERROR` and `WARN_ERROR_OPTIONS` are mutually exclusive. You can only specify one, even when you're specifying the config in multiple places (e.g. env var + CLI flag), otherwise, you'll see a usage error.
 :::
 
+To promote all warnings to errors, use the following:
+
+#### CLI flags
+
+<VersionBlock lastVersion="1.7"> 
+
+```bash 
+dbt --warn-error run 
+dbt --warn-error-options '{"include": "all"}' run 
+dbt --warn-error-options '{"include": "*"}' run 
+```
+</VersionBlock> 
+
+<VersionBlock firstVersion="1.8"> 
+
+```bash 
+dbt --warn-error run 
+dbt --warn-error-options '{"error": "all"}' run 
+dbt --warn-error-options '{"error": "*"}' run 
+```
+</VersionBlock>
+
+#### Environment variables
+
+<VersionBlock lastVersion="1.7"> 
+
+```bash 
+WARN_ERROR=true dbt run
+DBT_WARN_ERROR_OPTIONS='{"include": "all"}' dbt run 
+DBT_WARN_ERROR_OPTIONS='{"include": "*"}' dbt run 
+``` 
+
+</VersionBlock> 
+
+<VersionBlock firstVersion="1.8"> 
+
+```bash 
+WARN_ERROR=true dbt run 
+DBT_WARN_ERROR_OPTIONS='{"error": "all"}' dbt run 
+DBT_WARN_ERROR_OPTIONS='{"error": "*"}' dbt run 
+``` 
+
+</VersionBlock>
+
+### Example
+Here are some examples that show you how to configure `warn_error_options` using flags or file-based configuration.
+
+Some of the examples use `NoNodesForSelectionCriteria`, which is a specific warning that occurs when your `--select` flag doesn't match any nodes/resources in your dbt project:
+
 <VersionBlock lastVersion="1.7">
 
 ```text
-dbt --warn-error-options '{"include": "all"}' run
+dbt --warn-error-options '{"include": "all"}' run 
 ...
 ```
 

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -8,6 +8,14 @@ intro_text: "Use the --warn-error flag to promote all warnings to errors or --wa
 
 Enabling `WARN_ERROR` config or setting the `--warn-error` flag will convert _all_ dbt warnings into errors. Any time dbt would normally warn, it will instead raise an error. Examples include `--select` criteria that selects no resources, deprecations, configurations with no associated models, invalid test configurations, or tests and freshness checks that are configured to return warnings.
 
+<File name='Usage'>
+
+  ```text
+  dbt --warn-error run
+  ```
+
+</File>
+
 <VersionBlock firstVersion="1.8">
 
 :::caution Proceed with caution in production environments
@@ -15,13 +23,6 @@ Using the `--warn-error` flag or `--warn-error-options '{"error": "all"}'` will 
 
 This means that if a new warning is introduced in a future version of dbt Core, your production job may start failing unexpectedly. We recommend proceeding with caution when doing this in production environments, and explicitly listing only the warnings you want to treat as errors in production.
 :::
-
-Instead of using the `--warn-error` flag to promote _all_ warnings to errors, you can use [`--warn-error-options`](#use---warn-error-options-for-targeted-warnings) flag to promote _specific_ warnings to errors, including:
-
-- [Test warnings](/reference/resource-configs/severity) with the `--warn-error-options '{"error": ["LogTestResults"]}'` flag.
-- Jinja [exception warnings](/reference/dbt-jinja-functions/exceptions#warn) with `--warn-error-options '{"error": ["JinjaLogWarning"]}'`.
-- No nodes selected with `--warn-error-options '{"error": ["NoNodesForSelectionCriteria"]}'`.
-- Adapter deprecation warnings with `--warn-error-options '{"error": ["AdapterDeprecationWarning"]}'`.
 
 </VersionBlock>
 
@@ -33,22 +34,9 @@ Using the `--warn-error` flag or `--warn-error-options '{"include": "all"}'` wil
 This means that if a new warning is introduced in a future version of dbt Core, your production job may start failing unexpectedly. We recommend proceeding with caution when doing this in production environments, and explicitly listing only the warnings you want to treat as errors in production.
 :::
 
-Instead of using the `--warn-error` flag to promote _all_ warnings to errors, you can use [`--warn-error-options`](#use---warn-error-options-for-targeted-warnings) flag to promote _specific_ warnings to errors, including:
-
-- Test warnings with the `--warn-error-options '{"include": ["LogTestResults"]}'` flag.
-- Jinja-level warnings with the `--warn-error-options '{"include": ["JinjaLogWarning"]}'` flag or [`exceptions.warn`](/reference/dbt-jinja-functions/exceptions#warn).
-- Selection issues with the `--warn-error-options '{"include": ["NoNodesForSelectionCriteria"]}'` flag.
-- Adapter deprecation warnings with the `--warn-error-options '{"include": ["AdapterDeprecationWarning"]}'` flag.
-
 </VersionBlock>
 
-<File name='Usage'>
 
-  ```text
-  dbt --warn-error run
-  ```
-
-</File>
 
 ## Use `--warn-error-options` for targeted warnings
 
@@ -65,6 +53,13 @@ In some cases, you may want to convert _all_ warnings to errors. However, when y
   - Using the `--log-format json` flag.
 - The `include` parameter can be set to "all" or "*" to treat all warnings as exceptions, or to a list of specific warning names to treat as exceptions. When include is set to "all" or "*", the optional `exclude` parameter can be set to exclude specific warnings from being treated as exceptions.
 
+Here's how you can use [`--warn-error-options`](#use---warn-error-options-for-targeted-warnings) flag to promote _specific_ warnings to errors:
+
+- Test warnings with the `--warn-error-options '{"include": ["LogTestResults"]}'` flag.
+- Jinja-level warnings with the `--warn-error-options '{"include": ["JinjaLogWarning"]}'` flag or [`exceptions.warn`](/reference/dbt-jinja-functions/exceptions#warn).
+- Selection issues with the `--warn-error-options '{"include": ["NoNodesForSelectionCriteria"]}'` flag.
+- Adapter deprecation warnings with the `--warn-error-options '{"include": ["AdapterDeprecationWarning"]}'` flag.
+
 </VersionBlock>
 
 <VersionBlock firstVersion="1.8">
@@ -76,6 +71,12 @@ In some cases, you may want to convert _all_ warnings to errors. However, when y
   
   When `error` is set to `"all"` or `"*"`, the optional `warn` parameter can be set to exclude specific warnings from being treated as exceptions.
 - Use the `silence` parameter to ignore warnings. To silence certain warnings you want to ignore, you can specify them in the `silence` parameter. This is useful in large projects where certain warnings aren't critical and can be ignored to keep the noise low and logs clean.
+
+Here's how you can use [`--warn-error-options`](#use---warn-error-options-for-targeted-warnings) flag to promote _specific_ warnings to errors:
+- [Test warnings](/reference/resource-configs/severity) with the `--warn-error-options '{"error": ["LogTestResults"]}'` flag.
+- Jinja [exception warnings](/reference/dbt-jinja-functions/exceptions#warn) with `--warn-error-options '{"error": ["JinjaLogWarning"]}'`.
+- No nodes selected with `--warn-error-options '{"error": ["NoNodesForSelectionCriteria"]}'`.
+- Adapter deprecation warnings with `--warn-error-options '{"error": ["AdapterDeprecationWarning"]}'`.
 
 </VersionBlock>
 
@@ -106,10 +107,11 @@ In the following example, we're promoting all warnings to errors except for the 
 </VersionBlock>
 
 <VersionBlock firstVersion="1.8">
+
 You can choose to:
 
 - Promote all warnings to errors using `{"error": "all"}` or `--warn-error` flag.
-- Promote some warnings to errors using `error` and optionally exclude others from being treated as errors with `warn` with `--warn-error-options` flag. `warn` tells dbt to continue treating the warnings as warnings.
+- Promote specific warnings to errors using `error` and optionally exclude others from being treated as errors with `--warn-error-options` flag. `warn` tells dbt to continue treating the warnings as warnings.
 - Ignore warnings using `silence` with `--warn-error-options` flag.
 
 In the following example, we're silencing the [`NoNodesForSelectionCriteria` warning](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/events/types.py#L1227) in the `dbt_project.yml` file by adding it to the `silence` parameter:

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -74,7 +74,7 @@ In some cases, you may want to convert _all_ warnings to errors. However, when y
   - Downloading the JSON output logs from a run and searching for the warning.
 - The `error` parameter can be set to `"all"` or `"*"` to treat all warnings as exceptions (errors), or to a list of specific warning names to treat as exceptions. This behavior is the same as using the `--warn-error` flag.
   
-  When `error` is set to `"all"` or `"*"`, the optional `warn` parameter can be set to exclude specific warnings from being treated as exceptions &mdash; similar to the [`--warn-error-options`](#use---warn-error-options-for-targeted-warnings) flag.
+  When `error` is set to `"all"` or `"*"`, the optional `warn` parameter can be set to exclude specific warnings from being treated as exceptions &mdash.
 - Use the `silence` parameter to ignore warnings. To silence certain warnings you want to ignore, you can specify them in the `silence` parameter. This is useful in large projects where certain warnings aren't critical and can be ignored to keep the noise low and logs clean.
 
 </VersionBlock>

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -75,7 +75,7 @@ You can configure warnings as errors, which can be set through command flags, en
 
 <VersionBlock lastVersion="1.7"> 
 
-- Promote all warnings to errors using `{"include": "all"}` or `--warn-error-options` flag.
+- Promote all warnings to errors using `{"include": "all"}` or `--warn-error` flag.
 - Promote some warnings to errors using `include`.
 - Exclude warnings from being treated as errors using `exclude`.
 

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -63,7 +63,7 @@ In some cases, you may want to convert _all_ warnings to errors. However, when y
 - Warnings that should be treated as errors can be specified through `include` and/or `exclude` parameters. Warning names can be found in:
   - [dbt-core's types.py file](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/events/types.py), where each class name that inherits from `WarnLevel` corresponds to a warning name (e.g. `AdapterDeprecationWarning`, `NoNodesForSelectionCriteria`) 
   - Downloading the JSON output logs from a run and searching for the warning.
-- The `include` parameter can be set to "all" or "*" to treat all warnings as exceptions, or to a list of specific warning names to treat as exceptions. When include is set to "all" or "*", the optional exclude parameter can be set to exclude specific warnings from being treated as exceptions.
+- The `include` parameter can be set to "all" or "*" to treat all warnings as exceptions, or to a list of specific warning names to treat as exceptions. When include is set to "all" or "*", the optional `exclude` parameter can be set to exclude specific warnings from being treated as exceptions.
 
 </VersionBlock>
 

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -3,12 +3,12 @@ title: "Warnings"
 id: "warnings"
 sidebar: "Warnings"
 toc_max_heading_level: 2
-intro_text: "dbt's warnings can be converted to errors using --warn-error flag or WARN_ERROR config, with granular control through options."
+intro_text: "dbt's warnings can be converted to errors using the --warn-error flag to promote all warnings to errors or --warn-error-options for granular control through options."
 ---
 
 Enabling `WARN_ERROR` config or setting the `--warn-error` flag will convert _all_ dbt warnings into errors. Any time dbt would normally warn, it will instead raise an error. Examples include `--select` criteria that selects no resources, deprecations, configurations with no associated models, invalid test configurations, or tests and freshness checks that are configured to return warnings.
 
- You would commonly use the `--warn-error` flag to promote test warnings from `severity: warn` to errors, but it actually affects all warning types, including:
+You can use the `--warn-error` flag to promote all warnings to errors, such as:
 * Test warnings (for example, `LogTestResults`)
 * Jinja-level warnings (for example, `exceptions.warn`, or `JinjaLogWarning`)
 * Selection issues (for example, `NoNodesForSelectionCriteria`)

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -62,7 +62,7 @@ In some cases, you may want to convert _all_ warnings to errors. However, when y
 
 - Warnings that should be treated as errors can be specified through `include` and/or `exclude` parameters. Warning names can be found in:
   - [dbt-core's types.py file](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/events/types.py), where each class name that inherits from `WarnLevel` corresponds to a warning name (e.g. `AdapterDeprecationWarning`, `NoNodesForSelectionCriteria`) 
-  - Downloading the JSON output logs from a run and searching for the warning.
+  - Using the `--log-format json` flag.
 - The `include` parameter can be set to "all" or "*" to treat all warnings as exceptions, or to a list of specific warning names to treat as exceptions. When include is set to "all" or "*", the optional `exclude` parameter can be set to exclude specific warnings from being treated as exceptions.
 
 </VersionBlock>

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -75,7 +75,7 @@ In some cases, you may want to convert _all_ warnings to errors. However, when y
 - The `error` parameter can be set to `"all"` or `"*"` to treat all warnings as exceptions (errors), or to a list of specific warning names to treat as exceptions. This behavior is the same as using the `--warn-error` flag.
   
   When `error` is set to `"all"` or `"*"`, the optional `warn` parameter can be set to exclude specific warnings from being treated as exceptions &mdash; similar to the [`--warn-error-options`](#use---warn-error-options-for-targeted-warnings) flag.
-- Use the `silence` parameter to ignore warnings. For example, to silence deprecation warnings or certain warnings you want to ignore across your project, you can specify them in the `silence` parameter. This is useful in large projects where certain warnings aren't critical and can be ignored to keep the noise low and logs clean.
+- Use the `silence` parameter to ignore warnings. To silence certain warnings you want to ignore, you can specify them in the `silence` parameter. This is useful in large projects where certain warnings aren't critical and can be ignored to keep the noise low and logs clean.
 
 </VersionBlock>
 

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -20,7 +20,7 @@ Instead of using the `--warn-error` flag to promote _all_ warnings to errors, yo
 
 - Test warnings with the `--warn-error-options '{"error": ["LogTestResults"]}'` flag.
 - Jinja-level warnings with the `--warn-error-options '{"error": ["JinjaLogWarning"]}'` flag or [`exceptions.warn`](/reference/dbt-jinja-functions/exceptions#warn).
-- Selection issues with the `--warn-error-options '{"error": ["NoNodesForSelectionCriteria"]}'` flag.
+- No nodes selected with `--warn-error-options '{"error": ["NoNodesForSelectionCriteria"]}'.
 - Adapter deprecation warnings with `--warn-error-options '{"error": ["AdapterDeprecationWarning"]}'.
 
 </VersionBlock>

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -65,7 +65,7 @@ The `include` parameter can be set to "all" or "*" to treat all warnings as exce
 
   :::
 
-- Use the `silence` parameter to ignore warnings through project flags, without needing to re-specify the silence list every time. For example, to silence deprecation warnings or certain warnings you want to ignore across your project, you can specify them in the `silence` parameter. This is useful in large projects where certain warnings aren't critical and can be ignored to keep the noise low and logs clean.
+- Use the `silence` parameter to ignore warnings. For example, to silence deprecation warnings or certain warnings you want to ignore across your project, you can specify them in the `silence` parameter. This is useful in large projects where certain warnings aren't critical and can be ignored to keep the noise low and logs clean.
 
 </VersionBlock>
 

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -38,7 +38,7 @@ This means that if a new warning is introduced in a future version of dbt Core, 
 
 - Warnings that should be treated as errors can be specified through `error` and/or `warn` parameters. Warning names can be found in [dbt-core's types.py file](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/events/types.py), where each class name that inherits from `WarnLevel` corresponds to a warning name (e.g. `AdapterDeprecationWarning`, `NoNodesForSelectionCriteria`).
 
-- The `error` parameter can be set to `"all"` or `"*"` to treat all warnings as exceptions, or to a list of specific warning names to treat as exceptions. When `error` is set to `"all"` or `"*"`, the optional `warn` parameter can be set to exclude specific warnings from being treated as exceptions.
+- The `error` parameter can be set to `"all"` or `"*"` to treat all warnings as exceptions (errors), or to a list of specific warning names to treat as exceptions. When `error` is set to `"all"` or `"*"`, the optional `warn` parameter can be set to exclude specific warnings from being treated as exceptions.
   :::caution Proceed with caution in production environments
 
   Using `warn_error_options: error: "all"` will treat _all_ current and future warnings as errors.

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -10,12 +10,11 @@ Turning on the `WARN_ERROR` config will convert dbt warnings into errors. Any ti
 
 ```text
 dbt --warn-error run
-...
 ```
 
 </File>
 
-## About warning options
+## warn_error_options
 
 Converting any warnings to errors may suit your needs perfectly, but there may be some warnings you just don't care about, and some you care about a lot. The `WARN_ERROR_OPTIONS` config gives you more granular control over _exactly which types of warnings_ are treated as errors. 
 
@@ -50,41 +49,54 @@ This means that if a new warning is introduced in a future version of dbt Core, 
 
 - Use the `silence` parameter to ignore warnings through project flags, without needing to re-specify the silence list every time. For example, to silence deprecation warnings or certain warnings you want to ignore across your project, you can specify them in the `silence` parameter. This is useful in large projects where certain warnings aren't critical and can be ignored to keep the noise low and logs clean.
 
+  In the following example, we're silencing the [`NoNodesForSelectionCriteria` warning](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/events/types.py#L1227) in the `dbt_project.yml` file:
 
-<File name='dbt_project.yml'>
+  <File name='dbt_project.yml'>
 
-```yaml
-name: "my_dbt_project"
-tests:
-  +enabled: True
-flags:
-  warn_error_options:
-    error: # Previously called "include"
-    warn: # Previously called "exclude"
-    silence: # To silence or ignore warnings
-      - NoNodesForSelectionCriteria
-```
+  ```yaml
+  name: "my_dbt_project"
+  tests:
+    +enabled: True
+  flags:
+    warn_error_options:
+      error: # Previously called "include"
+      warn: # Previously called "exclude"
+      silence: # To silence or ignore warnings
+        - NoNodesForSelectionCriteria
+  ```
 
-</File>
+  </File>
 
 </VersionBlock>
 
-## Configure warnings as errors
+## Configuration
 
-You can configure warnings as errors, which can be set through CLI flags, environment variables, or configuration files like `dbt_project.yml` or `profiles.yml`.
+You can configure warnings as errors, which can be set through command flags, environment variables, or configuration files like `dbt_project.yml` or `profiles.yml`.
 
+<VersionBlock lastVersion="1.7"> 
+
+- Promote all warnings to errors (using `{"include": "all"}` or `--warn-error-options` flag)
+- Promote some warnings to errors using `include`
+- Exclude warnings from being treated as errors using `exclude`
+
+</VersionBlock>
+
+<VersionBlock firstVersion="1.8">
 You can choose to:
 
-- Promote all warnings to errors (using `{"error": "all"}` or `--warn-error`)
-- Promote some warnings to errors using `error`, `warn`, and `silence`
+- Promote all warnings to errors (using `{"error": "all"}` or `--warn-error` flag)
+- Promote some warnings to errors using `error` and optionally exclude others with `warn`
+- Silence or ignore warnings using `silence`
+
+</VersionBlock>
 
 :::info `WARN_ERROR` and `WARN_ERROR_OPTIONS` are mutually exclusive
-`WARN_ERROR` and `WARN_ERROR_OPTIONS` are mutually exclusive. You can only specify one, even when you're specifying the config in multiple places (e.g. env var + CLI flag), otherwise, you'll see a usage error.
+`WARN_ERROR` and `WARN_ERROR_OPTIONS` are mutually exclusive. You can only specify one, even when you're specifying the config in multiple places (like env var or a flag), otherwise, you'll see a usage error.
 :::
 
 To promote all warnings to errors, use the following:
 
-#### CLI flags
+#### dbt command flags
 
 <VersionBlock lastVersion="1.7"> 
 
@@ -112,8 +124,7 @@ dbt --warn-error-options '{"error": "*"}' run
 WARN_ERROR=true dbt run
 DBT_WARN_ERROR_OPTIONS='{"include": "all"}' dbt run 
 DBT_WARN_ERROR_OPTIONS='{"include": "*"}' dbt run 
-``` 
-
+```
 </VersionBlock> 
 
 <VersionBlock firstVersion="1.8"> 
@@ -122,40 +133,42 @@ DBT_WARN_ERROR_OPTIONS='{"include": "*"}' dbt run
 WARN_ERROR=true dbt run 
 DBT_WARN_ERROR_OPTIONS='{"error": "all"}' dbt run 
 DBT_WARN_ERROR_OPTIONS='{"error": "*"}' dbt run 
-``` 
+```
 
 </VersionBlock>
 
-### Example
+Note that using <VersionBlock firstVersion="1.8">`warn_error_options: error: "all"`</VersionBlock> <VersionBlock lastVersion="1.7">`warn_error_options: include: "all"`</VersionBlock> will treat all current and future warnings as errors.
+
+This means that if a new warning is introduced in a future version of dbt Core, your production job may start failing unexpectedly. We recommend explicitly listing only the warnings you want to treat as errors in production.
+
+## Example
 Here are some examples that show you how to configure `warn_error_options` using flags or file-based configuration.
 
 Some of the examples use `NoNodesForSelectionCriteria`, which is a specific warning that occurs when your `--select` flag doesn't match any nodes/resources in your dbt project:
 
 <VersionBlock lastVersion="1.7">
 
-```text
-dbt --warn-error-options '{"include": "all"}' run 
-...
-```
+- This command promotes all warnings to errors:
+  ```text
+  dbt --warn-error-options '{"include": "all"}' run 
+  ```
 
-```text
-dbt --warn-error-options '{"include": "all", "exclude": ["NoNodesForSelectionCriteria"]}' run
-...
-```
+- This command promotes all warnings to errors, except for `NoNodesForSelectionCriteria`:
+  ```text
+  dbt --warn-error-options '{"include": "all", "exclude": ["NoNodesForSelectionCriteria"]}' run
+  ```
 
+- This command promotes only `NoNodesForSelectionCriteria` as an error:
+  ```text
+  dbt --warn-error-options '{"include": ["NoNodesForSelectionCriteria"]}' run
+  ```
 
-```text
-dbt --warn-error-options '{"include": ["NoNodesForSelectionCriteria"]}' run
-...
-```
-
-```text
-DBT_WARN_ERROR_OPTIONS='{"include": ["NoNodesForSelectionCriteria"]}' dbt run
-...
-```
+- This promotes only `NoNodesForSelectionCriteria` as an error, using an environment variable:
+  ```text
+  DBT_WARN_ERROR_OPTIONS='{"include": ["NoNodesForSelectionCriteria"]}' dbt run
+  ```
 
 Values for `error`, `warn`, and/or `silence` should be passed on as arrays. For example, `dbt --warn-error-options '{"error": "all", "warn": ["NoNodesForSelectionCriteria"]}' run` not `dbt --warn-error-options '{"error": "all", "warn": "NoNodesForSelectionCriteria"}' run`.
-
 
 <File name='profiles.yml'>
 
@@ -173,39 +186,38 @@ config:
 
 <VersionBlock firstVersion="1.8">
 
-```text
-dbt --warn-error-options '{"error": "all"}' run
-...
-```
+- This command promotes all warnings to errors:
+  ```text
+  dbt --warn-error-options '{"error": "all"}' run
+  ```
 
-```text
-dbt --warn-error-options '{"error": "all", "warn": ["NoNodesForSelectionCriteria"]}' run
-...
-```
+- This command promotes all warnings to errors, except for `NoNodesForSelectionCriteria`:
+  ```text
+  dbt --warn-error-options '{"error": "all", "warn": ["NoNodesForSelectionCriteria"]}' run
+  ```
 
+- This command promotes only `NoNodesForSelectionCriteria` as an error:
+  ```text
+  dbt --warn-error-options '{"error": ["NoNodesForSelectionCriteria"]}' run
+  ```
 
-```text
-dbt --warn-error-options '{"error": ["NoNodesForSelectionCriteria"]}' run
-...
-```
+- This promotes only `NoNodesForSelectionCriteria` as an error, using an environment variable:
+  ```text
+  DBT_WARN_ERROR_OPTIONS='{"error": ["NoNodesForSelectionCriteria"]}' dbt run
+  ```
 
-```text
-DBT_WARN_ERROR_OPTIONS='{"error": ["NoNodesForSelectionCriteria"]}' dbt run
-...
-```
+The following example shows how to silence or ignore warnings using the `silence` parameter in the `profiles.yml` file:
+  <File name='profiles.yml'>
 
-<File name='profiles.yml'>
+  ```yaml
+  config:
+    warn_error_options:
+      error: # Previously called "include"
+      warn: # Previously called "exclude"
+        - NoNodesForSelectionCriteria
+      silence: # Silence or ignore warnings
+        - NoNodesForSelectionCriteria
+  ```
 
-```yaml
-config:
-  warn_error_options:
-    error: # Previously called "include"
-    warn: # Previously called "exclude"
-      - NoNodesForSelectionCriteria
-    silence: # Silence or ignore warnings
-      - NoNodesForSelectionCriteria
-```
-
-</File>
-
+  </File>
 </VersionBlock>

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -34,7 +34,9 @@ Converting any warnings to errors may suit your needs perfectly, but there may b
 
 <VersionBlock lastVersion="1.7">
 
-Warnings that should be treated as errors can be specified through `include` and/or `exclude` parameters. Warning names can be found in [dbt-core's types.py file](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/events/types.py), where each class name that inherits from `WarnLevel` corresponds to a warning name (e.g. `AdapterDeprecationWarning`, `NoNodesForSelectionCriteria`).
+Warnings that should be treated as errors can be specified through `include` and/or `exclude` parameters. Warning names can be found in:
+- [dbt-core's types.py file](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/events/types.py), where each class name that inherits from `WarnLevel` corresponds to a warning name (e.g. `AdapterDeprecationWarning`, `NoNodesForSelectionCriteria`) 
+- Downloading the JSON output logs from a run and searching for the warning.
 
 The `include` parameter can be set to "all" or "*" to treat all warnings as exceptions, or to a list of specific warning names to treat as exceptions. When include is set to "all" or "*", the optional exclude parameter can be set to exclude specific warnings from being treated as exceptions.
 
@@ -50,7 +52,9 @@ The `include` parameter can be set to "all" or "*" to treat all warnings as exce
 
 <VersionBlock firstVersion="1.8">
 
-- Warnings that should be treated as errors can be specified through `error` and/or `warn` parameters. Warning names can be found in [dbt-core's types.py file](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/events/types.py), where each class name that inherits from `WarnLevel` corresponds to a warning name (e.g. `AdapterDeprecationWarning`, `NoNodesForSelectionCriteria`).
+- Warnings that should be treated as errors can be specified through `error` and/or `warn` parameters. Warning names can be found in:
+- [dbt-core's types.py file](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/events/types.py), where each class name that inherits from `WarnLevel` corresponds to a warning name (e.g. `AdapterDeprecationWarning`, `NoNodesForSelectionCriteria`).
+- Downloading the JSON output logs from a run and searching for the warning.
 
 - The `error` parameter can be set to `"all"` or `"*"` to treat all warnings as exceptions (errors), or to a list of specific warning names to treat as exceptions. When `error` is set to `"all"` or `"*"`, the optional `warn` parameter can be set to exclude specific warnings from being treated as exceptions.
   :::caution Proceed with caution in production environments

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -81,7 +81,7 @@ In some cases, you may want to convert _all_ warnings to errors. However, when y
 
 ## Configuration
 
-You can configure warnings as errors or which warnings to silence, by setting the config through command flags, environment variables, or configuration files like `dbt_project.yml` or `profiles.yml`.
+You can configure warnings as errors or which warnings to silence, by warn error options through command flag, environment variable, or `dbt_project.yml`.
 
 <VersionBlock lastVersion="1.7"> 
 

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -112,7 +112,7 @@ You can choose to:
 - Promote some warnings to errors using `error` and optionally exclude others from being treated as errors with `warn`. `warn` tells dbt to continue treating the warnings as warnings.
 - Ignore warnings using `silence`.
 
-In the following example, we're ignoring the [`NoNodesForSelectionCriteria` warning](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/events/types.py#L1227) in the `dbt_project.yml` file by adding it to the `silence` parameter:
+In the following example, we're silencing the [`NoNodesForSelectionCriteria` warning](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/events/types.py#L1227) in the `dbt_project.yml` file by adding it to the `silence` parameter:
 
   <File name='dbt_project.yml'>
 

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -75,18 +75,18 @@ You can configure warnings as errors, which can be set through command flags, en
 
 <VersionBlock lastVersion="1.7"> 
 
-- Promote all warnings to errors (using `{"include": "all"}` or `--warn-error-options` flag)
-- Promote some warnings to errors using `include`
-- Exclude warnings from being treated as errors using `exclude`
+- Promote all warnings to errors using `{"include": "all"}` or `--warn-error-options` flag.
+- Promote some warnings to errors using `include`.
+- Exclude warnings from being treated as errors using `exclude`.
 
 </VersionBlock>
 
 <VersionBlock firstVersion="1.8">
 You can choose to:
 
-- Promote all warnings to errors (using `{"error": "all"}` or `--warn-error` flag)
-- Promote some warnings to errors using `error` and optionally exclude others with `warn`
-- Silence or ignore warnings using `silence`
+- Promote all warnings to errors using `{"error": "all"}` or `--warn-error` flag.
+- Promote some warnings to errors using `error` and optionally exclude others from being treated as errors with `warn`. `warn` tells dbt to continue treating the warnings as warnings.
+- Ignore warnings using `silence`.
 
 </VersionBlock>
 

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -137,7 +137,7 @@ DBT_WARN_ERROR_OPTIONS='{"error": "*"}' dbt run
 
 </VersionBlock>
 
-Note that using <VersionBlock firstVersion="1.8">`warn_error_options: error: "all"`</VersionBlock> <VersionBlock lastVersion="1.7">`warn_error_options: include: "all"`</VersionBlock> will treat all current and future warnings as errors.
+Note, as mentioned earlier, using <VersionBlock firstVersion="1.8">`warn_error_options: error: "all"`</VersionBlock> <VersionBlock lastVersion="1.7">`warn_error_options: include: "all"`</VersionBlock> will treat all current and future warnings as errors.
 
 This means that if a new warning is introduced in a future version of dbt Core, your production job may start failing unexpectedly. We recommend explicitly listing only the warnings you want to treat as errors in production.
 

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -43,7 +43,7 @@ This means that if a new warning is introduced in a future version of dbt Core, 
 
   Using `warn_error_options: error: "all"` will treat _all_ current and future warnings as errors.
 
-  This means that if a new warning is introduced in a future version of dbt Core, your production job may start failing unexpectedly. We recommend explicitly listing only the warnings you want to treat as errors in production.
+  This means that if a new warning is introduced in a future version of dbt Core, your production job may start failing unexpectedly. We recommend proceeding with caution when doing this in production environments, and explicitly listing only the warnings you want to treat as errors in production.
 
   :::
 
@@ -139,7 +139,7 @@ DBT_WARN_ERROR_OPTIONS='{"error": "*"}' dbt run
 
 Note, as mentioned earlier, using <VersionBlock firstVersion="1.8">`warn_error_options: error: "all"`</VersionBlock> <VersionBlock lastVersion="1.7">`warn_error_options: include: "all"`</VersionBlock> will treat all current and future warnings as errors.
 
-This means that if a new warning is introduced in a future version of dbt Core, your production job may start failing unexpectedly. We recommend explicitly listing only the warnings you want to treat as errors in production.
+This means that if a new warning is introduced in a future version of dbt Core, your production job may start failing unexpectedly. We recommend proceeding with caution when doing this in production environments, and explicitly listing only the warnings you want to treat as errors in production.
 
 ## Example
 Here are some examples that show you how to configure `warn_error_options` using flags or file-based configuration.

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -3,7 +3,7 @@ title: "Warnings"
 id: "warnings"
 sidebar: "Warnings"
 toc_max_heading_level: 2
-intro_text: "dbt's warnings can be converted to errors using the --warn-error flag to promote all warnings to errors or --warn-error-options for granular control through options."
+intro_text: "Use the --warn-error flag to promote all warnings to errors or --warn-error-options for granular control through options."
 ---
 
 Enabling `WARN_ERROR` config or setting the `--warn-error` flag will convert _all_ dbt warnings into errors. Any time dbt would normally warn, it will instead raise an error. Examples include `--select` criteria that selects no resources, deprecations, configurations with no associated models, invalid test configurations, or tests and freshness checks that are configured to return warnings.

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -2,9 +2,11 @@
 title: "Warnings"
 id: "warnings"
 sidebar: "Warnings"
+toc_max_heading_level: 2
+intro_text: "dbt's warnings can be converted to errors using --warn-error flag or WARN_ERROR config, with granular control through options."
 ---
 
-Enabling `WARN_ERROR`config or setting the `--warn-error` flag will convert dbt warnings into errors. Any time dbt would normally warn, it will instead raise an error. Examples include `--select` criteria that selects no resources, deprecations, configurations with no associated models, invalid test configurations, or tests and freshness checks that are configured to return warnings.
+Enabling `WARN_ERROR` config or setting the `--warn-error` flag will convert dbt warnings into errors. Any time dbt would normally warn, it will instead raise an error. Examples include `--select` criteria that selects no resources, deprecations, configurations with no associated models, invalid test configurations, or tests and freshness checks that are configured to return warnings.
 
  You would commonly use the `--warn-error` flag to promote test warnings from `severity: warn` to errors, but it actually affects all warning types, including:
 * Test warnings (for example, `LogTestResults`)
@@ -12,7 +14,7 @@ Enabling `WARN_ERROR`config or setting the `--warn-error` flag will convert dbt 
 * Selection issues (for example, `NoNodesForSelectionCriteria`)
 * Adapter deprecation warnings (for example, `AdapterDeprecationWarning`)
 
-Consider using [`--warn-error-options`](#using-warn_error_options-for-targeted-warnings) for more targeted control over which warnings are treated as errors.
+Consider using [`--warn-error-options`](#use---warn-error-options-for-targeted-warnings) for more targeted control over which warnings are treated as errors.
 
 <File name='Usage'>
 
@@ -22,14 +24,29 @@ dbt --warn-error run
 
 </File>
 
-
-### Using `--warn-error-options` for targeted warnings
+## Use `--warn-error-options` for targeted warnings
 
 Converting any warnings to errors may suit your needs perfectly, but there may be some warnings you just don't care about, and some you care about a lot. The `WARN_ERROR_OPTIONS` config or `--warn-error-options` flag gives you more granular control over _exactly which types of warnings_ are treated as errors. 
 
-:::info `WARN_ERROR` and `WARN_ERROR_OPTIONS` configs are mutually exclusive
-`WARN_ERROR` and `WARN_ERROR_OPTIONS` configs are mutually exclusive. You can only specify one, even when you're specifying the config in multiple places (e.g. env var + CLI flag), otherwise, you'll see a usage error.
+:::info `WARN_ERROR` and `WARN_ERROR_OPTIONS` are mutually exclusive
+`WARN_ERROR` and `WARN_ERROR_OPTIONS` are mutually exclusive. You can only specify one, even when you're specifying the config in multiple places (like env var or a flag), otherwise, you'll see a usage error.
 :::
+
+<VersionBlock lastVersion="1.7">
+
+Warnings that should be treated as errors can be specified through `include` and/or `exclude` parameters. Warning names can be found in [dbt-core's types.py file](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/events/types.py), where each class name that inherits from `WarnLevel` corresponds to a warning name (e.g. `AdapterDeprecationWarning`, `NoNodesForSelectionCriteria`).
+
+The `include` parameter can be set to "all" or "*" to treat all warnings as exceptions, or to a list of specific warning names to treat as exceptions. When include is set to "all" or "*", the optional exclude parameter can be set to exclude specific warnings from being treated as exceptions.
+
+  :::caution Proceed with caution in production environments
+
+  Using `warn_error_options: include: "all"` will treat _all_ current and future warnings as errors.
+
+  This means that if a new warning is introduced in a future version of dbt Core, your production job may start failing unexpectedly. We recommend proceeding with caution when doing this in production environments, and explicitly listing only the warnings you want to treat as errors in production.
+
+  :::
+
+</VersionBlock>
 
 <VersionBlock firstVersion="1.8">
 
@@ -46,7 +63,42 @@ Converting any warnings to errors may suit your needs perfectly, but there may b
 
 - Use the `silence` parameter to ignore warnings through project flags, without needing to re-specify the silence list every time. For example, to silence deprecation warnings or certain warnings you want to ignore across your project, you can specify them in the `silence` parameter. This is useful in large projects where certain warnings aren't critical and can be ignored to keep the noise low and logs clean.
 
-  In the following example, we're ignoring the [`NoNodesForSelectionCriteria` warning](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/events/types.py#L1227) in the `dbt_project.yml` file by adding it to the `silence` parameter:
+</VersionBlock>
+
+## Configuration
+
+You can configure warnings as errors, which can be set through command flags, environment variables, or configuration files like `dbt_project.yml` or `profiles.yml`.
+
+<VersionBlock lastVersion="1.7"> 
+
+- Promote all warnings to errors using `{"include": "all"}` or `--warn-error-options` flag.
+- Promote some warnings to errors using `include`.
+- Exclude warnings from being treated as errors using `exclude`.
+
+In the following example, we're ignoring the [`NoNodesForSelectionCriteria` warning](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/events/types.py#L1227) in the `profiles.yml` file by adding it to the `exclude` parameter:
+
+  <File name='profiles.yml'>
+
+  ```yaml
+  config:
+    warn_error_options:
+      include: all
+      exclude: 
+        - NoNodesForSelectionCriteria
+  ```
+
+  </File>
+
+</VersionBlock>
+
+<VersionBlock firstVersion="1.8">
+You can choose to:
+
+- Promote all warnings to errors using `{"error": "all"}` or `--warn-error` flag.
+- Promote some warnings to errors using `error` and optionally exclude others from being treated as errors with `warn`. `warn` tells dbt to continue treating the warnings as warnings.
+- Ignore warnings using `silence`.
+
+In the following example, we're ignoring the [`NoNodesForSelectionCriteria` warning](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/events/types.py#L1227) in the `dbt_project.yml` file by adding it to the `silence` parameter:
 
   <File name='dbt_project.yml'>
 
@@ -63,35 +115,106 @@ Converting any warnings to errors may suit your needs perfectly, but there may b
   ```
 
   </File>
-
 </VersionBlock>
 
-## Configuration
+## Examples
+Here are some examples that show you how to configure `warn_error_options` using flags or file-based configuration.
 
-You can configure warnings as errors, which can be set through command flags, environment variables, or configuration files like `dbt_project.yml` or `profiles.yml`.
+<!-- no toc -->
+- [Promote all warnings to errors or target specific warnings](#promote-all-warnings-to-errors-or-target-specific-warnings) &mdash; Promote all warnings to errors or target specific warnings.
+- [Ignore warnings in a YAML file](#ignore-warnings-in-a-yaml-file) &mdash; Ignores warnings using the in a YAML file.
+- [Promote all warnings to errors](#promote-all-warnings-to-errors) &mdash; Promote all warnings to errors using the `WARN_ERROR` environment variable or `--warn-error` command flag.
 
-<VersionBlock lastVersion="1.7"> 
-
-- Promote all warnings to errors using `{"include": "all"}` or `--warn-error-options` flag.
-- Promote some warnings to errors using `include`.
-- Exclude warnings from being treated as errors using `exclude`.
-
-</VersionBlock>
+### Promote all warnings to errors or target specific warnings
+Some of the examples use `NoNodesForSelectionCriteria`, which is a specific warning that occurs when your `--select` flag doesn't match any nodes/resources in your dbt project:
 
 <VersionBlock firstVersion="1.8">
-You can choose to:
 
-- Promote all warnings to errors using `{"error": "all"}` or `--warn-error` flag.
-- Promote some warnings to errors using `error` and optionally exclude others from being treated as errors with `warn`. `warn` tells dbt to continue treating the warnings as warnings.
-- Ignore warnings using `silence`.
+- This command promotes all warnings to errors:
+  ```text
+  dbt --warn-error-options '{"error": "all"}' run
+  ```
+
+- This command promotes all warnings to errors, except for `NoNodesForSelectionCriteria`:
+  ```text
+  dbt --warn-error-options '{"error": "all", "warn": ["NoNodesForSelectionCriteria"]}' run
+  ```
+
+- This command promotes only `NoNodesForSelectionCriteria` as an error:
+  ```text
+  dbt --warn-error-options '{"error": ["NoNodesForSelectionCriteria"]}' run
+  ```
+
+- This promotes only `NoNodesForSelectionCriteria` as an error, using an environment variable:
+  ```text
+  DBT_WARN_ERROR_OPTIONS='{"error": ["NoNodesForSelectionCriteria"]}' dbt run
+  ```
+
+Values for `error`, `warn`, and/or `silence` should be passed on as arrays. For example, `dbt --warn-error-options '{"error": "all", "warn": ["NoNodesForSelectionCriteria"]}' run` not `dbt --warn-error-options '{"error": "all", "warn": "NoNodesForSelectionCriteria"}' run`.
+</VersionBlock>
+
+<VersionBlock lastVersion="1.7">
+  
+- This command promotes all warnings to errors:
+  ```text
+  dbt --warn-error-options '{"include": "all"}' run 
+  ```
+
+- This command promotes all warnings to errors, except for `NoNodesForSelectionCriteria`:
+  ```text
+  dbt --warn-error-options '{"include": "all", "exclude": ["NoNodesForSelectionCriteria"]}' run
+  ```
+
+- This command promotes only `NoNodesForSelectionCriteria` as an error:
+  ```text
+  dbt --warn-error-options '{"include": ["NoNodesForSelectionCriteria"]}' run
+  ```
+
+- This promotes only `NoNodesForSelectionCriteria` as an error, using an environment variable:
+  ```text
+  DBT_WARN_ERROR_OPTIONS='{"include": ["NoNodesForSelectionCriteria"]}' dbt run
+  ```
+
+</VersionBlock>
+### Ignore warnings in a YAML file
+
+<VersionBlock firstVersion="1.8">
+
+The following example shows how to silence or ignore warnings using the `silence` parameter in the `profiles.yml` file:
+  <File name='profiles.yml'>
+
+  ```yaml
+  config:
+    warn_error_options:
+      error: # Previously called "include"
+      warn: # Previously called "exclude"
+        - NoNodesForSelectionCriteria
+      silence: # Silence or ignore warnings
+        - NoNodesForSelectionCriteria
+  ```
+
+  </File>
+</VersionBlock>
+
+<VersionBlock lastVersion="1.8">
+The following example shows how to exclude warnings using the `exclude` parameter in the `profiles.yml` file:
+<File name='profiles.yml'>
+
+```yaml
+config:
+  warn_error_options:
+    include: all
+    exclude: 
+      - NoNodesForSelectionCriteria
+```
+
+</File>
 
 </VersionBlock>
 
-:::info `WARN_ERROR` and `WARN_ERROR_OPTIONS` are mutually exclusive
-`WARN_ERROR` and `WARN_ERROR_OPTIONS` are mutually exclusive. You can only specify one, even when you're specifying the config in multiple places (like env var or a flag), otherwise, you'll see a usage error.
-:::
 
-To promote all warnings to errors, use the following:
+### Promote all warnings to errors
+Some additional examples of how to promote all warnings to errors using the `WARN_ERROR` environment variable or `--warn-error` command flag:
 
 #### dbt command flags
 
@@ -134,89 +257,8 @@ DBT_WARN_ERROR_OPTIONS='{"error": "*"}' dbt run
 
 </VersionBlock>
   
+:::caution
 Note, as mentioned earlier, using <VersionBlock firstVersion="1.8">`warn_error_options: error: "all"`</VersionBlock> <VersionBlock lastVersion="1.7">`warn_error_options: include: "all"`</VersionBlock> will treat all current and future warnings as errors.
 
 This means that if a new warning is introduced in a future version of dbt Core, your production job may start failing unexpectedly. We recommend proceeding with caution when doing this in production environments, and explicitly listing only the warnings you want to treat as errors in production.
-
-## Example
-Here are some examples that show you how to configure `warn_error_options` using flags or file-based configuration.
-
-Some of the examples use `NoNodesForSelectionCriteria`, which is a specific warning that occurs when your `--select` flag doesn't match any nodes/resources in your dbt project:
-
-<VersionBlock firstVersion="1.8">
-
-- This command promotes all warnings to errors:
-  ```text
-  dbt --warn-error-options '{"error": "all"}' run
-  ```
-
-- This command promotes all warnings to errors, except for `NoNodesForSelectionCriteria`:
-  ```text
-  dbt --warn-error-options '{"error": "all", "warn": ["NoNodesForSelectionCriteria"]}' run
-  ```
-
-- This command promotes only `NoNodesForSelectionCriteria` as an error:
-  ```text
-  dbt --warn-error-options '{"error": ["NoNodesForSelectionCriteria"]}' run
-  ```
-
-- This promotes only `NoNodesForSelectionCriteria` as an error, using an environment variable:
-  ```text
-  DBT_WARN_ERROR_OPTIONS='{"error": ["NoNodesForSelectionCriteria"]}' dbt run
-  ```
-
-The following example shows how to silence or ignore warnings using the `silence` parameter in the `profiles.yml` file:
-  <File name='profiles.yml'>
-
-  ```yaml
-  config:
-    warn_error_options:
-      error: # Previously called "include"
-      warn: # Previously called "exclude"
-        - NoNodesForSelectionCriteria
-      silence: # Silence or ignore warnings
-        - NoNodesForSelectionCriteria
-  ```
-
-  </File>
-</VersionBlock>
-
-<VersionBlock lastVersion="1.7">
-  
-- This command promotes all warnings to errors:
-  ```text
-  dbt --warn-error-options '{"include": "all"}' run 
-  ```
-
-- This command promotes all warnings to errors, except for `NoNodesForSelectionCriteria`:
-  ```text
-  dbt --warn-error-options '{"include": "all", "exclude": ["NoNodesForSelectionCriteria"]}' run
-  ```
-
-- This command promotes only `NoNodesForSelectionCriteria` as an error:
-  ```text
-  dbt --warn-error-options '{"include": ["NoNodesForSelectionCriteria"]}' run
-  ```
-
-- This promotes only `NoNodesForSelectionCriteria` as an error, using an environment variable:
-  ```text
-  DBT_WARN_ERROR_OPTIONS='{"include": ["NoNodesForSelectionCriteria"]}' dbt run
-  ```
-
-Values for `error`, `warn`, and/or `silence` should be passed on as arrays. For example, `dbt --warn-error-options '{"error": "all", "warn": ["NoNodesForSelectionCriteria"]}' run` not `dbt --warn-error-options '{"error": "all", "warn": "NoNodesForSelectionCriteria"}' run`.
-
-<File name='profiles.yml'>
-
-```yaml
-config:
-  warn_error_options:
-    include: all
-    exclude: 
-      - NoNodesForSelectionCriteria
-```
-
-</File>
-
-</VersionBlock>
-
-
+:::

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -11,7 +11,7 @@ Enabling `WARN_ERROR` config or setting the `--warn-error` flag will convert _al
 <VersionBlock firstVersion="1.8">
 
 :::caution Proceed with caution in production environments
-Using the `--warn-error` flag or `warn_error_options: error: "all"` will treat _all_ current and future warnings as errors.
+Using the `--warn-error` flag or `--warn-error-options '{"error": "all"}'` will treat _all_ current and future warnings as errors.
 
 This means that if a new warning is introduced in a future version of dbt Core, your production job may start failing unexpectedly. We recommend proceeding with caution when doing this in production environments, and explicitly listing only the warnings you want to treat as errors in production.
 :::

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -21,7 +21,7 @@ Instead of using the `--warn-error` flag to promote _all_ warnings to errors, yo
 - Test warnings with the `--warn-error-options '{"error": ["LogTestResults"]}'` flag.
 - Jinja-level warnings with the `--warn-error-options '{"error": ["JinjaLogWarning"]}'` flag or [`exceptions.warn`](/reference/dbt-jinja-functions/exceptions#warn).
 - Selection issues with the `--warn-error-options '{"error": ["NoNodesForSelectionCriteria"]}'` flag.
-- Adapter deprecation warnings with the `--warn-error-options '{"error": ["AdapterDeprecationWarning"]}'` flag.
+- Adapter deprecation warnings with `--warn-error-options '{"error": ["AdapterDeprecationWarning"]}'.
 
 </VersionBlock>
 

--- a/website/docs/reference/global-configs/warnings.md
+++ b/website/docs/reference/global-configs/warnings.md
@@ -20,8 +20,8 @@ Instead of using the `--warn-error` flag to promote _all_ warnings to errors, yo
 
 - Test warnings with the `--warn-error-options '{"error": ["LogTestResults"]}'` flag.
 - Jinja-level warnings with the `--warn-error-options '{"error": ["JinjaLogWarning"]}'` flag or [`exceptions.warn`](/reference/dbt-jinja-functions/exceptions#warn).
-- No nodes selected with `--warn-error-options '{"error": ["NoNodesForSelectionCriteria"]}'.
-- Adapter deprecation warnings with `--warn-error-options '{"error": ["AdapterDeprecationWarning"]}'.
+- No nodes selected with `--warn-error-options '{"error": ["NoNodesForSelectionCriteria"]}'`.
+- Adapter deprecation warnings with `--warn-error-options '{"error": ["AdapterDeprecationWarning"]}'`.
 
 </VersionBlock>
 


### PR DESCRIPTION
this pr adds a callout to inform users that they should be cautious using warn_error/warn_error_options in prod since it can promote all warnings into errors, including newly introduced ones.

also added some headers to distinguish content or try to provide structure

Resolves #7130

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-warn-error-dbt-labs.vercel.app/reference/global-configs/warnings

<!-- end-vercel-deployment-preview -->