### PR TITLE
add yaml file location to unit tests

### DIFF
--- a/website/docs/reference/resource-properties/data-formats.md
+++ b/website/docs/reference/resource-properties/data-formats.md
@@ -15,6 +15,8 @@ The `dict` data format is the default if no `format` is defined.
 
 `dict` requires an inline dictionary for `rows`:
 
+<File name='models/schema.yml'>
+
 ```yml
 
 unit_tests:
@@ -29,9 +31,13 @@ unit_tests:
 
 ```
 
+</File>
+
 ## CSV
 
 When using the `csv` format, you can use either an inline CSV string for `rows`:
+
+<File name='models/schema.yml'>
 
 ```yml
 
@@ -47,8 +53,12 @@ unit_tests:
           2,michelle
 
 ```
+</File>
+
 
 Or, you can provide the name of a CSV file in the `tests/fixtures` directory (or the configured `test-paths` location) of your project for `fixture`: 
+
+<File name='models/schema.yml'>
 
 ```yml
 
@@ -61,6 +71,7 @@ unit_tests:
         fixture: my_model_a_fixture
 
 ```
+</File>
 
 ## sql
 
@@ -71,6 +82,8 @@ Using this format:
 However, when using `format: sql` you must supply mock data for _all rows_.
 
 When using the `sql` format, you can use either an inline SQL query for `rows`:
+
+<File name='models/schema.yml'>
 
 ```yml
 
@@ -86,7 +99,11 @@ unit_tests:
 
 ```
 
+</File>
+
 Or, you can provide the name of a SQL file in the `tests/fixtures` directory (or the configured `test-paths` location) of your project for `fixture`: 
+
+<File name='models/schema.yml'>
 
 ```yml
 
@@ -99,5 +116,6 @@ unit_tests:
         fixture: my_model_a_fixture
 
 ```
+</File>
 
 **Note:** Jinja is unsupported in SQL fixtures for unit tests.

--- a/website/docs/reference/resource-properties/unit-test-input.md
+++ b/website/docs/reference/resource-properties/unit-test-input.md
@@ -13,8 +13,8 @@ Use inputs in your unit tests to reference a specific model or source for the te
     - If you do supply an input for a seed, we will use that input instead.
 - Use “empty” inputs by setting rows to an empty list `rows: []`
 
+<File name='models/schema.yml'>
 ```yml
-
 unit_tests:
   - name: test_is_valid_email_address # this is the unique name of the test
     model: dim_customers # name of the model I'm unit testing
@@ -32,3 +32,4 @@ unit_tests:
 ...
 
 ```
+</File>

--- a/website/docs/reference/resource-properties/unit-test-overrides.md
+++ b/website/docs/reference/resource-properties/unit-test-overrides.md
@@ -5,6 +5,9 @@ sidebar_label: "Overrides"
 
 When configuring your unit test, you can override the output of [macros](/docs/build/jinja-macros#macros), [project variables](/docs/build/project-variables), or [environment variables](/docs/build/environment-variables) for a given unit test. 
 
+
+<File name='models/schema.yml'>
+
 ```yml
 
  - name: test_my_model_overrides
@@ -31,12 +34,16 @@ When configuring your unit test, you can override the output of [macros](/docs/b
 
 ```
 
+</File>
+
 ## Macros
 
 You can override the output of any macro in your unit test defition. 
 
 If the model you're unit testing uses these macros, you must override them:
   - [`is_incremental`](/docs/build/incremental-models#understand-the-is_incremental-macro): If you're unit testing an incremental model, you must explicity set `is_incremental` to `true` or `false`. See more docs on unit testing incremental models [here](/docs/build/unit-tests#unit-testing-incremental-models). 
+
+<File name='models/schema.yml'>
 
   ```yml
 
@@ -50,8 +57,11 @@ If the model you're unit testing uses these macros, you must override them:
       ...
 
   ```
+</File>
 
   - [`dbt_utils.star`](/blog/star-sql-love-letter): If you're unit testing a model that uses the `star` macro, you must explicity set `star` to a list of columns. This is because the `star` only accepts a [relation](/reference/dbt-classes#relation) for the `from` argument; the unit test mock input data is injected directly into the model SQL, replacing the `ref('')` or `source('')` function, causing the `star` macro to fail unless overidden.
+
+<File name='models/schema.yml'>
 
   ```yml
 
@@ -65,3 +75,4 @@ If the model you're unit testing uses these macros, you must override them:
       ...
 
   ``` 
+</File>

--- a/website/docs/reference/resource-properties/unit-testing-versions.md
+++ b/website/docs/reference/resource-properties/unit-testing-versions.md
@@ -5,6 +5,8 @@ sidebar_label: "Versions"
 
 If your model has multiple versions, the default unit test will run on _all_ versions of your model. To specify version(s) of your model to unit test, use `include` or `exclude` for the desired versions in your model versions config:
 
+<File name='models/schema.yml'>
+
 ```yaml
 
 # my test_is_valid_email_address unit test will run on all versions of my_model
@@ -32,3 +34,4 @@ unit_tests:
     ...
 
 ```
+</File>

--- a/website/docs/reference/resource-properties/unit-tests.md
+++ b/website/docs/reference/resource-properties/unit-tests.md
@@ -7,7 +7,6 @@ datatype: test
 
 <VersionCallout version="1.8" />
 
-
 Unit tests validate your SQL modeling logic on a small set of static inputs before you materialize your full model in production. They support a test-driven development approach, improving both the efficiency of developers and reliability of code.
 
 To run only your unit tests, use the command:
@@ -21,7 +20,7 @@ To run only your unit tests, use the command:
 - Unit tests must be defined in a YML file in your `models/` directory.
 - If you want to unit test a model that depends on an ephemeral model, you must use `format: sql` for that input.
 
-<file name='dbt_project.yml'>
+<File name='models/schema.yml'>
 
 ```yml
 
@@ -59,9 +58,11 @@ unit_tests:
 
   ```
 
-</file>
+</File>
 
 ## Examples
+
+<File name='models/schema.yml'>
 
 ```yml
 
@@ -87,6 +88,9 @@ unit_tests:
         - {email: missingdot@gmailcom, is_valid_email_address: false}
 
 ```
+</File>
+
+<File name='models/schema.yml'>
 
 ```yml
 
@@ -111,6 +115,9 @@ unit_tests:
       fixture: valid_email_address_fixture_output
 
 ```
+</File>
+
+<File name='models/schema.yml'>
 
 ```yml
 
@@ -134,3 +141,4 @@ unit_tests:
       fixture: valid_email_address_fixture_output
 
 ```
+</File>


### PR DESCRIPTION
per user feedback collected via the page thumbs up/down, adding file location to code examples for unit tests.

[refer to docs exports](https://docs.google.com/spreadsheets/d/1ZI_Ah9d6Tef5s-bVjmFtYa0rY9czDDFe2t6R6a8KIvI/edit?usp=sharing)

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-add-file-location-dbt-labs.vercel.app/reference/resource-properties/data-formats
- https://docs-getdbt-com-git-add-file-location-dbt-labs.vercel.app/reference/resource-properties/unit-test-input
- https://docs-getdbt-com-git-add-file-location-dbt-labs.vercel.app/reference/resource-properties/unit-test-overrides
- https://docs-getdbt-com-git-add-file-location-dbt-labs.vercel.app/reference/resource-properties/unit-testing-versions
- https://docs-getdbt-com-git-add-file-location-dbt-labs.vercel.app/reference/resource-properties/unit-tests

<!-- end-vercel-deployment-preview -->