### PR TITLE
Update pr-template to include Bitbucket server/data center option

### DIFF
--- a/website/docs/docs/cloud/git/pr-template.md
+++ b/website/docs/docs/cloud/git/pr-template.md
@@ -73,6 +73,13 @@ https://gitlab.com/<org>/<repo>/-/merge_requests/new?merge_request[source_branch
 https://bitbucket.org/<org>/<repo>/pull-requests/new?source={{source}}&dest={{destination}}
 ```
 
+If you're using BitBucket Server or Data Center your template may look something like:
+
+```
+https://<bitbucket-server>/projects/<proj>/repos/<repo>/pull-requests?create&sourceBranch={{source}}&targetBranch={{destination}}
+```
+
+
 ### AWS CodeCommit
 ```
 https://console.aws.amazon.com/codesuite/codecommit/repositories/<repo>/pull-requests/new/refs/heads/{{destination}}/.../refs/heads/{{source}}

--- a/website/docs/docs/cloud/git/pr-template.md
+++ b/website/docs/docs/cloud/git/pr-template.md
@@ -79,7 +79,6 @@ If you're using BitBucket Server or Data Center your template may look something
 https://<bitbucket-server>/projects/<proj>/repos/<repo>/pull-requests?create&sourceBranch={{source}}&targetBranch={{destination}}
 ```
 
-
 ### AWS CodeCommit
 ```
 https://console.aws.amazon.com/codesuite/codecommit/repositories/<repo>/pull-requests/new/refs/heads/{{destination}}/.../refs/heads/{{source}}


### PR DESCRIPTION
## What are you changing in this pull request and why?
When someone is not using the Bitbucket cloud version, the URL may look very different to the template we propose. 
I added a suggestion to what I've discovered, by opening a PR directly from bitbucket and comparing the URL. 

## Checklist
- [X] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).
