### PR TITLE
docs: consolidate-duplicate-config-key

### DIFF
--- a/website/docs/reference/exposure-properties.md
+++ b/website/docs/reference/exposure-properties.md
@@ -32,9 +32,10 @@ exposures:
     url: <string>
     maturity: {high, medium, low}  # Indicates level of confidence or stability in the exposure
     [enabled](/reference/resource-configs/enabled): true | false
-    config: # 'tags' and 'meta' changed to config in v1.10
+    [config](/reference/resource-properties/config): # 'tags' and 'meta' changed to config in v1.10
       [tags](/reference/resource-configs/tags): [<string>] 
-      [meta](/reference/resource-configs/meta): {<dictionary>} 
+      [meta](/reference/resource-configs/meta): {<dictionary>}
+      enabled: true | false
     owner: # supports 'name' and 'email' only
       name: <string>
       email: <string>
@@ -46,8 +47,6 @@ exposures:
       - metric('metric_name')
       
     label: "Human-Friendly Name for this Exposure!"
-    [config](/reference/resource-properties/config):
-      enabled: true | false
 
   - name: ... # declare properties of additional exposures
 ```


### PR DESCRIPTION
## What are you changing in this pull request and why?

There's a duplicate `config` key in this exposure example, so I'm just moving `config.enabled` from the second (duplicate) `config` block to the first `config` block and removing the duplicate.

[This is the `exposure.yml` file](https://docs.getdbt.com/reference/exposure-properties#overview:~:text=config%3A%20%23%20%27tags,true%20%7C%20false) that includes the duplicate config blocks I'm referring to.

## Checklist
- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).