### PR TITLE
Separate example shell commands from files

### DIFF
--- a/website/docs/reference/resource-configs/bigquery-configs.md
+++ b/website/docs/reference/resource-configs/bigquery-configs.md
@@ -1009,14 +1009,21 @@ gcloud projects add-iam-policy-binding ${GOOGLE_CLOUD_PROJECT} --member=serviceA
 gcloud projects add-iam-policy-binding ${GOOGLE_CLOUD_PROJECT} --member=serviceAccount:dbt-bigframes-sa@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com --role=roles/iam.serviceAccountUser
 #Grant Colab Entperprise User
 gcloud projects add-iam-policy-binding ${GOOGLE_CLOUD_PROJECT} --member=serviceAccount:dbt-bigframes-sa@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com --role=roles/aiplatform.colabEnterpriseUser
+```
 
-# update the project.yaml file 
+<File name='dbt_project.yml'>
+
+```yaml
 models:
   my_dbt_project:
     submission_method: bigframes
+```
 
+</File>
 
-# update the profile.yaml file such as this
+<File name='profiles.yml'>
+
+```yaml
 my_dbt_project_sa:
   outputs:
     dev:
@@ -1033,8 +1040,8 @@ my_dbt_project_sa:
       threads: 1
       type: bigquery
   target: dev
-
 ```
+</File>
 
 </TabItem>
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
There were shell commands and example files all combined in the same code block when they should be separated.

## :tophat:

### Before

<img width="688" height="625" alt="image" src="https://github.com/user-attachments/assets/8f3e4087-a685-4151-ad99-b22ea8205c7b" />

### After

<img width="694" height="686" alt="image" src="https://github.com/user-attachments/assets/72003923-a46e-4b05-aba1-7a2c438eca2d" />

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/reference/resource-configs/bigquery-configs

<!-- end-vercel-deployment-preview -->