### PR TITLE
add links to new learn courses

### DIFF
--- a/website/docs/best-practices/materializations/materializations-guide-1-guide-overview.md
+++ b/website/docs/best-practices/materializations/materializations-guide-1-guide-overview.md
@@ -9,6 +9,13 @@ hoverSnippet: Read this guide to understand how using materializations in dbt is
 
 What _really_ happens when you type `dbt build`? Contrary to popular belief, a crack team of microscopic data elves do _not_ construct your data row by row, although the truth feels equally magical. This guide explores the real answer to that question, with an introductory look at the objects that get built into your warehouse, why they matter, and how dbt knows what to build.
 
+import CourseCallout from '/snippets/_materialization-video-callout.md';
+
+<CourseCallout resource="Snapshots" 
+url="https://learn.getdbt.com/courses/snapshots"
+course="Snapshots"
+/>
+
 The configurations that tell dbt how to construct these objects are called _materializations,_ and knowing how to use them is a crucial skill for effective analytics engineering. When you’ve completed this guide, you will have that ability to use the three core materializations that cover most common analytics engineering situations.
 
 :::info

--- a/website/docs/docs/build/incremental-models-overview.md
+++ b/website/docs/docs/build/incremental-models-overview.md
@@ -13,6 +13,13 @@ This page will provide you with a brief overview of incremental models, their im
 
 <Lightbox src="/img/docs/building-a-dbt-project/incremental-diagram.jpg" width="60%" title="A visual representation of how incremental models work. Source: Materialization best practices guide (https://docs.getdbt.com/best-practices/materializations/1-guide-overview)" />
 
+import CourseCallout from '/snippets/_materialization-video-callout.md';
+
+<CourseCallout resource="Incremental models"
+url="https://learn.getdbt.com/courses/incremental-models"
+course="Incremental models"
+/>
+
 ## Understand incremental models
 
 Incremental models enable you to significantly reduce the build time by just transforming new records. This is particularly useful for large datasets, where the cost of processing the entire dataset is high.

--- a/website/docs/docs/build/materializations.md
+++ b/website/docs/docs/build/materializations.md
@@ -14,8 +14,14 @@ pagination_next: "docs/build/incremental-models"
 - ephemeral
 - materialized view
 
-You can also configure [custom materializations](/guides/create-new-materializations?step=1) in dbt. Custom materializations are a powerful way to extend dbt's functionality to meet your specific needs. 
+You can also configure [custom materializations](/guides/create-new-materializations?step=1) in dbt. Custom materializations are a powerful way to extend dbt's functionality to meet your specific needs.
 
+import CourseCallout from '/snippets/_materialization-video-callout.md';
+
+<CourseCallout resource="Materializations" 
+url="https://learn.getdbt.com/courses/materializations-fundamentals" 
+course="Materializations fundamentals" 
+/>
 
 ## Configuring materializations
 By default, dbt models are materialized as "views". Models can be configured with a different materialization by supplying the [`materialized` configuration](/reference/resource-configs/materialized) parameter as shown in the following tabs.

--- a/website/docs/docs/build/snapshots.md
+++ b/website/docs/docs/build/snapshots.md
@@ -10,6 +10,13 @@ id: "snapshots"
 * [Snapshot properties](/reference/snapshot-properties)
 * [`snapshot` command](/reference/commands/snapshot)
 
+import CourseCallout from '/snippets/_materialization-video-callout.md';
+
+<CourseCallout resource="Snapshots" 
+url="https://learn.getdbt.com/courses/snapshots"
+course="Snapshots"
+/>
+
 ## What are snapshots?
 Analysts often need to "look back in time" at previous data states in their mutable tables. While some source data systems are built in a way that makes accessing historical data possible, this is not always the case. dbt provides a mechanism, **snapshots**, which records changes to a mutable <Term id="table" /> over time.
 

--- a/website/docs/guides/create-new-materializations.md
+++ b/website/docs/guides/create-new-materializations.md
@@ -25,6 +25,13 @@ This is an advanced feature of dbt. Let us know if you need a hand! We're always
 
 ## Creating a materialization
 
+import CourseCallout from '/snippets/_materialization-video-callout.md';
+
+<CourseCallout resource="Materializations" 
+url="https://learn.getdbt.com/courses/materializations-fundamentals" 
+course="Materializations fundamentals" 
+/>
+
 Materialization blocks make it possible for dbt to load custom materializations from packages. The materialization blocks work very much like `macro` blocks, with a couple of key exceptions. Materializations are defined as follows:
 
 ```sql

--- a/website/docs/reference/snapshot-configs.md
+++ b/website/docs/reference/snapshot-configs.md
@@ -3,15 +3,23 @@ title: Snapshot configurations
 description: "Read this guide to learn about using snapshot configurations in dbt."
 meta:
   resource_type: Snapshots
+intro_text: "Learn about using snapshot configurations in dbt, including snapshot-specific configurations and general configurations."
 ---
 
 import ConfigResource from '/snippets/_config-description-resource.md';
 import ConfigGeneral from '/snippets/_config-description-general.md';
+import CourseCallout from '/snippets/_materialization-video-callout.md';
+
 
 ## Related documentation
 * [Snapshots](/docs/build/snapshots)
 * The `dbt snapshot` [command](/reference/commands/snapshot)
 
+
+<CourseCallout resource="Snapshots" 
+url="https://learn.getdbt.com/courses/snapshots"
+course="Snapshots"
+/>
 
 ## Available configurations
 ### Snapshot-specific configurations

--- a/website/docs/reference/snapshot-properties.md
+++ b/website/docs/reference/snapshot-properties.md
@@ -1,7 +1,10 @@
 ---
 title: Snapshot properties
 description: "Read this guide to learn about using source properties in dbt."
+intro_text: "Define snapshot properties in YAML to document snapshots, configure settings, add tests, and describe columns."
 ---
+
+import CourseCallout from '/snippets/_materialization-video-callout.md';
 
 <VersionBlock firstVersion="1.9">
 
@@ -20,6 +23,11 @@ Note, in dbt v1.9 and later, snapshots are defined in an updated syntax using a 
 </VersionBlock>
 
 We recommend that you put them in the `snapshots/` directory. You can name these files `whatever_you_want.yml`, and nest them arbitrarily deeply in subfolders within the `snapshots/` or `models/` directory.
+
+<CourseCallout resource="Snapshots" 
+url="https://learn.getdbt.com/courses/snapshots"
+course="Snapshots"
+/>
 
 <VersionBlock firstVersion="1.9">
 

--- a/website/snippets/_materialization-video-callout.md
+++ b/website/snippets/_materialization-video-callout.md
@@ -1,0 +1,5 @@
+:::tip Learn by video!
+
+<span>For video tutorials on {props.resource}, go to dbt Learn and check out the <a href={props.url}>{props.course} course</a>.</span>
+
+:::


### PR DESCRIPTION
this pr uses a snippet to highlight the new materialization/snapshots/incremental model courses in dbt learn. 

it also adds intro text to snapshot docs

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-add-materialization-video-link-dbt-labs.vercel.app/best-practices/materializations/materializations-guide-1-guide-overview
- https://docs-getdbt-com-git-add-materialization-video-link-dbt-labs.vercel.app/docs/build/incremental-models-overview
- https://docs-getdbt-com-git-add-materialization-video-link-dbt-labs.vercel.app/docs/build/materializations
- https://docs-getdbt-com-git-add-materialization-video-link-dbt-labs.vercel.app/docs/build/snapshots
- https://docs-getdbt-com-git-add-materialization-video-link-dbt-labs.vercel.app/guides/create-new-materializations
- https://docs-getdbt-com-git-add-materialization-video-link-dbt-labs.vercel.app/reference/snapshot-configs
- https://docs-getdbt-com-git-add-materialization-video-link-dbt-labs.vercel.app/reference/snapshot-properties

<!-- end-vercel-deployment-preview -->