### PR TITLE
Remove grant of OPERATE on the warehouse

### DIFF
--- a/website/docs/docs/explore/external-metadata-ingestion.md
+++ b/website/docs/docs/explore/external-metadata-ingestion.md
@@ -60,7 +60,7 @@ CREATE OR REPLACE ROLE dbt_metadata_role;
 2. Grant access to a warehouse to run queries to view metadata:
 
 ```sql
-GRANT OPERATE, USAGE ON WAREHOUSE "<your-warehouse>" TO ROLE dbt_metadata_role;
+GRANT USAGE ON WAREHOUSE "<your-warehouse>" TO ROLE dbt_metadata_role;
 ```
 
 If you do not already have a user, create a dbt-specific user for metadata access. Replace `<your-password>` with a strong password and `<your-warehouse>` with the warehouse name used above:

--- a/website/docs/docs/explore/external-metadata-ingestion.md
+++ b/website/docs/docs/explore/external-metadata-ingestion.md
@@ -63,6 +63,7 @@ CREATE OR REPLACE ROLE dbt_metadata_role;
 GRANT USAGE ON WAREHOUSE "<your-warehouse>" TO ROLE dbt_metadata_role;
 ```
 
+If your warehouse needs to be restarted for metadata ingestions (doesn't have auto-resume enabled), you may need to grant `OPERATE` permissions to the role as well. 
 If you do not already have a user, create a dbt-specific user for metadata access. Replace `<your-password>` with a strong password and `<your-warehouse>` with the warehouse name used above:
 
 ```sql


### PR DESCRIPTION
## What are you changing in this pull request and why?
I can't see any reason why the metadata service needs to be able to edit the warehouse's configuration?
