### PR TITLE
adds periods to end of bullet points

### DIFF
--- a/website/docs/docs/get-started-dbt.md
+++ b/website/docs/docs/get-started-dbt.md
@@ -12,11 +12,11 @@ Begin your dbt journey by trying one of our quickstarts, which provides a step-b
 
 <Constant name="cloud" /> is a scalable solution that enables you to develop, test, deploy, and explore data products using a single, fully managed software service. It enables teams with diverse skills to build reliable data products at any scale, with capabilities including:
 
-- Development experiences tailored to multiple personas (in-browser [<Constant name="cloud_ide" />](/docs/cloud/dbt-cloud-ide/develop-in-the-cloud) or locally with the [<Constant name="cloud" /> CLI](/docs/cloud/cloud-cli-installation))
-- Out-of-the-box [CI/CD workflows](/docs/deploy/ci-jobs)
-- The [<Constant name="semantic_layer" />](/docs/use-dbt-semantic-layer/dbt-sl) for consistent metrics that can be delivered to any endpoint
-- Domain ownership of data with multi-project [<Constant name="mesh" />](/best-practices/how-we-mesh/mesh-1-intro) setups
-- [<Constant name="explorer" />](/docs/explore/explore-projects) for collaborative data discovery and understanding
+- Development experiences tailored to multiple personas (in-browser [<Constant name="cloud_ide" />](/docs/cloud/dbt-cloud-ide/develop-in-the-cloud) or locally with the [<Constant name="cloud" /> CLI](/docs/cloud/cloud-cli-installation)).
+- Out-of-the-box [CI/CD workflows](/docs/deploy/ci-jobs).
+- The [<Constant name="semantic_layer" />](/docs/use-dbt-semantic-layer/dbt-sl) for consistent metrics that can be delivered to any endpoint.
+- Domain ownership of data with multi-project [<Constant name="mesh" />](/best-practices/how-we-mesh/mesh-1-intro) setups.
+- [<Constant name="explorer" />](/docs/explore/explore-projects) for collaborative data discovery and understanding.
 
 Learn more about [<Constant name="cloud" /> features](/docs/cloud/about-cloud/dbt-cloud-features) and [start your free trial](https://www.getdbt.com/signup/) today.
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
This PR adds periods to the end of five bullet points in the "dbt Cloud capabilities" section of `website/docs/docs/get-started-dbt.md`. This change ensures consistent punctuation throughout the document, aligning with the style used in other bulleted lists on the page.

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).

---
[Slack Thread](https://dbt-labs.slack.com/archives/C0A16RWFC4E/p1764778772933839?thread_ts=1764778772.933839&cid=C0A16RWFC4E)

<a href="https://cursor.com/background-agent?bcId=bc-81a08318-72e4-42ae-97c9-2a71dfb4d3d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-81a08318-72e4-42ae-97c9-2a71dfb4d3d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

