### PR TITLE
adding info on defaults for snowflake

### DIFF
--- a/website/docs/reference/project-configs/query-comment.md
+++ b/website/docs/reference/project-configs/query-comment.md
@@ -37,14 +37,14 @@ The `query-comment` configuration can also call a macro that returns a string.
 
 ## Default
 
-By default dbt automatically inserts a <Term id="json" /> comment in each query it runs. This comment includes metadata such as the dbt version, profile and target names, and node ID for the resource generating the query.
+By default, dbt automatically inserts a <Term id="json" /> comment in each query it runs. This comment includes metadata such as the dbt version, profile and target names, and node ID for the resource generating the query.
 
 - For Snowflake, the comment appears at the *end* of the query. This prevents the comment from being stripped during processing.
 
 - For other adapters, the comment appears at the *beginning* of the query. For example:
 
   ```sql
-  /* {"app": "dbt", "dbt_version": "1.5.0rc2", "profile_name": "debug",
+  /* {"app": "dbt", "dbt_version": "1.10.0rc2", "profile_name": "debug",
       "target_name": "dev", "node_id": "model.dbt2.my_model"} */
 
   create view analytics.analytics.orders as (

--- a/website/docs/reference/project-configs/query-comment.md
+++ b/website/docs/reference/project-configs/query-comment.md
@@ -30,21 +30,27 @@ query-comment:
 </File>
 
 ## Definition
+
 A string to inject as a comment in each query that dbt runs against your database. This comment can attribute SQL statements to specific dbt resources like models and tests.
 
 The `query-comment` configuration can also call a macro that returns a string.
 
 ## Default
-By default, dbt will insert a <Term id="json" /> comment at the top of your query containing the information including the dbt version, profile and target names, and node ids for the resources it runs. For example:
 
-```sql
-/* {"app": "dbt", "dbt_version": "1.5.0rc2", "profile_name": "debug",
-    "target_name": "dev", "node_id": "model.dbt2.my_model"} */
+By default dbt automatically inserts a <Term id="json" /> comment in each query it runs. This comment includes metadata such as the dbt version, profile and target names, and node ID for the resource generating the query.
 
-create view analytics.analytics.orders as (
-    select ...
-  );
-```
+- For Snowflake, the comment appears at the *end* of the query. This prevents the comment from being stripped during processing.
+
+- For other adapters, the comment appears at the *beginning* of the query. For example:
+
+  ```sql
+  /* {"app": "dbt", "dbt_version": "1.5.0rc2", "profile_name": "debug",
+      "target_name": "dev", "node_id": "model.dbt2.my_model"} */
+
+  create view analytics.analytics.orders as (
+      select ...
+    );
+  ```
 
 ## Using the dictionary syntax
 The dictionary syntax includes two keys:


### PR DESCRIPTION
## What are you changing in this pull request and why?

Documenting this [core/adapters PR](https://github.com/dbt-labs/dbt-adapters/pull/1064) which adds new default for query comment s for Snowflake.

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-query-comment-def-dbt-labs.vercel.app/reference/project-configs/query-comment

<!-- end-vercel-deployment-preview -->