### PR TITLE
Update logs.md

### DIFF
--- a/website/docs/docs/dbt-versions/core-upgrade/11-Older versions/10-upgrading-to-v1.5.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/11-Older versions/10-upgrading-to-v1.5.md
@@ -33,7 +33,7 @@ This release includes significant new features, and rework to `dbt-core`'s CLI a
 Setting `log-path` and `target-path` in `dbt_project.yml` has been deprecated for consistency with other invocation-specific runtime configs ([dbt-core#6882](https://github.com/dbt-labs/dbt-core/issues/6882)). We recommend setting via env var or CLI flag instead.
 
 The `dbt list` command will now include `INFO` level logs by default. Previously, the `list` command (and _only_ the `list` command) had `WARN`-level stdout logging, to support piping its results to [`jq`](https://jqlang.github.io/jq/manual/), a file, or another process. To achieve that goal, you can use either of the following parameters:
-- `dbt --log-level warn list` (recommended; equivalent to previous default)
+- `dbt list --log-level warn` (recommended; equivalent to previous default)
 - `dbt --quiet list` (suppresses all logging less than ERROR level, except for "printed" messages and `list` output)
 
 The following env vars have been renamed, for consistency with the convention followed by all other parameters:

--- a/website/docs/reference/global-configs/logs.md
+++ b/website/docs/reference/global-configs/logs.md
@@ -4,7 +4,7 @@ id: "logs"
 sidebar: "logs"
 ---
 
-### Log Formatting
+### Log formatting
 
 dbt outputs logs to two different locations: CLI console and the log file.
 
@@ -69,7 +69,7 @@ The `LOG_LEVEL` config sets the minimum severity of events captured in the conso
 - Setting the `--log-level` will configure console and file logs. 
 
   ```text
-  dbt --log-level debug run
+  dbt run --log-level debug
   ```
 
 - Setting the `LOG_LEVEL` to `none` will disable information from being sent to either the console or file logs. 
@@ -81,7 +81,7 @@ The `LOG_LEVEL` config sets the minimum severity of events captured in the conso
 - To set the file log level as a different value than the console, use the `--log-level-file` flag. 
 
   ```text
-  dbt --log-level-file error run
+  dbt run --log-level-file error
   ```
 
 - To only disable writing to the logs file but keep console logs, set `LOG_LEVEL_FILE` config to none.
@@ -140,7 +140,7 @@ In [dbt version 1.5](/docs/dbt-versions/core-upgrade/Older%20versions/upgrading-
 
 You can use either of these parameters to ensure clean output that's compatible with downstream processes, such as piping results to [`jq`](https://jqlang.github.io/jq/manual/), a file, or another process:
 
-- `dbt --log-level warn list` (recommended; equivalent to previous default)
+- `dbt list --log-level warn` (recommended; equivalent to previous default)
 - `dbt --quiet list` (suppresses all logging less than `ERROR` level, except for "printed" messages and list output)
 
 


### PR DESCRIPTION
correcting erroneous commands per [internal slack](https://dbt-labs.slack.com/archives/C06FWKP5V28/p1745845588473549?thread_ts=1745595081.874369&cid=C06FWKP5V28). the dbt command should command before the `--log-level` flag.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-mirnawong1-patch-31-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/11-Older
- https://docs-getdbt-com-git-mirnawong1-patch-31-dbt-labs.vercel.app/versions/10-upgrading-to-v1.5
- https://docs-getdbt-com-git-mirnawong1-patch-31-dbt-labs.vercel.app/reference/global-configs/logs

<!-- end-vercel-deployment-preview -->