### PR TITLE
IDE Extension nav CTA

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -207,6 +207,7 @@ var siteSettings = {
           label: "Install VS Code extension",
           position: "right",
           to: "/docs/install-dbt-extension",
+          id: "nav-install-vs-code-extension",
           className: "nav-install-dbt-extension",
         },
       ],

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -203,6 +203,12 @@ var siteSettings = {
             },
           ],
         },
+        {
+          label: "Install dbt IDE extension",
+          position: "right",
+          to: "/docs/install-dbt-extension",
+          className: "nav-install-dbt-extension",
+        },
       ],
     },
     footer: {
@@ -361,8 +367,8 @@ var siteSettings = {
       src: "https://cdn.jsdelivr.net/npm/featherlight@1.7.14/release/featherlight.min.js",
       defer: true,
     },
-    { 
-      src: '/js/checkboxes.js', 
+    {
+      src: "/js/checkboxes.js",
       async: true,
     },
     "https://cdn.jsdelivr.net/npm/clipboard@2.0.11/dist/clipboard.min.js",

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -204,7 +204,7 @@ var siteSettings = {
           ],
         },
         {
-          label: "Install dbt IDE extension",
+          label: "Install VS Code extension",
           position: "right",
           to: "/docs/install-dbt-extension",
           className: "nav-install-dbt-extension",

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -257,6 +257,7 @@ display: flex;
 height: 22px;
 width: 22px;
 display: none;
+margin-top: 5px;
 }
 
 html[data-theme="dark"] .navbar__account:before {
@@ -1523,10 +1524,16 @@ html[data-theme="dark"] .main-wrapper nav a:active {
   }
 }
 
-[data-theme="dark"] button.DocSearch-Button {
+/* hide search text and keys until 1201px */
+button .DocSearch-Button-Placeholder,
+button .DocSearch-Button-Keys {
+  display: none;
+}
+
+/* [data-theme="dark"] button.DocSearch-Button {
   background-color: #FFF !important;
   color: #6A7282 !important;
-}
+} */
 
 @media screen and (max-width: 750px) {
   .card.large {
@@ -1553,18 +1560,14 @@ html[data-theme="dark"] .main-wrapper nav a:active {
   .DocSearch-Button .DocSearch-Search-Icon {
     color: var(--docsearch-muted-color);
   }
-
-  /* hide search text and keys until 1201px */
-  button .DocSearch-Button-Placeholder,
-  button .DocSearch-Button-Keys {
-    display: none;
-  }
 }
 
 @media screen and (min-width: 1320px) {
-
+  /* 9/8/25 NOTE: Disabled all desktop search bar styles
+     to fit the IDE Extension CTA into the nav
+  */
   /* search bar styles */
-  button.DocSearch-Button {
+  /* button.DocSearch-Button {
     border: 1px solid #D1D5DC;
     border-radius: 12px;
     height: 40px;
@@ -1579,7 +1582,7 @@ html[data-theme="dark"] .main-wrapper nav a:active {
     padding: 0 12px 0 8px;
   }
 
-  /* magnifying glass icon */
+  // magnifying glass icon
   button.DocSearch-Button .DocSearch-Search-Icon {
     color: var(--docsearch-muted-color);
     stroke-width: 2px;
@@ -1587,7 +1590,7 @@ html[data-theme="dark"] .main-wrapper nav a:active {
     height: 1em;
   }
 
-  /* keys wrapper */
+  // keys wrapper
   button .DocSearch-Button-Keys {
     border: none;
     padding: 0.24em 0.5em;
@@ -1595,7 +1598,7 @@ html[data-theme="dark"] .main-wrapper nav a:active {
     margin-right: -13px;
   }
 
-  /* single key */
+  // single key
   button .DocSearch-Button-Key {
     font-size: 1.12rem;
     line-height: 1em;  
@@ -1607,13 +1610,13 @@ html[data-theme="dark"] .main-wrapper nav a:active {
     gap: 0;
   }
 
-  /* Add dark background on hover for searchbox */
+  // Add dark background on hover for searchbox
   [data-theme="dark"] button.DocSearch-Button:active,
   [data-theme="dark"] button.DocSearch-Button:focus,
   [data-theme="dark"] button.DocSearch-Button:hover {
     background-color: #FFF !important;
     color: #6A7282 !important;
-  }
+  } */
 }
 
 @media (min-width: 1480px) {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -230,6 +230,17 @@ html[data-theme="dark"] input.sc-avest {
   order: 4;
 }
 
+.navbar__item.nav-install-dbt-extension {
+  order: 5;
+  background: var(--ifm-color-primary);
+  transition: all 0.3s ease-in-out;
+}
+
+.navbar__item.nav-install-dbt-extension:hover {
+  background-color: var(--ifm-color-primary) !important;
+  background-image: linear-gradient(oklab(0.865972 0.00164044 0.169914 / 0.5) 0%, rgba(0, 0, 0, 0) 50%) !important;
+}
+
 .navbar__account:before {
   background: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cpath%20d%3D%22M20%2021C20%2019.6044%2020%2018.9067%2019.8278%2018.3389C19.44%2017.0605%2018.4395%2016.06%2017.1611%2015.6722C16.5933%2015.5%2015.8956%2015.5%2014.5%2015.5H9.5C8.10444%2015.5%207.40665%2015.5%206.83886%2015.6722C5.56045%2016.06%204.56004%2017.0605%204.17224%2018.3389C4%2018.9067%204%2019.6044%204%2021%22%20stroke%3D%22%23030711%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22square%22%20stroke-linejoin%3D%22round%22/%3E%3Cpath%20d%3D%22M12%2012C14.4853%2012%2016.5%209.98528%2016.5%207.5C16.5%205.01472%2014.4853%203%2012%203C9.51472%203%207.5%205.01472%207.5%207.5C7.5%209.98528%209.51472%2012%2012%2012Z%22%20stroke%3D%22%23030711%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22square%22%20stroke-linejoin%3D%22round%22/%3E%3C/svg%3E") no-repeat;
 content: "";

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -1606,8 +1606,9 @@ button .DocSearch-Button-Keys {
 }
 
 @media screen and (min-width: 1530px) {
-  /* 9/8/25 NOTE: Disabled all desktop search bar styles
-     to fit the IDE Extension CTA into the nav
+  /* 
+    9/8/25 NOTE: Only showing full search bar styles
+    on 1530px and above to fit the IDE Extension CTA into the nav
   */
   /* search bar styles */
   [data-theme="dark"] button.DocSearch-Button {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -230,13 +230,22 @@ html[data-theme="dark"] input.sc-avest {
   order: 4;
 }
 
+/* IDE Extension nav item */
 .navbar__item.nav-install-dbt-extension {
   order: 5;
   background: var(--ifm-color-primary);
   transition: all 0.3s ease-in-out;
+  color: var(--color-neutral-primary);
 }
-
 .navbar__item.nav-install-dbt-extension:hover {
+  background-color: var(--ifm-color-primary) !important;
+  background-image: linear-gradient(oklab(0.865972 0.00164044 0.169914 / 0.5) 0%, rgba(0, 0, 0, 0) 50%) !important;
+}
+html[data-theme="dark"] .navbar__item.nav-install-dbt-extension {
+  color: var(--color-neutral-primary);
+}
+html[data-theme="dark"] .navbar__item.nav-install-dbt-extension:hover {
+  color: var(--color-neutral-primary) !important;
   background-color: var(--ifm-color-primary) !important;
   background-image: linear-gradient(oklab(0.865972 0.00164044 0.169914 / 0.5) 0%, rgba(0, 0, 0, 0) 50%) !important;
 }

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -547,7 +547,55 @@ a.code-link:hover {
   gap: 8px;
 }
 
-@media(max-width: 1258px) {
+/* Custom nav styles from right before mobile,
+   up to where nav begins to hit logo
+*/
+@media(min-width: 996px) and (max-width: 1154px) {
+  .navbar__items {
+    min-width: auto;
+    gap: 0 !important;
+  }
+
+  .navbar__items .navbar__brand {
+    min-width: 167px;
+    padding: 10px 0 0;
+  }
+
+  .navbar__items .navbar__brand .navbar__logo {
+    height: 1.5rem;
+  }
+
+  .navbar__items.navbar__items--right {
+    width: 100%;
+    flex-basis: 100%;
+  }
+}
+
+@media(min-width: 996px) and (max-width: 1199px) {
+  .navbar__items.navbar__items--right .navbar__item, .navbar__items.navbar__items--right .navbar__link {
+    font-size: 0.875rem;
+    padding: 10px 8px !important;
+  }
+}
+
+@media(min-width: 1200px) and (max-width: 1320px) {
+  .navbar__items.navbar__items--right .navbar__item, .navbar__items.navbar__items--right .navbar__link {
+    font-size: 0.938rem;
+    padding: 10px 8px !important;
+  }
+}
+
+@media(min-width: 996px) and (max-width: 1320px) {
+  .navbar__items {
+    gap: 0 !important;
+  }
+
+  .navbar__items.navbar__items--right .navbar__item, .navbar__items.navbar__items--right .navbar__link {
+    padding: 10px 8px !important;
+  }
+}
+
+@media(max-width: 1530px) {
   .navbar__items {
     gap: 4px;
   }
@@ -1530,11 +1578,6 @@ button .DocSearch-Button-Keys {
   display: none;
 }
 
-/* [data-theme="dark"] button.DocSearch-Button {
-  background-color: #FFF !important;
-  color: #6A7282 !important;
-} */
-
 @media screen and (max-width: 750px) {
   .card.large {
     height: auto;
@@ -1562,12 +1605,16 @@ button .DocSearch-Button-Keys {
   }
 }
 
-@media screen and (min-width: 1320px) {
+@media screen and (min-width: 1530px) {
   /* 9/8/25 NOTE: Disabled all desktop search bar styles
      to fit the IDE Extension CTA into the nav
   */
   /* search bar styles */
-  /* button.DocSearch-Button {
+  [data-theme="dark"] button.DocSearch-Button {
+    background-color: #FFF !important;
+    color: #6A7282 !important;
+  }
+  button.DocSearch-Button {
     border: 1px solid #D1D5DC;
     border-radius: 12px;
     height: 40px;
@@ -1580,9 +1627,10 @@ button .DocSearch-Button-Keys {
     font-size: 0.875rem;
     font-weight: 500;
     padding: 0 12px 0 8px;
+    display: inline-block;
   }
 
-  // magnifying glass icon
+  /* magnifying glass icon */
   button.DocSearch-Button .DocSearch-Search-Icon {
     color: var(--docsearch-muted-color);
     stroke-width: 2px;
@@ -1590,15 +1638,16 @@ button .DocSearch-Button-Keys {
     height: 1em;
   }
 
-  // keys wrapper
+  /* keys wrapper */
   button .DocSearch-Button-Keys {
     border: none;
     padding: 0.24em 0.5em;
     gap: 0;
     margin-right: -13px;
+    display: flex;
   }
 
-  // single key
+  /* single key */
   button .DocSearch-Button-Key {
     font-size: 1.12rem;
     line-height: 1em;  
@@ -1610,13 +1659,13 @@ button .DocSearch-Button-Keys {
     gap: 0;
   }
 
-  // Add dark background on hover for searchbox
+  /* Add dark background on hover for searchbox */
   [data-theme="dark"] button.DocSearch-Button:active,
   [data-theme="dark"] button.DocSearch-Button:focus,
   [data-theme="dark"] button.DocSearch-Button:hover {
     background-color: #FFF !important;
     color: #6A7282 !important;
-  } */
+  }
 }
 
 @media (min-width: 1480px) {


### PR DESCRIPTION
## What are you changing in this pull request and why?

[Notion task](https://www.notion.so/dbtlabs/Add-CTA-to-docs-nav-268bb38ebda781779a33c5e03ea09469?source=copy_link)

- Adds "Install dbt IDE extension" CTA to primary navigation
- Adjusts nav styles to:
  - Hide full searchbar styles until very wide desktop
  - Better fit and wrap all content until mobile nav styles kick in

## Preview
https://docs-getdbt-com-git-ide-nav-cta-dbt-labs.vercel.app/
