### PR TITLE
Use curlies for `s3_staging_dir` Athena connection profile config

### DIFF
--- a/website/docs/reference/resource-configs/athena-configs.md
+++ b/website/docs/reference/resource-configs/athena-configs.md
@@ -121,7 +121,7 @@ The saved location of a table is determined in precedence by the following condi
 
 1. If `external_location` is defined, that value is used.
 2. If `s3_data_dir` is defined, the path is determined by that and `s3_data_naming`.
-3. If `s3_data_dir` is not defined, data is stored under `s3_staging_dir/tables/`.
+3. If `s3_data_dir` is not defined, data is stored under `{s3_staging_dir}/tables/`.
 
 The following options are available for `s3_data_naming`:
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

This highlighted bit should have curly braces to match everything else in this section

<img width="500" height="434" alt="image" src="https://github.com/user-attachments/assets/19ebbedc-4d8b-4169-b99a-980ec312fcdd" />

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/reference/resource-configs/athena-configs

<!-- end-vercel-deployment-preview -->