### PR TITLE
Add note about backwards compatibility to legacy properties

### DIFF
--- a/website/docs/reference/resource-configs/access.md
+++ b/website/docs/reference/resource-configs/access.md
@@ -16,7 +16,9 @@ models:
 
 </File>
 
-You can apply access modifiers in config files, including the `dbt_project.yml`, or to models one-by-one in `properties.yml`. Applying access configs to a subfolder modifies the default for all models in that subfolder, so make sure you intend for this behavior. When setting individual model access, a group or subfolder might contain a variety of access levels, so when you designate a model with `access: public` make sure you intend for this behavior.
+You can apply `access` modifiers in config files, including the `dbt_project.yml`, or to models one-by-one in `properties.yml`. Applying `access` configs to a subfolder modifies the default for all models in that subfolder, so make sure you intend for this behavior. When setting individual model access, a group or subfolder might contain a variety of access levels, so when you designate a model with `access: public` make sure you intend for this behavior.
+
+Note that for backwards compatibility, `access` is supported as a top-level key, but without the capabilities of config inheritance.
 
 There are multiple approaches to configuring access:
 

--- a/website/docs/reference/resource-configs/docs.md
+++ b/website/docs/reference/resource-configs/docs.md
@@ -165,6 +165,8 @@ macros:
 
 </Tabs>
 
+Note that for backwards compatibility, `docs` is supported as a top-level key, but without the capabilities of config inheritance.
+
 ## Definition
 The `docs` property can be used to provide documentation-specific configuration to models. It supports the attribute `show`, which controls whether or not nodes are shown in the auto-generated documentation website. It also supports `node_color` for models, seeds, snapshots, and analyses. Other node types are not supported.
 

--- a/website/docs/reference/resource-configs/group.md
+++ b/website/docs/reference/resource-configs/group.md
@@ -286,6 +286,8 @@ saved_queries:
 
 </Tabs>
 
+Note that for backwards compatibility, `group` is supported as a top-level key, but without the capabilities of config inheritance.
+
 ## Definition
 An optional configuration for assigning a group to a resource. When a resource is grouped, dbt will allow it to reference private models within the same group.
 

--- a/website/docs/reference/resource-configs/tags.md
+++ b/website/docs/reference/resource-configs/tags.md
@@ -123,8 +123,8 @@ models:
 </File>
 
 </TabItem>
-
 </Tabs>
+Note that for backwards compatibility, `tags` is supported as a top-level key, but without the capabilities of config inheritance.
 
 ## Definition
 Apply a tag (or list of tags) to a resource.


### PR DESCRIPTION
## What are you changing in this pull request and why?
Closes: #7024 

## Checklist
- [X] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-issue-7024-legacy-properties-dbt-labs.vercel.app/reference/resource-configs/access
- https://docs-getdbt-com-git-issue-7024-legacy-properties-dbt-labs.vercel.app/reference/resource-configs/docs
- https://docs-getdbt-com-git-issue-7024-legacy-properties-dbt-labs.vercel.app/reference/resource-configs/group
- https://docs-getdbt-com-git-issue-7024-legacy-properties-dbt-labs.vercel.app/reference/resource-configs/tags

<!-- end-vercel-deployment-preview -->