### PR TITLE
Detail and Alert color adjustments

### DIFF
--- a/website/snippets/_new-sl-setup.md
+++ b/website/snippets/_new-sl-setup.md
@@ -56,7 +56,7 @@ This credential controls the physical access to underlying data accessed by the 
 - Starter plans can create multiple service tokens that link to a single underlying credential, but each project can only have one credential.
 - All Enterprise plans can [add multiple credentials](#4-add-more-credentials) and map those to service tokens for tailored access.
 
-<a href="https://www.getdbt.com/contact" style={{ color: 'white', backgroundColor: '#66c2c2', padding: '4px 8px', borderRadius: '4px', textDecoration: 'none', display: 'inline-block' }}>Book a free live demo</a> to discover the full potential of <Constant name="cloud" /> Enterprise and higher plans.
+<a href="https://www.getdbt.com/contact">Book a free live demo</a> to discover the full potential of <Constant name="cloud" /> Enterprise and higher plans.
 :::
 
 ### 3. View connection detail

--- a/website/src/components/detailsToggle/styles.module.css
+++ b/website/src/components/detailsToggle/styles.module.css
@@ -12,7 +12,7 @@
 
 :local(.disclaimer) {
     font-size: 0.8em;
-    color: #666;
+    color: var(--color-terminal-black-500);
     margin-left: 10px; /* Adjust as needed */
     text-decoration: none;
 }
@@ -43,11 +43,11 @@
     margin-left: 2em;
     margin-bottom: 10px;
     padding: 20px;
-    background-color: #e3f8f8;
+    background-color: var(--color-coalesce-purple-100);
 }
 
 :local(html[data-theme='dark'] .body) {
-  background: #333b47;
+  background: var(--color-coalesce-purple-950);
 }
 
 :local(.body > p:last-child) {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -5,14 +5,14 @@
 :root {
   /* Docusaurus Overrides */
   /* We need to keep these for components that are not using the new tokens */
-  --ifm-color-success: #086343 !important;
-  --ifm-color-info: #047377 !important;
+  --ifm-color-success: var(--color-green-800) !important;
+  --ifm-color-info: var(--color-coalesce-purple-600) !important;
   --ifm-color-warning: var(--color-yellow-400) !important;
   --ifm-color-danger: var(--color-pink-700) !important;
-  --ifm-color-success-light: #d6f3e2 !important;
-  --ifm-color-info-light: #d9f6f4 !important;
-  --ifm-color-warning-light: #ffe1be !important;
-  --ifm-color-danger-light: #f9d3d4 !important;
+  --ifm-color-success-light: var(--color-coalesce-purple-100) !important;
+  --ifm-color-info-light: var(--color-coalesce-purple-100) !important;
+  --ifm-color-warning-light: var(--color-yellow-50) !important;
+  --ifm-color-danger-light: var(--color-pink-50) !important;
   --ifm-color-gray-900: #030711;
   --ifm-font-weight-narrow: 400;
   --ifm-font-weight-semibold: 600;
@@ -869,6 +869,10 @@ i.theme-doc-sidebar-item-category.theme-doc-sidebar-item-category-level-2.menu__
   color: var(--ifm-color-gray-900);
 }
 
+html[data-theme="dark"] .alert--danger a:hover {
+  color: var(--ifm-color-gray-900) !important;
+}
+
 .alert--warning {
   --ifm-alert-background-color: var(--ifm-color-warning-light);
   --ifm-alert-border-color: var(--ifm-color-warning);
@@ -899,6 +903,15 @@ html[data-theme="dark"] .alert table {
 .alert--danger a,
 .alert--warning a {
   color: var(--ifm-color-gray-900) !important;
+}
+
+html[data-theme="dark"] main .row .col:first-of-type .alert--info a:hover,
+html[data-theme="dark"] main .row .col:first-of-type .alert--success a:hover,
+html[data-theme="dark"] main .row .col:first-of-type .alert--danger a:hover,
+html[data-theme="dark"] main .row .col:first-of-type .alert--warning a:hover {
+  color: var(--ifm-color-gray-900) !important;
+  text-decoration-thickness: 2px;
+  text-decoration-color: var(--ifm-link-color) !important;
 }
 
 .alert blockquote {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -5,7 +5,7 @@
 :root {
   /* Docusaurus Overrides */
   /* We need to keep these for components that are not using the new tokens */
-  --ifm-color-success: var(--color-green-800) !important;
+  --ifm-color-success: var(--color-coalesce-purple-600) !important;
   --ifm-color-info: var(--color-coalesce-purple-600) !important;
   --ifm-color-warning: var(--color-yellow-400) !important;
   --ifm-color-danger: var(--color-pink-700) !important;
@@ -851,7 +851,7 @@ i.theme-doc-sidebar-item-category.theme-doc-sidebar-item-category-level-2.menu__
   margin-top: 5px;
 }
 
-.alert--info {
+.alert--info, .alert--secondary {
   --ifm-alert-background-color: var(--ifm-color-info-light);
   --ifm-alert-border-color: var(--ifm-color-info);
   color: var(--ifm-color-gray-900);
@@ -879,14 +879,6 @@ html[data-theme="dark"] .alert--danger a:hover {
   color: var(--ifm-color-gray-900);
 }
 
-.alert--secondary,
-.alert--secondary a,
-.alert--secondary svg {
-  --ifm-alert-background-color: #474748;
-  color: white !important;
-  fill: white !important;
-}
-
 html[data-theme="dark"] .alert * {
   --ifm-alert-foreground-color: var(--ifm-color-gray-900);
 }
@@ -899,6 +891,7 @@ html[data-theme="dark"] .alert table {
 
 /* for dark mode */
 .alert--info a,
+.alert--secondary a,
 .alert--success a,
 .alert--danger a,
 .alert--warning a {
@@ -906,6 +899,7 @@ html[data-theme="dark"] .alert table {
 }
 
 html[data-theme="dark"] main .row .col:first-of-type .alert--info a:hover,
+html[data-theme="dark"] main .row .col:first-of-type .alert--secondary a:hover,
 html[data-theme="dark"] main .row .col:first-of-type .alert--success a:hover,
 html[data-theme="dark"] main .row .col:first-of-type .alert--danger a:hover,
 html[data-theme="dark"] main .row .col:first-of-type .alert--warning a:hover {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -2138,6 +2138,14 @@ section.discourse-forum-page {
   }
 }
 
+.docswiper .swiper {
+  padding-bottom: 10px;
+}
+
+.docswiper .swiper .swiper-horizontal > .docswiper .swiper .swiper-pagination-bullets, .docswiper .swiper .swiper-pagination-bullets.swiper-pagination-horizontal, .docswiper .swiper .swiper-pagination-custom, .docswiper .swiper .swiper-pagination-fraction {
+  bottom: -5px;
+}
+
 .docswiper .swiper .swiper-button-next,
 .docswiper .swiper .swiper-button-prev {
   color: var(--color-coalesce-purple-600);

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -2140,7 +2140,7 @@ section.discourse-forum-page {
 
 .docswiper .swiper .swiper-button-next,
 .docswiper .swiper .swiper-button-prev {
-  color: #047377;
+  color: var(--color-coalesce-purple-600);
   font-weight: 800;
   position: absolute;
   top: 0;
@@ -2168,11 +2168,11 @@ section.discourse-forum-page {
 }
 
 [data-theme='dark'] .docswiper .swiper-pagination-bullet {
-  background: var(--color-off-white);
+  background: var(--color-coalesce-purple-100);
 }
 
 [data-theme='dark'] .docswiper .swiper-pagination-bullet.swiper-pagination-bullet-active {
-  background: var(--color-light-teal);
+  background: var(--color-coalesce-purple-100);
 }
 
 /* Community Home styles */

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -2139,7 +2139,7 @@ section.discourse-forum-page {
 }
 
 .docswiper .swiper {
-  padding-bottom: 10px;
+  padding: 0 40px 10px;
 }
 
 .docswiper .swiper .swiper-horizontal > .docswiper .swiper .swiper-pagination-bullets, .docswiper .swiper .swiper-pagination-bullets.swiper-pagination-horizontal, .docswiper .swiper .swiper-pagination-custom, .docswiper .swiper .swiper-pagination-fraction {


### PR DESCRIPTION
## What are you changing in this pull request and why?
[Bug ticket](https://www.notion.so/dbtlabs/Featured-content-Info-color-is-that-still-correct-20fbb38ebda78056b782e6c528c5429a?source=copy_link)

Adjusts Detail and Alert section colors.

## Previews

Verify DetailToggle, `details` element, and info alert box colors are purple:
https://docs-getdbt-com-git-redesign-details-bg-dbt-labs.vercel.app/docs/use-dbt-semantic-layer/setup-sl

Verify danger alerts look good:
https://docs-getdbt-com-git-redesign-details-bg-dbt-labs.vercel.app/reference/dbt-jinja-functions/adapter

Verify warning alerts look good:
https://docs-getdbt-com-git-redesign-details-bg-dbt-labs.vercel.app/docs/cloud/manage-access/auth0-migration

Verify tip alerts look good:
https://docs-getdbt-com-git-redesign-details-bg-dbt-labs.vercel.app/blog/sql-comprehension-technologies

Verify note alerts look good:
https://docs-getdbt-com-git-redesign-details-bg-dbt-labs.vercel.app/docs/build/python-models#limitations

