### PR TITLE
Update references from Horizon to Managed Catalog

### DIFF
--- a/website/docs/docs/mesh/iceberg/snowflake-iceberg-support.md
+++ b/website/docs/docs/mesh/iceberg/snowflake-iceberg-support.md
@@ -20,7 +20,7 @@ Refer to [Configure catalog integration](#configure-catalog-integration-for-mana
 
 :::
 
-We recommend using the Iceberg catalog configuration and applying the catalog in the model config for ease of use and to future-proof your code. Using `table_format = 'iceberg'` directly on the model configuration is a legacy approach and limits usage to just Snowflake Horizon as the catalog. Catalog support is available on dbt 1.10+.
+We recommend using the Iceberg catalog configuration and applying the catalog in the model config for ease of use and to future-proof your code. Using `table_format = 'iceberg'` directly on the model configuration is a legacy approach and limits usage to just Snowflake Managed Catalog as the catalog. Catalog support is available on dbt 1.10+.
 
 ## Creating Iceberg tables
 
@@ -33,7 +33,7 @@ dbt supports creating Iceberg tables for three of the Snowflake materializations
 ## Iceberg catalogs
 
 Snowflake has support for Iceberg tables via built-in and external catalogs, including:
-- Snowflake Horizon (the built-in catalog) 
+- Snowflake Managed Catalog (the built-in catalog) 
 - Polaris/Open Catalog (managed Polaris)
 - Glue Data Catalog (Supported in dbt-snowflake through a [catalog-linked database](https://docs.snowflake.com/en/user-guide/tables-iceberg-catalog-linked-database#label-catalog-linked-db-create) with Iceberg REST)
 - Iceberg REST Compatible 
@@ -248,12 +248,12 @@ You can set the following properties in model configurations under the `adapter_
 ### Configure catalog integration for managed Iceberg tables
 
 1. Create a `catalogs.yml` at the top level of your dbt project.<br />
-<br />An example of Snowflake Horizon as the catalog:
+<br />An example of Snowflake Managed Catalog as the catalog:
 
 ```yaml
 
 catalogs:
-  - name: catalog_horizon
+  - name: snowflake_catalog
     active_write_integration: snowflake_write_integration
     write_integrations:
       - name: snowflake_write_integration
@@ -273,7 +273,7 @@ catalogs:
 {{
     config(
         materialized='table',
-        catalog_name = 'catalog_horizon'
+        catalog_name = 'snowflake_catalog'
 
     )
 }}
@@ -296,7 +296,7 @@ The syncing experience will be different depending on the catalog you choose. So
 
 ## Iceberg table format
 
-The dbt-snowflake adapter also supports applying `table_format` as a standalone configuration for dbt-snowflake models. We recommend against using this, as it is a legacy behavior, and you will only be able to write to Snowflake Horizon (not external Iceberg catalogs).
+The dbt-snowflake adapter also supports applying `table_format` as a standalone configuration for dbt-snowflake models. We recommend against using this, as it is a legacy behavior, and you will only be able to write to Snowflake Managed Catalog (not external Iceberg catalogs).
 
 The following configurations are supported.
 For more information, check out the Snowflake reference for [`CREATE ICEBERG TABLE` (Snowflake as the catalog)](https://docs.snowflake.com/en/sql-reference/sql/create-iceberg-table-snowflake).
@@ -355,7 +355,7 @@ An example model with a customized `base_location`:
 {{
     config(
         materialized='table',
-        catalog_name='catalog_horizon',
+        catalog_name='snowflake_catalog',
         base_location_root='foo',
         base_location_subpath='bar',
 
@@ -392,7 +392,7 @@ An example model with a customized `base_location`:
 {{
     config(
         materialized='table',
-        catalog_name='catalog_horizon',
+        catalog_name='snowflake_catalog',
         adapter_properties={
           'base_location_root': 'foo',
           'base_location_subpath': 'bar',
@@ -415,7 +415,7 @@ For example, in the following model config, `base_location_root`=`bar` overrides
 ```sql
 config(
     materialized='table',
-    catalog_name='catalog_horizon',
+    catalog_name='snowflake_catalog',
     'base_location_root': 'foo',
     'base_location_subpath': 'bar',
     adapter_properties={


### PR DESCRIPTION
Or "Snowflake Catalog" in reference to `catalog = 'Snowflake;`

## What are you changing in this pull request and why?

We reference Snowflake Horizon. Actual Iceberg DML/DDL only has reference to a `snowflake = 'catalog'`. There is no actual name for this in the documentation, hence the perhaps colloquial 'snowflake managed catalog.' 

Horizon is a feature [described in docs](https://docs.snowflake.com/en/user-guide/snowflake-horizon) for governance and visibility. This is not does seem to correspond to the name horizon and serves to confused users trying to get up and get going with dbt iceberg. Reverting to a simpler name reduces friction for ramp up.

Some folks may argue we _should_ call this Horizon, but there should be a direct reference to Snowflake docs or blogs, since we couldn't find any ourselves!

## Checklist
<!-- Ensure your PR meets the following items. Feel free to add additiona checklist items to the list if additional checks need to happen before the PR is merged, such as:
- [ ] Needs technical review
- [ ] Change base branch
- [ ] Merge on xyz date
-->
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [x] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).
<!--
PRE-RELEASE VERSION OF dbt (if so, uncomment):
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
<!-- 
ADDING OR REMOVING PAGES (if so, uncomment):
- [ ] Add/remove page in `website/sidebars.js`
- [ ] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages
-->

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-versusfacit-patch-1-dbt-labs.vercel.app/docs/mesh/iceberg/snowflake-iceberg-support

<!-- end-vercel-deployment-preview -->