### PR TITLE
Add gql endpoint

### DIFF
--- a/website/docs/docs/dbt-cloud-apis/sl-graphql.md
+++ b/website/docs/docs/dbt-cloud-apis/sl-graphql.md
@@ -234,9 +234,9 @@ List all saved queries for the specified environment.
 }
 ```
 
-#### List a single saved query
+#### List a saved query
 
-Lookup a single saved query using environment ID and query name.
+List a single saved query using environment ID and query name.
 
 ```graphql
 

--- a/website/docs/docs/dbt-cloud-apis/sl-graphql.md
+++ b/website/docs/docs/dbt-cloud-apis/sl-graphql.md
@@ -209,11 +209,11 @@ DimensionType = [CATEGORICAL, TIME]
 
 #### List saved queries
 
-List all saved queries for the specified environment.
+List all saved queries for the specified environment:
   
   ```graphql
   {
-  savedQueries(environmentId: 200532) {
+  savedQueries(environmentId: "123") {
     name
     description
     label
@@ -236,20 +236,29 @@ List all saved queries for the specified environment.
 
 #### List a saved query
 
-List a single saved query using environment ID and query name.
+List a single saved query using environment ID and query name:
 
 ```graphql
 
 {
-    savedQuery(environmentId: $environment_id, savedQueryName: "saved_query_name") {
-        name
-        queryParams {
-            metrics {
-                name
-            }
-        }
-        ...
+savedQuery(environmentId: "123", savedQueryName: "query_name") {
+  name
+  description
+  label
+  queryParams {
+    metrics {
+      name
     }
+    groupBy {
+      name
+      grain
+      datePart
+    }
+    where {
+      whereSqlTemplate
+    }
+  }
+}
 }
 ```
 

--- a/website/docs/docs/dbt-cloud-apis/sl-graphql.md
+++ b/website/docs/docs/dbt-cloud-apis/sl-graphql.md
@@ -208,6 +208,8 @@ DimensionType = [CATEGORICAL, TIME]
 ```
 
 #### List saved queries
+
+List all saved queries for the specified environment.
   
   ```graphql
   {
@@ -229,6 +231,25 @@ DimensionType = [CATEGORICAL, TIME]
       }
     }
   }
+}
+```
+
+#### List a single saved query
+
+Lookup a single saved query using environment ID and query name.
+
+```graphql
+
+{
+    savedQuery(environmentId: $environment_id, savedQueryName: "saved_query_name") {
+        name
+        queryParams {
+            metrics {
+                name
+            }
+        }
+        ...
+    }
 }
 ```
 

--- a/website/docs/docs/dbt-versions/release-notes.md
+++ b/website/docs/docs/dbt-versions/release-notes.md
@@ -19,6 +19,7 @@ Release notes are grouped by month for both multi-tenant and virtual private clo
 ## June 2025
 
 - **Enhancement**: Group owners can now specify multiple email addresses for model-level notifications, enabling broader team alerts. Previously, only a single email address was supported. Check out the [Configure groups](/docs/deploy/model-notifications#configure-groups) section to learn more.
+- **New**: The Semantic Layer GraphQL API has a new [List a save query](/dbt-cloud-apis/sl-graphql#list-a-saved-query) endpoint.
 
 ## May 2025
 

--- a/website/docs/docs/dbt-versions/release-notes.md
+++ b/website/docs/docs/dbt-versions/release-notes.md
@@ -19,7 +19,7 @@ Release notes are grouped by month for both multi-tenant and virtual private clo
 ## June 2025
 
 - **Enhancement**: Group owners can now specify multiple email addresses for model-level notifications, enabling broader team alerts. Previously, only a single email address was supported. Check out the [Configure groups](/docs/deploy/model-notifications#configure-groups) section to learn more.
-- **New**: The Semantic Layer GraphQL API has a new [List a save query](/docs/dbt-cloud-apis/sl-graphql#list-a-saved-query) endpoint.
+- **New**: The Semantic Layer GraphQL API now has a [`List a saved query`](/docs/dbt-cloud-apis/sl-graphql#list-a-saved-query) endpoint.
 
 ## May 2025
 

--- a/website/docs/docs/dbt-versions/release-notes.md
+++ b/website/docs/docs/dbt-versions/release-notes.md
@@ -19,7 +19,7 @@ Release notes are grouped by month for both multi-tenant and virtual private clo
 ## June 2025
 
 - **Enhancement**: Group owners can now specify multiple email addresses for model-level notifications, enabling broader team alerts. Previously, only a single email address was supported. Check out the [Configure groups](/docs/deploy/model-notifications#configure-groups) section to learn more.
-- **New**: The Semantic Layer GraphQL API has a new [List a save query](/dbt-cloud-apis/sl-graphql#list-a-saved-query) endpoint.
+- **New**: The Semantic Layer GraphQL API has a new [List a save query](/docs/dbt-cloud-apis/sl-graphql#list-a-saved-query) endpoint.
 
 ## May 2025
 


### PR DESCRIPTION
closes https://github.com/dbt-labs/docs-internal/issues/1076

## What are you changing in this pull request and why?

* Adding new endpoing and rn for GraphQL SL API

## Checklist
- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-add-gql-endpoint-dbt-labs.vercel.app/docs/dbt-cloud-apis/sl-graphql
- https://docs-getdbt-com-git-add-gql-endpoint-dbt-labs.vercel.app/docs/dbt-versions/release-notes

<!-- end-vercel-deployment-preview -->