### PR TITLE
Feedback widget text field

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -378,6 +378,11 @@ var siteSettings = {
     "/js/onetrust.js",
     "/js/mutiny.js",
     "/js/hide-forethought.js",
+    {
+      src: "https://www.google.com/recaptcha/api.js?render=6LeIksMrAAAAABYsWNCpUv15lXXzEZj91zdDCymo",
+      async: true,
+      defer: true,
+    },
   ],
   stylesheets: [
     "/css/fonts.css",

--- a/website/src/components/feedback/index.js
+++ b/website/src/components/feedback/index.js
@@ -84,6 +84,14 @@ export const Feedback = () => {
     setSubmissionStatus("loading");
 
     try {
+      // Execute reCAPTCHA
+      const token = await window.grecaptcha.execute(
+        "6LeIksMrAAAAABYsWNCpUv15lXXzEZj91zdDCymo",
+        {
+          action: "feedback_submission",
+        }
+      )
+      
       // TODO: Change to production URL
       // "https://www.getdbt.com/api/submit-feedback",
       // "https://docs-getdbt-com-git-feedback-input-dbt-labs.vercel.app/api/submit-feedback"
@@ -98,6 +106,7 @@ export const Feedback = () => {
             is_positive: selectedFeedback,
             message: textFeedback.trim(),
             page_url: window.location.href,
+            recaptcha_token: token,
           }),
         }
       );

--- a/website/src/components/feedback/index.js
+++ b/website/src/components/feedback/index.js
@@ -3,6 +3,7 @@ import Link from "@docusaurus/Link";
 import { ThumbsUp } from "./ThumbsUp";
 import { ThumbsDown } from "./ThumbsDown";
 import styles from "./styles.module.css";
+import { validateTextInput } from "../../utils/validate-text-input";
 
 /**
  * Feedback component to handle visitor feedback for the current docs page.
@@ -15,6 +16,7 @@ export const Feedback = () => {
   const [textFeedback, setTextFeedback] = useState("");
   const [hasSubmitted, setHasSubmitted] = useState(false);
   const [loadedFromStorage, setLoadedFromStorage] = useState(false);
+  const [validationError, setValidationError] = useState("");
 
   const FEEDBACK_STORAGE_KEY = 'page_feedback_data';
 
@@ -68,6 +70,18 @@ export const Feedback = () => {
     setSelectedFeedback(feedbackValue);
   };
 
+  const handleTextChange = (e) => {
+    const newText = e.target.value;
+    setTextFeedback(newText);
+    
+    // Validate input on change
+    if (newText.trim()) {
+      validateTextInput(newText, setValidationError);
+    } else {
+      setValidationError("");
+    }
+  };
+
   const handleFormSubmit = async (e) => {
     e.preventDefault();
     
@@ -78,6 +92,11 @@ export const Feedback = () => {
 
     // Require rating selection
     if (selectedFeedback === null) {
+      return;
+    }
+
+    // Validate text input before submission
+    if (textFeedback.trim() && !validateTextInput(textFeedback, setValidationError)) {
       return;
     }
 
@@ -180,8 +199,9 @@ export const Feedback = () => {
               <textarea
                 placeholder="Tell us what you think..."
                 value={textFeedback}
-                onChange={(e) => setTextFeedback(e.target.value)}
+                onChange={handleTextChange}
                 disabled={hasSubmitted && submissionStatus === "success"}
+                maxLength={2000}
               />
             </div>
               {submissionStatus === "loading" ? (
@@ -196,9 +216,15 @@ export const Feedback = () => {
                 <button
                   type="submit"
                   className={styles.feedbackSubmitButton}
+                  disabled={!!validationError}
                 >
                   Submit Feedback
                 </button>
+              )}
+              {validationError && (
+                <span className={`${styles.feedbackMessage} ${styles.validationError}`}>
+                  {validationError}
+                </span>
               )}
               {submissionStatus === "error" && (
                 <span className={styles.feedbackMessage}>

--- a/website/src/components/feedback/index.js
+++ b/website/src/components/feedback/index.js
@@ -84,6 +84,7 @@ export const Feedback = () => {
     setSubmissionStatus("loading");
 
     try {
+      // TODO: Change to production URL
       // "https://www.getdbt.com/api/submit-feedback",
       // "https://docs-getdbt-com-git-feedback-input-dbt-labs.vercel.app/api/submit-feedback"
       const response = await fetch(

--- a/website/src/components/feedback/index.js
+++ b/website/src/components/feedback/index.js
@@ -55,9 +55,6 @@ export const Feedback = () => {
       const feedbackArray = getFeedbackData();
       const existingFeedback = findPageFeedback(feedbackArray, currentUrl);
 
-      // TODO: Delete before merge
-      console.log("existingFeedback", existingFeedback);
-
       if (existingFeedback) {
         setSelectedFeedback(existingFeedback.is_positive);
         setHasSubmitted(true);
@@ -117,18 +114,8 @@ export const Feedback = () => {
         }
       );
 
-      // TODO: Delete before merge
-      console.log("hitting submit feedback api");
-      console.log("payload", {
-        is_positive: selectedFeedback,
-        message: textFeedback.trim(),
-        page_url: window.location.href,
-        recaptcha_token: token,
-      });
-
       // TODO: Change to production URL
       // "https://www.getdbt.com/api/submit-feedback",
-      // "http://localhost:3000/api/submit-feedback",
       const response = await fetch(
         "https://www-getdbt-com-git-feedback-input-dbt-labs.vercel.app/api/submit-feedback",
         {
@@ -145,13 +132,7 @@ export const Feedback = () => {
         }
       );
 
-      // TODO: Delete before merge
-      console.log("api response", response);
-
       const data = await response.json();
-
-      // TODO: Delete before merge
-      console.log("data", data);
 
       // If error, set submission status to error and throw error
       if (data?.error) {
@@ -176,9 +157,6 @@ export const Feedback = () => {
         page_url: currentUrl,
       };
 
-      // TODO: Delete before merge
-      console.log("newFeedbackItem", newFeedbackItem);
-
       if (existingFeedbackIndex >= 0) {
         // Update existing feedback
         feedbackArray[existingFeedbackIndex] = newFeedbackItem;
@@ -189,8 +167,6 @@ export const Feedback = () => {
 
       saveFeedbackData(feedbackArray);
     } catch (error) {
-      // TODO: Delete before merge
-      console.log("error submitting feedback", error);
       setSubmissionStatus("error");
     }
   };

--- a/website/src/components/feedback/index.js
+++ b/website/src/components/feedback/index.js
@@ -122,35 +122,44 @@ export const Feedback = () => {
   return (
     <div className={styles.feedbackContainer}>
       <h2 className={styles.feedbackHeader}>Was this page helpful?</h2>
-      <div className={styles.feedbackButtons}>
-        <button 
-          className={`${styles.feedbackButton} ${selectedFeedback === true ? styles.feedbackButtonSelected : ''}`}
-          onClick={() => handleFeedbackSubmit(true)}
-          disabled={hasSubmitted}
-        >
-          <ThumbsUp />
-          Yes
-        </button>
-        <button 
-          className={`${styles.feedbackButton} ${selectedFeedback === false ? styles.feedbackButtonSelected : ''}`}
-          onClick={() => handleFeedbackSubmit(false)}
-          disabled={hasSubmitted}
-        >
-          <ThumbsDown />
-          No
-        </button>
-        {submissionStatus === "loading" ? (
-          <span className={styles.feedbackMessage}>
-            Submitting feedback...
-          </span>
-          ) : submissionStatus === "success" ? (
-          <span className={styles.feedbackMessage}>Thank you for your feedback!</span>
-        ) : submissionStatus === "error" ? (
-          <span className={styles.feedbackMessage}>
-            Error submitting feedback. Please try again.
-          </span>
-        ) : null}
+      <div className={styles.feedbackActions}>
+        <div className={styles.feedbackButtons}>
+          <button
+            className={`${styles.feedbackButton} ${selectedFeedback === true ? styles.feedbackButtonSelected : ""}`}
+            onClick={() => handleFeedbackSubmit(true)}
+            disabled={hasSubmitted}
+          >
+            <ThumbsUp />
+            Yes
+          </button>
+          <button
+            className={`${styles.feedbackButton} ${selectedFeedback === false ? styles.feedbackButtonSelected : ""}`}
+            onClick={() => handleFeedbackSubmit(false)}
+            disabled={hasSubmitted}
+          >
+            <ThumbsDown />
+            No
+          </button>
+        </div>
+        <div className={styles.feedbackInput}>
+          <textarea placeholder="Tell us what you think..." />
+        </div>
       </div>
+      {submissionStatus && (
+        <div>
+          {submissionStatus === "loading" ? (
+            <span className={styles.feedbackMessage}>Submitting feedback...</span>
+          ) : submissionStatus === "success" ? (
+            <span className={styles.feedbackMessage}>
+              Thank you for your feedback!
+            </span>
+          ) : submissionStatus === "error" ? (
+            <span className={styles.feedbackMessage}>
+              Error submitting feedback. Please try again.
+            </span>
+          ) : null}
+        </div>
+    )}
       <div className={styles.feedbackLinks}>
         <Link
           href="https://www.getdbt.com/cloud/privacy-policy"
@@ -158,7 +167,7 @@ export const Feedback = () => {
           rel="noopener noreferrer"
         >
           Privacy policy
-        </Link> 
+        </Link>
         <Link
           href="https://github.com/dbt-labs/docs.getdbt.com/issues"
           target="_blank"

--- a/website/src/components/feedback/index.js
+++ b/website/src/components/feedback/index.js
@@ -70,9 +70,9 @@ export const Feedback = () => {
 
       // TODO: Change to production URL
       // "https://www.getdbt.com/api/submit-feedback",
-      // "https://www-getdbt-com-git-feedback-input-dbt-labs.vercel.app/api/submit-feedback",
+      // "http://localhost:3000/api/submit-feedback",
       const response = await fetch(
-        "http://localhost:3000/api/submit-feedback",
+        "https://www-getdbt-com-git-feedback-input-dbt-labs.vercel.app/api/submit-feedback",
         {
           method: "POST",
           headers: {

--- a/website/src/components/feedback/index.js
+++ b/website/src/components/feedback/index.js
@@ -113,9 +113,9 @@ export const Feedback = () => {
       
       // TODO: Change to production URL
       // "https://www.getdbt.com/api/submit-feedback",
-      // "https://docs-getdbt-com-git-feedback-input-dbt-labs.vercel.app/api/submit-feedback"
+      // "http://localhost:3000/api/submit-feedback",
       const response = await fetch(
-        "http://localhost:3000/api/submit-feedback",
+        "https://docs-getdbt-com-git-feedback-input-dbt-labs.vercel.app/api/submit-feedback",
         {
           method: "POST",
           headers: {

--- a/website/src/components/feedback/index.js
+++ b/website/src/components/feedback/index.js
@@ -83,37 +83,30 @@ export const Feedback = () => {
 
     setSubmissionStatus("loading");
 
-    console.log('submitting feedback')
-    console.log(JSON.stringify({
-      is_positive: selectedFeedback,
-      message: textFeedback.trim(),
-      page_url: window.location.href,
-    }))
-
     try {
       // "https://www.getdbt.com/api/submit-feedback",
       // "https://docs-getdbt-com-git-feedback-input-dbt-labs.vercel.app/api/submit-feedback"
-      // const response = await fetch(
-      //   "http://localhost:3000/api/submit-feedback",
-      //   {
-      //     method: "POST",
-      //     headers: {
-      //       "Content-Type": "application/json",
-      //     },
-      //     body: JSON.stringify({
-      //       is_positive: selectedFeedback,
-      //       message: textFeedback.trim(),
-      //       page_url: window.location.href,
-      //     }),
-      //   }
-      // );
+      const response = await fetch(
+        "http://localhost:3000/api/submit-feedback",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            is_positive: selectedFeedback,
+            message: textFeedback.trim(),
+            page_url: window.location.href,
+          }),
+        }
+      );
 
-      // const data = await response.json();
+      const data = await response.json();
 
-      // // If error, set submission status to error and throw error
-      // if (data?.error) {
-      //   throw new Error(data?.error);
-      // }
+      // If error, set submission status to error and throw error
+      if (data?.error) {
+        throw new Error(data?.error);
+      }
 
       // If success, set submission status to success and save to localStorage
       setSubmissionStatus("success");
@@ -145,8 +138,6 @@ export const Feedback = () => {
     } catch (error) {
       setSubmissionStatus("error");
     }
-
-    console.log('submissionStatus', submissionStatus);
   };
 
   return (

--- a/website/src/components/feedback/index.js
+++ b/website/src/components/feedback/index.js
@@ -68,11 +68,9 @@ export const Feedback = () => {
         }
       );
 
-      // TODO: Change to production URL
-      // "https://www.getdbt.com/api/submit-feedback",
-      // "http://localhost:3000/api/submit-feedback",
+      // Submit feedback to db
       const response = await fetch(
-        "https://www-getdbt-com-git-feedback-input-dbt-labs.vercel.app/api/submit-feedback",
+        "https://www.getdbt.com/api/submit-feedback",
         {
           method: "POST",
           headers: {

--- a/website/src/components/feedback/index.js
+++ b/website/src/components/feedback/index.js
@@ -116,7 +116,7 @@ export const Feedback = () => {
       // }
 
       // If success, set submission status to success and save to localStorage
-      setSubmissionStatus("error");
+      setSubmissionStatus("success");
       setHasSubmitted(true);
 
       // Save to localStorage array only on success
@@ -195,7 +195,6 @@ export const Feedback = () => {
                 <button
                   type="submit"
                   className={styles.feedbackSubmitButton}
-                  disabled={submissionStatus === "loading"}
                 >
                   Submit Feedback
                 </button>

--- a/website/src/components/feedback/index.js
+++ b/website/src/components/feedback/index.js
@@ -104,7 +104,7 @@ export const Feedback = () => {
 
   return (
     <div className={styles.feedbackContainer}>
-      <h2 className={styles.feedbackHeader}>Was this page helpful?</h2>
+      <h2 id="feedback-header" className={styles.feedbackHeader}>Was this page helpful?</h2>
       <form onSubmit={handleFormSubmit} className={styles.feedbackActions}>
         <div className={styles.feedbackButtons}>
           <button

--- a/website/src/components/feedback/index.js
+++ b/website/src/components/feedback/index.js
@@ -54,7 +54,7 @@ export const Feedback = () => {
       
       if (existingFeedback) {
         setSelectedFeedback(existingFeedback.is_positive);
-        setTextFeedback(existingFeedback.text_feedback || "");
+        setTextFeedback(existingFeedback.message || "");
         setHasSubmitted(true);
       }
     }
@@ -83,8 +83,10 @@ export const Feedback = () => {
     setSubmissionStatus("loading");
 
     try {
+      // "https://www.getdbt.com/api/submit-feedback",
+      // "https://docs-getdbt-com-git-feedback-input-dbt-labs.vercel.app/api/submit-feedback"
       const response = await fetch(
-        "https://www.getdbt.com/api/submit-feedback",
+        "http://localhost:3000/api/submit-feedback",
         {
           method: "POST",
           headers: {
@@ -92,7 +94,7 @@ export const Feedback = () => {
           },
           body: JSON.stringify({
             is_positive: selectedFeedback,
-            text_feedback: textFeedback.trim(),
+            message: textFeedback.trim(),
             page_url: window.location.href,
           }),
         }
@@ -108,13 +110,15 @@ export const Feedback = () => {
       // Save to localStorage array
       const currentUrl = window.location.href;
       const feedbackArray = getFeedbackData();
-      const existingFeedbackIndex = feedbackArray.findIndex(item => item.page_url === currentUrl);
-      
+      const existingFeedbackIndex = feedbackArray.findIndex(
+        (item) => item.page_url === currentUrl
+      );
+
       const newFeedbackItem = {
         is_positive: selectedFeedback,
-        text_feedback: textFeedback.trim(),
+        message: textFeedback.trim(),
         timestamp: Date.now(),
-        page_url: currentUrl
+        page_url: currentUrl,
       };
 
       if (existingFeedbackIndex >= 0) {
@@ -159,21 +163,25 @@ export const Feedback = () => {
             No
           </button>
         </div>
-        <div className={styles.feedbackInput}>
-          <textarea 
-            placeholder="Tell us what you think..." 
-            value={textFeedback}
-            onChange={(e) => setTextFeedback(e.target.value)}
-            disabled={hasSubmitted}
-          />
-        </div>
-        <button 
-          type="submit" 
-          className={styles.feedbackSubmitButton}
-          disabled={hasSubmitted || selectedFeedback === null || submissionStatus === "loading"}
-        >
-          {submissionStatus === "loading" ? "Submitting..." : "Submit Feedback"}
-        </button>
+        {selectedFeedback !== null && (
+          <>
+            <div className={styles.feedbackInput}>
+              <textarea 
+                placeholder="Tell us what you think..." 
+                value={textFeedback}
+                onChange={(e) => setTextFeedback(e.target.value)}
+                disabled={hasSubmitted}
+              />
+            </div>
+            <button 
+              type="submit" 
+              className={styles.feedbackSubmitButton}
+              disabled={hasSubmitted || submissionStatus === "loading"}
+            >
+              {submissionStatus === "loading" ? "Submitting..." : "Submit Feedback"}
+            </button>
+          </>
+        )}
       </form>
       {submissionStatus && (
         <div>

--- a/website/src/components/feedback/index.js
+++ b/website/src/components/feedback/index.js
@@ -18,12 +18,12 @@ export const Feedback = () => {
   const [loadedFromStorage, setLoadedFromStorage] = useState(false);
   const [validationError, setValidationError] = useState("");
 
-  const FEEDBACK_STORAGE_KEY = 'page_feedback_data';
+  const FEEDBACK_STORAGE_KEY = "page_feedback_data";
 
   // Get all feedback data from localStorage
   const getFeedbackData = () => {
-    if (typeof window === 'undefined') return [];
-    
+    if (typeof window === "undefined") return [];
+
     try {
       const data = localStorage.getItem(FEEDBACK_STORAGE_KEY);
       return data ? JSON.parse(data) : [];
@@ -34,8 +34,8 @@ export const Feedback = () => {
 
   // Save feedback data to localStorage
   const saveFeedbackData = (feedbackArray) => {
-    if (typeof window === 'undefined') return;
-    
+    if (typeof window === "undefined") return;
+
     try {
       localStorage.setItem(FEEDBACK_STORAGE_KEY, JSON.stringify(feedbackArray));
     } catch (error) {
@@ -45,16 +45,19 @@ export const Feedback = () => {
 
   // Find existing feedback for current page
   const findPageFeedback = (feedbackArray, pageUrl) => {
-    return feedbackArray.find(item => item.page_url === pageUrl);
+    return feedbackArray.find((item) => item.page_url === pageUrl);
   };
 
   // Load feedback state from localStorage on component mount
   useEffect(() => {
-    if (typeof window !== 'undefined') {
+    if (typeof window !== "undefined") {
       const currentUrl = window.location.href;
       const feedbackArray = getFeedbackData();
       const existingFeedback = findPageFeedback(feedbackArray, currentUrl);
-      
+
+      // TODO: Delete before merge
+      console.log("existingFeedback", existingFeedback);
+
       if (existingFeedback) {
         setSelectedFeedback(existingFeedback.is_positive);
         setHasSubmitted(true);
@@ -73,7 +76,7 @@ export const Feedback = () => {
   const handleTextChange = (e) => {
     const newText = e.target.value;
     setTextFeedback(newText);
-    
+
     // Validate input on change
     if (newText.trim()) {
       validateTextInput(newText, setValidationError);
@@ -84,7 +87,7 @@ export const Feedback = () => {
 
   const handleFormSubmit = async (e) => {
     e.preventDefault();
-    
+
     // Prevent resubmission if already submitted
     if (hasSubmitted) {
       return;
@@ -96,7 +99,10 @@ export const Feedback = () => {
     }
 
     // Validate text input before submission
-    if (textFeedback.trim() && !validateTextInput(textFeedback, setValidationError)) {
+    if (
+      textFeedback.trim() &&
+      !validateTextInput(textFeedback, setValidationError)
+    ) {
       return;
     }
 
@@ -109,13 +115,22 @@ export const Feedback = () => {
         {
           action: "feedback_submission",
         }
-      )
-      
+      );
+
+      // TODO: Delete before merge
+      console.log("hitting submit feedback api");
+      console.log("payload", {
+        is_positive: selectedFeedback,
+        message: textFeedback.trim(),
+        page_url: window.location.href,
+        recaptcha_token: token,
+      });
+
       // TODO: Change to production URL
       // "https://www.getdbt.com/api/submit-feedback",
       // "http://localhost:3000/api/submit-feedback",
       const response = await fetch(
-        "https://docs-getdbt-com-git-feedback-input-dbt-labs.vercel.app/api/submit-feedback",
+        "https://www-getdbt-com-git-feedback-input-dbt-labs.vercel.app/api/submit-feedback",
         {
           method: "POST",
           headers: {
@@ -130,7 +145,13 @@ export const Feedback = () => {
         }
       );
 
+      // TODO: Delete before merge
+      console.log("api response", response);
+
       const data = await response.json();
+
+      // TODO: Delete before merge
+      console.log("data", data);
 
       // If error, set submission status to error and throw error
       if (data?.error) {
@@ -155,6 +176,9 @@ export const Feedback = () => {
         page_url: currentUrl,
       };
 
+      // TODO: Delete before merge
+      console.log("newFeedbackItem", newFeedbackItem);
+
       if (existingFeedbackIndex >= 0) {
         // Update existing feedback
         feedbackArray[existingFeedbackIndex] = newFeedbackItem;
@@ -165,6 +189,8 @@ export const Feedback = () => {
 
       saveFeedbackData(feedbackArray);
     } catch (error) {
+      // TODO: Delete before merge
+      console.log("error submitting feedback", error);
       setSubmissionStatus("error");
     }
   };
@@ -204,33 +230,35 @@ export const Feedback = () => {
                 maxLength={2000}
               />
             </div>
-              {submissionStatus === "loading" ? (
-                <span className={styles.feedbackMessage}>
-                  Submitting feedback...
-                </span>
-              ) : submissionStatus === "success" ? (
-                <span className={styles.feedbackMessage}>
-                  Thank you for your feedback!
-                </span>
-              ) : (
-                <button
-                  type="submit"
-                  className={styles.feedbackSubmitButton}
-                  disabled={!!validationError}
-                >
-                  Submit Feedback
-                </button>
-              )}
-              {validationError && (
-                <span className={`${styles.feedbackMessage} ${styles.validationError}`}>
-                  {validationError}
-                </span>
-              )}
-              {submissionStatus === "error" && (
-                <span className={styles.feedbackMessage}>
-                  Error submitting feedback. Please try again.
-                </span>
-              )}
+            {submissionStatus === "loading" ? (
+              <span className={styles.feedbackMessage}>
+                Submitting feedback...
+              </span>
+            ) : submissionStatus === "success" ? (
+              <span className={styles.feedbackMessage}>
+                Thank you for your feedback!
+              </span>
+            ) : (
+              <button
+                type="submit"
+                className={styles.feedbackSubmitButton}
+                disabled={!!validationError}
+              >
+                Submit Feedback
+              </button>
+            )}
+            {validationError && (
+              <span
+                className={`${styles.feedbackMessage} ${styles.validationError}`}
+              >
+                {validationError}
+              </span>
+            )}
+            {submissionStatus === "error" && (
+              <span className={styles.feedbackMessage}>
+                Error submitting feedback. Please try again.
+              </span>
+            )}
           </>
         )}
       </form>

--- a/website/src/components/feedback/index.js
+++ b/website/src/components/feedback/index.js
@@ -262,21 +262,28 @@ export const Feedback = () => {
           </>
         )}
       </form>
-      <div className={styles.feedbackLinks}>
-        <Link
-          href="https://www.getdbt.com/cloud/privacy-policy"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Privacy policy
-        </Link>
-        <Link
-          href="https://github.com/dbt-labs/docs.getdbt.com/issues"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Create a GitHub issue
-        </Link>
+      <div>
+        <div className={styles.feedbackLinks}>
+          <Link
+            href="https://www.getdbt.com/cloud/privacy-policy"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Privacy policy
+          </Link>
+          <Link
+            href="https://github.com/dbt-labs/docs.getdbt.com/issues"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Create a GitHub issue
+          </Link>
+        </div>
+        <div className={styles.feedbackDisclaimer}>
+          <p>
+              This site is protected by reCAPTCHA and the Google <a href="https://policies.google.com/privacy">Privacy Policy</a> and <a href="https://policies.google.com/terms">Terms of Service</a> apply.
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/website/src/components/feedback/styles.module.css
+++ b/website/src/components/feedback/styles.module.css
@@ -57,7 +57,7 @@
 /* Submit Button */
 .feedbackContainer .feedbackSubmitButton {
   background: var(--ifm-color-primary);
-  transition: all 0.3s ease-in-out;
+  transition: background-color 0.3s ease, border-color 0.3s ease, color 0.3s ease;
   color: var(--color-neutral-primary);
   border: none;
   border-radius: .75rem;

--- a/website/src/components/feedback/styles.module.css
+++ b/website/src/components/feedback/styles.module.css
@@ -1,3 +1,4 @@
+/* Feedback Container */
 .feedbackContainer {
   margin-top: 4rem;
   display: flex;
@@ -9,6 +10,7 @@
   margin-bottom: 0;
 }
 
+/* Button Styles */
 .feedbackContainer .feedbackButtons {
   display: flex;
   gap: .75rem;
@@ -19,7 +21,7 @@
   background-color: transparent;
   color: var(--ifm-heading-color);
   border: 1px solid var(--color-neutral-primary);
-  transition: all 0.3s ease;
+  transition: background-color 0.3s ease, border-color 0.3s ease, color 0.3s ease;
   border-radius: .75rem;
   padding: 0.5rem 1rem;
   font-size: 1rem;
@@ -36,6 +38,11 @@
   cursor: pointer;
 }
 
+.feedbackContainer .feedbackButton:focus {
+  outline: 2px solid var(--color-coalesce-purple-600);
+  outline-offset: 2px;
+}
+
 .feedbackContainer .feedbackButtonSelected {
   background-color: var(--color-neutral-secondary);
   border-color: var(--color-neutral-secondary);
@@ -47,19 +54,44 @@
   cursor: not-allowed;
 }
 
-.feedbackContainer .feedbackButtons .feedbackMessage {
+/* Feedback Input */
+.feedbackContainer .feedbackInput {
+  margin-top: 1rem;
+  width: 100%;
+  max-width: 360px;
+}
+
+.feedbackContainer .feedbackInput textarea {
+  width: 100%;
+  padding: 0.75rem 1.5rem;
+  border: 1px solid var(--color-terminal-black-300);
+  border-radius: 0.75rem;
+  font-size: 0.875rem;
+  color: var(--color-terminal-black-500);
+  background-color: rgba(0, 0, 0, 0);
+}
+
+.feedbackContainer .feedbackInput textarea:focus {
+  outline: 2px solid var(--color-coalesce-purple-600);
+outline-offset: 2px;      
+}
+
+/* Submission Status */
+.feedbackContainer .feedbackMessage {
   margin-bottom: 0;
   font-size: 0.9rem;
   position: absolute;
   bottom: -1.6rem;
 }
 
+/* Additional Links */
 .feedbackContainer .feedbackLinks {
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
 }
 
+/* Dark Mode */
 html[data-theme="dark"] {
   .feedbackContainer .feedbackButton {
    background-color: var(--color-neutral-primary);

--- a/website/src/components/feedback/styles.module.css
+++ b/website/src/components/feedback/styles.module.css
@@ -10,6 +10,11 @@
   margin-bottom: 0;
 }
 
+/* Form Styles */
+.feedbackContainer .feedbackActions {
+  position: relative;
+}
+
 /* Button Styles */
 .feedbackContainer .feedbackButtons {
   display: flex;
@@ -117,10 +122,9 @@ outline-offset: 2px;
 
 /* Submission Status */
 .feedbackContainer .feedbackMessage {
-  margin-bottom: 0;
   font-size: 0.9rem;
-  position: absolute;
-  bottom: -1.6rem;
+  display: block;
+  margin: 1rem 0 0;
 }
 
 /* Additional Links */

--- a/website/src/components/feedback/styles.module.css
+++ b/website/src/components/feedback/styles.module.css
@@ -125,6 +125,8 @@ outline-offset: 2px;
   font-size: 0.9rem;
   display: block;
   margin: 1rem 0 0;
+  min-height: 33.5px;
+  
 }
 
 /* Additional Links */

--- a/website/src/components/feedback/styles.module.css
+++ b/website/src/components/feedback/styles.module.css
@@ -129,6 +129,11 @@ outline-offset: 2px;
   
 }
 
+.feedbackContainer .validationError {
+  color: var(--ifm-color-danger);
+  margin-top: 0.5rem;
+}
+
 /* Additional Links */
 .feedbackContainer .feedbackLinks {
   display: flex;

--- a/website/src/components/feedback/styles.module.css
+++ b/website/src/components/feedback/styles.module.css
@@ -141,6 +141,13 @@ outline-offset: 2px;
   gap: 1rem;
 }
 
+/* Disclaimer */
+.feedbackContainer .feedbackDisclaimer {
+  font-size: 0.8em;
+  margin-top: 1rem;
+  max-width: 360px;
+}
+
 /* Dark Mode */
 html[data-theme="dark"] {
   .feedbackContainer .feedbackButton {

--- a/website/src/components/feedback/styles.module.css
+++ b/website/src/components/feedback/styles.module.css
@@ -54,6 +54,45 @@
   cursor: not-allowed;
 }
 
+/* Submit Button */
+.feedbackContainer .feedbackSubmitButton {
+  background: var(--ifm-color-primary);
+  transition: all 0.3s ease-in-out;
+  color: var(--color-neutral-primary);
+  border: none;
+  border-radius: .75rem;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  margin-top: 1rem;
+  cursor: pointer;
+}
+
+.feedbackContainer .feedbackSubmitButton:hover:not(:disabled) {
+  background-color: var(--ifm-color-primary) !important;
+  background-image: linear-gradient(oklab(0.865972 0.00164044 0.169914 / 0.5) 0%, rgba(0, 0, 0, 0) 50%) !important;
+}
+
+.feedbackContainer .feedbackSubmitButton:focus {
+  outline: 2px solid var(--color-coalesce-purple-600);
+  outline-offset: 2px;
+}
+
+.feedbackContainer .feedbackSubmitButton:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+html[data-theme="dark"] .feedbackContainer .feedbackSubmitButton {
+  color: var(--color-neutral-primary);
+}
+
+html[data-theme="dark"] .feedbackContainer .feedbackSubmitButton:hover:not(:disabled) {
+  color: var(--color-neutral-primary) !important;
+  background-color: var(--ifm-color-primary) !important;
+  background-image: linear-gradient(oklab(0.865972 0.00164044 0.169914 / 0.5) 0%, rgba(0, 0, 0, 0) 50%) !important;
+}
+
 /* Feedback Input */
 .feedbackContainer .feedbackInput {
   margin-top: 1rem;
@@ -110,4 +149,9 @@ html[data-theme="dark"] {
    border-color: var(--color-white);
    color: var(--color-neutral-primary);
  }
+
+ .feedbackContainer .feedbackInput textarea {
+  border: 1px solid var(--color-white);
+  color: var(--color-white);
+}
 }

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -2915,3 +2915,8 @@ iframe#q-messenger-frame:not(.qlfd-maximized) {
   background-color: var(--bg-neutral-primary-hover);
   color: var(--text-neutral-primary);
 }
+
+/* Hide reCaptcha badge */
+.grecaptcha-badge {
+  display: none;
+}

--- a/website/src/utils/validate-text-input.js
+++ b/website/src/utils/validate-text-input.js
@@ -1,0 +1,63 @@
+/**
+ * Validates the input text for the textarea input.
+ * @param {string} text - The text to validate.
+ * @param {function} setValidationError - The function to set the validation error.
+ * @returns {boolean} - True if the text is valid, false otherwise.
+ */
+export const validateTextInput = (text, setValidationError) => {
+  // Reset validation error
+  setValidationError("");
+
+  // Check length limits
+  if (text.length > 2000) {
+    setValidationError("Feedback must be less than 2000 characters");
+    return false;
+  }
+
+  // Check for potential XSS patterns
+  const xssPatterns = [
+    /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,
+    /javascript:/gi,
+    /on\w+\s*=/gi,
+    /<iframe\b[^>]*>/gi,
+    /<object\b[^>]*>/gi,
+    /<embed\b[^>]*>/gi,
+    /<link\b[^>]*>/gi,
+    /<meta\b[^>]*>/gi,
+  ];
+
+  for (const pattern of xssPatterns) {
+    if (pattern.test(text)) {
+      setValidationError(
+        "Invalid characters detected. Please remove HTML tags or scripts"
+      );
+      return false;
+    }
+  }
+
+  // Check for SQL injection patterns
+  const sqlPatterns = [
+    /(\b(union|select|insert|update|delete|drop|create|alter|exec|execute)\b)/gi,
+    /(--|\/\*|\*\/)/g,
+    /('|(\\')|('')|(%27)|(%2527))/gi,
+  ];
+
+  for (const pattern of sqlPatterns) {
+    if (pattern.test(text)) {
+      setValidationError(
+        "Invalid characters detected. Please use plain text only"
+      );
+      return false;
+    }
+  }
+
+  // Check for excessive special characters (potential obfuscation)
+  const specialCharRatio =
+    (text.match(/[^a-zA-Z0-9\s.,!?()-]/g) || []).length / text.length;
+  if (specialCharRatio > 0.3 && text.length > 10) {
+    setValidationError("Too many special characters. Please use plain text");
+    return false;
+  }
+
+  return true;
+};

--- a/website/src/utils/validate-text-input.js
+++ b/website/src/utils/validate-text-input.js
@@ -16,7 +16,8 @@ export const validateTextInput = (text, setValidationError) => {
 
   // Check for potential XSS patterns
   const xssPatterns = [
-    /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,
+    /<script\b[^>]*>/gi, // matches <script ...>
+    /<\/script\b[^>]*>/gi, // matches </script ...>
     /javascript:/gi,
     /on\w+\s*=/gi,
     /<iframe\b[^>]*>/gi,


### PR DESCRIPTION
## What are you changing in this pull request and why?

[Notion task](https://www.notion.so/dbtlabs/Setup-text-field-for-Docs-feedback-widget-263bb38ebda7813c9ef7e9cedbac492b?source=copy_link)
[WWW PR](https://github.com/dbt-labs/www.getdbt.com-replatforming/pull/563)

- Adds text field to feedback widget
- Converts feedback widget to a form
- Adds Google reCaptcha
- Adds client-side validation util

## Preview

1. Open WWW [endpoint logs](https://github.com/dbt-labs/www.getdbt.com-replatforming/pull/563)
2. Submit feedback on a docs page
3. Verify the submission goes through successfully via the logs (or in Supabase if you have access)
4. Verify the success/error message shows, and text field and submit button hide after submission
5. Refresh the page and verify you can submit additional feedback

_I have this connected to a test database. It is safe to submit feedback without affecting the prod data._ 

https://docs-getdbt-com-git-feedback-input-dbt-labs.vercel.app/docs/introduction

## ⚠️ TODO Before Merge
- [x] Revert to production api endpoint URL