### PR TITLE
small fix to wording on Configs and properties

### DIFF
--- a/website/docs/reference/configs-and-properties.md
+++ b/website/docs/reference/configs-and-properties.md
@@ -24,4 +24,4 @@ Whereas you can use **configurations** to:
 * Change how a model will be materialized (<Term id="table" />, <Term id="view" />, incremental, etc)
 * Declare where a seed will be created in the database (`<database>.<schema>.<alias>`)
 * Declare whether a resource should persist its descriptions as comments in the database
-* Apply tags and "meta" properties
+* Apply tags and meta to a resource


### PR DESCRIPTION
![Screenshot 2025-05-22 at 3 23 34 PM](https://github.com/user-attachments/assets/de8611fd-0b86-4de3-a42e-8ea14636121b)

this wording is confusing - it's listed under "configurations" but we call them "properties"