### PR TITLE
Remove unwanted semicolon from SL quickstart

### DIFF
--- a/website/docs/guides/mf-time-spine.md
+++ b/website/docs/guides/mf-time-spine.md
@@ -69,7 +69,7 @@ The time spine is a dbt model that generates a series of dates (or timestamps) a
     select *
     from final
     where date_day > dateadd(year, -5, current_date())  -- Keep recent dates only
-      and date_day < dateadd(day, 30, current_date());
+      and date_day < dateadd(day, 30, current_date())
     ```
     </File>
       


### PR DESCRIPTION
This fails during dbt run because the semicolon breaks the create table statement

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-joellabes-patch-4-dbt-labs.vercel.app/guides/mf-time-spine

<!-- end-vercel-deployment-preview -->