### PR TITLE
clarify code extension bullets

### DIFF
--- a/website/docs/docs/about-dbt-extension.md
+++ b/website/docs/docs/about-dbt-extension.md
@@ -9,7 +9,7 @@ pagination_next: "docs/install-dbt-extension"
 # About the dbt VS Code Extension <Lifecycle status="preview" />
 
 The dbt VS Code extension brings a hyper-fast, intelligent, and cost-efficient dbt development experience to VS Code.
-This is the only way to enjoy all the power of the <Constant name="fusion_engine" /> while developing locally. 
+This is the only way to enjoy all the power of the <Constant name="fusion_engine" /> while developing locally.
 
 - _Save time and resources_ with near-instant parsing, live error detection, powerful IntelliSense capabilities, and more.
 - _Stay in flow_ with a seamless, end-to-end dbt development experience designed from scratch for local dbt development.

--- a/website/docs/docs/about-dbt-extension.md
+++ b/website/docs/docs/about-dbt-extension.md
@@ -8,14 +8,13 @@ pagination_next: "docs/install-dbt-extension"
 
 # About the dbt VS Code Extension <Lifecycle status="preview" />
 
-The dbt extension brings a hyper-fast, intelligent, and cost-efficient dbt development experience to VS Code.
-This is the only way to enjoy all the power of the new dbt Fusion engine while developing locally.
+The VS Code extension brings a hyper-fast, intelligent, and cost-efficient dbt development experience to VS Code.
+This is the only way to enjoy all the power of the dbt Fusion engine while developing locally. 
 
-_Save time and resources_ with near-instant parsing, live error detection, powerful IntelliSense capabilities, and more.
+- _Save time and resources_ with near-instant parsing, live error detection, powerful IntelliSense capabilities, and more.
+- _Stay in flow_ with a seamless, end-to-end dbt development experience designed from scratch for local dbt development.
 
-_Stay in flow_ with a seamless, end-to-end dbt development experience designed from scratch for local dbt development.
-
-_This is a public beta release. Behavior may change ahead of the broader generally available (GA) release._
+The VS Code extension is available in the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=dbtLabsInc.dbt). _Note, this is a public preview release. Behavior may change ahead of the broader generally available (GA) release._
 
 ## Productivity features
 

--- a/website/docs/docs/about-dbt-extension.md
+++ b/website/docs/docs/about-dbt-extension.md
@@ -9,7 +9,7 @@ pagination_next: "docs/install-dbt-extension"
 # About the dbt VS Code Extension <Lifecycle status="preview" />
 
 The VS Code extension brings a hyper-fast, intelligent, and cost-efficient dbt development experience to VS Code.
-This is the only way to enjoy all the power of the dbt Fusion engine while developing locally. 
+This is the only way to enjoy all the power of the <Constant name="fusion_engine" /> while developing locally. 
 
 - _Save time and resources_ with near-instant parsing, live error detection, powerful IntelliSense capabilities, and more.
 - _Stay in flow_ with a seamless, end-to-end dbt development experience designed from scratch for local dbt development.

--- a/website/docs/docs/about-dbt-extension.md
+++ b/website/docs/docs/about-dbt-extension.md
@@ -14,7 +14,7 @@ This is the only way to enjoy all the power of the <Constant name="fusion_engine
 - _Save time and resources_ with near-instant parsing, live error detection, powerful IntelliSense capabilities, and more.
 - _Stay in flow_ with a seamless, end-to-end dbt development experience designed from scratch for local dbt development.
 
-The VS Code extension is available in the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=dbtLabsInc.dbt). _Note, this is a public preview release. Behavior may change ahead of the broader generally available (GA) release._
+The dbt VS Code extension is available in the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=dbtLabsInc.dbt). _Note, this is a public preview release. Behavior may change ahead of the broader generally available (GA) release._
 
 ## Productivity features
 

--- a/website/docs/docs/about-dbt-extension.md
+++ b/website/docs/docs/about-dbt-extension.md
@@ -8,7 +8,7 @@ pagination_next: "docs/install-dbt-extension"
 
 # About the dbt VS Code Extension <Lifecycle status="preview" />
 
-The VS Code extension brings a hyper-fast, intelligent, and cost-efficient dbt development experience to VS Code.
+The dbt VS Code extension brings a hyper-fast, intelligent, and cost-efficient dbt development experience to VS Code.
 This is the only way to enjoy all the power of the <Constant name="fusion_engine" /> while developing locally. 
 
 - _Save time and resources_ with near-instant parsing, live error detection, powerful IntelliSense capabilities, and more.

--- a/website/snippets/_install-dbt-extension.md
+++ b/website/snippets/_install-dbt-extension.md
@@ -5,7 +5,7 @@ The [dbt extension](https://marketplace.visualstudio.com/items?itemName=dbtLabsI
 
 To use the extension, you must meet the following prerequisites:
 
-- <Constant name="fusion_engine" /> &mdash; The [dbt extension](https://marketplace.visualstudio.com/items?itemName=dbtLabsInc.dbt&ssr=false#overview) requires the <Constant name="fusion_engine" />. Installing the extension automatically installs the <Constant name="fusion_engine" />. You can also [manually install](/docs/fusion/install-fusion) it at any time, before or after installing the extension.
+- <Constant name="fusion_engine" /> &mdash; The [dbt extension](https://marketplace.visualstudio.com/items?itemName=dbtLabsInc.dbt&ssr=false#overview) requires the <Constant name="fusion_engine" />. Installing the extension prompts for installation of the <Constant name="fusion_engine" />. You can also [manually install](/docs/fusion/install-fusion) it at any time, before or after installing the extension.
 - Editor &mdash; You're using the [VS Code](https://code.visualstudio.com/) or [Cursor](https://www.cursor.com/en) code editor.
 - Disabled third-party dbt extensions &mdash; You aren't using (or have disabled) third-party dbt extensions.
 - Operating systems &mdash; You're using a macOS, Windows, or Linux-based computer.

--- a/website/snippets/_install-dbt-extension.md
+++ b/website/snippets/_install-dbt-extension.md
@@ -1,5 +1,5 @@
 
-The [dbt extension](https://marketplace.visualstudio.com/items?itemName=dbtLabsInc.dbt&ssr=false#overview) for VS Code and Cursor streamlines dbt development workflows. The dbt extension is powered by the <Constant name="fusion_engine" />.
+The [dbt extension](https://marketplace.visualstudio.com/items?itemName=dbtLabsInc.dbt&ssr=false#overview) for VS Code and Cursor, powered by the <Constant name="fusion_engine" />, streamlines dbt development workflows. 
 
 ## Prerequisites
 

--- a/website/snippets/_install-dbt-extension.md
+++ b/website/snippets/_install-dbt-extension.md
@@ -1,14 +1,14 @@
 
-The dbt extension for VS Code and Cursor streamlines dbt development workflows. The dbt extension is powered by the <Constant name="fusion_engine" />.
+The [dbt extension](https://marketplace.visualstudio.com/items?itemName=dbtLabsInc.dbt&ssr=false#overview) for VS Code and Cursor streamlines dbt development workflows. The dbt extension is powered by the <Constant name="fusion_engine" />.
 
 ## Prerequisites
 
 To use the extension, you must meet the following prerequisites:
 
-- The dbt extension requires installation of the <Constant name="fusion_engine" />. <Constant name="fusion" /> installation is part of the extension installation process, but you can also [manually install](/docs/fusion/install-fusion) separate from this workflow, either before or after the extension is installed. 
-- You are using the [VS Code](https://code.visualstudio.com/) or [Cursor](https://www.cursor.com/en) code editor.
-- You are not using (or have disabled) third-party dbt extensions.
-- You are using a macOS, Windows, or Linux-based computer.
+- dbt Fusion engine &mdash; The [dbt extension](https://marketplace.visualstudio.com/items?itemName=dbtLabsInc.dbt&ssr=false#overview) requires the <Constant name="fusion_engine" />. Installing the extension automatically installs the <Constant name="fusion_engine" />. You can also [manually install](/docs/fusion/install-fusion) it at any time, before or after installing the extension.
+- Editor &mdash; You're using the [VS Code](https://code.visualstudio.com/) or [Cursor](https://www.cursor.com/en) code editor.
+- Disabled third-party dbt extensions &mdash; You aren't using (or have disabled) third-party dbt extensions.
+- Operating systems &mdash; You're using a macOS, Windows, or Linux-based computer.
 
 ## Installation instructions
 

--- a/website/snippets/_install-dbt-extension.md
+++ b/website/snippets/_install-dbt-extension.md
@@ -7,7 +7,6 @@ To use the extension, you must meet the following prerequisites:
 
 - <Constant name="fusion_engine" /> &mdash; The [dbt extension](https://marketplace.visualstudio.com/items?itemName=dbtLabsInc.dbt&ssr=false#overview) requires the <Constant name="fusion_engine" />. Installing the extension prompts for installation of the <Constant name="fusion_engine" />. You can also [manually install](/docs/fusion/install-fusion) it at any time, before or after installing the extension.
 - Editor &mdash; You're using the [VS Code](https://code.visualstudio.com/) or [Cursor](https://www.cursor.com/en) code editor.
-- Disabled third-party dbt extensions &mdash; You aren't using (or have disabled) third-party dbt extensions.
 - Operating systems &mdash; You're using a macOS, Windows, or Linux-based computer.
 
 ## Installation instructions

--- a/website/snippets/_install-dbt-extension.md
+++ b/website/snippets/_install-dbt-extension.md
@@ -5,7 +5,7 @@ The [dbt extension](https://marketplace.visualstudio.com/items?itemName=dbtLabsI
 
 To use the extension, you must meet the following prerequisites:
 
-- dbt Fusion engine &mdash; The [dbt extension](https://marketplace.visualstudio.com/items?itemName=dbtLabsInc.dbt&ssr=false#overview) requires the <Constant name="fusion_engine" />. Installing the extension automatically installs the <Constant name="fusion_engine" />. You can also [manually install](/docs/fusion/install-fusion) it at any time, before or after installing the extension.
+- <Constant name="fusion_engine" /> &mdash; The [dbt extension](https://marketplace.visualstudio.com/items?itemName=dbtLabsInc.dbt&ssr=false#overview) requires the <Constant name="fusion_engine" />. Installing the extension automatically installs the <Constant name="fusion_engine" />. You can also [manually install](/docs/fusion/install-fusion) it at any time, before or after installing the extension.
 - Editor &mdash; You're using the [VS Code](https://code.visualstudio.com/) or [Cursor](https://www.cursor.com/en) code editor.
 - Disabled third-party dbt extensions &mdash; You aren't using (or have disabled) third-party dbt extensions.
 - Operating systems &mdash; You're using a macOS, Windows, or Linux-based computer.

--- a/website/snippets/_install-dbt-extension.md
+++ b/website/snippets/_install-dbt-extension.md
@@ -7,7 +7,7 @@ To use the extension, you must meet the following prerequisites:
 
 - <Constant name="fusion_engine" /> &mdash; The [dbt extension](https://marketplace.visualstudio.com/items?itemName=dbtLabsInc.dbt&ssr=false#overview) requires the <Constant name="fusion_engine" />. Installing the extension prompts for installation of the <Constant name="fusion_engine" />. You can also [manually install](/docs/fusion/install-fusion) it at any time, before or after installing the extension.
 - Editor &mdash; You're using the [VS Code](https://code.visualstudio.com/) or [Cursor](https://www.cursor.com/en) code editor.
-- Operating systems &mdash; You're using a macOS, Windows, or Linux-based computer.
+- Operating systems &mdash; You're using a macOS, Windows, or Linux-based computer. 
 
 ## Installation instructions
 


### PR DESCRIPTION
this pr:
-  clarifies the vs code extension prerequisites by adding 
- adds links to the vs code marketplace
- adds bullets for easier scanning and so its clear the engine is diff to the extension
- and slightl refactors first bullet of prerequisites

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-add-vs-code-link-dbt-labs.vercel.app/docs/about-dbt-extension

<!-- end-vercel-deployment-preview -->