### PR TITLE
Fixed link to data platforms

### DIFF
--- a/website/docs/docs/build/python-models.md
+++ b/website/docs/docs/build/python-models.md
@@ -4,7 +4,7 @@ description: "Configure Python models to enhance your dbt project."
 id: "python-models"
 ---
 
-Note that only [specific data platforms](#specific-data-platforms) support dbt-py models.
+Note that only specific data platforms (BigQuery, Databricks, and Snowflake) support dbt-py models.
 
 We encourage you to:
 - Read [the original discussion](https://github.com/dbt-labs/dbt-core/discussions/5261) that proposed this feature.
@@ -384,7 +384,10 @@ Currently, Python functions defined in one dbt model can't be imported and reuse
 
 ### Using PyPI packages
 
-You can also define functions that depend on third-party packages so long as those packages are installed and available to the Python runtime on your data platform. See notes on "Installing Packages" for [specific data platforms](#specific-data-platforms).
+You can also define functions that depend on third-party packages so long as those packages are installed and available to the Python runtime on your data platform. See notes on "Installing packages" for specific data platforms:
+- [BigQuery](/reference/resource-configs/bigquery-configs.md#python-model-configuration)
+- [Databricks](/reference/resource-configs/databricks-configs.md#python-model-configuration)
+- [Snowflake](/reference/resource-configs/snowflake-configs.md#python-model-configuration)
 
 In this example, we use the `holidays` package to determine if a given date is a holiday in France. The code below uses the pandas API for simplicity and consistency across platforms. The exact syntax, and the need to refactor for multi-node processing, still vary.
 <Tabs>

--- a/website/docs/docs/build/python-models.md
+++ b/website/docs/docs/build/python-models.md
@@ -4,7 +4,7 @@ description: "Configure Python models to enhance your dbt project."
 id: "python-models"
 ---
 
-Note that only specific data platforms (BigQuery, Databricks, and Snowflake) support dbt-py models.
+Note that only specific data platforms (BigQuery, Databricks, and Snowflake) support `dbt-py` models.
 
 We encourage you to:
 - Read [the original discussion](https://github.com/dbt-labs/dbt-core/discussions/5261) that proposed this feature.

--- a/website/docs/docs/build/python-models.md
+++ b/website/docs/docs/build/python-models.md
@@ -4,7 +4,7 @@ description: "Configure Python models to enhance your dbt project."
 id: "python-models"
 ---
 
-Note that only specific data platforms (BigQuery, Databricks, and Snowflake) support `dbt-py` models.
+Note that only specific data platforms support `dbt-py` models.
 
 We encourage you to:
 - Read [the original discussion](https://github.com/dbt-labs/dbt-core/discussions/5261) that proposed this feature.
@@ -384,10 +384,7 @@ Currently, Python functions defined in one dbt model can't be imported and reuse
 
 ### Using PyPI packages
 
-You can also define functions that depend on third-party packages so long as those packages are installed and available to the Python runtime on your data platform. See notes on "Installing packages" for specific data platforms:
-- [BigQuery](/reference/resource-configs/bigquery-configs.md#python-model-configuration)
-- [Databricks](/reference/resource-configs/databricks-configs.md#python-model-configuration)
-- [Snowflake](/reference/resource-configs/snowflake-configs.md#python-model-configuration)
+You can also define functions that depend on third-party packages so long as those packages are installed and available to the Python runtime on your data platform.
 
 In this example, we use the `holidays` package to determine if a given date is a holiday in France. The code below uses the pandas API for simplicity and consistency across platforms. The exact syntax, and the need to refactor for multi-node processing, still vary.
 <Tabs>

--- a/website/docs/docs/build/python-models.md
+++ b/website/docs/docs/build/python-models.md
@@ -4,7 +4,7 @@ description: "Configure Python models to enhance your dbt project."
 id: "python-models"
 ---
 
-Note that only specific data platforms support `dbt-py` models. Please check the platform configuration pages to confirm if python models are supported. 
+Note that only specific data platforms support `dbt-py` models. Check the [platform configuration pages](/reference/resource-configs/resource-configs) to confirm if Python models are supported. 
 
 We encourage you to:
 - Read [the original discussion](https://github.com/dbt-labs/dbt-core/discussions/5261) that proposed this feature.

--- a/website/docs/docs/build/python-models.md
+++ b/website/docs/docs/build/python-models.md
@@ -4,7 +4,7 @@ description: "Configure Python models to enhance your dbt project."
 id: "python-models"
 ---
 
-Note that only specific data platforms support `dbt-py` models.
+Note that only specific data platforms support `dbt-py` models. Please check the platform configuration pages to confirm if python models are supported. 
 
 We encourage you to:
 - Read [the original discussion](https://github.com/dbt-labs/dbt-core/discussions/5261) that proposed this feature.


### PR DESCRIPTION
## What are you changing in this pull request and why?
Specific data platforms section was removed in https://github.com/dbt-labs/docs.getdbt.com/pull/7259 when Python content was moved to warehouse-specific pages. Fixing the links in this PR. 

## Checklist
- [X] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-fix-link-python-models-dbt-labs.vercel.app/docs/build/python-models

<!-- end-vercel-deployment-preview -->