### PR TITLE
Add - LLM context menu ids and link

### DIFF
--- a/website/src/components/copyPage/config.js
+++ b/website/src/components/copyPage/config.js
@@ -13,6 +13,11 @@ export const LLM_SERVICES = {
     name: 'Claude',
     url: 'https://claude.ai/new?q=Read+from+{url}+so+I+can+ask+questions+about+it.',
     subtitle: 'Ask questions about this page'
+  },
+  perplexity: {
+    name: 'Perplexity',
+    url: 'https://www.perplexity.ai/search/new?q=Read+from+{url}+so+I+can+ask+questions+about+it.',
+    subtitle: 'Ask questions about this page'
   }
 };
 

--- a/website/src/components/copyPage/config.js
+++ b/website/src/components/copyPage/config.js
@@ -8,19 +8,19 @@ export const LLM_SERVICES = {
     name: 'ChatGPT',
     url: 'https://chatgpt.com/?hints=search&prompt=Read+from+{url}+so+I+can+ask+questions+about+it.',
     subtitle: 'Ask questions about this page',
-    id: 'open_in_chatgpt'
+    id: 'llm_open_in_chatgpt'
   },
   claude: {
     name: 'Claude',
     url: 'https://claude.ai/new?q=Read+from+{url}+so+I+can+ask+questions+about+it.',
     subtitle: 'Ask questions about this page',
-    id: 'open_in_claude'
+    id: 'llm_open_in_claude'
   },
   perplexity: {
     name: 'Perplexity',
     url: 'https://www.perplexity.ai/search/new?q=Read+from+{url}+so+I+can+ask+questions+about+it.',
     subtitle: 'Ask questions about this page',
-    id: 'open_in_perplexity'
+    id: 'llm_open_in_perplexity'
   }
 };
 

--- a/website/src/components/copyPage/config.js
+++ b/website/src/components/copyPage/config.js
@@ -7,17 +7,20 @@ export const LLM_SERVICES = {
   chatgpt: {
     name: 'ChatGPT',
     url: 'https://chatgpt.com/?hints=search&prompt=Read+from+{url}+so+I+can+ask+questions+about+it.',
-    subtitle: 'Ask questions about this page'
+    subtitle: 'Ask questions about this page',
+    id: 'open_in_chatgpt'
   },
   claude: {
     name: 'Claude',
     url: 'https://claude.ai/new?q=Read+from+{url}+so+I+can+ask+questions+about+it.',
-    subtitle: 'Ask questions about this page'
+    subtitle: 'Ask questions about this page',
+    id: 'open_in_claude'
   },
   perplexity: {
     name: 'Perplexity',
     url: 'https://www.perplexity.ai/search/new?q=Read+from+{url}+so+I+can+ask+questions+about+it.',
-    subtitle: 'Ask questions about this page'
+    subtitle: 'Ask questions about this page',
+    id: 'open_in_perplexity'
   }
 };
 

--- a/website/src/components/copyPage/index.js
+++ b/website/src/components/copyPage/index.js
@@ -12,8 +12,13 @@ import Link from '@docusaurus/Link';
  * - Open page in configured LLM services (ChatGPT, Claude, etc.)
  * - Full keyboard navigation and accessibility support
  * - Error handling and user feedback
+ *
+ * @param {Object} props
+ * @param {boolean} [props.dropdownRight=false] - Align dropdown to the right (used on guides pages)
+ * @param {string} [props.pageUrl] - Fully qualified canonical URL for the current page,
+ *   used to build LLM links. If omitted, the hook will fall back to window.location.
  */
-function CopyPage({ dropdownRight = false }) {
+function CopyPage({ dropdownRight = false, pageUrl }) {
   const {
     isDropdownOpen,
     copySuccess,
@@ -22,7 +27,7 @@ function CopyPage({ dropdownRight = false }) {
     dropdownRef,
     handleCopyPage,
     toggleDropdown,
-  } = useCopyPage();
+  } = useCopyPage({ pageUrl });
 
   return (
     <div className={styles.copyPageContainer} ref={dropdownRef}>

--- a/website/src/components/copyPage/index.js
+++ b/website/src/components/copyPage/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import styles from './styles.module.css';
 import { useCopyPage } from '../../utils/use-copy-page';
 import getSvgIcon from '../../utils/get-svg-icon';
+import Link from '@docusaurus/Link';
 
 /**
  * CopyPage Component
@@ -59,7 +60,7 @@ function CopyPage({ dropdownRight = false }) {
         </button>
 
         {Object.entries(llmServices).map(([serviceKey, service]) => (
-          <a
+          <Link
             key={serviceKey}
             id={service.id}
             className={styles.dropdownItem}
@@ -77,7 +78,7 @@ function CopyPage({ dropdownRight = false }) {
                 {service.subtitle}
               </div>
             </div>
-          </a>
+          </Link>
         ))}
       </div>
 

--- a/website/src/components/copyPage/index.js
+++ b/website/src/components/copyPage/index.js
@@ -20,7 +20,6 @@ function CopyPage({ dropdownRight = false }) {
     llmServices,
     dropdownRef,
     handleCopyPage,
-    handleOpenInLLM,
     toggleDropdown,
   } = useCopyPage();
 
@@ -38,49 +37,49 @@ function CopyPage({ dropdownRight = false }) {
         {getSvgIcon("chevron-down", { className: styles.dropdownIcon })}
       </button>
 
-      {isDropdownOpen && (
-        <div
-          className={`${styles.dropdown} ${dropdownRight ? styles.dropdownRight : ''}`}
-          role="menu"
-          aria-label="Copy page menu"
+      <div
+        className={`${styles.dropdown} ${dropdownRight ? styles.dropdownRight : ''} ${!isDropdownOpen ? styles.dropdownHidden : ''}`}
+        role="menu"
+        aria-label="Copy page menu"
+        aria-hidden={!isDropdownOpen}
+      >
+        <button
+          className={styles.dropdownItem}
+          onClick={handleCopyPage}
+          role="menuitem"
+          tabIndex={isDropdownOpen ? "0" : "-1"}
         >
-          <button
+          {getSvgIcon("copy", {})}
+          <div className={styles.dropdownItemContent}>
+            <div className={styles.dropdownItemTitle}>Copy page</div>
+            <div className={styles.dropdownItemSubtitle}>
+              Copy page as Markdown for LLMs
+            </div>
+          </div>
+        </button>
+
+        {Object.entries(llmServices).map(([serviceKey, service]) => (
+          <a
+            key={serviceKey}
+            id={service.id}
             className={styles.dropdownItem}
-            onClick={handleCopyPage}
+            href={service.computedUrl}
+            target="_blank"
             role="menuitem"
-            tabIndex="0"
+            tabIndex={isDropdownOpen ? "0" : "-1"}
           >
-            {getSvgIcon("copy", {})}
+            {getSvgIcon("external-link", {})}
             <div className={styles.dropdownItemContent}>
-              <div className={styles.dropdownItemTitle}>Copy page</div>
+              <div className={styles.dropdownItemTitle}>
+                Open in {service.name}
+              </div>
               <div className={styles.dropdownItemSubtitle}>
-                Copy page as Markdown for LLMs
+                {service.subtitle}
               </div>
             </div>
-          </button>
-
-          {Object.entries(llmServices).map(([serviceKey, service]) => (
-            <a
-              key={serviceKey}
-              id={service.id}
-              className={styles.dropdownItem}
-              href={service.computedUrl}
-              target="_blank"
-              role="menuitem"
-            >
-              {getSvgIcon("external-link", {})}
-              <div className={styles.dropdownItemContent}>
-                <div className={styles.dropdownItemTitle}>
-                  Open in {service.name}
-                </div>
-                <div className={styles.dropdownItemSubtitle}>
-                  {service.subtitle}
-                </div>
-              </div>
-            </a>
-          ))}
-        </div>
-      )}
+          </a>
+        ))}
+      </div>
 
       {copySuccess && (
         <div

--- a/website/src/components/copyPage/index.js
+++ b/website/src/components/copyPage/index.js
@@ -60,13 +60,13 @@ function CopyPage({ dropdownRight = false }) {
           </button>
 
           {Object.entries(llmServices).map(([serviceKey, service]) => (
-            <button
+            <a
               key={serviceKey}
               id={service.id}
               className={styles.dropdownItem}
-              onClick={() => handleOpenInLLM(serviceKey)}
+              href={service.computedUrl}
+              target="_blank"
               role="menuitem"
-              tabIndex="0"
             >
               {getSvgIcon("external-link", {})}
               <div className={styles.dropdownItemContent}>
@@ -77,7 +77,7 @@ function CopyPage({ dropdownRight = false }) {
                   {service.subtitle}
                 </div>
               </div>
-            </button>
+            </a>
           ))}
         </div>
       )}

--- a/website/src/components/copyPage/index.js
+++ b/website/src/components/copyPage/index.js
@@ -62,6 +62,7 @@ function CopyPage({ dropdownRight = false }) {
           {Object.entries(llmServices).map(([serviceKey, service]) => (
             <button
               key={serviceKey}
+              id={service.id}
               className={styles.dropdownItem}
               onClick={() => handleOpenInLLM(serviceKey)}
               role="menuitem"

--- a/website/src/components/copyPage/styles.module.css
+++ b/website/src/components/copyPage/styles.module.css
@@ -57,6 +57,15 @@
   min-width: 280px;
   z-index: 1000;
   overflow: hidden;
+  opacity: 1;
+  visibility: visible;
+  transition: opacity 0.2s ease, visibility 0.2s ease;
+}
+
+.dropdownHidden {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
 }
 
 .dropdownRight {

--- a/website/src/components/copyPage/styles.module.css
+++ b/website/src/components/copyPage/styles.module.css
@@ -78,10 +78,12 @@
   cursor: pointer;
   transition: background-color 0.2s ease;
   text-align: left;
+  text-decoration: none;
 }
 
 .dropdownItem:hover {
   background: #f9fafb;
+  text-decoration: none;
 }
 
 .dropdownItem svg {
@@ -95,6 +97,7 @@
   align-items: flex-start;
   gap: 2px;
   flex: 1;
+  text-decoration: none !important;
 }
 
 .dropdownItemTitle {
@@ -104,11 +107,20 @@
   line-height: 1.2;
 }
 
+.dropdownItemTitle:hover {
+  text-decoration: none !important;
+}
+
 .dropdownItemSubtitle {
   font-size: 0.75rem;
   font-weight: 400;
   color: #6b7280;
   line-height: 1.2;
+  text-decoration: none !important;
+}
+
+.dropdownItemSubtitle:hover {
+  text-decoration: none !important;
 }
 
 .success {
@@ -216,6 +228,7 @@
 
 [data-theme='dark'] .dropdownItem:hover {
   background: #374151;
+  text-decoration: none;
 }
 
 [data-theme='dark'] .copyIcon,

--- a/website/src/components/copyPage/styles.module.css
+++ b/website/src/components/copyPage/styles.module.css
@@ -90,9 +90,10 @@
   text-decoration: none;
 }
 
-.dropdownItem:hover {
+a.dropdownItem:hover, .dropdownItem:hover {
   background: #f9fafb;
-  text-decoration: none;
+  text-decoration: none !important;
+  color: #374151 !important;
 }
 
 .dropdownItem svg {
@@ -235,9 +236,14 @@
   color: #d1d5db;
 }
 
-[data-theme='dark'] .dropdownItem:hover {
+[data-theme='dark'] .copyPageContainer a.dropdownItem:hover, [data-theme='dark'] .dropdownItem:hover {
   background: #374151;
-  text-decoration: none;
+  text-decoration: none !important;
+  color: #d1d5db !important;
+}
+
+[data-theme='dark'] .copyPageContainer a.dropdownItem:hover .dropdownItemTitle {
+  color: #d1d5db !important;
 }
 
 [data-theme='dark'] .copyIcon,

--- a/website/src/theme/DocItem/Layout/index.js
+++ b/website/src/theme/DocItem/Layout/index.js
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import {useWindowSize} from '@docusaurus/theme-common';
 import { useDoc } from "@docusaurus/plugin-content-docs/client";
 import { useLocation } from '@docusaurus/router';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import DocItemPaginator from '@theme/DocItem/Paginator';
 import DocVersionBanner from '@theme/DocVersionBanner';
 import DocVersionBadge from '@theme/DocVersionBadge';
@@ -183,11 +184,14 @@ export default function DocItemLayout({children}) {
   const {frontMatter, metadata} = useDoc();
   const searchWeight = frontMatter?.search_weight && frontMatter.search_weight
 
+  // Get site URL from Docusaurus config so we can build a canonical, fully-qualified URL
+  const { siteConfig } = useDocusaurusContext();
+
   // Construct full URL for structured data
   const location = useLocation();
   const isGuidesRoute = location.pathname.includes('/guides/');
-  const siteUrl = typeof window !== 'undefined' ? window.location.origin : '';
-  const fullUrl = `${siteUrl}${location.pathname}`;
+  const siteUrl = siteConfig?.url || '';
+  const fullUrl = `${siteUrl}${location.pathname}${location.search}${location.hash}`;
 
   // Format date for structured data (use lastUpdatedAt if available)
   const formatDate = (timestamp) => {
@@ -211,7 +215,7 @@ export default function DocItemLayout({children}) {
           <article>
           <div className={styles.copyPageContainer}>
             <DocBreadcrumbs />
-            <CopyPage dropdownRight={isGuidesRoute} />
+            <CopyPage dropdownRight={isGuidesRoute} pageUrl={fullUrl} />
             </div>
             <DocVersionBadge />
             {docTOC.mobile}

--- a/website/src/utils/use-copy-page.js
+++ b/website/src/utils/use-copy-page.js
@@ -14,6 +14,22 @@ export function useCopyPage() {
   const dropdownRef = useRef(null);
   const rawMarkdownContent = useRawMarkdownContent();
 
+  // Compute LLM service URLs with the current page URL
+  const llmServicesWithUrls = Object.entries(LLM_SERVICES).reduce((acc, [key, service]) => {
+    // Always use the production domain to avoid localhost/preview URLs in LLM context
+    const productionUrl = typeof window !== 'undefined' 
+      ? `https://docs.getdbt.com${window.location.pathname}${window.location.search}${window.location.hash}`
+      : '';
+    const encodedUrl = encodeURIComponent(productionUrl);
+    const llmUrl = service.url.replace('{url}', encodedUrl);
+    
+    acc[key] = {
+      ...service,
+      computedUrl: llmUrl
+    };
+    return acc;
+  }, {});
+
   // Close dropdown when clicking outside
   useEffect(() => {
     function handleClickOutside(event) {
@@ -132,7 +148,7 @@ export function useCopyPage() {
     copySuccess,
     error,
     rawMarkdownContent,
-    llmServices: LLM_SERVICES,
+    llmServices: llmServicesWithUrls,
 
     // Refs
     dropdownRef,


### PR DESCRIPTION
## What are you changing in this pull request and why?
- Added unique `id` values to each dropdown option for Snowplow click tracking.  
- Added “Open in Perplexity” to the dropdown list.  
- Refactored the “Open in LLM” buttons:
  - Changed elements from `<button>` to `<a>` to enable link-based click tracking.  
  - Updated dropdown visibility logic from dynamic JS control to CSS-based toggling for improved tracking reliability.


## Preview

https://docs-getdbt-com-git-add-llm-cm-link-dbt-labs.vercel.app/reference/resource-configs/postgres-configs

## Testing

### Functional Testing
1. Open the preview link above.  
2. Use **Copy Page → Open in…** for each option.  
3. Confirm that each LLM (ChatGPT, Claude, Perplexity, etc.) opens with the content pre-populated as expected.  

### Snowplow Testing
1. Open the **Snowplow Debugger**.  
2. Repeat the steps above.  
3. Confirm that a **Self Describing Event** appears after clicking each LLM option.  

<img width="1673" height="1233" alt="DevTools_-_docs-getdbt-com-git-add-llm-cm-link-dbt-labs_vercel_app_reference_dbt_project_yml_and_ChatGPT" src="https://github.com/user-attachments/assets/6304b296-a04a-4238-aded-127295fe0549" />

## Additional Info
⚠️ During testing, I found that Snowplow’s `enableLinkClickTracking` (triggered via GTM) wasn’t firing consistently across client-side navigations.  
To fix this, I added a new GTM tag `refreshLinkClickTracking` which runs on every history change, ensuring link clicks continue to be tracked correctly on all pages.
```
<script>
  // Defer to next frame to ensure the new page DOM exists
  requestAnimationFrame(function () {
    if (window.snowplow) window.snowplow('refreshLinkClickTracking');
  });
</script>
```
