### PR TITLE
add setup doc for BQ PSC, add beta designation

### DIFF
--- a/website/docs/docs/cloud/secure/about-private-connectivity.md
+++ b/website/docs/docs/cloud/secure/about-private-connectivity.md
@@ -41,5 +41,6 @@ dbt Labs has globally connected private networks specifically used to host priva
 
 #### GCP
 - [Snowflake](/docs/cloud/secure/snowflake-psc)
+- [BigQuery (beta)](/docs/cloud/secure/bigquery-psc)
 
 <PrivateLinkHostnameWarning features={'/snippets/_private-connection-hostname-restriction.md'}/>

--- a/website/docs/docs/cloud/secure/about-private-connectivity.md
+++ b/website/docs/docs/cloud/secure/about-private-connectivity.md
@@ -41,6 +41,6 @@ dbt Labs has globally connected private networks specifically used to host priva
 
 #### GCP
 - [Snowflake](/docs/cloud/secure/snowflake-psc)
-- [BigQuery (beta)](/docs/cloud/secure/bigquery-psc)
+- [BigQuery](/docs/cloud/secure/bigquery-psc)<Lifecycle status="beta" />
 
 <PrivateLinkHostnameWarning features={'/snippets/_private-connection-hostname-restriction.md'}/>

--- a/website/docs/docs/cloud/secure/bigquery-psc.md
+++ b/website/docs/docs/cloud/secure/bigquery-psc.md
@@ -1,0 +1,42 @@
+---
+title: "Configuring BigQuery and GCP Private Service Connect (beta)"
+id: bigquery-psc
+description: "Configuring GCP Private Service Connect for BigQuery (beta)"
+sidebar_label: "GCP Private Service Connect for BigQuery (beta)"
+---
+
+# Configuring BigQuery Private Service Connect <Lifecycle status="managed_plus" /> (beta)
+
+import SetUpPages from '/snippets/_available-tiers-private-connection.md';
+import CloudProviders from '/snippets/_private-connection-across-providers.md';
+
+<SetUpPages features={'/snippets/_available-tiers-private-connection.md'}/>
+
+The following steps walk you through the setup of a GCP BigQuery Private Service Connect (PSC) endpoint in a <Constant name="cloud" /> multi-tenant environment.
+
+<CloudProviders type='BigQuery' />
+
+## Configure GCP Private Service Connect
+
+To enable dbt to privately connect to your BigQuery project via [Private Service Connect](https://cloud.google.com/vpc/docs/private-service-connect) the regional PSC endpoint will need to be enabled for your dbt account. Using the following template, submit a request to [dbt Support](/docs/dbt-support#dbt-cloud-support):
+
+```
+Subject: New Multi-Tenant GCP PSC Request
+- Type: BigQuery
+- BigQuery project region: 
+- dbt GCP multi-tenant environment:
+```
+
+import PrivateLinkSLA from '/snippets/_private-connection-SLA.md';
+
+<PrivateLinkSLA />
+
+## Create Connection in dbt
+
+Once <Constant name="cloud" /> support completes the configuration, you can start creating new connections using PrivateLink. 
+
+1. Navigate to **Settings** → **Create new project** → select **BigQuery**. 
+2. You will see two radio buttons: **Default Endpoint** and **PrivateLink Endpoint**. Select **PrivateLink Endpoint**. 
+3. Select the private endpoint from the dropdown (this will automatically populate the API endpoint field).
+4. Configure any remaining data platform details.
+5. Save the connection and test in either a project job or Studio session.

--- a/website/docs/docs/cloud/secure/bigquery-psc.md
+++ b/website/docs/docs/cloud/secure/bigquery-psc.md
@@ -5,12 +5,12 @@ description: "Configuring GCP Private Service Connect for BigQuery (beta)"
 sidebar_label: "GCP Private Service Connect for BigQuery (beta)"
 ---
 
-# Configuring BigQuery Private Service Connect <Lifecycle status="managed_plus" /> (beta)
+# Configuring BigQuery Private Service Connect <Lifecycle status="beta, managed_plus" />
 
 import SetUpPages from '/snippets/_available-tiers-private-connection.md';
 import CloudProviders from '/snippets/_private-connection-across-providers.md';
 
-<SetUpPages features={'/snippets/_available-tiers-private-connection.md'}/>
+<SetUpPages />
 
 The following steps walk you through the setup of a GCP BigQuery Private Service Connect (PSC) endpoint in a <Constant name="cloud" /> multi-tenant environment.
 

--- a/website/docs/docs/cloud/secure/bigquery-psc.md
+++ b/website/docs/docs/cloud/secure/bigquery-psc.md
@@ -12,13 +12,13 @@ import CloudProviders from '/snippets/_private-connection-across-providers.md';
 
 <SetUpPages />
 
-The following steps walk you through the setup of a GCP BigQuery Private Service Connect (PSC) endpoint in a <Constant name="cloud" /> multi-tenant environment.
+The following steps walk you through the setup of a GCP BigQuery [Private Service Connect](https://cloud.google.com/vpc/docs/private-service-connect) (PSC) endpoint in a <Constant name="cloud" /> multi-tenant environment.
 
 <CloudProviders type='BigQuery' />
 
 ## Configure GCP Private Service Connect
 
-To enable dbt to privately connect to your BigQuery project via [Private Service Connect](https://cloud.google.com/vpc/docs/private-service-connect) the regional PSC endpoint will need to be enabled for your dbt account. Using the following template, submit a request to [dbt Support](/docs/dbt-support#dbt-cloud-support):
+To enable dbt to privately connect to your BigQuery project via PSC, the regional PSC endpoint needs be enabled for your dbt account. Using the following template, submit a request to [dbt Support](/docs/dbt-support#dbt-cloud-support):
 
 ```
 Subject: New Multi-Tenant GCP PSC Request
@@ -31,9 +31,9 @@ import PrivateLinkSLA from '/snippets/_private-connection-SLA.md';
 
 <PrivateLinkSLA />
 
-## Create Connection in dbt
+## Create the connection in dbt
 
-Once <Constant name="cloud" /> support completes the configuration, you can start creating new connections using PrivateLink. 
+Once the dbt Support team completes the configuration, you can start creating new connections using PSC: 
 
 1. Navigate to **Settings** → **Create new project** → select **BigQuery**. 
 2. You will see two radio buttons: **Default Endpoint** and **PrivateLink Endpoint**. Select **PrivateLink Endpoint**. 

--- a/website/docs/docs/cloud/secure/secure-your-tenant.md
+++ b/website/docs/docs/cloud/secure/secure-your-tenant.md
@@ -83,4 +83,10 @@ hide_table_of_contents: true
     link="/docs/cloud/secure/snowflake-psc"
     icon="dbt-bit"/>
 
+<Card
+    title="GCP Private Service Connect for BigQuery (beta)"
+    body="Learn how to configure GCP Private Service Connect for BigQuery."
+    link="/docs/cloud/secure/bigquery-psc"
+    icon="dbt-bit"/>
+
 </div>

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -212,6 +212,7 @@ const sidebarSettings = {
                 "docs/cloud/secure/postgres-privatelink",
                 "docs/cloud/secure/az-postgres-private-link",
                 "docs/cloud/secure/az-synapse-private-link",
+                "docs/cloud/secure/bigquery-psc",
                 "docs/cloud/secure/vcs-privatelink",
               ],
             }, // PrivateLink

--- a/website/snippets/_private-connectivity-matrix.md
+++ b/website/snippets/_private-connectivity-matrix.md
@@ -19,7 +19,7 @@
 | Amazon Athena w/ AWS Glue                         |   ❌   |   ✅   |    -     |    -     |    -     |
 | Azure Synapse                                     |   -    |   -    |    ✅    |    ✅    |    -     |
 | Azure Fabric (cross-tenant not supported by Azure)|   -    |   -    |    ❌    |    ❌    |    -     |
-| Google BigQuery                                   |   -    |   -    |    -     |    -     |    ✅    |
+| Google BigQuery                                   |   -    |   -    |    -     |    -     |    ✅ (beta)    |
 | Teradata - Database Server                        |   ✅   |   ✅   |    ✅    |    ✅    |    ❌    |
 | <b>EGRESS - VCS (from <Constant name="cloud" />)</b>              |        |        |          |          |          |
 | GitHub Enteprise Server                           |   ✅   |   ✅   |    ✅    |    ✅    |    ❌    |


### PR DESCRIPTION
## What are you changing in this pull request and why?
Add a setup page for BigQuery Private Service Connect (PSC), which is GCPs version of PrivateLink. This is currently a beta feature, so I added a (beta) tag in various areas. Feel free to modify as needed.

## Checklist

- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).

ADDING OR REMOVING PAGES (if so, uncomment):
- [X] Add/remove page in `website/sidebars.js`
- [X] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-bigquery-psc-docs-dbt-labs.vercel.app/docs/cloud/secure/about-private-connectivity
- https://docs-getdbt-com-git-bigquery-psc-docs-dbt-labs.vercel.app/docs/cloud/secure/bigquery-psc
- https://docs-getdbt-com-git-bigquery-psc-docs-dbt-labs.vercel.app/docs/cloud/secure/secure-your-tenant

<!-- end-vercel-deployment-preview -->