### PR TITLE
Fix indentation in data-test-configs.md

### DIFF
--- a/website/docs/reference/data-test-configs.md
+++ b/website/docs/reference/data-test-configs.md
@@ -239,8 +239,8 @@ models:
       - name: id
         data_tests:
           - unique:
-            config:
-              tags: ['my_tag'] # changed to config in v1.10
+              config:
+                tags: ['my_tag'] # changed to config in v1.10
 ```
 
 </File>


### PR DESCRIPTION
Correct indentation for one of the test tag examples

## What are you changing in this pull request and why?
Fixing the indentation for the test config in one of the examples

## Checklist
- [X] Needs technical review
- [ ] Change base branch
- [ ] Merge on xyz date

- [X] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-bugfix-test-config-indentation-dbt-labs.vercel.app/reference/data-test-configs

<!-- end-vercel-deployment-preview -->