### PR TITLE
Add required perms and a snippet

### DIFF
--- a/website/docs/docs/about-dbt-install.md
+++ b/website/docs/docs/about-dbt-install.md
@@ -7,7 +7,7 @@ pagination_next: "docs/core/dbt-core-environments"
 pagination_prev: null
 ---
 
-<Constant name="dbt" /> enables data teams to transform data using analytics engineering best practices. You can choose your local development experience from these tools:
+<Constant name="dbt" /> enables data teams to transform data using analytics engineering best practices. Choose your local development experience from these tools:
 
 * Local command line interface (CLI) tools leveraging the speed and scale of the <Constant name="fusion_engine" /> or using our legacy Core product
 * VS Code or Cursor with the dbt extension

--- a/website/docs/docs/about-dbt-install.md
+++ b/website/docs/docs/about-dbt-install.md
@@ -7,21 +7,15 @@ pagination_next: "docs/core/dbt-core-environments"
 pagination_prev: null
 ---
 
-<Constant name="dbt" /> enables data teams to transform data using analytics engineering best practices. You can install dbt locally using these options:
+<Constant name="dbt" /> enables data teams to transform data using analytics engineering best practices. You can choose your local development experience from these tools:
 
 * Local command line interface (CLI) tools leveraging the speed and scale of the <Constant name="fusion_engine" /> or using our legacy Core product
-* VS Code and Cursor with dbt extension
+* VS Code or Cursor with dbt extension
 
 If you're interested in using the <Constant name="dbt_platform" />, our feature-rich, browser-based UI, you can learn more in [About dbt set up](/docs/cloud/about-cloud-setup).
-
- <!-- should I delete all of this next section?
  
- This section of our docs will guide you through various settings to get started:
+After choosing and installing your local development experience, you can get started:
 
-- [Connecting to a data platform](/docs/core/connect-data-platform/profiles.yml)
-- [How to run your dbt projects](/docs/running-a-dbt-project/run-your-dbt-projects)
-
-If you're interested in using a command line interface to [develop dbt projects in <Constant name="cloud" />](/docs/cloud/about-develop-dbt), the [<Constant name="cloud" /> CLI](/docs/cloud/cloud-cli-installation) lets you run dbt commands locally. The <Constant name="cloud" /> CLI is tailored for <Constant name="cloud" />'s infrastructure and integrates with all its [features](/docs/cloud/about-cloud/dbt-cloud-features).
- -->
-
-If you need a more detailed first-time setup guide for specific data platforms, read our [quickstart guides](/guides).
+- Explore a detailed first-time setup guide for [dbt Fusion engine](/guides/fusion?step=1).
+- [Connect to a data platform](/docs/core/connect-data-platform/about-core-connections).
+- Learn [how to run your dbt projects](/docs/running-a-dbt-project/run-your-dbt-projects).

--- a/website/docs/docs/about-dbt-install.md
+++ b/website/docs/docs/about-dbt-install.md
@@ -10,7 +10,7 @@ pagination_prev: null
 <Constant name="dbt" /> enables data teams to transform data using analytics engineering best practices. You can choose your local development experience from these tools:
 
 * Local command line interface (CLI) tools leveraging the speed and scale of the <Constant name="fusion_engine" /> or using our legacy Core product
-* VS Code or Cursor with dbt extension
+* VS Code or Cursor with the dbt extension
 
 If you're interested in using the <Constant name="dbt_platform" />, our feature-rich, browser-based UI, you can learn more in [About dbt set up](/docs/cloud/about-cloud-setup).
  

--- a/website/docs/docs/cloud/connect-data-platform/connect-bigquery.md
+++ b/website/docs/docs/cloud/connect-data-platform/connect-bigquery.md
@@ -5,10 +5,11 @@ description: "Configure BigQuery connection."
 sidebar_label: "Connect BigQuery"
 ---
 
-## Required permission
+## Required permissions
 
-BigQuery with <Constant name="fusion_engine" /> also requires users to have the following permission:
-- BigQuery Read Session User (provides access to the storage read API)
+import BigQueryPerms from '/snippets/_bigquery-permissions.md';
+
+<BigQueryPerms />
 
 ## Authentication
 
@@ -16,7 +17,7 @@ BigQuery with <Constant name="fusion_engine" /> also requires users to have the 
 
 - Development environments support:
     - Service JSON
-    - BigQuery Oauth <Lifecycle status="managed" />
+    - BigQuery OAuth <Lifecycle status="managed" />
 - Deployment environments support: 
     - Service JSON
     - BigQuery Workload Identity Federation (WIF) <Lifecycle status="managed" />

--- a/website/docs/docs/core/connect-data-platform/bigquery-setup.md
+++ b/website/docs/docs/core/connect-data-platform/bigquery-setup.md
@@ -22,6 +22,12 @@ import SetUpPages from '/snippets/_setup-pages-intro.md';
 
 <SetUpPages meta={frontMatter.meta} />
 
+## Required permissions
+
+import BigQueryPerms from '/snippets/_bigquery-permissions.md';
+
+<BigQueryPerms />
+
 ## Authentication Methods
 
 BigQuery targets can be specified using one of four methods:
@@ -491,26 +497,6 @@ my-profile:
 For a full list of possible configuration fields that can be passed in `dataproc_batch`, refer to the [Dataproc Serverless Batch](https://cloud.google.com/dataproc-serverless/docs/reference/rpc/google.cloud.dataproc.v1#google.cloud.dataproc.v1.Batch) documentation.
 
 
-## Required permissions
-
-BigQuery's permission model is dissimilar from more conventional databases like Snowflake and Redshift. The following permissions are required for dbt user accounts:
-- BigQuery Data Editor
-- BigQuery User
-
-BigQuery with <Constant name="fusion_engine" /> also requires users to have the following permission:
-- BigQuery Read Session User (provides access to the storage read API)
-
-Required roles and permissions for BigQuery DataFrames:
-- BigQuery Job User
-- BigQuery Read Session User
-- Notebook Runtime User
-- Code Creator
-- colabEnterpriseUser
-
-
-
-
-This set of permissions will permit dbt users to read from and create tables and <Term id="view">views</Term> in a BigQuery project.
 
 ## Local OAuth gcloud setup
 

--- a/website/snippets/_bigquery-permissions.md
+++ b/website/snippets/_bigquery-permissions.md
@@ -1,11 +1,11 @@
-BigQuery's permission model differs from conventional databases like Snowflake and Redshift. dbt uer accounts need the following permissions to read from and create tables and <Term id="view">views</Term> in a BigQuery project:
+dbt user accounts need the following permissions to read from and create tables and <Term id="view">views</Term> in a BigQuery project:
 - BigQuery Data Editor
 - BigQuery User
 
 For BigQuery with <Constant name="fusion_engine" />, users also need:
 - BigQuery Read Session User (for Storage Read API access)
 
-For BigQuery DataFrames, users need these additional roles:
+For BigQuery DataFrames, users need these additional permissions:
 - BigQuery Job User
 - BigQuery Read Session User
 - Notebook Runtime User

--- a/website/snippets/_bigquery-permissions.md
+++ b/website/snippets/_bigquery-permissions.md
@@ -1,0 +1,13 @@
+BigQuery's permission model differs from conventional databases like Snowflake and Redshift. dbt uer accounts need the following permissions to read from and create tables and <Term id="view">views</Term> in a BigQuery project:
+- BigQuery Data Editor
+- BigQuery User
+
+For BigQuery with <Constant name="fusion_engine" />, users also need:
+- BigQuery Read Session User (for Storage Read API access)
+
+For BigQuery DataFrames, users need these additional roles:
+- BigQuery Job User
+- BigQuery Read Session User
+- Notebook Runtime User
+- Code Creator
+- colabEnterpriseUser

--- a/website/snippets/_fusion-dwh.md
+++ b/website/snippets/_fusion-dwh.md
@@ -3,7 +3,7 @@
     - Service Account / User Token
     - Native OAuth
     - External OAuth
-   - Users must be granted BigQuery Read Session User permission (provides access to the storage read API)
+    - [Required permissions](/docs/core/connect-data-platform/bigquery-setup#required-permissions)
 
   </Expandable>
 

--- a/website/snippets/_fusion-prereqs.md
+++ b/website/snippets/_fusion-prereqs.md
@@ -7,7 +7,7 @@ Learn more about installing Fusion locally, along with important prerequisites, 
 Before installing Fusion, ensure that you:
 
 - Have administrative privileges to install software on your local machine.
-- Are comfortable using a command-line interface (Terminal on macOS/Linux<!--, PowerShell on Windows-->).
+- Are comfortable using a command-line interface (Terminal on macOS/Linux, PowerShell on Windows).
 - Use a supported data warehouse and authentication method and configure permissions as needed:
   <FusionDWH /> 
 - Use a supported operating system:

--- a/website/snippets/_fusion-prereqs.md
+++ b/website/snippets/_fusion-prereqs.md
@@ -4,13 +4,13 @@ Learn more about installing Fusion locally, along with important prerequisites, 
 
 ## Prerequisites
 
-Before installing Fusion, ensure:
+Before installing Fusion, ensure that you:
 
-- You have administrative privileges to install software on your local machine.
-- You are familiar with command-line interfaces (Terminal on macOS/Linux<!--, PowerShell on Windows-->).
-- You are using a supported data warehouse and authentication method.
+- Have administrative privileges to install software on your local machine.
+- Are comfortable using a command-line interface (Terminal on macOS/Linux<!--, PowerShell on Windows-->).
+- Use a supported data warehouse and authentication method and configure permissions as needed:
   <FusionDWH /> 
-- You are using a supported OS and architecture:
+- Use a supported operating system:
 
   🟢 - Supported <br/>
   🟡 - Not yet supported

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -44,6 +44,11 @@
       "permanent": true
     },
     {
+      "source": "/docs/core/about-core-setup",
+      "destination": "/docs/about-dbt-install",
+      "permanent": true
+    },
+    {
       "source": "/docs/cloud/secure/about-privatelink",
       "destination": "/docs/cloud/secure/about-private-connectivity",
       "permanent": true


### PR DESCRIPTION
## What are you changing in this pull request and why?

* Adds redirect for deleted page
* Rewrites the requirements for Fusion
* Adds snippet for BigQuery permissions.
* Links to required permissions instead of including it in the Fusion prereqs.
* Adds back some deleted info from the about dbt install page, such as off ramps to next steps.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-ff-fusion-preview-dbt-labs.vercel.app/docs/about-dbt-install
- https://docs-getdbt-com-git-ff-fusion-preview-dbt-labs.vercel.app/docs/cloud/connect-data-platform/connect-bigquery
- https://docs-getdbt-com-git-ff-fusion-preview-dbt-labs.vercel.app/docs/core/connect-data-platform/bigquery-setup

<!-- end-vercel-deployment-preview -->