### PR TITLE
Fix explanation for `schema_table_unique` option for `s3_data_naming`

### DIFF
--- a/website/docs/reference/resource-configs/athena-configs.md
+++ b/website/docs/reference/resource-configs/athena-configs.md
@@ -129,7 +129,7 @@ The following options are available for `s3_data_naming`:
 - `table`: `{s3_data_dir}/{table}/`
 - `table_unique`: `{s3_data_dir}/{table}/{uuid4()}/`
 - `schema_table`: `{s3_data_dir}/{schema}/{table}/`
-- `s3_data_naming=schema_table_unique`: `{s3_data_dir}/{schema}/{table}/{uuid4()}/`
+- `schema_table_unique`: `{s3_data_dir}/{schema}/{table}/{uuid4()}/`
 
 To set the `s3_data_naming` globally in the target profile, overwrite the value in the table config, or set up the value for groups of the models in dbt_project.yml.
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

The highlighted section below shouldn't be there:

<img width="724" height="440" alt="image" src="https://github.com/user-attachments/assets/7890431d-30c0-4bcc-89eb-8daec0cb9050" />

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/reference/resource-configs/athena-configs

<!-- end-vercel-deployment-preview -->