### PR TITLE
Include required `cloud-platform` scope

### DIFF
--- a/website/docs/docs/core/connect-data-platform/bigquery-setup.md
+++ b/website/docs/docs/core/connect-data-platform/bigquery-setup.md
@@ -503,7 +503,7 @@ For a full list of possible configuration fields that can be passed in `dataproc
 To connect to BigQuery using the `oauth` method, follow these steps:
 
 1. Make sure the `gcloud` command is [installed on your computer](https://cloud.google.com/sdk/downloads)
-2. Activate the application-default account with
+2. Activate the application-default account with:
 
 ```shell
 gcloud auth application-default login \           

--- a/website/docs/docs/core/connect-data-platform/bigquery-setup.md
+++ b/website/docs/docs/core/connect-data-platform/bigquery-setup.md
@@ -506,10 +506,11 @@ To connect to BigQuery using the `oauth` method, follow these steps:
 2. Activate the application-default account with
 
 ```shell
-gcloud auth application-default login \
+gcloud auth application-default login \           
   --scopes=https://www.googleapis.com/auth/bigquery,\
 https://www.googleapis.com/auth/drive.readonly,\
-https://www.googleapis.com/auth/iam.test
+https://www.googleapis.com/auth/iam.test,\
+https://www.googleapis.com/auth/cloud-platform
 ```
 
 A browser window should open, and you should be prompted to log into your Google account. Once you've done that, dbt will use your OAuth'd credentials to connect to BigQuery!


### PR DESCRIPTION
## What are you changing in this pull request and why?
When I ran the previous command for [setting up local OAuth for BigQuery](https://docs.getdbt.com/docs/core/connect-data-platform/bigquery-setup#local-oauth-gcloud-setup), I got this error:

```
ERROR: (gcloud.auth.application-default.login) Invalid value for [--scopes]: https://www.googleapis.com/auth/cloud-platform scope is required but not requested. Please include it in the --scopes flag.
```

But when I added the required scope like the following, then it worked:

```shell
gcloud auth application-default login \
  --scopes=https://www.googleapis.com/auth/bigquery,\
https://www.googleapis.com/auth/drive.readonly,\
https://www.googleapis.com/auth/iam.test,\
https://www.googleapis.com/auth/cloud-platform
```

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/docs/cloud/configure-cloud-cli
- https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/docs/core/connect-data-platform/bigquery-setup
- https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/docs/deploy/ci-jobs
- https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/docs/deploy/merge-jobs

<!-- end-vercel-deployment-preview -->