### PR TITLE
removes dataframes preview tag

### DIFF
--- a/website/docs/docs/build/python-models.md
+++ b/website/docs/docs/build/python-models.md
@@ -577,7 +577,7 @@ def model(dbt, session):
 def model(dbt, session):
     dbt.config(submission_method="bigframes")
 
-    # You can also use @bpd.udf )
+    # You can also use @bpd.udf
     @bpd.remote_function(dataset='jialuo_test_us')
     def my_func(x: int) -> int:
         return x * 1100

--- a/website/docs/docs/build/python-models.md
+++ b/website/docs/docs/build/python-models.md
@@ -291,7 +291,7 @@ def model(dbt, session):
 
 </TabItem>
 
-<TabItem value="BigQuery DataFrames"> <Lifecycle status="Preview" />
+<TabItem value="BigQuery DataFrames"> 
 
 <File name='models/my_python_model.py'>
 
@@ -419,7 +419,7 @@ def model(dbt, session):
 
 </TabItem>
 
-<TabItem value="BigQuery DataFrames"> <Lifecycle status="Preview" />
+<TabItem value="BigQuery DataFrames">
 
 <File name='models/my_python_model.py'>
 
@@ -569,7 +569,7 @@ def model(dbt, session):
 
 </TabItem>
 
-<TabItem value="BigQuery DataFrames"> <Lifecycle status="Preview" />
+<TabItem value="BigQuery DataFrames"> 
 
 <File name='models/my_python_model.py'>
 
@@ -577,7 +577,7 @@ def model(dbt, session):
 def model(dbt, session):
     dbt.config(submission_method="bigframes")
 
-    # You can also use @bpd.udf (currently a preview feature)
+    # You can also use @bpd.udf )
     @bpd.remote_function(dataset='jialuo_test_us')
     def my_func(x: int) -> int:
         return x * 1100


### PR DESCRIPTION
this pr removes the BQ dataframes preview tag in th epython doc

[raised in internal slack](https://dbt-labs.slack.com/archives/C02NCQ9483C/p1760465953246299?thread_ts=1760465948.636219&cid=C02NCQ9483C)

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-bq-dataframe-dbt-labs.vercel.app/docs/build/python-models

<!-- end-vercel-deployment-preview -->