### PR TITLE
Gaining access to the Latest Fusion release track

### DIFF
--- a/website/docs/docs/dbt-versions/upgrade-dbt-version-in-cloud.md
+++ b/website/docs/docs/dbt-versions/upgrade-dbt-version-in-cloud.md
@@ -75,7 +75,10 @@ For more on version support and future releases, see [Understanding <Constant na
 ### dbt Fusion engine
 
 dbt Labs has introduced the new [dbt Fusion engine](/docs/fusion/about-fusion), a ground-up rebuild of dbt. This is currently in beta on the dbt platform. Eligible customers can update environments to Fusion using the same workflows as v1.x, but there are a few things to keep in mind:
-- **To gain access to the Fusion Latest release track, you must reach out to your dbt Labs account team to request it. Week by week we'll expand the beta cohort based on project eligibility**. To increase the likelihood your project is compatible, update all jobs and environments to the `Latest` release track and follow our [upgrade guide](/docs/dbt-versions/core-upgrade/upgrading-to-fusion)
+- **To gain access to the Fusion Latest release track, you must reach out to your dbt Labs account team to request it. Week by week we'll expand the beta cohort based on project eligibility, including Starter plans**. Once we transition from Beta to Preview, all users will see it as an option for their environments, projects, jobs, etc.
+
+
+ To increase the likelihood your project is compatible, update all jobs and environments to the `Latest` release track and follow our [upgrade guide](/docs/dbt-versions/core-upgrade/upgrading-to-fusion)
 - There are some significant changes, these can also be found in the [upgrade guide](/docs/dbt-versions/core-upgrade/upgrading-to-fusion).
 - Currently, the only supported adapter is Snowflake. More adapter support coming soon!
 - When you change your development environment(s) to `Fusion Latest`, every user will have to restart the IDE.

--- a/website/docs/docs/dbt-versions/upgrade-dbt-version-in-cloud.md
+++ b/website/docs/docs/dbt-versions/upgrade-dbt-version-in-cloud.md
@@ -78,7 +78,7 @@ dbt Labs has introduced the new [dbt Fusion engine](/docs/fusion/about-fusion), 
 - **To gain access to the Fusion Latest release track, you must reach out to your dbt Labs account team to request it. Week by week we'll expand the beta cohort based on project eligibility, including Starter plans**. Once we transition from Beta to Preview, all users will see it as an option for their environments, projects, jobs, etc.
 
 
- To increase the likelihood your project is compatible, update all jobs and environments to the `Latest` release track and follow our [upgrade guide](/docs/dbt-versions/core-upgrade/upgrading-to-fusion)
+ To increase the compatibility of your project, update all jobs and environments to the `Latest` release track and follow our [upgrade guide](/docs/dbt-versions/core-upgrade/upgrading-to-fusion). 
 - There are some significant changes, these can also be found in the [upgrade guide](/docs/dbt-versions/core-upgrade/upgrading-to-fusion).
 - Currently, the only supported adapter is Snowflake. More adapter support coming soon!
 - When you change your development environment(s) to `Fusion Latest`, every user will have to restart the IDE.


### PR DESCRIPTION
## What are you changing in this pull request and why?
A question that has come up a few times ([example](https://getdbt.slack.com/archives/C088YCAB6GH/p1748647656700249?thread_ts=1748538769.200989&cid=C088YCAB6GH
)):

> I'm on a Starter plan and don't have an account manager to reach out to -- when will I be able to choose the Fusion release track in the dbt platform?

This PR tries to answer this question 🤓 

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-dbeatty10-patch-2-dbt-labs.vercel.app/docs/cloud/about-cloud/about-dbt-cloud
- https://docs-getdbt-com-git-dbeatty10-patch-2-dbt-labs.vercel.app/docs/dbt-versions/upgrade-dbt-version-in-cloud
- https://docs-getdbt-com-git-dbeatty10-patch-2-dbt-labs.vercel.app/docs/explore/dbt-explorer-faqs
- https://docs-getdbt-com-git-dbeatty10-patch-2-dbt-labs.vercel.app/docs/explore/explore-projects
- https://docs-getdbt-com-git-dbeatty10-patch-2-dbt-labs.vercel.app/docs/explore/external-metadata-ingestion
- https://docs-getdbt-com-git-dbeatty10-patch-2-dbt-labs.vercel.app/docs/fusion/about-fusion
- https://docs-getdbt-com-git-dbeatty10-patch-2-dbt-labs.vercel.app/docs/fusion/install-fusion
- https://docs-getdbt-com-git-dbeatty10-patch-2-dbt-labs.vercel.app/docs/fusion/new-concepts
- https://docs-getdbt-com-git-dbeatty10-patch-2-dbt-labs.vercel.app/docs/install-dbt-extension
- https://docs-getdbt-com-git-dbeatty10-patch-2-dbt-labs.vercel.app/reference/global-configs/behavior-changes
- https://docs-getdbt-com-git-dbeatty10-patch-2-dbt-labs.vercel.app/reference/resource-configs/snowflake-configs

<!-- end-vercel-deployment-preview -->