### PR TITLE
Joellabes service token updates

### DIFF
--- a/website/docs/docs/cloud/manage-access/enterprise-permissions.md
+++ b/website/docs/docs/cloud/manage-access/enterprise-permissions.md
@@ -213,9 +213,9 @@ Notable features:
 - No other access to <Constant name="cloud" /> features. 
 
 </Expandable>
-<Expandable alt_header="Stakeholder">
+<Expandable alt_header="Stakeholder/Read-Only">
 
-Stakeholder is a read-only permission set, similar to viewer, but without access to sensitive content such as account settings or billing information. Useful for personas who need to monitor projects and their configurations.
+The Stakeholder/Read-Only permission set is similar to Viewer, but without access to sensitive content such as account settings or billing information. Useful for personas who need to monitor projects and their configurations.
 
 Notable features: 
 - Stakeholder is a project-level set.

--- a/website/docs/docs/dbt-cloud-apis/service-tokens.md
+++ b/website/docs/docs/dbt-cloud-apis/service-tokens.md
@@ -6,12 +6,6 @@ description: "Service account tokens help you define permissions for securing ac
 
 # Service account tokens <Lifecycle status="self_service,managed,managed_plus" />
 
-:::info Important service account token update
-
-If you have service tokens created on or before July 18, 2023, please read [this important update](/docs/dbt-cloud-apis/service-tokens#service-token-update).
-
-:::
-
 Service account tokens enable you to securely authenticate with the <Constant name="cloud" /> API by assigning each token a narrow set of permissions that more precisely manages access to the API. While similar to [personal access tokens](user-tokens), service account tokens belong to an account rather than a user.
 
 You can use service account tokens for system-level integrations that do not run on behalf of any one user. Assign any permission sets available in <Constant name="cloud" /> to your service account token, which can vary slightly depending on your plan:
@@ -69,15 +63,17 @@ Refer to [Enterprise permissions](/docs/cloud/manage-access/enterprise-permissio
 - Stakeholder
 - Team Admin
 
-
 ## Service token update
 
-On July 18, 2023, dbt Labs made critical infrastructure changes to service account tokens. These enhancements improve the security and performance of all tokens created after July 18, 2023. To ensure security best practices are in place, we recommend you rotate your service tokens created before this date.
+On July 18, 2023, dbt Labs changed how tokens are generated and validated to increase performance. These improvements only apply to tokens created after July 18, 2023.
+
+Old tokens remain valid, but if they are used in high-frequency API invocations, we recommend you rotate them for reduced latency.
 
 To rotate your token:
+
 1. Navigate to **Account settings** and click **Service tokens** on the left side pane.
-2. Verify the **Created** date for the token is _on or before_ July 18, 2023. 
-3. Click **+ New Token** on the top right side of the screen. Ensure the new token has the same permissions as the old one. 
+2. Verify the **Created** date for the token is _on or before_ July 18, 2023.
+3. Click **+ New Token** on the top right side of the screen. Ensure the new token has the same permissions as the old one.
 4. Copy the new token and replace the old one in your systems. Store it in a safe place, as it will not be available again once the creation screen is closed.
 5. Delete the old token in <Constant name="cloud" /> by clicking the **trash can icon**. _Only take this action after the new token is in place to avoid service disruptions_.
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

While generating some service tokens, I noticed two confusing things: 
- The UI references a Read-Only permission set, but the linked docs don't describe it 
- There is a callout describing the changes as for security reasons, which was worrying
<img width="1359" height="741" alt="image" src="https://github.com/user-attachments/assets/2c9d0755-5205-44c0-b7f8-f5f43e27d7e9" />

I clarified with the engineering team that: 
- [Read-Only is a synonym for Stakeholder](https://dbt-labs.slack.com/archives/C02N953LRDF/p1753848013497209) 
- [The change was purely for performance](https://dbt-labs.slack.com/archives/C02N953LRDF/p1753906816213149?thread_ts=1753847928.913409&cid=C02N953LRDF), and there's no security implications to not rotating the tokens, so the description in app and on docs is inaccurate. 

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-joellabes-service-token-updates-dbt-labs.vercel.app/docs/cloud/manage-access/enterprise-permissions
- https://docs-getdbt-com-git-joellabes-service-token-updates-dbt-labs.vercel.app/docs/dbt-cloud-apis/service-tokens

<!-- end-vercel-deployment-preview -->