### PR TITLE
Fix sidebar collapse button styles

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -71,7 +71,6 @@
   --docusaurus-collapse-button-bg-hover: var(--color-off-white) !important;
 
   --light-dark-toggle: "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0iTTQuMzA4IDMuMzg1YzAtMS4xNzguMTczLTIuMzcuNjE1LTMuMzg1QzEuOTgzIDEuMjggMCA0LjI4MiAwIDcuNjkyQTguMzA4IDguMzA4IDAgMCAwIDguMzA4IDE2YzMuNDEgMCA2LjQxMi0xLjk4MyA3LjY5Mi00LjkyMy0xLjAxNS40NDItMi4yMDcuNjE1LTMuMzg1LjYxNWE4LjMwOCA4LjMwOCAwIDAgMS04LjMwNy04LjMwN1oiIGZpbGw9IiM5MkEwQjMiLz48L3N2Zz4=";
-  --ifm-menu-link-sublist-icon: url("data:image/svg+xml,%3Csvg viewBox='0 0 12 7' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M2 2L6 6L10 2' stroke='%23030711' stroke-width='1.5' stroke-linecap='square' stroke-linejoin='round'/%3E%3C/svg%3E");
 
   --ifm-h3-font-size: var(--text-4xl) !important;
 
@@ -725,22 +724,6 @@ i.theme-doc-sidebar-item-category.theme-doc-sidebar-item-category-level-2.menu__
 
 .menu__list-item-collapsible:hover {
   background-color: transparent;
-}
-
-
-/* Mobile ToC caret */
-.docs-doc-page .theme-doc-toc-mobile .clean-btn:after {
-  content: '';
-  display: inline-block;
-  border: solid currentColor;
-  border-width: 0 2px 2px 0;
-  padding: 3px;
-  transform: rotate(-45deg);
-  transition: transform 0.2s ease;
-}
-
-.docs-doc-page .theme-doc-toc-mobile[class*="Expanded"] .clean-btn:after {
-  transform: rotate(45deg);
 }
 
 /* < icon */

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -65,6 +65,11 @@
   --filter-brightness-low: 1.1;
   --filter-brightness-high: 1.5;
   --darkmode-link-color: #9786FF;
+
+  /* sidebar collapse button */
+  --docusaurus-collapse-button-bg: var(--color-white) !important;
+  --docusaurus-collapse-button-bg-hover: var(--color-off-white) !important;
+
   --light-dark-toggle: "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0iTTQuMzA4IDMuMzg1YzAtMS4xNzguMTczLTIuMzcuNjE1LTMuMzg1QzEuOTgzIDEuMjggMCA0LjI4MiAwIDcuNjkyQTguMzA4IDguMzA4IDAgMCAwIDguMzA4IDE2YzMuNDEgMCA2LjQxMi0xLjk4MyA3LjY5Mi00LjkyMy0xLjAxNS40NDItMi4yMDcuNjE1LTMuMzg1LjYxNWE4LjMwOCA4LjMwOCAwIDAgMS04LjMwNy04LjMwN1oiIGZpbGw9IiM5MkEwQjMiLz48L3N2Zz4=";
   --ifm-menu-link-sublist-icon: url("data:image/svg+xml,%3Csvg viewBox='0 0 12 7' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M2 2L6 6L10 2' stroke='%23030711' stroke-width='1.5' stroke-linecap='square' stroke-linejoin='round'/%3E%3C/svg%3E");
 
@@ -116,6 +121,10 @@ html[data-theme="dark"] {
   --ifm-table-cell-color: var(--color-green-blue);
 
   --ifm-link-color: var(--darkmode-link-color);
+
+  /* sidebar collapse button */
+  --docusaurus-collapse-button-bg: var(--color-neutral-primary) !important;
+  --docusaurus-collapse-button-bg-hover: var(--color-neutral-secondary) !important;
 }
 
 /* For /dbt-cloud/api REDOC Page */


### PR DESCRIPTION
## What are you changing in this pull request and why?
[Notion task](https://www.notion.so/dbtlabs/Sidebar-at-the-bottom-of-the-page-with-the-grey-arrows-cover-some-of-the-menu-options-211bb38ebda7809784a7c1833ea8f2d6?source=copy_link)

- Adjusts sidebar collapse button background color
- Removes custom mobile TOC dropdown arrow styles to use default styles instead

## Preview

https://docs-getdbt-com-git-sidebar-collapse-btn-dbt-labs.vercel.app/docs/introduction

- Verify docs sidebar content now hides behind collapse button
- Verify TOC dropdown arrow looks correct on mobile

![image](https://github.com/user-attachments/assets/0fd02124-e60d-4711-8519-92dc92325b12)
