### PR TITLE
update docs to mcp ga

### DIFF
--- a/website/docs/docs/dbt-ai/about-mcp.md
+++ b/website/docs/docs/dbt-ai/about-mcp.md
@@ -26,7 +26,7 @@ There are two ways to access the dbt-mcp server: locally hosted or remotely host
 
 You can install dbt MCP locally or remotely:
 
-- [Local MCP server setup guide](/docs/dbt-ai/setup-local-mcp) <Lifecycle status="beta" />
+- [Local MCP server setup guide](/docs/dbt-ai/setup-local-mcp) 
 - [Remote MCP server setup guide](/docs/dbt-ai/setup-remote-mcp)
 
 ## Available Tools

--- a/website/docs/docs/dbt-ai/integrate-mcp-claude.md
+++ b/website/docs/docs/dbt-ai/integrate-mcp-claude.md
@@ -7,8 +7,6 @@ id: "integrate-mcp-claude"
 
 import MCPExample from '/snippets/_mcp-config-files.md';
 
-# Integrate Claude with dbt MCP <Lifecycle status="beta" />
-
 Claude is an AI assistant from Anthropic with two primary interfaces: 
 - [Claude Code](https://www.anthropic.com/claude-code): a terminal/IDE tool for development
 - [Claude for desktop](https://claude.ai/download): a GUI with MCP support for file access and commands as well as basic coding features 

--- a/website/docs/docs/dbt-ai/integrate-mcp-cursor.md
+++ b/website/docs/docs/dbt-ai/integrate-mcp-cursor.md
@@ -5,8 +5,6 @@ description: "Guide to set up Cursor with dbt-mcp"
 id: "integrate-mcp-cursor"
 ---
 
-# Integrate Cursor with dbt MCP <Lifecycle status="beta" />
-
 [Cursor](https://docs.cursor.com/context/model-context-protocol) is an AI-powered code editor, powered by Microsoft Visual Studio Code (VS Code). 
 
 After setting up your MCP server, you connect it to Cursor. Log in to Cursor and follow the steps that align with your hosting method.

--- a/website/docs/docs/dbt-ai/integrate-mcp-vscode.md
+++ b/website/docs/docs/dbt-ai/integrate-mcp-vscode.md
@@ -7,8 +7,6 @@ id: "integrate-mcp-vscode"
 
 import MCPExample from '/snippets/_mcp-config-files.md';
 
-# Integrate VS Code with MCP <Lifecycle status="beta" />
-
 [Microsoft Visual Studio Code (VS Code)](https://code.visualstudio.com/mcp) is a powerful and popular integrated development environment (IDE).
 
 These instructions are for integrating dbt MCP and VS Code. To get started, in VS Code:

--- a/website/docs/docs/dbt-ai/setup-local-mcp.md
+++ b/website/docs/docs/dbt-ai/setup-local-mcp.md
@@ -7,8 +7,6 @@ id: "setup-local-mcp"
 
 import MCPExample from '/snippets/_mcp-config-files.md';
 
-# Set up local MCP
-
 [The local dbt MCP server](https://github.com/dbt-labs/dbt-mcp) runs locally on your machine. Set up the local dbt MCP server with the following directions: 
 
 1. [Install uv](https://docs.astral.sh/uv/getting-started/installation/) to be able to run `dbt-mcp` and [related dependencies](https://github.com/dbt-labs/dbt-mcp/blob/main/pyproject.toml) into an isolated virtual environment.

--- a/website/docs/docs/dbt-versions/release-notes.md
+++ b/website/docs/docs/dbt-versions/release-notes.md
@@ -23,6 +23,7 @@ Release notes are grouped by month for both multi-tenant and virtual private clo
 
 The following features are new or enhanced as part of [dbt's Coalesce analytics engineering conference](https://coalesce.getdbt.com/event/21662b38-2c17-4c10-9dd7-964fd652ab44/summary) from October 13-16, 2025:
 
+- **New**: The [dbt MCP server](/docs/dbt-ai/about-mcp) is now generally available (GA). For more information on the dbt MCP server and dbt Agents, refer to the [Announcing dbt Agents and the remote dbt MCP Server: Trusted AI for analytics](https://www.getdbt.com/blog/dbt-agents-remote-dbt-mcp-server-trusted-ai-for-analytics) blog post.
 - **Private preview**: The [dbt platform (powered by Fusion)](/docs/dbt-versions/upgrade-dbt-version-in-cloud#dbt-fusion-engine) is now in private preview. If you have any questions, please reach out to your account manager.
   - [About data platform connections](/docs/cloud/connect-data-platform/about-connections) lists all available <Constant name="dbt_platform" /> connections on Fusion and the supported authentication methods per connection. 
 - **New**: Fusion‑specific configuration is now available for BigQuery, Databricks, Redshift, and Snowflake. For more information, see [Connect Fusion to your data platform](/docs/fusion/connect-data-platform-fusion/profiles.yml).


### PR DESCRIPTION
dbt mcp was [announced as ga here](https://www.getdbt.com/blog/dbt-agents-remote-dbt-mcp-server-trusted-ai-for-analytics)

this pr updates all the mcp docs and adds a releasea note.

@DevonFulcher opened up the original pr and this adds to it: https://github.com/dbt-labs/docs.getdbt.com/pull/8073

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-mcp-beta-dbt-labs.vercel.app/docs/dbt-ai/about-mcp
- https://docs-getdbt-com-git-update-mcp-beta-dbt-labs.vercel.app/docs/dbt-ai/integrate-mcp-claude
- https://docs-getdbt-com-git-update-mcp-beta-dbt-labs.vercel.app/docs/dbt-ai/integrate-mcp-cursor
- https://docs-getdbt-com-git-update-mcp-beta-dbt-labs.vercel.app/docs/dbt-ai/integrate-mcp-vscode
- https://docs-getdbt-com-git-update-mcp-beta-dbt-labs.vercel.app/docs/dbt-ai/setup-local-mcp
- https://docs-getdbt-com-git-update-mcp-beta-dbt-labs.vercel.app/docs/dbt-versions/release-notes

<!-- end-vercel-deployment-preview -->