### PR TITLE
Fix broken link

### DIFF
--- a/website/docs/docs/fusion/about-fusion.md
+++ b/website/docs/docs/fusion/about-fusion.md
@@ -48,7 +48,7 @@ Go straight to the [Quickstart](/guides/fusion) to _feel the Fusion_ as fast as 
 
 ## What's next?
 
-dbt Labs launched the dbt Fusion engine as a public beta on May 28, 2025, with plans to reach full feature parity with <Constant name="core" /> ahead of [Fusion's general availability](https://docs.getdbt.com/blog/2025-05-28-dbt-fusion-engine-path-to-ga).
+dbt Labs launched the dbt Fusion engine as a public beta on May 28, 2025, with plans to reach full feature parity with <Constant name="core" /> ahead of [Fusion's general availability](https://docs.getdbt.com/blog/dbt-fusion-engine-path-to-ga).
 
 import AboutFusion from '/snippets/_about-fusion.md';
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

Link is going [here](https://docs.getdbt.com/blog/2025-05-28-dbt-fusion-engine-path-to-ga) instead of [here](https://docs.getdbt.com/blog/dbt-fusion-engine-path-to-ga).

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/docs/fusion/about-fusion

<!-- end-vercel-deployment-preview -->