### PR TITLE
Fix trailing comma in MCP config

### DIFF
--- a/website/docs/docs/dbt-ai/setup-local-mcp.md
+++ b/website/docs/docs/dbt-ai/setup-local-mcp.md
@@ -101,7 +101,7 @@ id: "setup-local-mcp"
             "<path-to-.env-file>",
             "dbt-mcp"
           ]
-        },
+        }
       }
     }
     ```

--- a/website/docs/docs/dbt-ai/setup-local-mcp.md
+++ b/website/docs/docs/dbt-ai/setup-local-mcp.md
@@ -97,7 +97,7 @@ id: "setup-local-mcp"
         "dbt-mcp": {
           "command": "uvx",
           "args": [
-          "--env-file",
+            "--env-file",
             "<path-to-.env-file>",
             "dbt-mcp"
           ]


### PR DESCRIPTION
## What are you changing in this pull request and why?

JSON shouldn't have trailing commas.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-devonfulcher-patch-1-dbt-labs.vercel.app/docs/dbt-ai/setup-local-mcp

<!-- end-vercel-deployment-preview -->