### PR TITLE
Correct version number in title for dbt-core Upgrading 1.11

### DIFF
--- a/website/docs/docs/dbt-versions/core-upgrade/04-upgrading-to-v1.11.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/04-upgrading-to-v1.11.md
@@ -5,7 +5,7 @@ description: New features and changes in dbt Core v1.11
 displayed_sidebar: "docs"
 ---
 
-# Upgrading to v1.1 <Lifecycle status="beta" />
+# Upgrading to v1.11 <Lifecycle status="beta" />
 
 :::note Installing Beta v1.11 on the command line 
 When using Core v1.11 on the command line (not in dbt platform), you need to install a beta version of dbt-core For example, `install --upgrade --pre dbt-core`


### PR DESCRIPTION
## What are you changing in this pull request and why?

The h1 title for the [Upgrading to v1.11](https://docs.getdbt.com/docs/dbt-versions/core-upgrade/upgrading-to-v1.11) shows `1.1` instead of `1.11`

This pull requests corrects the title

## Checklist

- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [x] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).
