### PR TITLE
Fix nav border

### DIFF
--- a/website/src/components/discourse/styles.module.css
+++ b/website/src/components/discourse/styles.module.css
@@ -57,8 +57,10 @@
   color: #fff;
 }
 .discourseCta:hover {
-  background: var(--color-light-teal);
+  background: var(--ifm-color-primary);
   color: #fff;
+  text-decoration: underline;
+  border-color: var(--ifm-color-primary);
 }
 
 /* Loading icon */

--- a/website/src/components/discourse/styles.module.css
+++ b/website/src/components/discourse/styles.module.css
@@ -44,7 +44,7 @@
   font-size: 18px;
 }
 [data-theme="dark"] .discourseTopics ul li a {
-  color: #91D0CB;
+  color: var(--ifm-link-color);
 }
 .discourseTopics blockquote {
   margin-bottom: 0;

--- a/website/src/components/discourseBlogComments/styles.module.css
+++ b/website/src/components/discourseBlogComments/styles.module.css
@@ -59,8 +59,10 @@
     border: none;
   }
 .discourseCta:hover {
-  background: var(--color-light-teal);
+  background: var(--ifm-color-primary);
   color: #fff;
+  text-decoration: underline;
+  border-color: var(--ifm-color-primary);
 }
 
 .loadMoreCta {

--- a/website/src/components/hubspotForm/styles.module.css
+++ b/website/src/components/hubspotForm/styles.module.css
@@ -72,7 +72,7 @@ textarea:global(.hs-input) {
 }
 
 :global(.hs-submit .hs-button:hover) {
-    background: var(--color-light-teal);
+    background: var(--ifm-color-primary);
 }
 
 :global(.submitted-message) {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -1552,6 +1552,11 @@ html[data-theme="dark"] .main-wrapper nav a:active {
   }
 }
 
+@media (min-width: 1480px) {
+  .dbt__brand {
+    border-right: 1px solid var(--ifm-toc-border-color);
+  }
+}
 
 @media (min-width: 1440px) {
   .container--fluid {
@@ -1560,7 +1565,6 @@ html[data-theme="dark"] .main-wrapper nav a:active {
 
   .dbt__brand {
     background-color: var(--ifm-background-color);
-    border-right: 1px solid var(--ifm-toc-border-color);
   }
 }
 

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -33,7 +33,7 @@
   --ifm-link-hover-color: #632FF5;
   --ifm-button-border-radius: var(--radius-xl);
   --ifm-menu-color: #030711;
-  --ifm-menu-color-active: #009999;
+  --ifm-menu-color-active: var(--color-coalesce-purple-600);
   --ifm-pagination-nav-color-hover: #047377;
   --ifm-tabs-color-active: #047377;
   --ifm-menu-color-background-active: var(--color-coalesce-purple-100);

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -1464,12 +1464,6 @@ html[data-theme="dark"] .main-wrapper nav a:active {
   color: #6A7282 !important;
 }
 
-@media(max-width: 1199px) {
-  [data-theme="dark"] button.DocSearch-Button {
-    background-color: transparent !important;
-  }
-}
-
 @media screen and (max-width: 750px) {
   .card.large {
     height: auto;
@@ -1477,7 +1471,13 @@ html[data-theme="dark"] .main-wrapper nav a:active {
   }
 }
 
-@media screen and (max-width: 1199px) {
+@media(max-width: 1319px) {
+  [data-theme="dark"] button.DocSearch-Button {
+    background-color: transparent !important;
+  }
+}
+
+@media screen and (max-width: 1319px) {
   button.DocSearch-Button {
     background: none;
   }
@@ -1497,7 +1497,7 @@ html[data-theme="dark"] .main-wrapper nav a:active {
   }
 }
 
-@media screen and (min-width: 1200px) {
+@media screen and (min-width: 1320px) {
 
   /* search bar styles */
   button.DocSearch-Button {


### PR DESCRIPTION
## What are you changing in this pull request and why?
[Notion task](https://www.notion.so/dbtlabs/Longer-version-name-offsets-header-line-20fbb38ebda780a78670dae71b0c03d4?source=copy_link)

This fixes an issue where the navigation pushes the logo container border to the left, causing it to become unaligned with the sidebar border. I adjusted the media query to hide the border earlier.

This PR also adjusts the nav search, to switch to the search icon earlier to provide more room for the nav items as the screen still gets smaller.

There's still overlap on the logo at the smallest desktop screen size before the mobile nav kicks in. We would have to adjust the mobile nav to kick in earlier to solve for this. But we can handle that in a separate task if requested to do so.

## Preview

To test, select the `dbt Fusion engine (v2.0 Beta)` version in the nav, which is the longest version name. Reduce the screen size, and verify the border disappears before being pushed to the left.