### PR TITLE
Update find-a-partner link

### DIFF
--- a/website/docs/community/resources/getting-help.md
+++ b/website/docs/community/resources/getting-help.md
@@ -66,7 +66,7 @@ We use a number of different mediums to share information
 
 ## Receiving dedicated support
 
-If you need dedicated support to build your dbt project, consider reaching out regarding [professional services](https://www.getdbt.com/contact/), or engaging one of our [consulting partners](https://partners.getdbt.com/english/directory/).
+If you need dedicated support to build your dbt project, consider reaching out regarding [professional services](https://www.getdbt.com/contact/), or engaging one of our [consulting partners](https://www.getdbt.com/partner-directory).
 
 ## dbt Training
 

--- a/website/docs/docs/dbt-support.md
+++ b/website/docs/docs/dbt-support.md
@@ -133,5 +133,5 @@ Leave feedback or submit a feature request for <Constant name="cloud" /> or <Con
 
 For SQL writing, project performance review, or project building, refer to dbt Preferred Consulting Providers and dbt Labs' Services.
 For help writing SQL, reviewing the overall performance of your project, or want someone to actually help build your dbt project, refer to the following pages:
-- List of [dbt Consulting Partners](https://partners.getdbt.com/english/directory/).
+- List of [dbt Consulting Partners](https://www.getdbt.com/partner-directory).
 - dbt Labs' [Services](https://www.getdbt.com/dbt-labs/services/).

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -71,7 +71,8 @@ var siteSettings = {
     },
     announcementBar: {
       id: "virtual-event",
-      content: "Join our live event: Modernize self-service analytics with dbt — cut costs, reduce bottlenecks, and keep the tools analysts love. Register now.",
+      content:
+        "Join our live event: Modernize self-service analytics with dbt — cut costs, reduce bottlenecks, and keep the tools analysts love. Register now.",
       isCloseable: true,
     },
     announcementBarActive: true,
@@ -240,7 +241,7 @@ var siteSettings = {
               <h5 class="heading-5">Support</h5>
               <a href='/docs/dbt-support'>Contact Support</a>
               <a href="https://www.getdbt.com/services" target="_blank">Professional Services</a>
-              <a href="https://partners.getdbt.com/english/directory/" target="_blank">Find a Partner</a>
+              <a href="https://www.getdbt.com/partner-directory" target="_blank">Find a Partner</a>
               <a href="https://status.getdbt.com/" target="_blank">System Status</a>
             </div>
             <div class="footer-grid-item">
@@ -308,8 +309,8 @@ var siteSettings = {
           remarkPlugins: [math],
           rehypePlugins: [katex],
           // Un-truncated blog posts will throw an error
-          // https://docusaurus.io/blog/releases/3.5#onuntruncatedblogposts          
-          onUntruncatedBlogPosts: 'throw',
+          // https://docusaurus.io/blog/releases/3.5#onuntruncatedblogposts
+          onUntruncatedBlogPosts: "throw",
         },
       },
     ],
@@ -325,10 +326,10 @@ var siteSettings = {
     path.resolve("plugins/buildQuickstartIndexPage"),
     path.resolve("plugins/buildRSSFeeds"),
     [
-      'vercel-analytics',
+      "vercel-analytics",
       {
         debug: false,
-        mode: 'auto',
+        mode: "auto",
       },
     ],
   ],


### PR DESCRIPTION
## What are you changing in this pull request and why?
[Notion task](https://www.notion.so/dbtlabs/Update-partners-link-in-Docs-footer-224bb38ebda780869302f0ef839ee04e?source=copy_link)

## Previews

Verify `Find a partner` link in footer links to correct WWW page:
https://docs-getdbt-com-git-update-partners-link-dbt-labs.vercel.app/

Verify the partner link in this section links correctly:
https://docs-getdbt-com-git-update-partners-link-dbt-labs.vercel.app/community/resources/getting-help#receiving-dedicated-support

Verify partner link at the bottom of this page links correctly:
https://docs-getdbt-com-git-update-partners-link-dbt-labs.vercel.app/docs/dbt-support