### PR TITLE
add callout to deprecations page

### DIFF
--- a/website/docs/reference/deprecations.md
+++ b/website/docs/reference/deprecations.md
@@ -6,7 +6,7 @@ title: "Deprecations"
 
 Deprecated functionality still works in the v1.10 release, but it is no longer supported and will be removed in a future version.  
 
-This means the deprecated features only present a warning but don't prevent runs and other commands (unless you've customized the behavior). 
+This means the deprecated features only present a warning but don't prevent runs and other commands (unless you've configured [warnings as errors](/reference/global-configs/warnings)). 
 
 When the functionality is eventually removed, it will cause errors in your dbt runs after you upgrade if the deprecations are not addressed.
 

--- a/website/docs/reference/deprecations.md
+++ b/website/docs/reference/deprecations.md
@@ -8,7 +8,7 @@ title: "Deprecations"
 
 :::
 
-As dbt runs, it generates different categories of [events](/reference/events-logging), one of which is _deprecations_. Deprecations are a special type of warning that lets you know that there are problems in parts of your project that will result in breaking changes in a future version of dbt. It is important to resolve any deprecation warnings in your project before the changes are made.
+As dbt runs, it generates different categories of [events](/reference/events-logging), one of which is _deprecations_. Deprecations are a special type of warning that lets you know that there are problems in parts of your project that will result in breaking changes in a future version of dbt. Although it’s just a warning for now, it is important to resolve any deprecation warnings in your project to enable you to work with more safety, feedback, and confidence going forward.
 
 ## Identify deprecation warnings
 

--- a/website/docs/reference/deprecations.md
+++ b/website/docs/reference/deprecations.md
@@ -4,7 +4,12 @@ title: "Deprecations"
 
 :::note
 
-"Deprecated functionality" means that the functionality still works today, but only for historical purposes and it will be removed in a future version.
+Deprecated functionality still works in the v1.10 release, but it is no longer supported and will be removed in a future version.  
+
+This means the deprecated features only present a warning but don't prevent runs and other commands (unless you've customized the behavior). 
+
+When the functionality is eventually removed, it will cause errors in your dbt runs after you upgrade if the deprecations are not addressed.
+
 
 :::
 

--- a/website/docs/reference/deprecations.md
+++ b/website/docs/reference/deprecations.md
@@ -2,6 +2,12 @@
 title: "Deprecations"
 ---
 
+:::note
+
+"Deprecated functionality" means that the functionality still works today, but only for historical purposes and it will be removed in a future version.
+
+:::
+
 As dbt runs, it generates different categories of [events](/reference/events-logging), one of which is _deprecations_. Deprecations are a special type of warning that lets you know that there are problems in parts of your project that will result in breaking changes in a future version of dbt. It is important to resolve any deprecation warnings in your project before the changes are made.
 
 ## Identify deprecation warnings


### PR DESCRIPTION
Adding a callout to clarify what "deprecated" means on deprecations page - see [internal slack thread](https://dbt-labs.slack.com/archives/C08JLMFRAP6/p1747953186263939?thread_ts=1747952665.893659&cid=C08JLMFRAP6)