### PR TITLE
Clarify server works with any MCP client

### DIFF
--- a/website/docs/docs/dbt-ai/about-mcp.md
+++ b/website/docs/docs/dbt-ai/about-mcp.md
@@ -85,7 +85,9 @@ There are two ways to install dbt MCP: [local](#local) and [remote](#remote).
 
 ## MCP integrations 
 
-The dbt MCP server integrates with any [MCP client](https://modelcontextprotocol.io/clients) with tool use capabilities. We have specific integration guides for the following clients:
+The dbt MCP server integrates with any [MCP client](https://modelcontextprotocol.io/clients) that supports token authentication and tool use capabilities. 
+
+We have also created integration guides for the following clients:
 - [Claude](/docs/dbt-ai/integrate-mcp-claude)
 - [Cursor](/docs/dbt-ai/integrate-mcp-cursor)
 - [VS Code](/docs/dbt-ai/integrate-mcp-vscode)

--- a/website/docs/docs/dbt-ai/about-mcp.md
+++ b/website/docs/docs/dbt-ai/about-mcp.md
@@ -85,7 +85,7 @@ There are two ways to install dbt MCP: [local](#local) and [remote](#remote).
 
 ## MCP integrations 
 
-The dbt MCP server integrates with the following clients:
+The dbt MCP server integrates with any [MCP client](https://modelcontextprotocol.io/clients) with tool use capabilities. We have specific integration guides for the following clients:
 - [Claude](/docs/dbt-ai/integrate-mcp-claude)
 - [Cursor](/docs/dbt-ai/integrate-mcp-cursor)
 - [VS Code](/docs/dbt-ai/integrate-mcp-vscode)


### PR DESCRIPTION
## What are you changing in this pull request and why?
The MCP docs say that we support 3 specific clients. Actually, you can connect to _any_ client that understands the MCP protocol.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-joellabes-patch-4-dbt-labs.vercel.app/docs/dbt-ai/about-mcp

<!-- end-vercel-deployment-preview -->