### PR TITLE
clarify exclude and include

### DIFF
--- a/website/docs/docs/collaborate/govern/model-versions.md
+++ b/website/docs/docs/collaborate/govern/model-versions.md
@@ -281,6 +281,8 @@ models:
 
 </Tabs>
 
+Note: If none of your model versions specify columns, you don't need to define columns at all and can omit the `include`/`exclude` keys from the versioned model. In this case, dbt will automatically use all top-level columns for all versions. 
+
 The configuration above says: Instead of two unrelated models, I have two versioned definitions of the same model: `dim_customers_v1` and `dim_customers_v2`.
 
 **Where are they defined?** dbt expects each model version to be defined in a file named `<model_name>_v<v>`. In this case: `dim_customers_v1.sql` and `dim_customers_v2.sql`. It's also possible to define the "latest" version in `dim_customers.sql` (no suffix), without additional configuration. Finally, you can override this convention by setting [`defined_in: any_file_name_you_want`](/reference/resource-properties/versions#defined_in)—but we strongly encourage you to follow the convention, unless you have a very good reason.

--- a/website/docs/docs/collaborate/govern/model-versions.md
+++ b/website/docs/docs/collaborate/govern/model-versions.md
@@ -281,7 +281,7 @@ models:
 
 </Tabs>
 
-Note: If none of your model versions specify columns, you don't need to define columns at all and can omit the `include`/`exclude` keys from the versioned model. In this case, dbt will automatically use all top-level columns for all versions. 
+Note: If none of your model versions specify columns, you don't need to define columns at all and can omit the `columns/include`/`exclude` keys from the versioned model. In this case, dbt will automatically use all top-level columns for all versions. 
 
 The configuration above says: Instead of two unrelated models, I have two versioned definitions of the same model: `dim_customers_v1` and `dim_customers_v2`.
 

--- a/website/docs/reference/resource-properties/versions.md
+++ b/website/docs/reference/resource-properties/versions.md
@@ -92,7 +92,7 @@ Not to be confused with the `--select/--exclude` [syntax](/reference/node-select
 :::
 </VersionBlock>
 
-The `columns` list of a versioned model can have _at most one_ `include/exclude` element. However, if none of your model versions specify columns, you don't need to define columns at all and can omit the `include`/`exclude` keys from the versioned model. In this case, dbt will automatically use all top-level columns for all versions. 
+The `columns` list of a versioned model can have _at most one_ `include/exclude` element. However, if none of your model versions specify columns, you don't need to define columns at all and can omit the `columns/include`/`exclude` keys from the versioned model. In this case, dbt will automatically use all top-level columns for all versions. 
 
 You may declare additional columns within the version's `columns` list. If a version-specific column's `name` matches a column included from the top level, the version-specific entry will override that column for that version.
 

--- a/website/docs/reference/resource-properties/versions.md
+++ b/website/docs/reference/resource-properties/versions.md
@@ -68,13 +68,31 @@ Note that the value of `defined_in` and the `alias` configuration of a model are
 
 The specification of which columns are defined in a model's top-level `columns` property to include or exclude in a versioned implementation of that model.
 
-`include` is either:
-- a list of specific column names to include
-- `'*'` or `'all'`, indicating that **all** columns from the top-level `columns` property should be included in the versioned model
+- `include` is either:
+  - a list of specific column names to include
+  - `'*'` or `'all'`, indicating that **all** columns from the top-level `columns` property should be included in the versioned model
+- `exclude` is a list of column names to exclude. It can only be declared if `include` is set to one of `'*'` or `'all'`. 
 
-`exclude` is a list of column names to exclude. It can only be declared if `include` is set to one of `'*'` or `'all'`. 
+<VersionBlock lastVersion="1.7">
 
-The `columns` list of a versioned model can have _at most one_ `include/exclude` element.
+:::tip
+Not to be confused with:
+
+- The [`--warn-error-options` flag](/reference/global-configs/warnings#use---warn-error-options-for-targeted-warnings), which also uses `include`/`exclude` to control which warnings are treated as errors.
+- The `--select/--exclude` [syntax](/reference/node-selection/exclude) used for model selection.
+
+These features use similar syntax but apply to different contexts (model versioning, command behavior, and model selection).
+:::
+</VersionBlock>
+
+<VersionBlock firstVersion="1.8">
+
+:::tip
+Not to be confused with the `--select/--exclude` [syntax](/reference/node-selection/exclude), which is used for model selection.
+:::
+</VersionBlock>
+
+The `columns` list of a versioned model can have _at most one_ `include/exclude` element. However, if none of your model versions specify columns, you don't need to define columns at all and can omit the `include`/`exclude` keys from the versioned model. In this case, dbt will automatically use all top-level columns for all versions. 
 
 You may declare additional columns within the version's `columns` list. If a version-specific column's `name` matches a column included from the top level, the version-specific entry will override that column for that version.
 


### PR DESCRIPTION
this pr clarifies that exclude/include are only needed if you have columns. if you don't, you don't need to define them at all using the column/include/exclude keys. 

it also addes a callout to distinguish difference ways the include/exclude syntax is used.

Resolves #3665

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-clarify-include-exclude-dbt-labs.vercel.app/docs/collaborate/govern/model-versions
- https://docs-getdbt-com-git-clarify-include-exclude-dbt-labs.vercel.app/reference/resource-properties/versions

<!-- end-vercel-deployment-preview -->