### PR TITLE
clarify unique key

### DIFF
--- a/website/docs/docs/build/incremental-models.md
+++ b/website/docs/docs/build/incremental-models.md
@@ -92,7 +92,7 @@ import Incrementalpredicates from '/snippets/_incremental-predicates.md';
 
 ### Defining a unique key
 
-Defining the optional `unique_key` parameter enables updating existing rows instead of just appending new rows. If new information arrives for an existing `unique_key`, that new information can replace the current information instead of being appended to the table. If a duplicate row arrives, it can be ignored. Refer to [strategy specific configs](/docs/build/incremental-strategy#strategy-specific-configs) for more options on managing this update behavior, like choosing only specific columns to update.
+Defining the optional [`unique_key` parameter](/reference/resource-configs/unique_key) enables updating existing rows instead of just appending new rows. If new information arrives for an existing `unique_key`, that new information can replace the current information instead of being appended to the table. If a duplicate row arrives, it can be ignored. Refer to [strategy specific configs](/docs/build/incremental-strategy#strategy-specific-configs) for more options on managing this update behavior, like choosing only specific columns to update.
 
 If you don't specify a `unique_key`, most adapters will result in `append`-only behavior, which means dbt inserts all rows returned by the model's SQL into the preexisting target table without regard for whether the rows represent duplicates.
 

--- a/website/docs/docs/build/incremental-models.md
+++ b/website/docs/docs/build/incremental-models.md
@@ -90,11 +90,11 @@ import Incrementalpredicates from '/snippets/_incremental-predicates.md';
 
 <Incrementalpredicates />
 
-### Defining a unique key (optional)
+### Defining a unique key
 
-A `unique_key` enables updating existing rows instead of just appending new rows. If new information arrives for an existing `unique_key`, that new information can replace the current information instead of being appended to the table. If a duplicate row arrives, it can be ignored. Refer to [strategy specific configs](/docs/build/incremental-strategy#strategy-specific-configs) for more options on managing this update behavior, like choosing only specific columns to update.
+Defining the optional `unique_key` parameter enables updating existing rows instead of just appending new rows. If new information arrives for an existing `unique_key`, that new information can replace the current information instead of being appended to the table. If a duplicate row arrives, it can be ignored. Refer to [strategy specific configs](/docs/build/incremental-strategy#strategy-specific-configs) for more options on managing this update behavior, like choosing only specific columns to update.
 
-Not specifying a `unique_key` will result in append-only behavior, which means dbt inserts all rows returned by the model's SQL into the preexisting target table without regard for whether the rows represent duplicates.
+If you don't specify a `unique_key`, most adapters will result in `append`-only behavior, which means dbt inserts all rows returned by the model's SQL into the preexisting target table without regard for whether the rows represent duplicates.
 
 The optional `unique_key` parameter specifies a field (or combination of fields) that defines the grain of your model. That is, the field(s) identify a single unique row. You can define `unique_key` in a configuration block at the top of your model, and it can be a single column name or a list of column names.
 

--- a/website/docs/reference/resource-configs/unique_key.md
+++ b/website/docs/reference/resource-configs/unique_key.md
@@ -109,6 +109,10 @@ This parameter is optional. If you don't provide a `unique_key`, your adapter wi
 
 If you leave out the `unique_key` parameter and use strategies like `merge`, `insert_overwrite`, `delete+insert`, or `microbatch`, the adapter will fall back to using `incremental_strategy: append`.
 
+This is different for BigQuery:
+- For `incremental_strategy = merge`, you must provide a `unique_key`; leaving it out leads to ambiguous or failing behavior.
+- For `insert_overwrite` or `microbatch`, `unique_key` is not required because they work by partition replacement rather than row-level upserts.
+
 ## Examples
 ### Use an `id` column as a unique key
 

--- a/website/docs/reference/resource-configs/unique_key.md
+++ b/website/docs/reference/resource-configs/unique_key.md
@@ -105,7 +105,7 @@ Providing a non-unique key will result in unexpected snapshot results. dbt **wil
 
 ## Default
 
-This parameter is optional. If you don't provide a `unique_key`, adapters will default to using `incremental_strategy: append`.
+This parameter is optional. If you don't provide a `unique_key`, your adapter will default to using `incremental_strategy: append`.
 
 If you leave out the `unique_key` parameter and use strategies like `merge`, `insert_overwrite`, `delete+insert`, or `microbatch`, the adapter will fall back to using `incremental_strategy: append`.
 

--- a/website/docs/reference/resource-configs/unique_key.md
+++ b/website/docs/reference/resource-configs/unique_key.md
@@ -104,8 +104,10 @@ Providing a non-unique key will result in unexpected snapshot results. dbt **wil
 :::
 
 ## Default
-This is a **required parameter**. No default is provided.
 
+This parameter is optional. If you don't provide a `unique_key`, adapters will default to using `incremental_strategy: append`.
+
+If you leave out the `unique_key` parameter and use strategies like `merge`, `insert_overwrite`, `delete+insert`, or `microbatch`, the adapter will fall back to using `incremental_strategy: append`.
 
 ## Examples
 ### Use an `id` column as a unique key


### PR DESCRIPTION
this pr fixes up the confusion that unique_key is optional, not required. 

this was raised in the community slack: https://getdbt.slack.com/archives/CBSQTAPLG/p1762788156202979

Closes #8157

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-adapter-strategy-dbt-labs.vercel.app/docs/build/incremental-models
- https://docs-getdbt-com-git-adapter-strategy-dbt-labs.vercel.app/reference/resource-configs/unique_key

<!-- end-vercel-deployment-preview -->