### PR TITLE
remove the rest of the Beta flags for BQ PSC support

### DIFF
--- a/website/docs/docs/cloud/secure/about-private-connectivity.md
+++ b/website/docs/docs/cloud/secure/about-private-connectivity.md
@@ -41,6 +41,6 @@ dbt Labs has globally connected private networks specifically used to host priva
 
 #### GCP
 - [Snowflake](/docs/cloud/secure/snowflake-psc)
-- [BigQuery](/docs/cloud/secure/bigquery-psc)<Lifecycle status="beta" />
+- [BigQuery](/docs/cloud/secure/bigquery-psc)
 
 <PrivateLinkHostnameWarning features={'/snippets/_private-connection-hostname-restriction.md'}/>

--- a/website/docs/docs/cloud/secure/bigquery-psc.md
+++ b/website/docs/docs/cloud/secure/bigquery-psc.md
@@ -1,11 +1,11 @@
 ---
-title: "Configuring BigQuery and GCP Private Service Connect (beta)"
+title: "Configuring BigQuery and GCP Private Service Connect"
 id: bigquery-psc
-description: "Configuring GCP Private Service Connect for BigQuery (beta)"
-sidebar_label: "GCP Private Service Connect for BigQuery (beta)"
+description: "Configuring GCP Private Service Connect for BigQuery"
+sidebar_label: "GCP Private Service Connect for BigQuery"
 ---
 
-# Configuring BigQuery Private Service Connect <Lifecycle status="beta, managed_plus" />
+# Configuring BigQuery Private Service Connect <Lifecycle status="managed_plus" />
 
 import SetUpPages from '/snippets/_available-tiers-private-connection.md';
 import CloudProviders from '/snippets/_private-connection-across-providers.md';

--- a/website/docs/docs/cloud/secure/secure-your-tenant.md
+++ b/website/docs/docs/cloud/secure/secure-your-tenant.md
@@ -84,7 +84,7 @@ hide_table_of_contents: true
     icon="dbt-bit"/>
 
 <Card
-    title="GCP Private Service Connect for BigQuery (beta)"
+    title="GCP Private Service Connect for BigQuery"
     body="Learn how to configure GCP Private Service Connect for BigQuery."
     link="/docs/cloud/secure/bigquery-psc"
     icon="dbt-bit"/>


### PR DESCRIPTION
## What are you changing in this pull request and why?
Follow up to this PR to remove Beta designation from BigQuery PSC support
https://github.com/dbt-labs/docs.getdbt.com/pull/8085

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-bigquery-psc-remove-beta-dbt-labs.vercel.app/docs/cloud/secure/about-private-connectivity
- https://docs-getdbt-com-git-bigquery-psc-remove-beta-dbt-labs.vercel.app/docs/cloud/secure/bigquery-psc
- https://docs-getdbt-com-git-bigquery-psc-remove-beta-dbt-labs.vercel.app/docs/cloud/secure/secure-your-tenant

<!-- end-vercel-deployment-preview -->