### PR TITLE
Removing some support to reduce confusion

### DIFF
--- a/website/docs/docs/about-dbt-extension.md
+++ b/website/docs/docs/about-dbt-extension.md
@@ -118,7 +118,7 @@ Usage:
 Preview a CTE’s output, or an entire model, directly from inside your editor for faster validation and debugging.
 
 Usage:
-- Click the **table icon** or use keyboard shortcut `cmd+enter` (macOS) / `ctrl+enter` (Windows/Linux) to preview query results.
+- Click the **table icon** or use keyboard shortcut `cmd+enter` (macOS) / `ctrl+enter` (<!--Windows/-->Linux) to preview query results.
 - Click the **Preview CTE** codelens to preview CTE results.
 - Results will be displayed in the **Query Results** tab in the bottom panel.
 - The preview table is sortable and results are stored until the tab is closed.
@@ -169,7 +169,7 @@ Usage:
 Use the command palette to quickly build models using complex selectors. 
 
 Usage:
-- Click the **dbt icon** or use keyboard shortcut `cmd+shift+enter` (macOS) / `ctrl+shift+enter` (Windows/Linux) to launch a quickpick menu.
+- Click the **dbt icon** or use keyboard shortcut `cmd+shift+enter` (macOS) / `ctrl+shift+enter` (<!--Windows/-->Linux) to launch a quickpick menu.
 - Select a command to run.
 
 <video width="100%" height="100%" playsinline muted controls>
@@ -186,7 +186,7 @@ Once installed, the dbt extension automatically activates when you open any `.sq
 
 After installation, you may want to configure the extension to better fit your development workflow:
 
-1. Open the VS Code settings by pressing `Ctrl+,` (Windows/Linux) or `Cmd+,` (Mac).
+1. Open the VS Code settings by pressing `Ctrl+,` (<!--Windows/-->Linux) or `Cmd+,` (Mac).
 2. Search for `dbt`. On this page, you can adjust the extension’s configuration options as to fit your needs.
 
 ## FAQs

--- a/website/docs/docs/fusion/install-fusion.md
+++ b/website/docs/docs/fusion/install-fusion.md
@@ -29,7 +29,7 @@ Before installing Fusion, ensure:
   | Operating System    | X86-64 | ARM  |
   |-------------------|----------|------|
   | macOS             |   🟢     |  🟢  |
-  | Linux             |   🟢     |  🟡  |
+  | Linux             |   🟢     |  🟢  |
   | Windows           |   🟡     |  🟡  |
 
 

--- a/website/docs/docs/fusion/install-fusion.md
+++ b/website/docs/docs/fusion/install-fusion.md
@@ -18,13 +18,13 @@ This guide walks you through installing Fusion locally, including important prer
 Before installing Fusion, ensure:
 
 - You have administrative privileges to install software on your local machine.
-- You are familiar with command-line interfaces (Terminal on macOS/Linux, PowerShell on Windows).
+- You are familiar with command-line interfaces (Terminal on macOS/Linux<!--, PowerShell on Windows-->).
 - You are using a supported data warehouse and authentication method.
   <FusionDWH /> 
 - You are using a supported OS and architecture:
 
   🟢 - Supported <br/>
-  🟡 - Not yet supported - Support expected by 2025-07-18
+  🟡 - Not yet supported
 
   | Operating System    | X86-64 | ARM  |
   |-------------------|----------|------|
@@ -38,7 +38,7 @@ Before installing Fusion, ensure:
 Fusion can be installed via the command line from our official CDN:
 
 - **macOS/Linux:** Using `curl`
-- **Windows:** Using `irm`
+<!--- **Windows:** Using `irm` -->
 
 ### macOS & Linux installation
 
@@ -56,7 +56,7 @@ exec $SHELL
 
 Or, close and reopen your Terminal window. This will load the updated environment settings into the new session.
 
-### Windows installation (PowerShell)
+<!-- ### Windows installation (PowerShell)
 
 Run the following command in PowerShell:
 
@@ -71,6 +71,7 @@ Start-Process powershell
 ```
 
 Or, close and reopen PowerShell. This will load the updated environment settings into the new session.
+-->
 
 ### Verify the installation
 
@@ -80,10 +81,8 @@ After installation, open a new command-line window and verify that Fusion is ins
 dbtf --version
 ```
 
-Fusion will be installed in the following locations:
-
-- **macOS & Linux:** `$HOME/.local/bin/dbt`
-- **Windows:** `C:\Users\<YourUsername>\.local\bin\dbt.exe`
+- **macOS** & **Linux**: $HOME/.local/bin/dbt
+<!--- **Windows:** `C:\Users\<YourUsername>\.local\bin\dbt.exe` -->
 
 This location is automatically added to your path to easily execute the `dbtf` command, but it requires reloading your shell.
 

--- a/website/docs/docs/fusion/install-fusion.md
+++ b/website/docs/docs/fusion/install-fusion.md
@@ -30,7 +30,10 @@ Before installing Fusion, ensure:
   |-------------------|----------|------|
   | macOS             |   🟢     |  🟢  |
   | Linux             |   🟢     |  🟢  |
-  | Windows           |   🟡     |  🟡  |
+  | Windows*           |   🟡     |  🟡  |
+  
+  *Support for Windows is coming soon. Watch this page for updates. 
+ 
 
 
 ## Install Fusion

--- a/website/docs/docs/install-dbt-extension.md
+++ b/website/docs/docs/install-dbt-extension.md
@@ -15,7 +15,7 @@ To use the extension, you must meet the following prerequisites:
 
 - You are using the [VS Code](https://code.visualstudio.com/) or [Cursor](https://www.cursor.com/en) code editor.
 - You are not using (or have disabled) 3rd party dbt extensions.
-- You are using a macOS, Windows, or a Linux-based computer.
+- You are using a macOS<!--, Windows,--> or a Linux-based computer.
 - The dbt extension requires installation of the dbt Fusion engine. Fusion installation is part of the extension installation process.
 
 ## Installation instructions
@@ -75,7 +75,7 @@ file during registration. If you do not have a `~/.dbt/dbt_cloud.yml` file downl
 4. In the **Set up your credentials** section, click **Download credentials**. This downloads the `dbt_cloud.yml` file. 
     <Lightbox src="/img/docs/extension/download-registration-2.png" width="60%" title="Download the dbt_cloud.yml file to complete registration."/>
 5. Move the downloaded `dbt_cloud.yml` file to your `~/.dbt/` directory.
-6. To update your registration in VS Code, open the command palette (`ctrl+shift+P` (Windows/Linux) or `cmd+shift+p` (macOS)), then select `dbt: Register dbt extension` to complete the registration.
+6. To update your registration in VS Code, open the command palette (`ctrl+shift+P` (<!--Windows/-->Linux) or `cmd+shift+p` (macOS)), then select `dbt: Register dbt extension` to complete the registration.
 
 </Expandable>
 
@@ -87,7 +87,7 @@ file during registration. If you do not have a `~/.dbt/dbt_cloud.yml` file downl
 4. In the **Configure Cloud authentication** section, click **Download CLI configuration file**. This downloads the `dbt_cloud.yml` file. 
     <Lightbox src="/img/docs/extension/download-registration.png" width="60%" title="Download the dbt_cloud.yml file to complete registration."/>
 5. Move the downloaded `dbt_cloud.yml` file to your `~/.dbt/` directory.
-6. To update your registration in VS Code, open the command palette (`ctrl+shift+P` (Windows/Linux) or `cmd+shift+p` (macOS)), then select `dbt: Register dbt extension` to complete the registration.
+6. To update your registration in VS Code, open the command palette (`ctrl+shift+P` (<!--Windows/-->Linux) or `cmd+shift+p` (macOS)), then select `dbt: Register dbt extension` to complete the registration.
 
 </Expandable>
 
@@ -106,7 +106,7 @@ Note: It is possible to "hide" status bar items in VS Code. Double-check if the 
 
 If you are not seeing dbt LSP features in your editor, first consult the general troubleshooting steps above. If you have confirmed that the dbt extension is installed correctly, but you still do not see dbt Language Server features (autocomplete, go-to-definition, hover text, etc):
  - Check the version of your dbt extension on the extensions page in your editor. Ensure that you are using the latest available version of the dbt extension.
- - Try reinstalling the dbt Language Server by pressing `cmd+shift+P` (macOS) or `ctrl+shift+P` (Windows/Linux) and selecting the `dbt: Reinstall dbt LSP` command.
+ - Try reinstalling the dbt Language Server by pressing `cmd+shift+P` (macOS) or `ctrl+shift+P` (<!--Windows/-->Linux) and selecting the `dbt: Reinstall dbt LSP` command.
 
 #### Unsupported dbt version
 

--- a/website/docs/docs/install-dbt-extension.md
+++ b/website/docs/docs/install-dbt-extension.md
@@ -15,7 +15,7 @@ To use the extension, you must meet the following prerequisites:
 
 - You are using the [VS Code](https://code.visualstudio.com/) or [Cursor](https://www.cursor.com/en) code editor.
 - You are not using (or have disabled) 3rd party dbt extensions.
-- You are using a macOS<!--, Windows,--> or a Linux-based computer.
+- You are using a macOS<!--, Windows,--> or Linux-based computer.
 - The dbt extension requires installation of the dbt Fusion engine. Fusion installation is part of the extension installation process.
 
 ## Installation instructions


### PR DESCRIPTION
## What are you changing in this pull request and why?

* Communicating Windows as not yet supported for Fusion because seeing the instructions was confusing.

## Checklist
- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).
<!--
PRE-RELEASE VERSION OF dbt (if so, uncomment):
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
<!-- 
ADDING OR REMOVING PAGES (if so, uncomment):
- [ ] Add/remove page in `website/sidebars.js`
- [ ] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages
-->

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-windows-fs-dbt-labs.vercel.app/docs/about-dbt-extension
- https://docs-getdbt-com-git-windows-fs-dbt-labs.vercel.app/docs/fusion/install-fusion
- https://docs-getdbt-com-git-windows-fs-dbt-labs.vercel.app/docs/install-dbt-extension

<!-- end-vercel-deployment-preview -->