### PR TITLE
adding course callouts to certain pages

### DIFF
--- a/website/docs/best-practices/how-we-mesh/mesh-1-intro.md
+++ b/website/docs/best-practices/how-we-mesh/mesh-1-intro.md
@@ -22,5 +22,6 @@ For additional information, refer to the [<Constant name="mesh" /> FAQs](/best-p
 - Develop an intuition for various **<Constant name="mesh" /> patterns** and how to design a multi-project architecture for your organization.
 - Establish recommended steps to **incrementally adopt** these patterns in your dbt implementation.
 
-import MeshCourseCallout from '../../snippets/_mesh-course-callout.md';
+import MeshCourseCallout from '/snippets/_mesh-course-callout.md';
+
 <MeshCourseCallout />

--- a/website/docs/best-practices/how-we-mesh/mesh-1-intro.md
+++ b/website/docs/best-practices/how-we-mesh/mesh-1-intro.md
@@ -21,3 +21,6 @@ For additional information, refer to the [<Constant name="mesh" /> FAQs](/best-p
 - Understand the **purpose and tradeoffs** of building a multi-project architecture.
 - Develop an intuition for various **<Constant name="mesh" /> patterns** and how to design a multi-project architecture for your organization.
 - Establish recommended steps to **incrementally adopt** these patterns in your dbt implementation.
+
+import MeshCourseCallout from '../../snippets/_mesh-course-callout.md';
+<MeshCourseCallout />

--- a/website/docs/best-practices/how-we-mesh/mesh-2-who-is-dbt-mesh-for.md
+++ b/website/docs/best-practices/how-we-mesh/mesh-2-who-is-dbt-mesh-for.md
@@ -18,6 +18,9 @@ Is <Constant name="mesh" /> a good fit in this scenario? Absolutely! There is no
 
 - **Managing shared macros**: Teams operating at this scale will benefit from a separate repository containing a dbt package of reusable utility macros that all other projects will install. This is different from public models, which provide data-as-a-service (a set of “API endpoints”) — this is distributed as a **library**. This package can also standardize imports of other third-party packages, as well as providing wrappers / shims for those macros. This package should have a dedicated team of maintainers — probably the central platform team, or a set of “superusers” from domain-aligned data modeling teams.
 
+import MeshCourseCallout from '../../snippets/_mesh-course-callout.md';
+<MeshCourseCallout />
+
 ### Adoption challenges
 
 - Onboarding hundreds of people and dozens of projects is full of friction! The challenges of a scaled, global organization are not to be underestimated. To start the migration, prioritize teams that have strong dbt familiarity and fundamentals. <Constant name="mesh" /> is an advancement of core dbt deployments, so these teams are likely to have a smoother transition. 

--- a/website/docs/best-practices/how-we-mesh/mesh-2-who-is-dbt-mesh-for.md
+++ b/website/docs/best-practices/how-we-mesh/mesh-2-who-is-dbt-mesh-for.md
@@ -18,7 +18,8 @@ Is <Constant name="mesh" /> a good fit in this scenario? Absolutely! There is no
 
 - **Managing shared macros**: Teams operating at this scale will benefit from a separate repository containing a dbt package of reusable utility macros that all other projects will install. This is different from public models, which provide data-as-a-service (a set of “API endpoints”) — this is distributed as a **library**. This package can also standardize imports of other third-party packages, as well as providing wrappers / shims for those macros. This package should have a dedicated team of maintainers — probably the central platform team, or a set of “superusers” from domain-aligned data modeling teams.
 
-import MeshCourseCallout from '../../snippets/_mesh-course-callout.md';
+import MeshCourseCallout from '/snippets/_mesh-course-callout.md';
+
 <MeshCourseCallout />
 
 ### Adoption challenges

--- a/website/docs/best-practices/how-we-mesh/mesh-3-structures.md
+++ b/website/docs/best-practices/how-we-mesh/mesh-3-structures.md
@@ -19,6 +19,7 @@ At a high level, you’ll need to decide:
 - How to manage your code -- do you want multiple dbt Projects living in the same repository (mono-repo) or do you want to have multiple repos with one repo per project?
 
 import MeshCourseCallout from '/snippets/_mesh-course-callout.md';
+
 <MeshCourseCallout />
 
 ## Define your project interfaces by splitting your DAG
@@ -43,7 +44,6 @@ Horizontal splits separate your DAG based on source or domain. These splits are 
 - **Data from different sources.** For example, clickstream event data and transactional ecommerce data may need to be modeled independently of each other.
 - **Team workflows.** For example, if two embedded groups operate at different paces, you may want to split the projects up so they can move independently.
 
-
 <Lightbox src="/img/best-practices/how-we-mesh/horizontal_split.png" title="A simplified dbt DAG with a dotted line representing a horizontal split." />
 
 ### Combining these strategies
@@ -52,9 +52,7 @@ Horizontal splits separate your DAG based on source or domain. These splits are 
 - **Pick one type of split and focus on that first**. If you have a hub-and-spoke team topology for example, handle breaking out the central platform project before you split the remainder into domains. Then if you need to break those domains up horizontally you can focus on that after the fact.
 - **DRY applies to underlying data, not just code.** Regardless of your strategy, you should not be sourcing the same rows and columns into multiple nodes. When working within a mesh pattern it becomes increasingly important that we don't duplicate logic or data.
 
-
 <Lightbox src="/img/best-practices/how-we-mesh/combined_splits.png" title="A simplified dbt DAG with two dotted lines representing both a vertical and horizontal split." />
-
 
 ## Determine your git strategy
 

--- a/website/docs/best-practices/how-we-mesh/mesh-3-structures.md
+++ b/website/docs/best-practices/how-we-mesh/mesh-3-structures.md
@@ -18,7 +18,7 @@ At a high level, you’ll need to decide:
 - Where to draw the lines between your dbt Projects -- i.e. how do you determine where to split your DAG and which models go in which project?
 - How to manage your code -- do you want multiple dbt Projects living in the same repository (mono-repo) or do you want to have multiple repos with one repo per project?
 
-import MeshCourseCallout from '../../snippets/_mesh-course-callout.md';
+import MeshCourseCallout from '/snippets/_mesh-course-callout.md';
 <MeshCourseCallout />
 
 ## Define your project interfaces by splitting your DAG

--- a/website/docs/best-practices/how-we-mesh/mesh-3-structures.md
+++ b/website/docs/best-practices/how-we-mesh/mesh-3-structures.md
@@ -18,6 +18,9 @@ At a high level, you’ll need to decide:
 - Where to draw the lines between your dbt Projects -- i.e. how do you determine where to split your DAG and which models go in which project?
 - How to manage your code -- do you want multiple dbt Projects living in the same repository (mono-repo) or do you want to have multiple repos with one repo per project?
 
+import MeshCourseCallout from '../../snippets/_mesh-course-callout.md';
+<MeshCourseCallout />
+
 ## Define your project interfaces by splitting your DAG
 
 The first (and perhaps most difficult!) decision when migrating to a multi-project architecture is deciding where to draw the line in your DAG to define the interfaces between your projects. Let's explore some language for discussing the design of these patterns.

--- a/website/docs/best-practices/how-we-mesh/mesh-4-implementation.md
+++ b/website/docs/best-practices/how-we-mesh/mesh-4-implementation.md
@@ -29,11 +29,9 @@ When attempting to define your project interfaces, you should consider investiga
 
 Let's go through an example process of taking a monolithing project, using groups and access to define the interfaces, and then splitting it into multiple projects.
 
-import MeshCourseCallout from '../../snippets/_mesh-course-callout.md';
+import MeshCourseCallout from '/snippets/_mesh-course-callout.md';
+
 <MeshCourseCallout />
-
-To learn more,  
-
 
 ## Defining project interfaces with groups and access
 

--- a/website/docs/best-practices/how-we-mesh/mesh-4-implementation.md
+++ b/website/docs/best-practices/how-we-mesh/mesh-4-implementation.md
@@ -29,7 +29,10 @@ When attempting to define your project interfaces, you should consider investiga
 
 Let's go through an example process of taking a monolithing project, using groups and access to define the interfaces, and then splitting it into multiple projects.
 
-To learn more, refer to our freely available [<Constant name="mesh" /> learning course](https://learn.getdbt.com/courses/dbt-mesh). 
+import MeshCourseCallout from '../../snippets/_mesh-course-callout.md';
+<MeshCourseCallout />
+
+To learn more,  
 
 
 ## Defining project interfaces with groups and access

--- a/website/docs/docs/build/data-tests.md
+++ b/website/docs/docs/build/data-tests.md
@@ -43,7 +43,7 @@ There are two ways of defining data tests in dbt:
 Defining data tests is a great way to confirm that your outputs and inputs are as expected, and helps prevent regressions when your code changes. Because you can use them over and over again, making similar assertions with minor variations, generic data tests tend to be much more common—they should make up the bulk of your dbt data testing suite. That said, both ways of defining data tests have their time and place.
 
 :::tip Creating your first data tests
-If you're new to dbt, we recommend that you check out our [quickstart guide](/guides) to build your first dbt project with models and tests.
+If you're new to dbt, we recommend that you check out our [online dbt Fundamentals course](https://learn.getdbt.com/learn/course/dbt-fundamentals/data-tests-30min/building-tests?page=1) or [quickstart guide](/guides) to build your first dbt project with models and tests.
 :::
 
 ## Singular data tests

--- a/website/docs/docs/build/unit-tests.md
+++ b/website/docs/docs/build/unit-tests.md
@@ -32,7 +32,7 @@ There is an additional type of test to dbt - unit tests. In software programming
 - Redshift sources need to be in the same database as the models.
 
 :::tip
-If you enjoy video courses, check out our [Unit tests on-demand course](https://learn.getdbt.com/learn/course/unit-testing/welcome-to-unit-testing-5min/introduction-to-unit-testing) to learn how to add unit tests and more!
+Check out our [Unit tests on-demand course](https://learn.getdbt.com/learn/course/unit-testing/welcome-to-unit-testing-5min/introduction-to-unit-testing) to learn how to add unit tests and more!
 :::
 
 Read the [reference doc](/reference/resource-properties/unit-tests) for more details about formatting your unit tests.

--- a/website/docs/docs/build/unit-tests.md
+++ b/website/docs/docs/build/unit-tests.md
@@ -32,7 +32,7 @@ There is an additional type of test to dbt - unit tests. In software programming
 - Redshift sources need to be in the same database as the models.
 
 :::info
-If you enjoy video courses, check out our [Unit tests on-demand course](https://learn.getdbt.com/learn/course/unit-testing/welcome-to-unit-testing-5min/introduction-to-unit-testing) to learn when and how to add, run, troubleshoot, and edit unit tests within a dbt environment, 
+If you enjoy video courses, check out our [Unit tests on-demand course](https://learn.getdbt.com/learn/course/unit-testing/welcome-to-unit-testing-5min/introduction-to-unit-testing) to learn how to add unit tests and more!
 :::
 
 Read the [reference doc](/reference/resource-properties/unit-tests) for more details about formatting your unit tests.

--- a/website/docs/docs/build/unit-tests.md
+++ b/website/docs/docs/build/unit-tests.md
@@ -31,6 +31,10 @@ There is an additional type of test to dbt - unit tests. In software programming
 - Redshift customers need to be aware of a [limitation when building unit tests](/reference/resource-configs/redshift-configs#unit-test-limitations) that requires a workaround.
 - Redshift sources need to be in the same database as the models.
 
+:::info
+If you enjoy video courses, check out our [Unit tests on-demand course](https://learn.getdbt.com/learn/course/unit-testing/welcome-to-unit-testing-5min/introduction-to-unit-testing) to learn when and how to add, run, troubleshoot, and edit unit tests within a dbt environment, 
+:::
+
 Read the [reference doc](/reference/resource-properties/unit-tests) for more details about formatting your unit tests.
 
 ### When to add a unit test to your model

--- a/website/docs/docs/build/unit-tests.md
+++ b/website/docs/docs/build/unit-tests.md
@@ -31,7 +31,7 @@ There is an additional type of test to dbt - unit tests. In software programming
 - Redshift customers need to be aware of a [limitation when building unit tests](/reference/resource-configs/redshift-configs#unit-test-limitations) that requires a workaround.
 - Redshift sources need to be in the same database as the models.
 
-:::info
+:::tip
 If you enjoy video courses, check out our [Unit tests on-demand course](https://learn.getdbt.com/learn/course/unit-testing/welcome-to-unit-testing-5min/introduction-to-unit-testing) to learn how to add unit tests and more!
 :::
 

--- a/website/docs/docs/cloud/use-dbt-copilot.md
+++ b/website/docs/docs/cloud/use-dbt-copilot.md
@@ -24,7 +24,7 @@ This page explains how to use <Constant name="copilot" /> to:
 - [Analyze data with the <Constant name="copilot" /> agent](#analyze-data-with-the-copilot-agent) &mdash; Use <Constant name="copilot" /> to analyze your data and get contextualized results in real time by asking a natural language question to the <Constant name="copilot" /> agent.
 
 :::tip
-If you enjoy video courses, check out our [dbt Copilot on-demand course](https://learn.getdbt.com/learn/course/dbt-copilot/welcome-to-dbt-copilot/welcome-5-mins) to learn how to use <Constant name="copilot" /> to generate resources, and more!
+Check out our [dbt Copilot on-demand course](https://learn.getdbt.com/learn/course/dbt-copilot/welcome-to-dbt-copilot/welcome-5-mins) to learn how to use <Constant name="copilot" /> to generate resources, and more!
 :::
 
 ## Generate resources 

--- a/website/docs/docs/cloud/use-dbt-copilot.md
+++ b/website/docs/docs/cloud/use-dbt-copilot.md
@@ -23,6 +23,10 @@ This page explains how to use <Constant name="copilot" /> to:
 - [Build queries](#build-queries) &mdash; Use <Constant name="copilot" /> to generate queries in [<Constant name="query_page" />](/docs/explore/dbt-insights) for exploratory data analysis using natural language prompts.
 - [Analyze data with the <Constant name="copilot" /> agent](#analyze-data-with-the-copilot-agent) &mdash; Use <Constant name="copilot" /> to analyze your data and get contextualized results in real time by asking a natural language question to the <Constant name="copilot" /> agent.
 
+:::info
+If you enjoy video courses, check out our [dbt Copilot on-demand course](https://learn.getdbt.com/learn/course/dbt-copilot/welcome-to-dbt-copilot/welcome-5-mins) to learn how to use <Constant name="copilot" /> to generate resources, and more!
+:::
+
 ## Generate resources 
 
 <CopilotResources/>

--- a/website/docs/docs/cloud/use-dbt-copilot.md
+++ b/website/docs/docs/cloud/use-dbt-copilot.md
@@ -23,7 +23,7 @@ This page explains how to use <Constant name="copilot" /> to:
 - [Build queries](#build-queries) &mdash; Use <Constant name="copilot" /> to generate queries in [<Constant name="query_page" />](/docs/explore/dbt-insights) for exploratory data analysis using natural language prompts.
 - [Analyze data with the <Constant name="copilot" /> agent](#analyze-data-with-the-copilot-agent) &mdash; Use <Constant name="copilot" /> to analyze your data and get contextualized results in real time by asking a natural language question to the <Constant name="copilot" /> agent.
 
-:::info
+:::tip
 If you enjoy video courses, check out our [dbt Copilot on-demand course](https://learn.getdbt.com/learn/course/dbt-copilot/welcome-to-dbt-copilot/welcome-5-mins) to learn how to use <Constant name="copilot" /> to generate resources, and more!
 :::
 

--- a/website/snippets/_mesh-course-callout.md
+++ b/website/snippets/_mesh-course-callout.md
@@ -1,4 +1,4 @@
 
 :::info
-To help you get started, check out our [Quickstart with <Constant name="mesh" />](/guides/mesh-qs) or [available <Constant name="mesh" /> learning courses](https://learn.getdbt.com/courses/dbt-mesh) to learn more more and get started.
+To help you get started, check out our [Quickstart with <Constant name="mesh" />](/guides/mesh-qs) or our online [<Constant name="mesh" /> course](https://learn.getdbt.com/courses/dbt-mesh) to learn more!
 :::

--- a/website/snippets/_mesh-course-callout.md
+++ b/website/snippets/_mesh-course-callout.md
@@ -1,4 +1,4 @@
 
-:::info
+:::tip
 To help you get started, check out our [Quickstart with <Constant name="mesh" />](/guides/mesh-qs) or our online [<Constant name="mesh" /> course](https://learn.getdbt.com/courses/dbt-mesh) to learn more!
 :::

--- a/website/snippets/_mesh-course-callout.md
+++ b/website/snippets/_mesh-course-callout.md
@@ -1,0 +1,4 @@
+
+:::info
+To help you get started, check out our [Quickstart with <Constant name="mesh" />](/guides/mesh-qs) or [available <Constant name="mesh" /> learning courses](https://learn.getdbt.com/courses/dbt-mesh) to learn more more and get started.
+:::


### PR DESCRIPTION
this pr adds course callouts to pages so users know they can also video learn. raised intenrally : https://dbt-labs.slack.com/archives/C02NCQ9483C/p1759999054914819?thread_ts=1759936280.516449&cid=C02NCQ9483C

[notion](https://www.notion.so/dbtlabs/Add-course-links-throughout-docs-287bb38ebda7807492bfd78fdf79d1c0?source=copy_link)

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-add-course-links-dbt-labs.vercel.app/best-practices/how-we-mesh/mesh-1-intro
- https://docs-getdbt-com-git-add-course-links-dbt-labs.vercel.app/best-practices/how-we-mesh/mesh-2-who-is-dbt-mesh-for
- https://docs-getdbt-com-git-add-course-links-dbt-labs.vercel.app/best-practices/how-we-mesh/mesh-3-structures
- https://docs-getdbt-com-git-add-course-links-dbt-labs.vercel.app/best-practices/how-we-mesh/mesh-4-implementation
- https://docs-getdbt-com-git-add-course-links-dbt-labs.vercel.app/docs/build/data-tests
- https://docs-getdbt-com-git-add-course-links-dbt-labs.vercel.app/docs/build/unit-tests
- https://docs-getdbt-com-git-add-course-links-dbt-labs.vercel.app/docs/cloud/use-dbt-copilot

<!-- end-vercel-deployment-preview -->