### PR TITLE
Pin GitHub Actions to specific SHAs (1 actions in 1 files)

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: dbt-labs/internal-actions/changed-files@changed-files-v1
+        uses: dbt-labs/internal-actions/changed-files@6ff66921e5028a073bdc567410d363b1b78e3f59  # dbt-labs/internal-actions/changed-files@changed-files-v1
         with:
           files: |
             website/**/*.md


### PR DESCRIPTION
## 📌 Pin GitHub Actions to Specific SHAs

This PR updates GitHub Actions references from tags/branches to specific commit SHAs for improved security and reproducibility.

### 📊 Summary
- **Files changed**: 1
- **Actions pinned**: 1

### 📝 Changes by file

#### `.github/workflows/vale.yml`

- 📌 `dbt-labs/internal-actions/changed-files@changed-files-v1` → `dbt-labs/internal-actions/changed-files@6ff66921e5028a073bdc567410d363b1b78e3f59  # dbt-labs/internal-actions/changed-files@changed-files-v1`

