### PR TITLE
Update keyboard-shortcuts.md

### DIFF
--- a/website/docs/docs/cloud/dbt-cloud-ide/keyboard-shortcuts.md
+++ b/website/docs/docs/cloud/dbt-cloud-ide/keyboard-shortcuts.md
@@ -20,7 +20,7 @@ Use this <Constant name="cloud_ide" />  page to help you quickly reference some 
 | Open the command palette to invoke dbt commands and actions.  | Command-P / Command-Shift-P | Control-P / Control-Shift-P |
 | Multi-edit in the editor by selecting multiple lines. | Option-Click / Shift-Option-Command / Shift-Option-Click  | Hold Alt and Click |
 | Open the [**Invocation History Drawer**](/docs/cloud/dbt-cloud-ide/ide-user-interface#invocation-history) located at the bottom of the IDE.  | Control-backtick (or Control + `)  | Control-backtick (or Ctrl + `) | 
-| Add a block comment to the selected code. SQL files will use the Jinja syntax `({# #})` rather than the SQL one `(/* */)`.<br /> <br /> Markdown files will use the Markdown syntax `(<!-- -->)`. | Shift-Option-A | Shift-Alt-A |
+| Add a block comment to the selected code. SQL files will use the Jinja syntax `({# #})` rather than the SQL one `(/* */)`. | Shift-Option-A | Shift-Alt-A |
 
 ## Related docs
 

--- a/website/docs/docs/cloud/dbt-cloud-ide/keyboard-shortcuts.md
+++ b/website/docs/docs/cloud/dbt-cloud-ide/keyboard-shortcuts.md
@@ -20,7 +20,7 @@ Use this <Constant name="cloud_ide" />  page to help you quickly reference some 
 | Open the command palette to invoke dbt commands and actions.  | Command-P / Command-Shift-P | Control-P / Control-Shift-P |
 | Multi-edit in the editor by selecting multiple lines. | Option-Click / Shift-Option-Command / Shift-Option-Click  | Hold Alt and Click |
 | Open the [**Invocation History Drawer**](/docs/cloud/dbt-cloud-ide/ide-user-interface#invocation-history) located at the bottom of the IDE.  | Control-backtick (or Control + `)  | Control-backtick (or Ctrl + `) | 
-| Add a block comment to the selected code. SQL files will use the Jinja syntax `({# #})` rather than the SQL one `(/* */)`.<br /> <br /> Markdown files will use the Markdown syntax `(<!-- -->)`. | Command-Option-/ | Control-Alt-/ |
+| Add a block comment to the selected code. SQL files will use the Jinja syntax `({# #})` rather than the SQL one `(/* */)`.<br /> <br /> Markdown files will use the Markdown syntax `(<!-- -->)`. | Shift-Option-A | Shift-Alt-A |
 
 ## Related docs
 


### PR DESCRIPTION
the block comment shortcuts support the standard vs code one. this pr updates the shortcut to that for sql files.

[refer to the internal link](https://dbt-labs.slack.com/archives/C012TTNN0JK/p1759158861666379?thread_ts=1758891339.850579&cid=C012TTNN0JK)

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-mirnawong1-patch-27-dbt-labs.vercel.app/docs/cloud/dbt-cloud-ide/keyboard-shortcuts

<!-- end-vercel-deployment-preview -->