### PR TITLE
remove note about ai account integrations

### DIFF
--- a/website/docs/docs/cloud/account-integrations.md
+++ b/website/docs/docs/cloud/account-integrations.md
@@ -37,9 +37,3 @@ To configure an OAuth account integration:
 4. For custom OAuth providers, under **Custom OAuth integrations**, click on **Add integration** and select the [OAuth provider](/docs/cloud/manage-access/sso-overview) from the list. Fill in the required fields and click **Save**.
 
 <Lightbox src="/img/docs/dbt-cloud/account-integration-oauth.png" width="85%" title="Example of the OAuth integration page" />
-
-:::info
-
-We’ve moved the AI integrations section to [Enable dbt Copilot](/docs/cloud/enable-dbt-copilot#ai-integrations).
-
-:::


### PR DESCRIPTION
this pr removes the note about ai integration page moving as discussed in docs sync

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-mirnawong1-patch-30-dbt-labs.vercel.app/docs/cloud/account-integrations

<!-- end-vercel-deployment-preview -->