### PR TITLE
Open pull request for fix

### DIFF
--- a/website/docs/docs/mesh/govern/project-dependencies.md
+++ b/website/docs/docs/mesh/govern/project-dependencies.md
@@ -9,6 +9,12 @@ keyword: dbt mesh, project dependencies, ref, cross project ref, project depende
 
 # Project dependencies <Lifecycle status='managed,managed_plus'/>
 
+<IntroText>
+
+Available on dbt Cloud [Enterprise or Enterprise+](https://www.getdbt.com/pricing) plans.
+
+</IntroText>
+
 For a long time, dbt has supported code reuse and extension by installing other projects as [packages](/docs/build/packages). When you install another project as a package, you are pulling in its full source code, and adding it to your own. This enables you to call macros and run models defined in that other project.
 
 While this is a great way to reuse code, share utility macros, and establish a starting point for common transformations, it's not a great way to enable collaboration across teams and at scale, especially in larger organizations.

--- a/website/docs/docs/mesh/govern/project-dependencies.md
+++ b/website/docs/docs/mesh/govern/project-dependencies.md
@@ -11,7 +11,7 @@ keyword: dbt mesh, project dependencies, ref, cross project ref, project depende
 
 <IntroText>
 
-Available on dbt Cloud [Enterprise or Enterprise+](https://www.getdbt.com/pricing) plans.
+Available on dbt [Enterprise or Enterprise+](https://www.getdbt.com/pricing) plans.
 
 </IntroText>
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
This PR adds an `<IntroText>` component to the "Project dependencies" page (`website/docs/docs/mesh/govern/project-dependencies.md`).

The `<IntroText>` component states: "Available on dbt Cloud [Enterprise or Enterprise+](https://www.getdbt.com/pricing) plans." This clarifies the plan requirements for the feature, following the established pattern of using `<IntroText>` for subtitles or plan information after the page title, similar to its usage on the dbt Semantic Layer page.

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).

---
[Slack Thread](https://dbt-labs.slack.com/archives/C0A16RWFC4E/p1764797799658409?thread_ts=1764797799.658409&cid=C0A16RWFC4E)

<a href="https://cursor.com/background-agent?bcId=bc-3516573f-5dfe-47e9-8cbf-c8fe0346f56b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3516573f-5dfe-47e9-8cbf-c8fe0346f56b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

