### PR TITLE
Fix - Adjust hyperlinks to match WWW

### DIFF
--- a/website/src/components/card/styles.module.css
+++ b/website/src/components/card/styles.module.css
@@ -4,6 +4,7 @@
 
 .cardWrapper a {
   color: inherit;
+  text-decoration: none;
 }
 .cardWrapper a:hover {
   text-decoration: none;

--- a/website/src/components/quickstartTOC/styles.module.css
+++ b/website/src/components/quickstartTOC/styles.module.css
@@ -142,6 +142,7 @@ html[data-theme="dark"] .buttonContainer > a:hover > svg {
 
 .buttonContainer .nextButton {
     margin-left: auto;
+    text-decoration: none;
 }
 
 .buttonContainer .nextButton i {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -118,14 +118,6 @@ html[data-theme="dark"] {
   --ifm-link-color: var(--darkmode-link-color);
 }
 
-/* Linked `code` tags visibility adjustment */
-html[data-theme=dark] a code {
-  color: var(--darkmode-link-color);
-}
-html[data-theme=dark] a code:hover {
-  color: var(--darkmode-link-color);
-}
-
 /* For /dbt-cloud/api REDOC Page */
 html[data-theme="dark"] .api-content h2,
 html[data-theme="dark"] .api-content h3,
@@ -371,8 +363,17 @@ code {
   font-size: var(--text-sm);
 }
 
-.main-wrapper .home .col>p {
-  font-size: 1.25rem;
+a code {
+  color: rgba(61, 24, 154, 1);
+}
+
+.markdown a {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.markdown a:hover {
+  text-decoration: none !important;
 }
 
 /* Wish we didn't need to do this... */


### PR DESCRIPTION
## What are you changing in this pull request and why?
This PR fixes the both the standard hyperlinks and also hyperlinks within code blocks.

The style in this PR matches the brand guidelines from WWW where hyperlinks are underlined and when hover the underline is removed ([see here](https://www.getdbt.com/blog/dbt-launch-showcase-2025-recap)).

![image](https://github.com/user-attachments/assets/3992abef-fbeb-47ff-a977-2aab694f3e17)

## Preview Link
https://docs-getdbt-com-git-fix-code-hyperlink-dbt-labs.vercel.app/reference/resource-configs/contract

## Testing
Use the preview link above to confirm both hyperlinks and hyperlinks used within code blocks have the correct style applied.
