### PR TITLE
Fix nav for subpages

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -1669,9 +1669,14 @@ button .DocSearch-Button-Keys {
   }
 }
 
-@media (min-width: 1480px) {
+@media (min-width: 1670px) {
   .dbt__brand {
     border-right: 1px solid var(--ifm-toc-border-color);
+    padding: 0 var(--ifm-navbar-padding-horizontal) 0 0;
+    min-height: var(--ifm-navbar-height);
+    max-height: var(--ifm-navbar-height);
+    width: 300px;
+    min-width: 5.5em;
   }
 }
 
@@ -1686,14 +1691,6 @@ button .DocSearch-Button-Keys {
 }
 
 @media (min-width: 997px) {
-  .dbt__brand {
-    padding: 0 var(--ifm-navbar-padding-horizontal) 0 0;
-    min-height: var(--ifm-navbar-height);
-    max-height: var(--ifm-navbar-height);
-    width: 300px;
-    min-width: 5.5em;
-  }
-
   html.docs-version-current .navbar {
     width: 100%;
     margin-left: 0;


### PR DESCRIPTION
## What are you changing in this pull request and why?

Follow up to the cta to nav [Notion task](https://www.notion.so/dbtlabs/Add-CTA-to-docs-nav-268bb38ebda781779a33c5e03ea09469?source=copy_link)

The nav breaks on smaller desktop windows on subpages where the sidebar exists due to custom navbar logo styles for subpages with sidebars. This adjusts those styles to only kick in on wide desktop to prevent the nav from breaking when it collapses down.

## Preview
https://docs-getdbt-com-git-adjust-nav-subpages-dbt-labs.vercel.app/docs/introduction
https://docs-getdbt-com-git-adjust-nav-subpages-dbt-labs.vercel.app/guides
https://docs-getdbt-com-git-adjust-nav-subpages-dbt-labs.vercel.app/best-practices

On the live site, you can create the issue by shrinking the desktop window down on subpages:
https://docs.getdbt.com/docs/introduction

