### PR TITLE
tiny syntax and captialization fixes

### DIFF
--- a/website/docs/docs/mesh/iceberg/bigquery-iceberg-support.md
+++ b/website/docs/docs/mesh/iceberg/bigquery-iceberg-support.md
@@ -76,7 +76,7 @@ select * from {{ ref('jaffle_shop_customers') }}
 
 ### Limitations
 
-BigQuery today does not support connecting to external Iceberg catalogs. In terms of SQL operations and table management features, please refer to the (BigQuery docs)[https://cloud.google.com/bigquery/docs/iceberg-tables#limitations] for more information. 
+BigQuery today does not support connecting to external Iceberg catalogs. In terms of SQL operations and table management features, please refer to the [BigQuery docs](https://cloud.google.com/bigquery/docs/iceberg-tables#limitations) for more information. 
 
 
 <VersionBlock firstVersion="1.9">

--- a/website/docs/docs/mesh/iceberg/bigquery-iceberg-support.md
+++ b/website/docs/docs/mesh/iceberg/bigquery-iceberg-support.md
@@ -14,7 +14,7 @@ dbt supports creating Iceberg tables for two of the BigQuery materializations:
 - [Table](/docs/build/materializations#table)
 - [Incremental](/docs/build/materializations#incremental)
 
-## Bigquery Iceberg catalogs
+## BigQuery Iceberg catalogs
 
 BigQuery supports Iceberg tables via its built-in catalog [BigLake Metastore](https://cloud.google.com/bigquery/docs/iceberg-tables#architecture) today. No setup is needed to access the BigLake Metastore. However, you will need to have a [storage bucket and the required BigQuery roles](https://cloud.google.com/bigquery/docs/iceberg-tables#create-iceberg-tables) configured prior to creating an Iceberg table. 
 

--- a/website/docs/docs/mesh/iceberg/snowflake-iceberg-support.md
+++ b/website/docs/docs/mesh/iceberg/snowflake-iceberg-support.md
@@ -180,7 +180,7 @@ catalogs:
 ```
 
 2. Apply the catalog configuration at either the model, folder, or project level. <br />
-<br />An example of `iceberg_model.yml`:
+<br />An example of `iceberg_model.sql`:
 
 ```yaml
 


### PR DESCRIPTION
- Bigquery to BigQuery
- Fixes a link markup issue
- Changes .yml example to .sql as it's clearly a model

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-bugfix-tiny-typo-24-06-dbt-labs.vercel.app/docs/mesh/iceberg/bigquery-iceberg-support
- https://docs-getdbt-com-git-bugfix-tiny-typo-24-06-dbt-labs.vercel.app/docs/mesh/iceberg/snowflake-iceberg-support

<!-- end-vercel-deployment-preview -->