### PR TITLE
autocomplete doesn't trigger when replacing existing names

### DIFF
--- a/website/docs/docs/dbt-extension-features.md
+++ b/website/docs/docs/dbt-extension-features.md
@@ -53,7 +53,7 @@ Parse even the largest projects up to 30x faster than with dbt Core.
 Autocomplete SQL functions, model names, macros and more.
 
 Usage:
-- Autocomplete `ref`s and `source` calls. For example, type `{{ ref(`  or `{{ source(` and you will see a list of available resources and their type complete the function call.
+- Autocomplete `ref`s and `source` calls. For example, type `{{ ref(`  or `{{ source(` and you will see a list of available resources and their type complete the function call. Autocomplete doesn’t trigger when replacing existing model names inside parentheses.
 - Autocomplete dialect-specific function names.
 
 <Lightbox src="/img/docs/extension/vsce-intellisense.gif" width="100%" title="Example of the VS Code extension IntelliSense"/>


### PR DESCRIPTION
this pr clarifies that autocomplete doesn’t trigger when replacing existing model names inside parenthesis.

raised internally: https://dbt-labs.slack.com/archives/C08USPUN8F4/p1763570990283609

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-clarify-autocomplete-dbt-labs.vercel.app/docs/dbt-extension-features

<!-- end-vercel-deployment-preview -->