### PR TITLE
Adjust EOP cta

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -232,7 +232,7 @@ var siteSettings = {
               </div>
               <div class="cta-section">
                 <a href="https://marketplace.visualstudio.com/items?itemName=dbtLabsInc.dbt" target="_blank" class="primary-cta">Install free extension</a>
-                <a href="https://www.getdbt.com/signup" target="_blank" class="secondary-cta">Request your demo</a>
+                <a href="https://www.getdbt.com/contact" target="_blank" class="secondary-cta">Request your demo</a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## What are you changing in this pull request and why?
- Fixing the End of Page CTA: CTA on "Request your demo" is linking to `/signup`, but should be `/contact`