### PR TITLE
`dbt show` only supports selecting a single node

### DIFF
--- a/website/docs/reference/commands/show.md
+++ b/website/docs/reference/commands/show.md
@@ -5,8 +5,9 @@ id: "show"
 ---
 
 Use `dbt show` to:
-- Compile the dbt-SQL definition of a `model`, `test`, `analysis`, or an arbitrary dbt-SQL query passed `--inline`
+- Compile the dbt-SQL definition of a single `model`, `test`, `analysis`, or an arbitrary dbt-SQL query passed `--inline`
   - `dbt show` does not support [Python (dbt-py)](/docs/build/python-models) models.
+  - only selecting a single node is supported so [selector methods](/reference/node-selection/methods), [graph operators](https://docs.getdbt.com/reference/node-selection/graph-operators), etc. that select multiple nodes will not be utilized
 - Run that query against the data warehouse
 - Preview the results in the terminal
 

--- a/website/docs/reference/commands/show.md
+++ b/website/docs/reference/commands/show.md
@@ -7,7 +7,7 @@ id: "show"
 Use `dbt show` to:
 - Compile the dbt-SQL definition of a single `model`, `test`, `analysis`, or an arbitrary dbt-SQL query passed `--inline`
   - `dbt show` does not support [Python (dbt-py)](/docs/build/python-models) models.
-  - only selecting a single node is supported so [selector methods](/reference/node-selection/methods), [graph operators](https://docs.getdbt.com/reference/node-selection/graph-operators), etc. that select multiple nodes will not be utilized
+  - Only selecting a single node is supported. [Selector methods](/reference/node-selection/methods), [graph operators](/reference/node-selection/graph-operators), and other methods that select multiple nodes will not be utilized.
 - Run that query against the data warehouse
 - Preview the results in the terminal
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

Clarify that `dbt show` only supports selecting a single node.

See https://github.com/dbt-labs/dbt-core/issues/11964 for context.

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/docs/cloud/connect-data-platform/connect-bigquery
- https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/docs/cloud/manage-access/about-access
- https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/docs/cloud/manage-access/set-up-sso-google-workspace
- https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/docs/cloud/manage-access/set-up-sso-microsoft-entra-id
- https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/docs/cloud/manage-access/set-up-sso-okta
- https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/docs/cloud/manage-access/set-up-sso-saml-2.0
- https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/docs/cloud/migration
- https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/docs/dbt-versions/dbt-cloud-release-notes-gen
- https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/reference/commands/show

<!-- end-vercel-deployment-preview -->