### PR TITLE
Athena/Glue do not have PL support in MT AWS envs, fixing matrix

### DIFF
--- a/website/snippets/_private-connectivity-matrix.md
+++ b/website/snippets/_private-connectivity-matrix.md
@@ -15,7 +15,7 @@
 | Redshift (Managed)                                |   ✅   |   ✅   |    -     |    -     | 
 | Redshift Severless (Interface)                    |   ✅   |   ✅   |    -     |    -     | 
 | Redshift Serverless (Managed)                     |   ✅   |   ✅   |    -     |    -     |
-| Amazon Athena w/ AWS Glue                         |   ✅   |   ✅   |    -     |    -     |
+| Amazon Athena w/ AWS Glue                         |   ❌   |   ✅   |    -     |    -     |
 | Azure Synapse                                     |   -    |   -    |    ✅    |    ✅    |
 | Azure Fabric (cross-tenant not supported by Azure)|   -    |   -    |    ❌    |    ❌    |
 | Google BigQuery                                   |   -    |   -    |    -     |    -     |


### PR DESCRIPTION
## What are you changing in this pull request and why?
The private connectivity matrix in the public docs currently list Athena/Glue PrivateLink as supported in MT/MC environments, which is inaccurate. Updating.