### PR TITLE
update developer ent permission

### DIFF
--- a/website/snippets/_enterprise-permissions-table.md
+++ b/website/snippets/_enterprise-permissions-table.md
@@ -104,7 +104,7 @@ Key:
 {`
 |Project-level permission  | Admin | Analyst | Database admin | Developer | Git Admin | Job admin | Job runner  | Job viewer  | Metadata (Discovery API only) | Semantic Layer | Stakeholder | Team admin |
 |--------------------------|:-----:|:-------:|:--------------:|:---------:|:---------:|:---------:|:-----------:|:-----------:|:---------------------------------------:|:--------------:|:-----------:|:----------:| 
-| Environment credentials  |   W   |    W    |       W        |     W     |     R     |     W     |    -        |      -      |                  -                      |        -       |     R       |     R      |
+| Environment credentials  |   W   |    W    |       W        |     R     |     R     |     W     |    -        |      -      |                  -                      |        -       |     R       |     R      |
 | Custom env. variables    |   W   |    W#  |       W         |     W#   |     W     |     W     |     -       |      R      |                  -                      |        -       |     R       |     W      |
 | Data platform configs    |   W   |    W    |       W        |     W     |     R     |     W     |     -       |      -      |                  -                      |       -        |     R       |     R      |
 | Develop (IDE or CLI)     |   W   |    W    |       -        |     W     |     -     |     -     |     -       |      -      |                  -                      |       -        |     -       |      -     |


### PR DESCRIPTION
In order to modify the deployment credentials the user must have environments_write and the Developer permission set does not have that permission. currently is has `ProjectPermission.environments_read`

this pr fixes the doc as it states developers have write access. 

confirmed by [eng](https://dbt-labs.slack.com/archives/C02N953LRDF/p1744647264020429?thread_ts=1744640898.358629&cid=C02N953LRDF) and [raised](https://dbt-labs.slack.com/archives/C02NCQ9483C/p1744636152985939) by @toshi-dbt 

