### PR TITLE
Update state-aware-interface.md

### DIFF
--- a/website/docs/docs/deploy/state-aware-interface.md
+++ b/website/docs/docs/deploy/state-aware-interface.md
@@ -23,7 +23,7 @@ You can also view the number of reused models per project in the **Accounts home
 
 <DocCarousel slidesPerView={1}>
 <Lightbox src="/img/docs/dbt-cloud/using-dbt-cloud/account-home-chart.png" width="90%" title="Models built and reused chart in Account home"/>
-<Lightbox src="/img/docs/deploy/sao-model-reuse.png" width="100%" title="View reused models count per project in the Accounts home page"/>
+<Lightbox src="/img/docs/deploy/sao-model-reuse.png" width="90%" title="View reused models count per project in the Accounts home page"/>
 </DocCarousel>
 
 ## Model consumption view in jobs


### PR DESCRIPTION
update width to eliminate img overage on the right of the carousel


<img width="1183" height="741" alt="Screenshot 2025-11-03 at 11 48 08" src="https://github.com/user-attachments/assets/310839c1-70ba-4572-8f4f-ee3620014bd9" />

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-mirnawong1-patch-27-dbt-labs.vercel.app/docs/deploy/state-aware-interface

<!-- end-vercel-deployment-preview -->