### PR TITLE
Add link to SQL comprehension blog on new concepts page

### DIFF
--- a/website/docs/docs/fusion/new-concepts.md
+++ b/website/docs/docs/fusion/new-concepts.md
@@ -15,7 +15,7 @@ import FusionBeta from '/snippets/_fusion-beta-callout.md';
 
 <IntroText>
 
-The dbt Fusion engine fully comprehends your project's SQL, enabling advanced capabilities like dialect-aware validation and precise column-level lineage.
+The dbt Fusion engine [fully comprehends your project's SQL](/blog/the-levels-of-sql-comprehension), enabling advanced capabilities like dialect-aware validation and precise column-level lineage.
 
 It can do this because its compilation step is more comprehensive than that of the <Constant name="core" /> engine. When <Constant name="core" /> referred to _compilation_, it only meant _rendering_ &mdash; converting Jinja-templated strings into a SQL query to send to a database.
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
The 3 levels of SQL comprehension is useful prior knowledge when digging into static analysis

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-joellabes-patch-4-dbt-labs.vercel.app/docs/fusion/new-concepts

<!-- end-vercel-deployment-preview -->