### PR TITLE
docs: compatibility matrix and configs updation

### DIFF
--- a/website/docs/docs/core/connect-data-platform/teradata-setup.md
+++ b/website/docs/docs/core/connect-data-platform/teradata-setup.md
@@ -27,18 +27,19 @@ import SetUpPages from '/snippets/_setup-pages-intro.md';
 
 ## Python compatibility
 
-| Plugin version | Python 3.9 | Python 3.10 | Python 3.11 | Python 3.12 |
-|----------------|------------|-------------|-------------|-------------|
-| 1.0.0.x        | ✅          | ❌           | ❌           | ❌           |
-| 1.1.x.x        | ✅          | ✅           | ❌           | ❌           |
-| 1.2.x.x        | ✅          | ✅           | ❌           | ❌           |
-| 1.3.x.x        | ✅          | ✅           | ❌           | ❌           |
-| 1.4.x.x        | ✅          | ✅           | ✅           | ❌           |
-| 1.5.x          | ✅          | ✅           | ✅           | ❌           |
-| 1.6.x          | ✅          | ✅           | ✅           | ❌           |
-| 1.7.x          | ✅          | ✅           | ✅           | ❌           |
-| 1.8.x          | ✅          | ✅           | ✅           | ✅           |
-| 1.9.x          | ✅          | ✅           | ✅           | ✅           |
+| Plugin version | Python 3.9 | Python 3.10 | Python 3.11 | Python 3.12 | Python 3.13 | 
+|----------------|------------|-------------|-------------|-------------|-------------|
+| 1.0.0.x        | ✅          | ❌           | ❌           | ❌           | ❌           |
+| 1.1.x.x        | ✅          | ✅           | ❌           | ❌           | ❌           |
+| 1.2.x.x        | ✅          | ✅           | ❌           | ❌           | ❌           |
+| 1.3.x.x        | ✅          | ✅           | ❌           | ❌           | ❌           |
+| 1.4.x.x        | ✅          | ✅           | ✅           | ❌           | ❌           |
+| 1.5.x          | ✅          | ✅           | ✅           | ❌           | ❌           |
+| 1.6.x          | ✅          | ✅           | ✅           | ❌           | ❌           |
+| 1.7.x          | ✅          | ✅           | ✅           | ❌           | ❌           |
+| 1.8.x          | ✅          | ✅           | ✅           | ✅           | ❌           |
+| 1.9.x          | ✅          | ✅           | ✅           | ✅           | ❌           |
+| 1.10.x         | ✅          | ✅           | ✅           | ✅           | ✅           |
 
 ## dbt dependent packages version compatibility
 
@@ -51,6 +52,7 @@ import SetUpPages from '/snippets/_setup-pages-intro.md';
 | 1.8.x        | 1.8.x    | 1.2.0             | 1.2.0          |
 | 1.8.x        | 1.8.x    | 1.3.0             | 1.3.0          |
 | 1.9.x        | 1.9.x    | 1.3.0             | 1.3.0          |
+| 1.10.x       | 1.10.x   | 1.3.0             | 1.3.0          |
 
 
 ### Connecting to Teradata
@@ -145,7 +147,8 @@ The following incremental materialization strategies are supported:
 * `append` (default)
 * `delete+insert`
 * `merge`
-* `valid_history` (early access)
+* `valid_history`
+* `microbatch`
 
 :::info
 - To learn more about dbt incremental strategies, refer to [the dbt incremental strategy documentation](/docs/build/incremental-strategy).

--- a/website/docs/reference/resource-configs/teradata-configs.md
+++ b/website/docs/reference/resource-configs/teradata-configs.md
@@ -497,10 +497,10 @@ sources:
               data_type: CHAR(1)
 ```
 
-### Fallback Schema
-The dbt-teradata adapter internally creates temporary tables to fetch the metadata of views for manifest and catalog creation. In cases you don't have permission to create tables on the schema you are working on, you can define a fallback_schema (to which you have the proper `create`/`drop` privileges) in the dbt_project.yml as a variable.
+### temporary_metadata_generation_schema (earlier fallback_schema)
+The dbt-teradata adapter internally creates temporary tables to fetch the metadata of views for manifest and catalog creation. In cases you don't have permission to create tables on the schema you are working on, you can define a temporary_metadata_generation_schema (to which you have the proper `create`/`drop` privileges) in the dbt_project.yml as a variable.
 
 ```yaml
 vars:
-  fallback_schema: <schema-name>
+  temporary_metadata_generation_schema: <schema-name>
 ```

--- a/website/docs/reference/resource-configs/teradata-configs.md
+++ b/website/docs/reference/resource-configs/teradata-configs.md
@@ -497,8 +497,8 @@ sources:
               data_type: CHAR(1)
 ```
 
-### temporary_metadata_generation_schema (earlier fallback_schema)
-The dbt-teradata adapter internally creates temporary tables to fetch the metadata of views for manifest and catalog creation. In cases you don't have permission to create tables on the schema you are working on, you can define a temporary_metadata_generation_schema (to which you have the proper `create`/`drop` privileges) in the dbt_project.yml as a variable.
+### `temporary_metadata_generation_schema` (previously `fallback_schema`)
+The dbt-teradata adapter internally creates temporary tables to fetch the metadata of views for manifest and catalog creation. If you lack permission to create tables on the schema you are working with, you can define a `temporary_metadata_generation_schema` (to which you have the proper `create`/`drop` privileges) in the `dbt_project.yml` as a variable.
 
 ```yaml
 vars:


### PR DESCRIPTION
## What are you changing in this pull request and why?

With dbt-teradata upgrading v1.10:
* Added Python 3.13 support
* Microbatch strategy has already been supported so added to the list.
* **Fallback_schema** config has been renamed to **temporary_metadata_generation_schema** due to technical reasons so made changes for the same
