### PR TITLE
Fix commands in the show command doc

### DIFF
--- a/website/docs/reference/commands/show.md
+++ b/website/docs/reference/commands/show.md
@@ -16,10 +16,14 @@ The results of the preview query are not materialized in the data warehouse, or 
 
 Example:
 
-```dbt show --select "model_name.sql"
 ```
+dbt show --select "model_name.sql"
+```
+
 or
-```dbt show --inline "select * from {{ ref('model_name') }}"
+
+```
+dbt show --inline "select * from {{ ref('model_name') }}"
 ```
 
 The following is an example of `dbt show` output for a model named `stg_orders`:


### PR DESCRIPTION
## What are you changing in this pull request and why?
Fixes missing commands in https://docs.getdbt.com/reference/commands/show

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-fix-show-command-dbt-labs.vercel.app/reference/commands/show

<!-- end-vercel-deployment-preview -->