### PR TITLE
add packages to header

### DIFF
--- a/website/docs/reference/project-configs/require-dbt-version.md
+++ b/website/docs/reference/project-configs/require-dbt-version.md
@@ -56,7 +56,7 @@ The `require-dbt-version` also signals whether a project or package supports the
 
 Refer to [pin to a range](#pin-to-a-range) for more info on how to define a version range.§
 
-<Expandable alt_header="Use dbt-autofix to update your dbt project to the latest best practices">
+<Expandable alt_header="Use dbt-autofix to update dbt projects and packages">
 
 [`dbt-autofix` tool](https://github.com/dbt-labs/dbt-autofix) automatically scans your dbt project for deprecated configurations and updates them to align with the latest best practices and prepare for <Constant name="fusion"/> migration. When it runs, it'll also check your `packages.yml` to determine which packages it can automatically upgrade:
 


### PR DESCRIPTION
this pr adds the word 'packages' to simplify it and make it clear to the user that autofix can be used for packages too

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-mirnawong1-patch-30-dbt-labs.vercel.app/reference/project-configs/require-dbt-version

<!-- end-vercel-deployment-preview -->