### PR TITLE
Fix SQL syntax for `is_positive_int` function

### DIFF
--- a/website/docs/docs/build/udfs.md
+++ b/website/docs/docs/build/udfs.md
@@ -165,7 +165,7 @@ To define UDFs in dbt, refer to the following steps:
     ```sql
     select
         maybe_positive_int_column,
-        {{ function('is_positive_int') }}(maybe_positive_int_column)
+        {{ function('is_positive_int') }}(maybe_positive_int_column) as is_positive_int
     from {{ ref('a_model_i_like') }}
     ```
     </File>


### PR DESCRIPTION
## What are you changing in this pull request and why?
For BigQuery, you will get the following error if the column does not have an alias

```
22:30:29  Failure in model my_model (models/my_model.sql)
22:30:29    Database Error in model my_model (models/my_model.sql)
  CREATE VIEW columns must be named, but column 2 has no name at [6:6]
  compiled code at target/run/my_project/models/my_model.sql
```

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-dbeatty10-patch-1-dbt-labs.vercel.app/docs/build/udfs

<!-- end-vercel-deployment-preview -->