### PR TITLE
enforce that blogs must contain truncation

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -307,6 +307,9 @@ var siteSettings = {
           blogSidebarCount: 5,
           remarkPlugins: [math],
           rehypePlugins: [katex],
+          // Un-truncated blog posts will throw an error
+          // https://docusaurus.io/blog/releases/3.5#onuntruncatedblogposts          
+          onUntruncatedBlogPosts: 'throw',
         },
       },
     ],


### PR DESCRIPTION
## What are you changing in this pull request and why?

resolves: #7558 

blocked by: #7557 

it's [currently failing](https://vercel.com/dbt-labs/docs-getdbt-com/HsHRZgsa6ytKKmSG1cteMchaahts?filter=errors) for a good reason! huzzah!

```
[cause]: Error: Docusaurus found blog posts without truncation markers:
  - "blog/2025-06-16-the-new-dbt-vscode-extension.md"
```


<img width="932" alt="image" src="https://github.com/user-attachments/assets/fbdda50c-48cf-46f8-a30f-661653b1cc57" />
