### PR TITLE
[merge after may 8th] mark core versions 1.7 and 1.8 as EOL

### DIFF
--- a/website/snippets/core-versions-table.md
+++ b/website/snippets/core-versions-table.md
@@ -3,8 +3,8 @@
 |                      dbt Core                                 | Initial release |      Support level and end date      |
 |:-------------------------------------------------------------:|:---------------:|:-------------------------------------:|
 | [**v1.9**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.9) | Dec 9, 2024  | <b> Active Support &mdash; Dec 8, 2025</b>|
-| [**v1.8**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.8) | May 9, 2024   | <b>Active Support &mdash; May 8, 2025</b>|
-| [**v1.7**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.7) | Nov 2, 2023   | <div align="left">**dbt Core and dbt Cloud Developer & Team customers:** End of Life <br /> **dbt Cloud Enterprise customers:** Critical Support until further notice <sup>1</sup></div> | 
+| [**v1.8**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.8) | May 9, 2024   | End of Life ⚠️ |
+| [**v1.7**](/docs/dbt-versions/core-upgrade/upgrading-to-v1.7) | Nov 2, 2023   | End of Life ⚠️ | 
 | [**v1.6**](/docs/dbt-versions/core-upgrade/Older%20versions/upgrading-to-v1.6) | Jul 31, 2023  | End of Life ⚠️ |  
 | [**v1.5**](/docs/dbt-versions/core-upgrade/Older%20versions/upgrading-to-v1.5) | Apr 27, 2023  | End of Life ⚠️ |
 | [**v1.4**](/docs/dbt-versions/core-upgrade/Older%20versions/upgrading-to-v1.4) | Jan 25, 2023  | End of Life ⚠️ | 


### PR DESCRIPTION
## What are you changing in this pull request and why?
<!--
Describe your changes and why you're making them. If related to an open issue or a pull request on dbt Core or another repository, then link to them here! 

To learn more about the writing conventions used in the dbt Labs docs, see the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md).
-->

As of May 8th, `1.8` is now EOL. See internal [slack thread](https://dbt-labs.slack.com/archives/C044WU55X7Y/p1746633581068599?thread_ts=1746625066.966619&cid=C044WU55X7Y).
