### PR TITLE
refreshes the Fusion quickstart

### DIFF
--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -254,7 +254,7 @@ If you don’t configure this correctly, cross-platform references will not reso
 
 <Expandable alt_header="dbt extension not activating">
 
-If the dbt extension has activated successfully, you will see the dbt Extension label in the status bar at the bottom left of your editor. You can view diagnostic information about the dbt extension by clicking the dbt Extension button.
+If the dbt extension has activated successfully, you will see the **dbt Extension** label in the status bar at the bottom left of your editor. You can view diagnostic information about the dbt extension by clicking the **dbt Extension** button.
 
 If the dbt extension label is not present, then it is likely that the dbt extension was not installed successfully. If this happens, try uninstalling the extension, restarting your editor, and then reinstalling the extension.
 

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -102,7 +102,7 @@ The following are the essential steps from the [<Constant name="fusion_engine" /
     ```bash
     dbtf --version
     ```
-2. You should see the following output:
+2. You should see output similar to the following:
     ```bash
     dbt-fusion 2.0.0-preview.45
     ```

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -138,7 +138,7 @@ Now let's create your first dbt project powered by <Constant name="fusion" />!
     dbtf init --skip-profile-setup
     ```
 
-    If you created new credentials through the interactive prompts, `init` will automatically run `dbtf debug` at the end. This will check to ensure the newly created profile establishes a valid connection with the database.
+    If you created new credentials through the interactive prompts, `init` automatically runs `dbtf debug` at the end. This ensures the newly created profile establishes a valid connection with the database.
 
 2. Change directories into your newly created project:
     ```bash

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -125,20 +125,15 @@ The dbt VS Code extension is available in the [Visual Studio extension marketpla
 ## Initialize the Jaffle Shop project
 Now let's create your first dbt project powered by <Constant name="fusion" />!
 
-1. Set up an example project and configure a database connection profile. 
-   
-   - If you *do not* already have a connection profile that you want to use, start with this command and prompts will guide you through configuring a profile:
-    ```bash
-    dbtf init
-    ```
-
+1. Run `dbt init` to set up an example project and configure a database connection profile.
+   - If you *do not* already have a connection profile that you want to use, start with `dbt init` abd use the prompts to configure a profile:
     - If you already have a connection profile that you want to use, use the `--skip-profile-setup` flag then edit the generated `dbt_project.yml` to replace `profile: jaffle_shop` with `profile: <YOUR-PROFILE-NAME>`.
 
     ```bash
     dbtf init --skip-profile-setup
     ```
 
-    If you created new credentials through the interactive prompts, `init` automatically runs `dbtf debug` at the end. This ensures the newly created profile establishes a valid connection with the database.
+    - If you created new credentials through the interactive prompts, `init` automatically runs `dbtf debug` at the end. This ensures the newly created profile establishes a valid connection with the database.
 
 2. Change directories into your newly created project:
     ```bash
@@ -185,10 +180,20 @@ Now that your project works, open it in VS Code and see Fusion in action:
 Now you're ready to see some of these awesome features in action!
 
 <!--no toc -->
-- [Preview data and code](#preview-data-and-code)
-- [Navigate your project with lineage tools](#navigate-your-project-with-lineage-tools)
-- [Use the power of SQL understanding](#use-the-power-of-sql-understanding)
-- [Speeding up common dbt commands](#speeding-up-common-dbt-commands)
+- [Introduction](#introduction)
+  - [About the dbt Fusion engine](#about-the-dbt-fusion-engine)
+- [Prerequisites](#prerequisites)
+  - [What you’ll learn](#what-youll-learn)
+- [Installation](#installation)
+  - [Verify the  installation](#verify-the--installation)
+  - [Install the dbt VS Code extension](#install-the-dbt-vs-code-extension)
+- [Initialize the Jaffle Shop project](#initialize-the-jaffle-shop-project)
+- [Explore with the dbt VS Code extension](#explore-with-the-dbt-vs-code-extension)
+    - [Preview data and code](#preview-data-and-code)
+    - [Navigate your project with lineage tools](#navigate-your-project-with-lineage-tools)
+    - [Use the power of SQL understanding](#use-the-power-of-sql-understanding)
+    - [Speed up common dbt commands](#speed-up-common-dbt-commands)
+- [Troubleshooting](#troubleshooting)
 
 #### Preview data and code
 

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -118,7 +118,7 @@ The dbt VS Code extension is available in the [Visual Studio extension marketpla
 2. Search for `dbt` and choose the one from the publisher `dbt Labs Inc`.
     <Lightbox src="/img/docs/extension/extension-marketplace.png" width="60%" title="Search for the extension"/>
 3. Click **Install**.
-4. When prompted, register or skip (you can register later). You can also check out our [installation instructions](/docs/install-dbt-extension) to come back to it later.
+4. When the prompt appears, you can register the extension now or skip it (you can register later). You can also check out our [installation instructions](/docs/install-dbt-extension) to come back to it later.
 5. Confirm you've installed it by looking for the **dbt Extension** label in the status bar. If you see it, the extension was installed successfully!
     <Lightbox src="/img/docs/extension/extension-lsp-download.png" width="60%" title="Verify installation in the status bar."/>
 

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -46,7 +46,7 @@ To take full advantage of this guide, you'll need to meet the following prerequi
     <FusionDWH /> 
 - You need a macOS (Terminal), Linux, or Windows (Powershell) machine to run the <Constant name="fusion_engine" />. 
 - You need to have [Visual Studio Code](https://code.visualstudio.com/) installed. The [Cursor](https://www.cursor.com/en) code editor will also work, but these instructions will focus on VS Code.
-- You'll need admin or install privileges on your machine.  
+- You need admin or install privileges on your machine.  
 
 ### What you’ll learn
 

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -263,7 +263,7 @@ Note: It is possible to "hide" status bar items in VS Code. Double-check if the 
 
 <Expandable alt_header="Missing dbt LSP features">
 
-If you receive a no active LSP for this workspace error message or aren't seeing dbt Language Server (LSP) features in your editor (like autocomplete, go-to-definition, or hover text), start by first following the general troubleshooting steps mentioned earlier.
+If you receive a `no active LSP for this workspace` error message or aren't seeing dbt Language Server (LSP) features in your editor (like autocomplete, go-to-definition, or hover text), start by first following the general troubleshooting steps mentioned earlier.
 
 If you've confirmed the dbt extension is installed correctly but don't see LSP features, try the following:
 

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -114,7 +114,7 @@ You can run these commands using `dbt`, or use `dbtf` as an unambiguous alias fo
 
 The dbt VS Code extension is available in the [Visual Studio extension marketplace](https://marketplace.visualstudio.com/items?itemName=dbtLabsInc.dbt). Download it directly from your VS Code editor:
 
-1. Navigate to the **Extensions** tab of VS Code (or Cursor)
+1. Navigate to the **Extensions** tab of VS Code (or Cursor).
 2. Search for `dbt` and choose the one from the publisher `dbt Labs Inc`.
     <Lightbox src="/img/docs/extension/extension-marketplace.png" width="60%" title="Search for the extension"/>
 3. Click **Install**.

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -269,7 +269,7 @@ If you've confirmed the dbt extension is installed correctly but don't see LSP f
 
 1. Check extension version — Ensure that you're using the latest available version of the dbt extension by:
    - Opening the Extensions page in your editor, or
-   - Going to the Output tab and looking for the version number, or
+   - Going to the **Output** tab and looking for the version number, or
    - Running `dbtf --version` in the terminal.
 2. Reinstall the LSP — If the version is correct, reinstall the LSP:
    1. Open the Command Palette: Command + Shift + P (macOS) or Ctrl + Shift + P (Windows/Linux).

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -273,7 +273,7 @@ If you've confirmed the dbt extension is installed correctly but don't see LSP f
    - Running `dbtf --version` in the terminal.
 2. Reinstall the LSP — If the version is correct, reinstall the LSP:
    - Open the Command Palette: Command + Shift + P (macOS) or Ctrl + Shift + P (Windows/Linux).
-   - Paste `dbt: Reinstall dbt LSP` and enter.
+   2. Paste `dbt: Reinstall dbt LSP` and enter.
 
 This command downloads the LSP and re-activates the extension to resolve the error.
 

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -244,66 +244,9 @@ This is just the start. There is so much more available and so much more coming.
 
 ## Troubleshooting
 
-If you run into any issues, check out the troubleshooting section below.
+import FusionTroubleshooting from '/snippets/_fusion-troubleshooting.md';
 
-<Expandable  alt_header="dbt platform configurations">
-
-If you're a cloud-based dbt platform user who has the `dbt-cloud:` config in the `dbt_project.yml` file and are also using dbt Mesh, you must have the project ID configured:
-    ```yaml
-    dbt-cloud:
-    project-id: 12345 # Required
-    ```
-If you don’t configure this correctly, cross-platform references will not resolve properly, and you will encounter errors executing dbt commands.
-
-</Expandable>
-
-<Expandable alt_header="dbt extension not activating">
-
-If the dbt extension has activated successfully, you will see the **dbt Extension** label in the status bar at the bottom left of your editor. You can view diagnostic information about the dbt extension by clicking the **dbt Extension** button.
-
-If the **dbt Extension** label is not present, then it is likely that the dbt extension was not installed successfully. If this happens, try uninstalling the extension, restarting your editor, and then reinstalling the extension.
-
-**Note:** It is possible to "hide" status bar items in VS Code. Double-check if the dbt Extension status bar label is hidden by right-clicking on the status bar in your editor. If you see dbt Extension in the right-click menu, then the extension has installed successfully.
-</Expandable>
-
-<Expandable alt_header="Missing dbt LSP features">
-
-If you receive a `no active LSP for this workspace` error message or aren't seeing dbt Language Server (LSP) features in your editor (like autocomplete, go-to-definition, or hover text), start by first following the general troubleshooting steps mentioned earlier.
-
-If you've confirmed the dbt extension is installed correctly but don't see LSP features, try the following:
-
-1. Check extension version — Ensure that you're using the latest available version of the dbt extension by:
-   - Opening the **Extensions** page in your editor, or
-   - Going to the **Output** tab and looking for the version number, or
-   - Running `dbtf --version` in the terminal.
-2. Reinstall the LSP — If the version is correct, reinstall the LSP:
-   1. Open the Command Palette: Command + Shift + P (macOS) or Ctrl + Shift + P (Windows/Linux).
-   2. Paste `dbt: Reinstall dbt LSP` and enter.
-
-This command downloads the LSP and re-activates the extension to resolve the error.
-
-</Expandable>
-
-<Expandable alt_header="Unsupported dbt version">
-
-If you see an error message indicating that your version of dbt is unsupported, then there is likely a problem with your environment.
-
-Check the dbt Path setting in your VS Code settings. If this path is set, ensure that it is pointing to a valid dbt Fusion Engine executable.
-If necessary, you can also install the dbt Fusion Engine directly using these instructions: [Install the Fusion CLI](/docs/fusion/install-fusion-cli)
-</Expandable>
-
-<Expandable alt_header="Addressing the 'dbt language server is not running in this workspace' error">
-
-To resolve the `dbt language server is not running in this workspace` error, you need to add your dbt project folder to a workspace: 
-
-1. In VS Code, click **File** in the toolbar then select **Add Folder to Workspace**.
-2. Select the dbt project file you want to add to a workspace.
-3. To save your workspace, click **File** then select **Save Workspace As**.  
-4. Navigate to the location you want to save your workspace.
-
-This should resolve the error and open your dbt project by opening the workspace it belongs to. For more information on workspaces, refer to [What is a VS Code workspace?](https://code.visualstudio.com/docs/editing/workspaces/workspaces).
-</Expandable>
-
+<FusionTroubleshooting />
 
 import AboutFusion from '/snippets/_about-fusion.md';
 

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -127,7 +127,7 @@ Now let's create your first dbt project powered by <Constant name="fusion" />!
 
 1. Set up an example project and configure a database connection profile. 
    
-   If you *do not* already have a connection profile that you want to use, start with this command and prompts will guide you through configuring a profile:
+   - If you *do not* already have a connection profile that you want to use, start with this command and prompts will guide you through configuring a profile:
     ```bash
     dbtf init
     ```

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -199,7 +199,7 @@ You can quickly access model results and underlying data structures directly fro
     <Lightbox src="/img/docs/extension/preview-query-results.png" width="80%" title="Preview model query results."/>
 2. Click **Preview CTE** above `orders as (` to preview results in the **Query Results** tab.
     <Lightbox src="/img/docs/extension/preview-cte-query-results-3.png" width="80%" title="Preview CTE query results."/>
-1. Locate the code icon for **Compile File** in between the dbt and the table icons. Clicking it will open a window with the compiled version of the model.
+3. Locate the code icon for **Compile File** in between the dbt and the table icons. Clicking this icon opens a window with the compiled version of the model.
     <Lightbox src="/img/docs/extension/compile-file-icon.png" width="50%" title="Compile File icon."/>
     <Lightbox src="/img/docs/extension/compile-file.png" width="80%" title="Compile File results."/>
 

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -246,11 +246,9 @@ This is just the start. There is so much more available and so much more coming.
 
 </ConfettiTrigger>
 
-
 ## Troubleshooting
 
 If you run into any issues, check out the troubleshooting section below.
-
 
 <Expandable  alt_header="dbt platform configurations">
 

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -197,7 +197,7 @@ You can quickly access model results and underlying data structures directly fro
 
 1. Locate the **table icon** for **Preview File** in the upper right corner. Click it to preview results in the **Query Results** tab.
     <Lightbox src="/img/docs/extension/preview-query-results.png" width="80%" title="Preview model query results."/>
-1. Click **Preview CTE** above `orders as (` to preview results in the **Query Results** tab.
+2. Click **Preview CTE** above `orders as (` to preview results in the **Query Results** tab.
     <Lightbox src="/img/docs/extension/preview-cte-query-results-3.png" width="80%" title="Preview CTE query results."/>
 1. Locate the code icon for **Compile File** in between the dbt and the table icons. Clicking it will open a window with the compiled version of the model.
     <Lightbox src="/img/docs/extension/compile-file-icon.png" width="50%" title="Compile File icon."/>

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -119,7 +119,7 @@ The dbt VS Code extension is available in the [Visual Studio extension marketpla
     <Lightbox src="/img/docs/extension/extension-marketplace.png" width="60%" title="Search for the extension"/>
 3. Click **Install**.
 4. When the prompt appears, you can register the extension now or skip it (you can register later). You can also check out our [installation instructions](/docs/install-dbt-extension) to come back to it later.
-5. Confirm you've installed it by looking for the **dbt Extension** label in the status bar. If you see it, the extension was installed successfully!
+5. Confirm you've installed the extension by looking for the **dbt Extension** label in the status bar. If you see it, the extension was installed successfully!
     <Lightbox src="/img/docs/extension/extension-lsp-download.png" width="60%" title="Verify installation in the status bar."/>
 
 ## Initialize the Jaffle Shop project

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -179,7 +179,7 @@ Now that your project works, open it in VS Code and see Fusion in action:
     ```bash
         models/marts/orders.sql
     ```
-5. Locate **Lineage** and **Query Results** in the lower panel and the **dbt icon** in the upper right corner next to your editor groups. If you see all of these, the extension is installed correctly and running!
+5. Locate **Lineage** and **Query Results** in the lower panel, and the **dbt icon** in the upper right corner next to your editor groups. If you see all of these, the extension is installed correctly and running!
     <Lightbox src="/img/docs/extension/extension-running.png" width="80%" title="The VS Code UI with the extension running."/>
 
 Now you're ready to see some of these awesome features in action!

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -132,7 +132,7 @@ Now let's create your first dbt project powered by <Constant name="fusion" />!
     dbtf init
     ```
 
-    If you do already have a connection profile that you want to use, use the `--skip-profile-setup` flag then edit the generated `dbt_project.yml` to replace `profile: jaffle_shop` with `profile: <YOUR-PROFILE-NAME>`.
+    - If you already have a connection profile that you want to use, use the `--skip-profile-setup` flag then edit the generated `dbt_project.yml` to replace `profile: jaffle_shop` with `profile: <YOUR-PROFILE-NAME>`.
 
     ```bash
     dbtf init --skip-profile-setup

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -184,20 +184,11 @@ Now that your project works, open it in VS Code and see Fusion in action:
 
 Now you're ready to see some of these awesome features in action!
 
-- [Introduction](#introduction)
-  - [About the dbt Fusion engine](#about-the-dbt-fusion-engine)
-- [Prerequisites](#prerequisites)
-  - [What you’ll learn](#what-youll-learn)
-- [Installation](#installation)
-  - [Verify the  installation](#verify-the--installation)
-  - [Install the dbt VS Code extension](#install-the-dbt-vs-code-extension)
-- [Initialize the Jaffle Shop project](#initialize-the-jaffle-shop-project)
-- [Explore with the dbt VS Code extension](#explore-with-the-dbt-vs-code-extension)
-    - [Preview data and code](#preview-data-and-code)
-    - [Navigate your project with lineage tools](#navigate-your-project-with-lineage-tools)
-    - [Use the power of SQL understanding](#use-the-power-of-sql-understanding)
-    - [Speeding up common dbt commands](#speeding-up-common-dbt-commands)
-- [Troubleshooting](#troubleshooting)
+<!--no toc -->
+- [Preview data and code](#preview-data-and-code)
+- [Navigate your project with lineage tools](#navigate-your-project-with-lineage-tools)
+- [Use the power of SQL understanding](#use-the-power-of-sql-understanding)
+- [Speeding up common dbt commands](#speeding-up-common-dbt-commands)
 
 #### Preview data and code
 

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -272,7 +272,7 @@ If you've confirmed the dbt extension is installed correctly but don't see LSP f
    - Going to the Output tab and looking for the version number, or
    - Running `dbtf --version` in the terminal.
 2. Reinstall the LSP — If the version is correct, reinstall the LSP:
-   - Open the Command Palette: Command + Shift + P (macOS) or Ctrl + Shift + P (Windows/Linux).
+   1. Open the Command Palette: Command + Shift + P (macOS) or Ctrl + Shift + P (Windows/Linux).
    2. Paste `dbt: Reinstall dbt LSP` and enter.
 
 This command downloads the LSP and re-activates the extension to resolve the error.

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -256,7 +256,7 @@ If you don’t configure this correctly, cross-platform references will not reso
 
 If the dbt extension has activated successfully, you will see the **dbt Extension** label in the status bar at the bottom left of your editor. You can view diagnostic information about the dbt extension by clicking the **dbt Extension** button.
 
-If the dbt extension label is not present, then it is likely that the dbt extension was not installed successfully. If this happens, try uninstalling the extension, restarting your editor, and then reinstalling the extension.
+If the **dbt Extension** label is not present, then it is likely that the dbt extension was not installed successfully. If this happens, try uninstalling the extension, restarting your editor, and then reinstalling the extension.
 
 Note: It is possible to "hide" status bar items in VS Code. Double-check if the dbt Extension status bar label is hidden by right-clicking on the status bar in your editor. If you see dbt Extension in the right-click menu, then the extension has installed successfully.
 </Expandable>

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -221,7 +221,7 @@ Code smarter, not harder. The autocomplete and context clues help avoid mistakes
 1. Hover over any `*` to see the list of column names and data types being selected.
     <Lightbox src="/img/docs/extension/hover-star.png" width="80%" title="Hovering over * to see column names and data types."/>
 
-#### Speeding up common dbt commands
+#### Speed up common dbt commands
 
 Testing, testing... is this mic on? It is and it's ready to execute your commands with blazing fast speeds! When you want to test your code against various dbt commands: 
 

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -268,7 +268,7 @@ If you receive a `no active LSP for this workspace` error message or aren't seei
 If you've confirmed the dbt extension is installed correctly but don't see LSP features, try the following:
 
 1. Check extension version — Ensure that you're using the latest available version of the dbt extension by:
-   - Opening the Extensions page in your editor, or
+   - Opening the **Extensions** page in your editor, or
    - Going to the **Output** tab and looking for the version number, or
    - Running `dbtf --version` in the terminal.
 2. Reinstall the LSP — If the version is correct, reinstall the LSP:

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -35,7 +35,7 @@ This quickstart guide will get you from zero to running your first dbt project w
 | **dbt CLI (local)** | [Install <Constant name="fusion_engine" />](/docs/fusion/install-fusion) locally following this guide. |
 | **VS Code / Cursor IDE** | [Install the dbt extension](/docs/install-dbt-extension) to unlock <Constant name="fusion" />'s interactive power in your editor. |
 
-Tip: Read more [about the <Constant name="fusion_engine" />](/docs/fusion/about-fusion) to understand what’s new, what’s changed, and what’s deprecated.
+**Tip:** Read more [about the <Constant name="fusion_engine" />](/docs/fusion/about-fusion) to understand what’s new, what’s changed, and what’s deprecated.
 
 ## Prerequisites
 

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -258,7 +258,7 @@ If the dbt extension has activated successfully, you will see the **dbt Extensio
 
 If the **dbt Extension** label is not present, then it is likely that the dbt extension was not installed successfully. If this happens, try uninstalling the extension, restarting your editor, and then reinstalling the extension.
 
-Note: It is possible to "hide" status bar items in VS Code. Double-check if the dbt Extension status bar label is hidden by right-clicking on the status bar in your editor. If you see dbt Extension in the right-click menu, then the extension has installed successfully.
+**Note:** It is possible to "hide" status bar items in VS Code. Double-check if the dbt Extension status bar label is hidden by right-clicking on the status bar in your editor. If you see dbt Extension in the right-click menu, then the extension has installed successfully.
 </Expandable>
 
 <Expandable alt_header="Missing dbt LSP features">

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -18,214 +18,287 @@ import FusionLifecycle from '/snippets/_fusion-lifecycle-callout.md';
 
 <FusionLifecycle />
 
-The dbt Fusion engine is a powerful new approach to classic dbt ideas! Completely rebuilt from the ground up in Rust, Fusion enables you to compile and run your dbt projects faster than ever. 
+The <Constant name="fusion_engine" /> is a powerful new approach to classic dbt ideas! Completely rebuilt from the ground up in Rust, <Constant name="fusion" /> lets you compile and run your dbt projects faster than ever — often in seconds. 
 
-This quickstart guide aims to give you an idea of how Fusion works in your development and production environments, focusing on the dbt extension and CLI combined experience.
+This quickstart guide will get you from zero to running your first dbt project with <Constant name="fusion" /> + VS Code. By the end, you’ll have:
+- A working dbt project (`jaffle_shop`) built with the <Constant name="fusion_engine" />
+- The dbt VS Code extension installed and connected  
+- The ability to preview, compile, and run dbt commands directly from your IDE 
 
 ### About the dbt Fusion engine
 
-Fusion and the powerful features that the engine provides are available in the following:
+<Constant name="fusion" /> and the features it provides are available in multiple environments:
 
-- **dbt Studio:** If you are using the cloud-based dbt Studio IDE, Fusion features and functionality are automatically available, and you don't need to install anything. You will need to [upgrade your environment(s)](/docs/dbt-versions/upgrade-dbt-version-in-cloud#dbt-fusion-engine) to use the Fusion engine.
-- **dbt CLI:** If you are using your local machine for development, see the [dbt Fusion engine installation guide](/docs/fusion/install-fusion) for instructions for installing it on your local machine.
-- **VS Code extension** If you are using the [Visual Studio Code (VS Code)](https://code.visualstudio.com/) or [Cursor](https://www.cursor.com/en) IDE, you can get hands on with many of Fusions powerful features directly in your editor by installing the [dbt extension](/docs/install-dbt-extension).
+| Environment | How to use <Constant name="fusion" /> |
+|--------------|-------------------|
+| **<Constant name="cloud_ide" />** | <Constant name="fusion" /> is automatically enabled; just [upgrade your environment(s)](/docs/dbt-versions/upgrade-dbt-version-in-cloud#dbt-fusion-engine). |
+| **dbt CLI (local)** | [Install <Constant name="fusion_engine" />](/docs/fusion/install-fusion) locally following this guide. |
+| **VS Code / Cursor IDE** | [Install the dbt extension](/docs/install-dbt-extension) to unlock <Constant name="fusion" />'s interactive power in your editor. |
 
-Read more [about the dbt Fusion engine](/docs/fusion/about-fusion) to get a better understanding of what's new, what's changed, and what's been deprecated.
+Tip: Read more [about the <Constant name="fusion_engine" />](/docs/fusion/about-fusion) to understand what’s new, what’s changed, and what’s deprecated.
 
 ## Prerequisites
 
 To take full advantage of this guide, you'll need to meet the following prerequisites:
-- You should have a basic understanding of dbt projects, git workflows, and data warehouse requirements.
+
+- You should have a basic understanding of [dbt projects](/docs/build/projects), [git workflows](/docs/cloud/git/git-version-control), and [data warehouse requirements](/docs/supported-data-platforms).
 - Make sure you're using a supported adapter and authentication method:
-  <FusionDWH /> 
-- You need a macOS (Terminal), Linux, or Windows (Powershell) machine to run the dbt Fusion engine. 
+    <FusionDWH /> 
+- You need a macOS (Terminal), Linux, or Windows (Powershell) machine to run the <Constant name="fusion_engine" />. 
 - You need to have [Visual Studio Code](https://code.visualstudio.com/) installed. The [Cursor](https://www.cursor.com/en) code editor will also work, but these instructions will focus on VS Code.
+- You'll need admin or install privileges on your machine.  
 
-### What you'll learn
+### What you’ll learn
 
-In this quickstart guide, you'll learn how to install and use the dbt Fusion engine, enabling you to get set up quickly and efficiently. This guide will demonstrate how to:
-- Set up a fully functional dbt environment with an operational and executable project.
-- Install and use the dbt extension and dbt Fusion engine via VS Code. 
-- Run any dbt command from the environment’s terminal.
+By following this guide, you will:
+- Set up a fully functional dbt environment with an operational project  
+- Install and use the <Constant name="fusion_engine" /> + dbt VS Code extension  
+- Run dbt commands from your IDE or terminal  
+- Preview data, view lineage, and write SQL faster with autocomplete, and more! 
 
-You can learn more through high-quality [dbt Learn courses and workshops](https://learn.getdbt.com/).
-
-### Related content
-
-- [Create a GitHub repository](/guides/manual-install?step=2)
-- [Build your first models](/guides/manual-install?step=3)
-- [Test and document your project](/guides/manual-install?step=4)
+You can learn more through high-quality [dbt Learn courses and workshops](https://learn.getdbt.com/).  
 
 ## Installation
 
-It's easy to think of the dbt Fusion engine and the dbt extension as two different products, but they're a powerful combo that works together to unlock the full potential of dbt. Think of the Fusion engine as exactly that —an engine. The dbt extension and VS Code are the chassis, and together they form a powerful vehicle for transforming your data. It's important to note:
-- You can install the dbt Fusion engine and use it standalone with the dbt CLI.
-- You _cannot_ install and use the dbt extension without also installing Fusion.
+It's easy to think of the <Constant name="fusion_engine" /> and the dbt extension as two different products, but they're a powerful combo that works together to unlock the full potential of dbt. Think of the <Constant name="fusion_engine" /> as exactly that — an engine. The dbt extension and VS Code are the chassis, and together they form a powerful vehicle for transforming your data. 
 
-The following are the essential steps from the [dbt Fusion engine](/docs/fusion/install-fusion) and [extension](/docs/install-dbt-extension) installation guides:
+:::info
+- You can install the <Constant name="fusion_engine" /> and use it standalone with the CLI.
+- You *cannot* use the dbt extension without <Constant name="fusion" /> installed.
+:::
 
-### Fusion macOS & Linux installation
+The following are the essential steps from the [<Constant name="fusion_engine" />](/docs/fusion/install-fusion) and [extension](/docs/install-dbt-extension) installation guides:
 
-Run the following command in the terminal:
+<Tabs queryString="installation">
+<TabItem value="mac-linux" label="macOS & Linux">
 
-```shell
-curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh -s -- --update
-```
+1. Run the following command in the terminal to install the `dbtf` binary — <Constant name="fusion" />’s CLI command.
+    ```shell
+    curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh -s -- --update
+    ```
+2. To use `dbtf` immediately after installation, reload your shell so that the new `$PATH` is recognized:
+    ```shell
+    exec $SHELL
+    ```
+    Or you can close and reopen your terminal window. This will load the updated environment settings into the new session.
+</TabItem>
+<TabItem value="windows" label="Windows (PowerShell)">
 
-To use `dbtf` immediately after installation, reload your shell so that the new `$PATH` is recognized:
+1. Run the following command in PowerShell to install the `dbtf` binary:
+    ```powershell
+    irm https://public.cdn.getdbt.com/fs/install/install.ps1 | iex
+    ```
+2. To use `dbtf` immediately after installation, reload your shell so that the new `Path` is recognized:
+    ```powershell
+    Start-Process powershell
+    ```
+    Or you can close and reopen your terminal window. This will load the updated environment settings into the new session.
+</TabItem>
+</Tabs>
 
-```shell
-exec $SHELL
-```
+### Verify the <Constant name="fusion_engine" /> installation
 
-Or, simply close and reopen your terminal window. This will load the updated environment settings into the new session.
-
-### Fusion Windows installation (PowerShell)
-
-Run the following command in PowerShell:
-
-```powershell
-irm https://public.cdn.getdbt.com/fs/install/install.ps1 | iex
-```
-
-To use `dbtf` immediately after installation, reload your shell so that the new `Path` is recognized:
-
-```powershell
-Start-Process powershell
-```
-
-Or, simply close and reopen PowerShell. This will load the updated environment settings into the new session.
-
-### Verify the Fusion installation
-
-After installation, open a new command-line window and verify that Fusion is installed correctly by checking the version. You can run these commands using `dbt`, or use `dbtf` as an unambiguous alias for Fusion, if you have another dbt CLI installed on your machine.
-
-```bash
-dbtf --version
-```
+1. After installation, open a new command-line window to confirm that <Constant name="fusion" /> was installed correctly by checking the version. 
+    ```bash
+    dbtf --version
+    ```
+2. You should see the following output:
+    ```bash
+    dbt-fusion 2.0.0-preview.45
+    ```
+:::tip
+You can run these commands using `dbt`, or use `dbtf` as an unambiguous alias for <Constant name="fusion" />, if you have another dbt CLI installed on your machine.
+:::
 
 ### Install the dbt VS Code extension
 
 The dbt VS Code extension is available in the [Visual Studio extension marketplace](https://marketplace.visualstudio.com/items?itemName=dbtLabsInc.dbt). Download it directly from your VS Code editor:
 
-1. Navigate to the **Extensions** tab of VS Code (or Cursor) and search for `dbt`. Locate the extension from the publisher `dbt Labs Inc`.
+1. Navigate to the **Extensions** tab of VS Code (or Cursor)
+2. Search for `dbt` and choose the one from the publisher `dbt Labs Inc`.
     <Lightbox src="/img/docs/extension/extension-marketplace.png" width="60%" title="Search for the extension"/>
-2. Click **Install**.
-3. You will see a prompt to register the extension. You can skip this step for now, but check out our [installation instructions](/docs/install-dbt-extension) to come back to it later.
-4. If you see the **dbt Extension** label in your editor's status bar, then the extension has installed successfully.
+3. Click **Install**.
+4. When prompted, register or skip (you can register later). You can also check out our [installation instructions](/docs/install-dbt-extension) to come back to it later.
+5. Confirm you've installed it by looking for the **dbt Extension** label in the status bar. If you see it, the extension was installed successfully!
     <Lightbox src="/img/docs/extension/extension-lsp-download.png" width="60%" title="Verify installation in the status bar."/>
 
 ## Initialize the Jaffle Shop project
+Now let's create your first dbt project powered by <Constant name="fusion" />!
 
-1. Run this command from your command line to set up an example project and configure a database connection profile:
+1. Run the following command from your command line to set up an example project and configure a database connection profile. 
+   
+   If you *do not* already have a connection profile that you want to use, start with this command and prompts will guide you through configuring a profile:
+    ```bash
+    dbtf init
+    ```
 
-If you do **not** already have a connection profile that you want to use, start with this command and prompts will guide you through configuring a profile:
+    If you do already have a connection profile that you want to use, use the `--skip-profile-setup` flag then edit the generated `dbt_project.yml` to replace `profile: jaffle_shop` with `profile: <YOUR-PROFILE-NAME>`.
 
-```bash
-dbtf init
-```
+    ```bash
+    dbtf init --skip-profile-setup
+    ```
 
-If you do already have a connection profile that you want to use, use the `--skip-profile-setup` flag then edit the generated `dbt_project.yml` to replace `profile: jaffle_shop` with `profile: <YOUR-PROFILE-NAME>`.
-
-```bash
-dbtf init --skip-profile-setup
-```
-
-If you created new credentials through the interactive prompts, `init` will automatically run `dbtf debug` at the end. This will check to ensure the newly created profile establishes a valid connection with the database.
+    If you created new credentials through the interactive prompts, `init` will automatically run `dbtf debug` at the end. This will check to ensure the newly created profile establishes a valid connection with the database.
 
 2. Change directories into your newly created project:
-
-```bash
-cd jaffle_shop
-```
+    ```bash
+    cd jaffle_shop
+    ```
 
 3. Build your dbt project (which includes creating example data):
+    ```bash
+    dbtf build
+    ```
 
-```bash
-dbtf build
-```
-
-The following should now be done:
-
-- Synthetic data loaded into your warehouse
-- Development environment set up and ready to go
-- The project built and tested
+This will:
+- Load example data into your warehouse
+- Create, build, and test models
+- Verify your dbt environment is fully operational
 
 ## Explore with the dbt VS Code extension
 
-The dbt VS Code extension compiles and builds your project with the dbt Fusion engine, a powerful and blazing fast rebuild of dbt from the ground up. 
+The dbt VS Code extension compiles and builds your project with the <Constant name="fusion_engine" />, a powerful and blazing fast rebuild of dbt from the ground up. 
 
-Want to see Fusion in action? Check out the following video to get a sense of how it works:
+Want to see <Constant name="fusion" /> in action? Check out the following video to get a sense of how it works:
 
 <div style={{ position: 'relative', maxWidth: '960px', margin: '2rem auto', overflow: 'hidden', borderRadius: '12px', height: '500px', boxShadow: 'var(--ifm-global-shadow-lw)' }}>
   <iframe
-    src="https://app.storylane.io/share/a1rkqx0mbd7a"
+    src="https://app.storylane.io/share/a1rkqx0mbd7a" 
     title="dbt Fusion + VS Code extension walkthrough"
     style={{ position: 'relative', top: '-48px', height: '900px', width: '100%', border: 0, paddingBottom:'calc(42.20% + 25px)',transform: 'scale(1)'}}
     allow="fullscreen; autoplay; encrypted-media"
   />
 </div>
 
-To explore the features and functionality of the dbt VS Code extension, you'll want to do a few things:
+Now that your project works, open it in VS Code and see Fusion in action:
 
-1. Open the **View** menu and click **Command Palette** and enter `Workspaces: Add Folder to Workspace`. Choose your `jaffle_shop` folder that we created earlier. Without adding the root folder of the dbt project to the workspace, the LSP won't load within the workspace.
-2. Open the `models/marts/orders.sql` file to see the definition for the `orders` model. This is the model we'll use in all of the examples below.
-3. Locate `Lineage` and `Query Results` in the lower panel and the **dbt icon** in the upper right corner next to your editor groups. If you see all of these, the extension is installed correctly and running!
-    <Lightbox src="/img/docs/extension/extension-running.png" width="60%" title="The VS Code UI with the extension running."/>
+1. In VS Code, open the **View** menu and click **Command Palette** then type **Workspaces: Add Folder to Workspace**.
+2. Select your `jaffle_shop` folder
+3. If you skip this step, the [dbt language server](https://docs.getdbt.com/blog/dbt-fusion-engine-components#the-dbt-vs-code-extension-and-language-server) (LSP) will not run. The LSP enables features like autocomplete, hover info, and inline error highlights.
+4. Open a model file to see the definition for the `orders` model. This is the model we'll use in all of the examples below.
+    ```bash
+        models/marts/orders.sql
+    ```
+5. Locate **Lineage** and **Query Results** in the lower panel and the **dbt icon** in the upper right corner next to your editor groups. If you see all of these, the extension is installed correctly and running!
+    <Lightbox src="/img/docs/extension/extension-running.png" width="80%" title="The VS Code UI with the extension running."/>
 
 Now you're ready to see some of these awesome features in action!
 
-### Preview data and code
+- [Introduction](#introduction)
+  - [About the dbt Fusion engine](#about-the-dbt-fusion-engine)
+- [Prerequisites](#prerequisites)
+  - [What you’ll learn](#what-youll-learn)
+- [Installation](#installation)
+  - [Verify the  installation](#verify-the--installation)
+  - [Install the dbt VS Code extension](#install-the-dbt-vs-code-extension)
+- [Initialize the Jaffle Shop project](#initialize-the-jaffle-shop-project)
+- [Explore with the dbt VS Code extension](#explore-with-the-dbt-vs-code-extension)
+    - [Preview data and code](#preview-data-and-code)
+    - [Navigate your project with lineage tools](#navigate-your-project-with-lineage-tools)
+    - [Use the power of SQL understanding](#use-the-power-of-sql-understanding)
+    - [Speeding up common dbt commands](#speeding-up-common-dbt-commands)
+- [Troubleshooting](#troubleshooting)
 
-Gain valuable insights into your data transformation during each step of your developement process. 
+#### Preview data and code
+
+Gain valuable insights into your data transformation during each step of your development process. 
 You can quickly access model results and underlying data structures directly from your code. These previews help validate your code step-by-step. 
 
 1. Locate the **table icon** for **Preview File** in the upper right corner. Click it to preview results in the **Query Results** tab.
-    <Lightbox src="/img/docs/extension/preview-query-results.png" width="60%" title="Preview model query results."/>
+    <Lightbox src="/img/docs/extension/preview-query-results.png" width="80%" title="Preview model query results."/>
 1. Click **Preview CTE** above `orders as (` to preview results in the **Query Results** tab.
-    <Lightbox src="/img/docs/extension/preview-cte-query-results-3.png" width="60%" title="Preview CTE query results."/>
+    <Lightbox src="/img/docs/extension/preview-cte-query-results-3.png" width="80%" title="Preview CTE query results."/>
 1. Locate the code icon for **Compile File** in between the dbt and the table icons. Clicking it will open a window with the compiled version of the model.
-    <Lightbox src="/img/docs/extension/compile-file-icon.png" width="30%" title="Compile File icon."/>
-    <Lightbox src="/img/docs/extension/compile-file.png" width="60%" title="Compile File results."/>
+    <Lightbox src="/img/docs/extension/compile-file-icon.png" width="50%" title="Compile File icon."/>
+    <Lightbox src="/img/docs/extension/compile-file.png" width="80%" title="Compile File results."/>
 
-### Navigate your project with lineage tools
+#### Navigate your project with lineage tools
 
 Almost as important as where your data is going is where it's been. The lineage tools in the extension let you visualize the lineage of the resources in your models as well as the column-level lineage. These capabilities deepen your understanding of model relationships and dependencies.
 
 1. Open the **Lineage** tab to visualize the model-level lineage of this model.
-    <Lightbox src="/img/docs/extension/extension-pane.png" width="60%" title="Visualizing model-level lineage."/>
+    <Lightbox src="/img/docs/extension/extension-pane.png" width="80%" title="Visualizing model-level lineage."/>
 1. Open the **View** menu, click **Command Palette** and enter `dbt: Show Column Lineage` to visualize the column-level lineage in the **Lineage** tab.
-    <Lightbox src="/img/docs/extension/show-cll.png" width="60%" title="Show column-level lineage."/>
+    <Lightbox src="/img/docs/extension/show-cll.png" width="80%" title="Show column-level lineage."/>
 
-### Use the power of SQL understanding
+#### Use the power of SQL understanding
 
 Code smarter, not harder. The autocomplete and context clues help avoid mistakes and enable you to write fast and accurate SQL. Catch issues before you commit them!
 
 1. To see **Autocomplete** in action, delete `ref('stg_orders')`, and begin typing `ref(stg_` to see the subset of matching model names. Use up and down arrows to select `stg_orders`.
-    <Lightbox src="/img/docs/extension/autocomplete.png" width="60%" title="Autocomplete for a model name."/>
+    <Lightbox src="/img/docs/extension/autocomplete.png" width="80%" title="Autocomplete for a model name."/>
 1. Hover over any `*` to see the list of column names and data types being selected.
-    <Lightbox src="/img/docs/extension/hover-star.png" width="60%" title="Hovering over * to see column names and data types."/>
+    <Lightbox src="/img/docs/extension/hover-star.png" width="80%" title="Hovering over * to see column names and data types."/>
 
-### Speeding up common dbt commands
+#### Speeding up common dbt commands
 
 Testing, testing... is this mic on? It is and it's ready to execute your commands with blazing fast speeds! When you want to test your code against various dbt commands: 
 
 1. The dbt icon in the top right opens a list of extension-specific commands:
-    <Lightbox src="/img/docs/extension/run-command.png" width="60%" title="Select a command via the dbt icon."/>
+    <Lightbox src="/img/docs/extension/run-command.png" width="80%" title="Select a command via the dbt icon."/>
 1. Opening the **View** menu, clicking the **Command Palette**, and entering `>dbt:` in the command bar shows all the new commands that are available.
-    <Lightbox src="/img/docs/extension/extension-commands-all.png" width="60%" title="dbt commands in the command bar."/>
+    <Lightbox src="/img/docs/extension/extension-commands-all.png" width="80%" title="dbt commands in the command bar."/>
 
+<ConfettiTrigger>
 Try choosing some of them and see what they do 😎
 
-This is just the start. There is so much more available and so much more coming. Be sure to check out our resources for all the information about the dbt Fusion engine and the dbt VS Code extension!
+This is just the start. There is so much more available and so much more coming. Be sure to check out our resources for all the information about the <Constant name="fusion_engine" /> and the dbt VS Code extension!
 
-import AboutFusion from '/snippets/_about-fusion.md';
+</ConfettiTrigger>
 
-<AboutFusion />
 
 ## Troubleshooting
 
-#### Addressing the `dbt language server is not running in this workspace` error
+If you run into any issues, check out the troubleshooting section below.
+
+
+<Expandable  alt_header="dbt platform configurations">
+
+If you're a cloud-based dbt platform user who has the `dbt-cloud:` config in the `dbt_project.yml` file and are also using dbt Mesh, you must have the project ID configured:
+    ```yaml
+    dbt-cloud:
+    project-id: 12345 # Required
+    ```
+If you don’t configure this correctly, cross-platform references will not resolve properly, and you will encounter errors executing dbt commands.
+
+</Expandable>
+
+<Expandable alt_header="dbt extension not activating">
+
+If the dbt extension has activated successfully, you will see the dbt Extension label in the status bar at the bottom left of your editor. You can view diagnostic information about the dbt extension by clicking the dbt Extension button.
+
+If the dbt extension label is not present, then it is likely that the dbt extension was not installed successfully. If this happens, try uninstalling the extension, restarting your editor, and then reinstalling the extension.
+
+Note: It is possible to "hide" status bar items in VS Code. Double-check if the dbt Extension status bar label is hidden by right-clicking on the status bar in your editor. If you see dbt Extension in the right-click menu, then the extension has installed successfully.
+</Expandable>
+
+<Expandable alt_header="Missing dbt LSP features">
+
+If you receive a no active LSP for this workspace error message or aren't seeing dbt Language Server (LSP) features in your editor (like autocomplete, go-to-definition, or hover text), start by first following the general troubleshooting steps mentioned earlier.
+
+If you've confirmed the dbt extension is installed correctly but don't see LSP features, try the following:
+
+1. Check extension version — Ensure that you're using the latest available version of the dbt extension by:
+   - Opening the Extensions page in your editor, or
+   - Going to the Output tab and looking for the version number, or
+   - Running `dbtf --version` in the terminal.
+2. Reinstall the LSP — If the version is correct, reinstall the LSP:
+   - Open the Command Palette: Command + Shift + P (macOS) or Ctrl + Shift + P (Windows/Linux).
+   - Paste `dbt: Reinstall dbt LSP` and enter.
+
+This command downloads the LSP and re-activates the extension to resolve the error.
+
+</Expandable>
+
+<Expandable alt_header="Unsupported dbt version">
+
+If you see an error message indicating that your version of dbt is unsupported, then there is likely a problem with your environment.
+
+Check the dbt Path setting in your VS Code settings. If this path is set, ensure that it is pointing to a valid dbt Fusion Engine executable.
+If necessary, you can also install the dbt Fusion Engine directly using these instructions: [Install the Fusion CLI](/docs/fusion/install-fusion-cli)
+</Expandable>
+
+<Expandable alt_header="Addressing the 'dbt language server is not running in this workspace' error">
 
 To resolve the `dbt language server is not running in this workspace` error, you need to add your dbt project folder to a workspace: 
 
@@ -235,5 +308,11 @@ To resolve the `dbt language server is not running in this workspace` error, you
 4. Navigate to the location you want to save your workspace.
 
 This should resolve the error and open your dbt project by opening the workspace it belongs to. For more information on workspaces, refer to [What is a VS Code workspace?](https://code.visualstudio.com/docs/editing/workspaces/workspaces).
+</Expandable>
+
+
+import AboutFusion from '/snippets/_about-fusion.md';
+
+<AboutFusion />
 
 </div>

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -125,7 +125,7 @@ The dbt VS Code extension is available in the [Visual Studio extension marketpla
 ## Initialize the Jaffle Shop project
 Now let's create your first dbt project powered by <Constant name="fusion" />!
 
-1. Run the following command from your command line to set up an example project and configure a database connection profile. 
+1. Set up an example project and configure a database connection profile. 
    
    If you *do not* already have a connection profile that you want to use, start with this command and prompts will guide you through configuring a profile:
     ```bash

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -169,7 +169,7 @@ Now that your project works, open it in VS Code and see Fusion in action:
 
 1. In VS Code, open the **View** menu and click **Command Palette**. Enter **Workspaces: Add Folder to Workspace**.
 2. Select your `jaffle_shop` folder.
-3. If you skip this step, the [dbt language server](https://docs.getdbt.com/blog/dbt-fusion-engine-components#the-dbt-vs-code-extension-and-language-server) (LSP) will not run. The LSP enables features like autocomplete, hover info, and inline error highlights.
+        If you don't add the root folder of the dbt project to the workspace, the [dbt language server](https://docs.getdbt.com/blog/dbt-fusion-engine-components#the-dbt-vs-code-extension-and-language-server) (LSP) will not run. The LSP enables features like autocomplete, hover info, and inline error highlights.
 4. Open a model file to see the definition for the `orders` model. This is the model we'll use in all of the examples below.
     ```bash
         models/marts/orders.sql

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -172,7 +172,7 @@ Want to see <Constant name="fusion" /> in action? Check out the following video 
 
 Now that your project works, open it in VS Code and see Fusion in action:
 
-1. In VS Code, open the **View** menu and click **Command Palette** then type **Workspaces: Add Folder to Workspace**.
+1. In VS Code, open the **View** menu and click **Command Palette**. Enter **Workspaces: Add Folder to Workspace**.
 2. Select your `jaffle_shop` folder
 3. If you skip this step, the [dbt language server](https://docs.getdbt.com/blog/dbt-fusion-engine-components#the-dbt-vs-code-extension-and-language-server) (LSP) will not run. The LSP enables features like autocomplete, hover info, and inline error highlights.
 4. Open a model file to see the definition for the `orders` model. This is the model we'll use in all of the examples below.

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -129,9 +129,9 @@ Now let's create your first dbt project powered by <Constant name="fusion" />!
    - If you *do not* have a connection profile that you want to use, start with `dbt init` and use the prompts to configure a profile:
     - If you already have a connection profile that you want to use, use the `--skip-profile-setup` flag then edit the generated `dbt_project.yml` to replace `profile: jaffle_shop` with `profile: <YOUR-PROFILE-NAME>`.
 
-    ```bash
-    dbtf init --skip-profile-setup
-    ```
+        ```bash
+        dbtf init --skip-profile-setup
+        ```
 
     - If you created new credentials through the interactive prompts, `init` automatically runs `dbtf debug` at the end. This ensures the newly created profile establishes a valid connection with the database.
 

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -126,7 +126,7 @@ The dbt VS Code extension is available in the [Visual Studio extension marketpla
 Now let's create your first dbt project powered by <Constant name="fusion" />!
 
 1. Run `dbt init` to set up an example project and configure a database connection profile.
-   - If you *do not* already have a connection profile that you want to use, start with `dbt init` abd use the prompts to configure a profile:
+   - If you *do not* have a connection profile that you want to use, start with `dbt init` and use the prompts to configure a profile:
     - If you already have a connection profile that you want to use, use the `--skip-profile-setup` flag then edit the generated `dbt_project.yml` to replace `profile: jaffle_shop` with `profile: <YOUR-PROFILE-NAME>`.
 
     ```bash

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -180,20 +180,10 @@ Now that your project works, open it in VS Code and see Fusion in action:
 Now you're ready to see some of these awesome features in action!
 
 <!--no toc -->
-- [Introduction](#introduction)
-  - [About the dbt Fusion engine](#about-the-dbt-fusion-engine)
-- [Prerequisites](#prerequisites)
-  - [What you’ll learn](#what-youll-learn)
-- [Installation](#installation)
-  - [Verify the  installation](#verify-the--installation)
-  - [Install the dbt VS Code extension](#install-the-dbt-vs-code-extension)
-- [Initialize the Jaffle Shop project](#initialize-the-jaffle-shop-project)
-- [Explore with the dbt VS Code extension](#explore-with-the-dbt-vs-code-extension)
-    - [Preview data and code](#preview-data-and-code)
-    - [Navigate your project with lineage tools](#navigate-your-project-with-lineage-tools)
-    - [Use the power of SQL understanding](#use-the-power-of-sql-understanding)
-    - [Speed up common dbt commands](#speed-up-common-dbt-commands)
-- [Troubleshooting](#troubleshooting)
+- [Preview data and code](#preview-data-and-code)
+- [Navigate your project with lineage tools](#navigate-your-project-with-lineage-tools)
+- [Use the power of SQL understanding](#use-the-power-of-sql-understanding)
+- [Speed up common dbt commands](#speed-up-common-dbt-commands)
 
 #### Preview data and code
 

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -173,7 +173,7 @@ Want to see <Constant name="fusion" /> in action? Check out the following video 
 Now that your project works, open it in VS Code and see Fusion in action:
 
 1. In VS Code, open the **View** menu and click **Command Palette**. Enter **Workspaces: Add Folder to Workspace**.
-2. Select your `jaffle_shop` folder
+2. Select your `jaffle_shop` folder.
 3. If you skip this step, the [dbt language server](https://docs.getdbt.com/blog/dbt-fusion-engine-components#the-dbt-vs-code-extension-and-language-server) (LSP) will not run. The LSP enables features like autocomplete, hover info, and inline error highlights.
 4. Open a model file to see the definition for the `orders` model. This is the model we'll use in all of the examples below.
     ```bash

--- a/website/snippets/_fusion-troubleshooting.md
+++ b/website/snippets/_fusion-troubleshooting.md
@@ -1,0 +1,59 @@
+If you run into any issues, check out the troubleshooting section below.
+
+<Expandable  alt_header="dbt platform configurations">
+
+If you're a cloud-based dbt platform user who has the `dbt-cloud:` config in the `dbt_project.yml` file and are also using dbt Mesh, you must have the project ID configured:
+    ```yaml
+    dbt-cloud:
+    project-id: 12345 # Required
+    ```
+If you don’t configure this correctly, cross-platform references will not resolve properly, and you will encounter errors executing dbt commands.
+
+</Expandable>
+
+<Expandable alt_header="dbt extension not activating">
+
+If the dbt extension has activated successfully, you will see the **dbt Extension** label in the status bar at the bottom left of your editor. You can view diagnostic information about the dbt extension by clicking the **dbt Extension** button.
+
+If the **dbt Extension** label is not present, then it is likely that the dbt extension was not installed successfully. If this happens, try uninstalling the extension, restarting your editor, and then reinstalling the extension.
+
+**Note:** It is possible to "hide" status bar items in VS Code. Double-check if the dbt Extension status bar label is hidden by right-clicking on the status bar in your editor. If you see dbt Extension in the right-click menu, then the extension has installed successfully.
+</Expandable>
+
+<Expandable alt_header="Missing dbt LSP features">
+
+If you receive a `no active LSP for this workspace` error message or aren't seeing dbt Language Server (LSP) features in your editor (like autocomplete, go-to-definition, or hover text), start by first following the general troubleshooting steps mentioned earlier.
+
+If you've confirmed the dbt extension is installed correctly but don't see LSP features, try the following:
+
+1. Check extension version — Ensure that you're using the latest available version of the dbt extension by:
+   - Opening the **Extensions** page in your editor, or
+   - Going to the **Output** tab and looking for the version number, or
+   - Running `dbtf --version` in the terminal.
+2. Reinstall the LSP — If the version is correct, reinstall the LSP:
+   1. Open the Command Palette: Command + Shift + P (macOS) or Ctrl + Shift + P (Windows/Linux).
+   2. Paste `dbt: Reinstall dbt LSP` and enter.
+
+This command downloads the LSP and re-activates the extension to resolve the error.
+
+</Expandable>
+
+<Expandable alt_header="Unsupported dbt version">
+
+If you see an error message indicating that your version of dbt is unsupported, then there is likely a problem with your environment.
+
+Check the dbt Path setting in your VS Code settings. If this path is set, ensure that it is pointing to a valid dbt Fusion Engine executable.
+If necessary, you can also install the dbt Fusion Engine directly using these instructions: [Install the Fusion CLI](/docs/fusion/install-fusion-cli)
+</Expandable>
+
+<Expandable alt_header="Addressing the 'dbt language server is not running in this workspace' error">
+
+To resolve the `dbt language server is not running in this workspace` error, you need to add your dbt project folder to a workspace: 
+
+1. In VS Code, click **File** in the toolbar then select **Add Folder to Workspace**.
+2. Select the dbt project file you want to add to a workspace.
+3. To save your workspace, click **File** then select **Save Workspace As**.  
+4. Navigate to the location you want to save your workspace.
+
+This should resolve the error and open your dbt project by opening the workspace it belongs to. For more information on workspaces, refer to [What is a VS Code workspace?](https://code.visualstudio.com/docs/editing/workspaces/workspaces).
+</Expandable>

--- a/website/snippets/_install-dbt-extension.md
+++ b/website/snippets/_install-dbt-extension.md
@@ -152,44 +152,65 @@ file during registration. If you do not have a `~/.dbt/dbt_cloud.yml` file downl
 ## Troubleshooting
 <!-- This anchor is linked from the  VS Code extension. Please do not change it -->
 
-#### dbt platform configurations
+If you run into any issues, check out the troubleshooting section below.
 
-If you're a cloud-based dbt platform user who has the `dbt-cloud:` config in the `dbt_project.yml` file and are also using [dbt Mesh](/docs/mesh/about-mesh), you must have the project ID configured:
+<Expandable  alt_header="dbt platform configurations">
 
-```yaml
-dbt-cloud:
-  project-id: 12345 # Required
-```
-
+If you're a cloud-based dbt platform user who has the `dbt-cloud:` config in the `dbt_project.yml` file and are also using dbt Mesh, you must have the project ID configured:
+    ```yaml
+    dbt-cloud:
+    project-id: 12345 # Required
+    ```
 If you don’t configure this correctly, cross-platform references will not resolve properly, and you will encounter errors executing dbt commands.
 
-#### General troubleshooting tips
+</Expandable>
 
-If the dbt extension has activated successfully, you will see the `dbt Extension` label in the status bar at the bottom left of your editor. You can view diagnostic information about the dbt extension by clicking the **dbt Extension** button.
+<Expandable alt_header="dbt extension not activating">
+
+If the dbt extension has activated successfully, you will see the dbt Extension label in the status bar at the bottom left of your editor. You can view diagnostic information about the dbt extension by clicking the dbt Extension button.
 
 If the dbt extension label is not present, then it is likely that the dbt extension was not installed successfully. If this happens, try uninstalling the extension, restarting your editor, and then reinstalling the extension.
 
-Note: It is possible to "hide" status bar items in VS Code. Double-check if the **dbt Extension** status bar label is hidden by right-clicking on the status bar in your editor. If you see **dbt Extension** in the right-click menu, then the extension has installed successfully.
+Note: It is possible to "hide" status bar items in VS Code. Double-check if the dbt Extension status bar label is hidden by right-clicking on the status bar in your editor. If you see dbt Extension in the right-click menu, then the extension has installed successfully.
+</Expandable>
 
-#### Missing dbt LSP features
+<Expandable alt_header="Missing dbt LSP features">
 
-If you receive a `no active LSP for this workspace` error message or aren't seeing [dbt Language Server (LSP)](https://docs.getdbt.com/blog/dbt-fusion-engine-components#the-dbt-vs-code-extension-and-language-server) features in your editor (like autocomplete, go-to-definition, or hover text), start by first following the general [troubleshooting steps](#troubleshooting) mentioned earlier. 
+If you receive a no active LSP for this workspace error message or aren't seeing dbt Language Server (LSP) features in your editor (like autocomplete, go-to-definition, or hover text), start by first following the general troubleshooting steps mentioned earlier.
 
 If you've confirmed the dbt extension is installed correctly but don't see LSP features, try the following:
-1. Check extension version &mdash; Ensure that you're using the latest available version of the dbt extension by:
-    - Opening the Extensions page in your editor, or
-    - Going to the **Output** tab and looking for the version number.
-2. Reinstall the LSP &mdash; If the version is correct, reinstall the LSP:
-   1. Open the Command Palette: Command + Shift + P (macOS) or Ctrl + Shift + P (Windows/Linux).
-   2. Paste `dbt: Reinstall dbt LSP` and enter.
+
+1. Check extension version — Ensure that you're using the latest available version of the dbt extension by:
+   - Opening the Extensions page in your editor, or
+   - Going to the Output tab and looking for the version number, or
+   - Running `dbtf --version` in the terminal.
+2. Reinstall the LSP — If the version is correct, reinstall the LSP:
+   - Open the Command Palette: Command + Shift + P (macOS) or Ctrl + Shift + P (Windows/Linux).
+   - Paste `dbt: Reinstall dbt LSP` and enter.
 
 This command downloads the LSP and re-activates the extension to resolve the error.
 
-#### Unsupported dbt version
+</Expandable>
+
+<Expandable alt_header="Unsupported dbt version">
 
 If you see an error message indicating that your version of dbt is unsupported, then there is likely a problem with your environment.
-- Check the **dbt Path** setting in your VS Code settings. If this path is set, ensure that it is pointing to a valid <Constant name="fusion_engine" />  executable.
-- If necessary, you can also install the <Constant name="fusion_engine" />  directly using these instructions: [Install the Fusion CLI](/docs/fusion/install-fusion).
+
+Check the dbt Path setting in your VS Code settings. If this path is set, ensure that it is pointing to a valid dbt Fusion Engine executable.
+If necessary, you can also install the dbt Fusion Engine directly using these instructions: [Install the Fusion CLI](/docs/fusion/install-fusion-cli)
+</Expandable>
+
+<Expandable alt_header="Addressing the 'dbt language server is not running in this workspace' error">
+
+To resolve the `dbt language server is not running in this workspace` error, you need to add your dbt project folder to a workspace: 
+
+1. In VS Code, click **File** in the toolbar then select **Add Folder to Workspace**.
+2. Select the dbt project file you want to add to a workspace.
+3. To save your workspace, click **File** then select **Save Workspace As**.  
+4. Navigate to the location you want to save your workspace.
+
+This should resolve the error and open your dbt project by opening the workspace it belongs to. For more information on workspaces, refer to [What is a VS Code workspace?](https://code.visualstudio.com/docs/editing/workspaces/workspaces).
+</Expandable>
 
 import AboutFusion from '/snippets/_about-fusion.md';
 

--- a/website/snippets/_install-dbt-extension.md
+++ b/website/snippets/_install-dbt-extension.md
@@ -152,65 +152,9 @@ file during registration. If you do not have a `~/.dbt/dbt_cloud.yml` file downl
 ## Troubleshooting
 <!-- This anchor is linked from the  VS Code extension. Please do not change it -->
 
-If you run into any issues, check out the troubleshooting section below.
+import FusionTroubleshooting from '/snippets/_fusion-troubleshooting.md';
 
-<Expandable  alt_header="dbt platform configurations">
-
-If you're a cloud-based dbt platform user who has the `dbt-cloud:` config in the `dbt_project.yml` file and are also using dbt Mesh, you must have the project ID configured:
-    ```yaml
-    dbt-cloud:
-    project-id: 12345 # Required
-    ```
-If you don’t configure this correctly, cross-platform references will not resolve properly, and you will encounter errors executing dbt commands.
-
-</Expandable>
-
-<Expandable alt_header="dbt extension not activating">
-
-If the dbt extension has activated successfully, you will see the dbt Extension label in the status bar at the bottom left of your editor. You can view diagnostic information about the dbt extension by clicking the dbt Extension button.
-
-If the dbt extension label is not present, then it is likely that the dbt extension was not installed successfully. If this happens, try uninstalling the extension, restarting your editor, and then reinstalling the extension.
-
-Note: It is possible to "hide" status bar items in VS Code. Double-check if the dbt Extension status bar label is hidden by right-clicking on the status bar in your editor. If you see dbt Extension in the right-click menu, then the extension has installed successfully.
-</Expandable>
-
-<Expandable alt_header="Missing dbt LSP features">
-
-If you receive a no active LSP for this workspace error message or aren't seeing dbt Language Server (LSP) features in your editor (like autocomplete, go-to-definition, or hover text), start by first following the general troubleshooting steps mentioned earlier.
-
-If you've confirmed the dbt extension is installed correctly but don't see LSP features, try the following:
-
-1. Check extension version — Ensure that you're using the latest available version of the dbt extension by:
-   - Opening the Extensions page in your editor, or
-   - Going to the Output tab and looking for the version number, or
-   - Running `dbtf --version` in the terminal.
-2. Reinstall the LSP — If the version is correct, reinstall the LSP:
-   - Open the Command Palette: Command + Shift + P (macOS) or Ctrl + Shift + P (Windows/Linux).
-   - Paste `dbt: Reinstall dbt LSP` and enter.
-
-This command downloads the LSP and re-activates the extension to resolve the error.
-
-</Expandable>
-
-<Expandable alt_header="Unsupported dbt version">
-
-If you see an error message indicating that your version of dbt is unsupported, then there is likely a problem with your environment.
-
-Check the dbt Path setting in your VS Code settings. If this path is set, ensure that it is pointing to a valid dbt Fusion Engine executable.
-If necessary, you can also install the dbt Fusion Engine directly using these instructions: [Install the Fusion CLI](/docs/fusion/install-fusion-cli)
-</Expandable>
-
-<Expandable alt_header="Addressing the 'dbt language server is not running in this workspace' error">
-
-To resolve the `dbt language server is not running in this workspace` error, you need to add your dbt project folder to a workspace: 
-
-1. In VS Code, click **File** in the toolbar then select **Add Folder to Workspace**.
-2. Select the dbt project file you want to add to a workspace.
-3. To save your workspace, click **File** then select **Save Workspace As**.  
-4. Navigate to the location you want to save your workspace.
-
-This should resolve the error and open your dbt project by opening the workspace it belongs to. For more information on workspaces, refer to [What is a VS Code workspace?](https://code.visualstudio.com/docs/editing/workspaces/workspaces).
-</Expandable>
+<FusionTroubleshooting />
 
 import AboutFusion from '/snippets/_about-fusion.md';
 


### PR DESCRIPTION
this pr tweaks the fusion-qs.md and _install-dbt-extension.md snippet/files. it adds:
- tabs to the installation so it's easier to parse
- rewrote intro to use constants (<Constant name="fusion_engine" />, <Constant name="fusion" />) and set clear outcomes for the quickstart.
- added `<ConfettiTrigger>` and moved the About Fusion snippet to the end after troubleshooting.
- added expandable blocks for common IDE/LSP/version issues, mirroring the snippet structure.
- made various copyedits for clarity and consistency (terminology, punctuation, small fixes).

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-vs-fusion-qs-dbt-labs.vercel.app/guides/fusion-qs

<!-- end-vercel-deployment-preview -->