### PR TITLE
Fix broken link to section header in "External Metadata Ingestion" page

### DIFF
--- a/website/docs/docs/explore/external-metadata-ingestion.md
+++ b/website/docs/docs/explore/external-metadata-ingestion.md
@@ -43,7 +43,7 @@ To enable external metadata ingestion:
 5. Apply filters to restrict which metadata is ingested:
     - You can filter by **database**, **schema**, **table**, or **view**.
     - Strongly recommend you filter by certain schemas. See [Important Considerations](/docs/explore/external-metadata-ingestion#important-considerations) for more information.
-    - These fields accept CSV-formatted regular expressions
+    - These fields accept CSV-formatted regular expressions:
         - Example: `DIM` matches `DIM_ORDERS` and `DIMENSION_TABLE` (basic "contains" match)
         - Wildcards are supported: `DIM*` matches `DIM_ORDERS`, `DIM_PRODUCTS`, etc.
 

--- a/website/docs/docs/explore/external-metadata-ingestion.md
+++ b/website/docs/docs/explore/external-metadata-ingestion.md
@@ -42,7 +42,7 @@ To enable external metadata ingestion:
     - *Optional*: Enable additional features such as **cost optimization**
 5. Apply filters to restrict which metadata is ingested:
     - You can filter by **database**, **schema**, **table**, or **view**
-    - Strongly recommend you filter by certain schemas. See [Best practices](/docs/explore/external-metadata-ingestion#best-practices) for more informtion
+    - Strongly recommend you filter by certain schemas. See [Important Considerations](/docs/explore/external-metadata-ingestion#important-considerations) for more information
     - These fields accept CSV-formatted regular expressions
         - Example: `DIM` matches `DIM_ORDERS` and `DIMENSION_TABLE` (basic "contains" match)
         - Wildcards are supported: `DIM*` matches `DIM_ORDERS`, `DIM_PRODUCTS`, etc.

--- a/website/docs/docs/explore/external-metadata-ingestion.md
+++ b/website/docs/docs/explore/external-metadata-ingestion.md
@@ -42,7 +42,7 @@ To enable external metadata ingestion:
     - *Optional*: Enable additional features such as **cost optimization**
 5. Apply filters to restrict which metadata is ingested:
     - You can filter by **database**, **schema**, **table**, or **view**
-    - Strongly recommend you filter by certain schemas. See [Important Considerations](/docs/explore/external-metadata-ingestion#important-considerations) for more information
+    - Strongly recommend you filter by certain schemas. See [Important Considerations](/docs/explore/external-metadata-ingestion#important-considerations) for more information.
     - These fields accept CSV-formatted regular expressions
         - Example: `DIM` matches `DIM_ORDERS` and `DIMENSION_TABLE` (basic "contains" match)
         - Wildcards are supported: `DIM*` matches `DIM_ORDERS`, `DIM_PRODUCTS`, etc.

--- a/website/docs/docs/explore/external-metadata-ingestion.md
+++ b/website/docs/docs/explore/external-metadata-ingestion.md
@@ -41,7 +41,7 @@ To enable external metadata ingestion:
     - This allows metadata from this connection to populate the <Constant name="explorer" />
     - *Optional*: Enable additional features such as **cost optimization**
 5. Apply filters to restrict which metadata is ingested:
-    - You can filter by **database**, **schema**, **table**, or **view**
+    - You can filter by **database**, **schema**, **table**, or **view**.
     - Strongly recommend you filter by certain schemas. See [Important Considerations](/docs/explore/external-metadata-ingestion#important-considerations) for more information.
     - These fields accept CSV-formatted regular expressions
         - Example: `DIM` matches `DIM_ORDERS` and `DIMENSION_TABLE` (basic "contains" match)


### PR DESCRIPTION
## What are you changing in this pull request and why?

In a previous commit https://github.com/dbt-labs/docs.getdbt.com/commit/1dcced331723bc90402a6088fb9169f56e0e04ba, there was a change to a section heading ("Best Practices" --> "Important Considerations"), which was linked from within the same page.  Fixed the link and corrected a minor typo

## Checklist

- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
