### PR TITLE
Change Repository Access Reccomendations in Manual-Install Guide

### DIFF
--- a/website/docs/guides/manual-install-qs.md
+++ b/website/docs/guides/manual-install-qs.md
@@ -32,7 +32,10 @@ After setting up BigQuery to work with dbt, you are ready to create a starter pr
 The following steps use [GitHub](https://github.com/) as the <Constant name="git" /> provider for this guide, but you can use any <Constant name="git" /> provider. You should have already [created a GitHub account](https://github.com/join).
 
 1. [Create a new GitHub repository](https://github.com/new) named `dbt-tutorial`.
-2. Select **Private**. This is so you don't accidentially share any credentials for your Google Cloud account. You can always make it public later.
+2. Select:
+    - **Private (recommended):** To secure your environment and prevent private information (like credentials) from being public.
+    - **Public:** If you need to easily collaborate and share with others, especially outside of your organization. 
+You can always change the privacy settings later. 
 3. Leave the default values for all other settings.
 4. Click **Create repository**.
 5. Save the commands from "…or create a new repository on the command line" to use later in [Commit your changes](/guides/manual-install?step=6).

--- a/website/docs/guides/manual-install-qs.md
+++ b/website/docs/guides/manual-install-qs.md
@@ -35,6 +35,7 @@ The following steps use [GitHub](https://github.com/) as the <Constant name="git
 2. Select:
     - **Private (recommended):** To secure your environment and prevent private information (like credentials) from being public.
     - **Public:** If you need to easily collaborate and share with others, especially outside of your organization. 
+
 You can always change the privacy settings later. 
 3. Leave the default values for all other settings.
 4. Click **Create repository**.

--- a/website/docs/guides/manual-install-qs.md
+++ b/website/docs/guides/manual-install-qs.md
@@ -32,11 +32,10 @@ After setting up BigQuery to work with dbt, you are ready to create a starter pr
 The following steps use [GitHub](https://github.com/) as the <Constant name="git" /> provider for this guide, but you can use any <Constant name="git" /> provider. You should have already [created a GitHub account](https://github.com/join).
 
 1. [Create a new GitHub repository](https://github.com/new) named `dbt-tutorial`.
-2. Select:
+2. Select one of the following (You can always change this setting later):
     - **Private (recommended):** To secure your environment and prevent private information (like credentials) from being public.
     - **Public:** If you need to easily collaborate and share with others, especially outside of your organization. 
 
-You can always change the privacy settings later. 
 3. Leave the default values for all other settings.
 4. Click **Create repository**.
 5. Save the commands from "…or create a new repository on the command line" to use later in [Commit your changes](/guides/manual-install?step=6).

--- a/website/docs/guides/manual-install-qs.md
+++ b/website/docs/guides/manual-install-qs.md
@@ -32,7 +32,7 @@ After setting up BigQuery to work with dbt, you are ready to create a starter pr
 The following steps use [GitHub](https://github.com/) as the <Constant name="git" /> provider for this guide, but you can use any <Constant name="git" /> provider. You should have already [created a GitHub account](https://github.com/join).
 
 1. [Create a new GitHub repository](https://github.com/new) named `dbt-tutorial`.
-2. Select **Public** so the repository can be shared with others. You can always make it private later.
+2. Select **Private**. This is so you don't accidentially share any credentials for your Google Cloud account. You can always make it public later.
 3. Leave the default values for all other settings.
 4. Click **Create repository**.
 5. Save the commands from "…or create a new repository on the command line" to use later in [Commit your changes](/guides/manual-install?step=6).


### PR DESCRIPTION
## What are you changing in this pull request and why?
Changed repository access recommendation from public to private.

As this is a guide, and likely to be used by beginners, these recommendations are best practice and will help ensure people do not commit service accounts or other forms of private credentials to their repositories by accident.

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.