### PR TITLE
clarify default groups

### DIFF
--- a/website/docs/docs/cloud/manage-access/about-access.md
+++ b/website/docs/docs/cloud/manage-access/about-access.md
@@ -62,7 +62,7 @@ There are three default groups available as soon as you create your <Constant na
 - **Member:** This group is for the general members of your organization, who will also have full access to the account. You cannot change the permissions. By default, <Constant name="cloud" /> adds new users to this group.
 - **Everyone:** A general group for all members of your organization. Customize the permissions to fit your organizational needs. By default, <Constant name="cloud" /> adds new users to this group.
 
-We recommend deleting the default `Owner`, `Member`, and `Everyone` groups before deploying and replacing them with your organizational groups. This prevents users from receiving more elevated privileges than they should and helps admins ensure they are properly placed.
+Default groups are automatically provisioned for all accounts to simplify the initial set up. We recommend  creating your own organizational groups so you can customize the permissions. Once you create your own groups, you can delete the default groups.
 
 ### Create new groups <Lifecycle status="managed" />
 


### PR DESCRIPTION
this pr clarifies that the 3 default groups (owner member, everyone) can be deleted once the user sets up their own org groups.

refer to [internal slack thread](https://dbt-labs.slack.com/archives/C02N953LRDF/p1745336421998209?thread_ts=1745317650.696009&cid=C02N953LRDF)

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-groups-dbt-labs.vercel.app/docs/cloud/manage-access/about-access

<!-- end-vercel-deployment-preview -->