### PR TITLE
Un-deprecating `--add-package` flag

### DIFF
--- a/website/docs/docs/dbt-versions/core-upgrade/04-upgrading-to-fusion.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/04-upgrading-to-fusion.md
@@ -104,7 +104,6 @@ One exception to this rule: The `--models` / `--model` / `-m` flag was renamed t
 | `--single-threaded` / `--no-single-threaded` | No action required |
 | `dbt source freshness` [`--output` / `-o`](/docs/deploy/source-freshness)  | |
 | [`--config-dir`](/reference/commands/debug)  | No action required | 
-| [`--add-package`](/reference/commands/deps) | No action required |
 | [`--resource-type` / `--exclude-resource-type`](/reference/global-configs/resource-type) | change to `--resource-types` / `--exclude-resource-types` |
 | `--show-resource-report` / `--no-show-resource-report` | No action required |
 | [`--log-cache-events` / `--no-log-cache-events`](/reference/global-configs/logs#logging-relational-cache-events) | No action required | 


### PR DESCRIPTION
## What are you changing in this pull request and why?

We are implementing https://github.com/dbt-labs/dbt-fusion/issues/266 which will un-deprecate the `--add-package` flag.

We are leaving the `--source` flag as deprecated.

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/04-upgrading-to-fusion

<!-- end-vercel-deployment-preview -->