### PR TITLE
Change package support to a table

### DIFF
--- a/website/snippets/_fusion-supported-packages.md
+++ b/website/snippets/_fusion-supported-packages.md
@@ -1,37 +1,37 @@
 The following packages are verified and supported on the <Constant name="fusion_engine" />:
 
-| Organization | Package | Repository | Notes |
-|--------------|---------|------------|-------|
-| AxelThevenot | dbt_assertions | [GitHub](https://github.com/AxelThevenot/dbt-assertions) | |
-| Datavault-UK | automate_dv | [GitHub](https://github.com/Datavault-UK/dbtvault.git) | |
-| dbt-labs | audit_helper | [GitHub](https://github.com/dbt-labs/dbt-audit-helper.git) | |
-| dbt-labs | codegen | [GitHub](https://github.com/dbt-labs/dbt-codegen.git) | |
-| dbt-labs | dbt_project_evaluator | [GitHub](https://github.com/dbt-labs/dbt-project-evaluator.git) | Versions 1.1.1 and above |
-| dbt-labs | dbt_utils | [GitHub](https://github.com/dbt-labs/dbt-utils.git) | |
-| elementary-data | elementary | [GitHub](https://github.com/elementary-data/dbt-data-reliability.git) | |
-| entechlog | dbt_snow_mask | [GitHub](https://github.com/entechlog/dbt-snow-mask.git) | |
-| fivetran | ad_reporting | [GitHub](https://github.com/fivetran/dbt_ad_reporting.git) | |
-| fivetran | facebook_ads | [GitHub](https://github.com/fivetran/dbt_facebook_ads.git) | |
-| fivetran | fivetran_log | [GitHub](https://github.com/fivetran/dbt_fivetran_log.git) | |
-| fivetran | fivetran_utils | [GitHub](https://github.com/fivetran/dbt_fivetran_utils.git) | |
-| fivetran | google_ads | [GitHub](https://github.com/fivetran/dbt_google_ads.git) | |
-| fivetran | hubspot | [GitHub](https://github.com/fivetran/dbt_hubspot.git) | |
-| fivetran | jira | [GitHub](https://github.com/fivetran/dbt_jira.git) | |
-| fivetran | linkedin | [GitHub](https://github.com/dbt-labs/dbt-project-evaluator.git) | |
-| fivetran | microsoft_ads | [GitHub](https://github.com/fivetran/dbt_microsoft_ads.git) | |
-| fivetran | pendo | [GitHub](https://github.com/fivetran/dbt_pendo.git) | |
-| fivetran | qualtrics | [GitHub](https://github.com/fivetran/dbt_qualtrics.git) | |
-| fivetran | salesforce | [GitHub](https://github.com/fivetran/dbt_salesforce.git) | |
-| fivetran | salesforce_formula_utils | [GitHub](https://github.com/fivetran/dbt_salesforce_formula_utils.git) | |
-| fivetran | social_media_reporting | [GitHub](https://github.com/fivetran/dbt_social_media_reporting.git) | |
-| fivetran | zendesk | [GitHub](https://github.com/fivetran/dbt_zendesk.git) | |
-| GJMcClintock | dbt_tld | [GitHub](https://github.com/GJMcClintock/dbt_tld.git) | |
-| godatadriven | dbt_date | [GitHub](https://github.com/godatadriven/dbt-date.git) | |
-| kristeligt-dagblad | dbt_ml | [GitHub](https://github.com/kristeligt-dagblad/dbt_ml.git) | |
-| LewisDavies | upstream_prod | [GitHub](https://github.com/LewisDavies/upstream-prod.git) | Versions 0.9.6 and above |
-| metaplane | dbt_expectations | [GitHub](https://github.com/metaplane/dbt-expectations.git) | |
-| Montreal-Analytics | snowflake_utils | [GitHub](https://github.com/Montreal-Analytics/dbt-snowflake-utils.git) | |
-| Snowflake-Labs | dbt_semantic_view | [GitHub](https://github.com/Snowflake-Labs/dbt_semantic_view) | |
+| Package | Repository | Notes |
+|---------|------------|-------|
+| AxelThevenot/dbt_assertions | [GitHub](https://github.com/AxelThevenot/dbt-assertions) | |
+| Datavault-UK/automate_dv | [GitHub](https://github.com/Datavault-UK/dbtvault.git) | |
+| dbt-labs/audit_helper | [GitHub](https://github.com/dbt-labs/dbt-audit-helper.git) | |
+| dbt-labs/codegen | [GitHub](https://github.com/dbt-labs/dbt-codegen.git) | |
+| dbt-labs/dbt_project_evaluator | [GitHub](https://github.com/dbt-labs/dbt-project-evaluator.git) | Versions 1.1.1 and above |
+| dbt-labs/dbt_utils | [GitHub](https://github.com/dbt-labs/dbt-utils.git) | |
+| elementary-data/elementary | [GitHub](https://github.com/elementary-data/dbt-data-reliability.git) | |
+| entechlog/dbt_snow_mask | [GitHub](https://github.com/entechlog/dbt-snow-mask.git) | |
+| fivetran/ad_reporting | [GitHub](https://github.com/fivetran/dbt_ad_reporting.git) | |
+| fivetran/facebook_ads | [GitHub](https://github.com/fivetran/dbt_facebook_ads.git) | |
+| fivetran/fivetran_log | [GitHub](https://github.com/fivetran/dbt_fivetran_log.git) | |
+| fivetran/fivetran_utils | [GitHub](https://github.com/fivetran/dbt_fivetran_utils.git) | |
+| fivetran/google_ads | [GitHub](https://github.com/fivetran/dbt_google_ads.git) | |
+| fivetran/hubspot | [GitHub](https://github.com/fivetran/dbt_hubspot.git) | |
+| fivetran/jira | [GitHub](https://github.com/fivetran/dbt_jira.git) | |
+| fivetran/linkedin | [GitHub](https://github.com/dbt-labs/dbt-project-evaluator.git) | |
+| fivetran/microsoft_ads | [GitHub](https://github.com/fivetran/dbt_microsoft_ads.git) | |
+| fivetran/pendo | [GitHub](https://github.com/fivetran/dbt_pendo.git) | |
+| fivetran/qualtrics | [GitHub](https://github.com/fivetran/dbt_qualtrics.git) | |
+| fivetran/salesforce | [GitHub](https://github.com/fivetran/dbt_salesforce.git) | |
+| fivetran/salesforce_formula_utils | [GitHub](https://github.com/fivetran/dbt_salesforce_formula_utils.git) | |
+| fivetran/social_media_reporting | [GitHub](https://github.com/fivetran/dbt_social_media_reporting.git) | |
+| fivetran/zendesk | [GitHub](https://github.com/fivetran/dbt_zendesk.git) | |
+| GJMcClintock/dbt_tld | [GitHub](https://github.com/GJMcClintock/dbt_tld.git) | |
+| godatadriven/dbt_date | [GitHub](https://github.com/godatadriven/dbt-date.git) | |
+| kristeligt-dagblad/dbt_ml | [GitHub](https://github.com/kristeligt-dagblad/dbt_ml.git) | |
+| LewisDavies/upstream_prod | [GitHub](https://github.com/LewisDavies/upstream-prod.git) | Versions 0.9.6 and above |
+| metaplane/dbt_expectations | [GitHub](https://github.com/metaplane/dbt-expectations.git) | |
+| Montreal-Analytics/snowflake_utils | [GitHub](https://github.com/Montreal-Analytics/dbt-snowflake-utils.git) | |
+| Snowflake-Labs/dbt_semantic_view | [GitHub](https://github.com/Snowflake-Labs/dbt_semantic_view) | |
 
 Additionally, the Fivetran `source` and `transformation` packages have been combined into a single package. If you manually installed source packages like `fivetran/github_source`, you need to ensure `fivetran/github` is installed and deactivate the transformation models.
 

--- a/website/snippets/_fusion-supported-packages.md
+++ b/website/snippets/_fusion-supported-packages.md
@@ -1,37 +1,37 @@
 The following packages are verified and supported on the <Constant name="fusion_engine" />:
 
-| Package | Repository | Notes |
-|---------|------------|-------|
-| AxelThevenot/dbt_assertions | [GitHub](https://github.com/AxelThevenot/dbt-assertions) | |
-| Datavault-UK/automate_dv | [GitHub](https://github.com/Datavault-UK/dbtvault.git) | |
-| dbt-labs/audit_helper | [GitHub](https://github.com/dbt-labs/dbt-audit-helper.git) | |
-| dbt-labs/codegen | [GitHub](https://github.com/dbt-labs/dbt-codegen.git) | |
-| dbt-labs/dbt_project_evaluator | [GitHub](https://github.com/dbt-labs/dbt-project-evaluator.git) | Versions 1.1.1 and above |
-| dbt-labs/dbt_utils | [GitHub](https://github.com/dbt-labs/dbt-utils.git) | |
-| elementary-data/elementary | [GitHub](https://github.com/elementary-data/dbt-data-reliability.git) | |
-| entechlog/dbt_snow_mask | [GitHub](https://github.com/entechlog/dbt-snow-mask.git) | |
-| fivetran/ad_reporting | [GitHub](https://github.com/fivetran/dbt_ad_reporting.git) | |
-| fivetran/facebook_ads | [GitHub](https://github.com/fivetran/dbt_facebook_ads.git) | |
-| fivetran/fivetran_log | [GitHub](https://github.com/fivetran/dbt_fivetran_log.git) | |
-| fivetran/fivetran_utils | [GitHub](https://github.com/fivetran/dbt_fivetran_utils.git) | |
-| fivetran/google_ads | [GitHub](https://github.com/fivetran/dbt_google_ads.git) | |
-| fivetran/hubspot | [GitHub](https://github.com/fivetran/dbt_hubspot.git) | |
-| fivetran/jira | [GitHub](https://github.com/fivetran/dbt_jira.git) | |
-| fivetran/linkedin | [GitHub](https://github.com/dbt-labs/dbt-project-evaluator.git) | |
-| fivetran/microsoft_ads | [GitHub](https://github.com/fivetran/dbt_microsoft_ads.git) | |
-| fivetran/pendo | [GitHub](https://github.com/fivetran/dbt_pendo.git) | |
-| fivetran/qualtrics | [GitHub](https://github.com/fivetran/dbt_qualtrics.git) | |
-| fivetran/salesforce | [GitHub](https://github.com/fivetran/dbt_salesforce.git) | |
-| fivetran/salesforce_formula_utils | [GitHub](https://github.com/fivetran/dbt_salesforce_formula_utils.git) | |
-| fivetran/social_media_reporting | [GitHub](https://github.com/fivetran/dbt_social_media_reporting.git) | |
-| fivetran/zendesk | [GitHub](https://github.com/fivetran/dbt_zendesk.git) | |
-| GJMcClintock/dbt_tld | [GitHub](https://github.com/GJMcClintock/dbt_tld.git) | |
-| godatadriven/dbt_date | [GitHub](https://github.com/godatadriven/dbt-date.git) | |
-| kristeligt-dagblad/dbt_ml | [GitHub](https://github.com/kristeligt-dagblad/dbt_ml.git) | |
-| LewisDavies/upstream_prod | [GitHub](https://github.com/LewisDavies/upstream-prod.git) | Versions 0.9.6 and above |
-| metaplane/dbt_expectations | [GitHub](https://github.com/metaplane/dbt-expectations.git) | |
-| Montreal-Analytics/snowflake_utils | [GitHub](https://github.com/Montreal-Analytics/dbt-snowflake-utils.git) | |
-| Snowflake-Labs/dbt_semantic_view | [GitHub](https://github.com/Snowflake-Labs/dbt_semantic_view) | |
+| Organization | Package | Repository | Notes |
+|--------------|---------|------------|-------|
+| AxelThevenot | dbt_assertions | [GitHub](https://github.com/AxelThevenot/dbt-assertions) | |
+| Datavault-UK | automate_dv | [GitHub](https://github.com/Datavault-UK/dbtvault.git) | |
+| dbt-labs | audit_helper | [GitHub](https://github.com/dbt-labs/dbt-audit-helper.git) | |
+| dbt-labs | codegen | [GitHub](https://github.com/dbt-labs/dbt-codegen.git) | |
+| dbt-labs | dbt_project_evaluator | [GitHub](https://github.com/dbt-labs/dbt-project-evaluator.git) | Versions 1.1.1 and above |
+| dbt-labs | dbt_utils | [GitHub](https://github.com/dbt-labs/dbt-utils.git) | |
+| elementary-data | elementary | [GitHub](https://github.com/elementary-data/dbt-data-reliability.git) | |
+| entechlog | dbt_snow_mask | [GitHub](https://github.com/entechlog/dbt-snow-mask.git) | |
+| fivetran | ad_reporting | [GitHub](https://github.com/fivetran/dbt_ad_reporting.git) | |
+| fivetran | facebook_ads | [GitHub](https://github.com/fivetran/dbt_facebook_ads.git) | |
+| fivetran | fivetran_log | [GitHub](https://github.com/fivetran/dbt_fivetran_log.git) | |
+| fivetran | fivetran_utils | [GitHub](https://github.com/fivetran/dbt_fivetran_utils.git) | |
+| fivetran | google_ads | [GitHub](https://github.com/fivetran/dbt_google_ads.git) | |
+| fivetran | hubspot | [GitHub](https://github.com/fivetran/dbt_hubspot.git) | |
+| fivetran | jira | [GitHub](https://github.com/fivetran/dbt_jira.git) | |
+| fivetran | linkedin | [GitHub](https://github.com/dbt-labs/dbt-project-evaluator.git) | |
+| fivetran | microsoft_ads | [GitHub](https://github.com/fivetran/dbt_microsoft_ads.git) | |
+| fivetran | pendo | [GitHub](https://github.com/fivetran/dbt_pendo.git) | |
+| fivetran | qualtrics | [GitHub](https://github.com/fivetran/dbt_qualtrics.git) | |
+| fivetran | salesforce | [GitHub](https://github.com/fivetran/dbt_salesforce.git) | |
+| fivetran | salesforce_formula_utils | [GitHub](https://github.com/fivetran/dbt_salesforce_formula_utils.git) | |
+| fivetran | social_media_reporting | [GitHub](https://github.com/fivetran/dbt_social_media_reporting.git) | |
+| fivetran | zendesk | [GitHub](https://github.com/fivetran/dbt_zendesk.git) | |
+| GJMcClintock | dbt_tld | [GitHub](https://github.com/GJMcClintock/dbt_tld.git) | |
+| godatadriven | dbt_date | [GitHub](https://github.com/godatadriven/dbt-date.git) | |
+| kristeligt-dagblad | dbt_ml | [GitHub](https://github.com/kristeligt-dagblad/dbt_ml.git) | |
+| LewisDavies | upstream_prod | [GitHub](https://github.com/LewisDavies/upstream-prod.git) | Versions 0.9.6 and above |
+| metaplane | dbt_expectations | [GitHub](https://github.com/metaplane/dbt-expectations.git) | |
+| Montreal-Analytics | snowflake_utils | [GitHub](https://github.com/Montreal-Analytics/dbt-snowflake-utils.git) | |
+| Snowflake-Labs | dbt_semantic_view | [GitHub](https://github.com/Snowflake-Labs/dbt_semantic_view) | |
 
 Additionally, the Fivetran `source` and `transformation` packages have been combined into a single package. If you manually installed source packages like `fivetran/github_source`, you need to ensure `fivetran/github` is installed and deactivate the transformation models.
 

--- a/website/snippets/_fusion-supported-packages.md
+++ b/website/snippets/_fusion-supported-packages.md
@@ -1,35 +1,37 @@
 The following packages are verified and supported on the <Constant name="fusion_engine" />:
 
-- [AxelThevenot/dbt_assertions](https://github.com/AxelThevenot/dbt-assertions)
-- [Datavault-UK/automate_dv](https://github.com/Datavault-UK/dbtvault.git)
-- [dbt-labs/audit_helper](https://github.com/dbt-labs/dbt-audit-helper.git)
-- [dbt-labs/codegen](https://github.com/dbt-labs/dbt-codegen.git)
-- [dbt-labs/dbt_project_evaluator](https://github.com/dbt-labs/dbt-project-evaluator.git) (versions 1.1.1 and above)
-- [dbt-labs/dbt_utils](https://github.com/dbt-labs/dbt-utils.git)
-- [elementary-data/elementary](https://github.com/elementary-data/dbt-data-reliability.git)
-- [entechlog/dbt_snow_mask](https://github.com/entechlog/dbt-snow-mask.git)
-- [fivetran/ad_reporting](https://github.com/fivetran/dbt_ad_reporting.git)
-- [fivetran/facebook_ads](https://github.com/fivetran/dbt_facebook_ads.git)
-- [fivetran/fivetran_log](https://github.com/fivetran/dbt_fivetran_log.git)
-- [fivetran/fivetran_utils](https://github.com/fivetran/dbt_fivetran_utils.git)
-- [fivetran/google_ads](https://github.com/fivetran/dbt_google_ads.git)
-- [fivetran/hubspot](https://github.com/fivetran/dbt_hubspot.git)
-- [fivetran/jira](https://github.com/fivetran/dbt_jira.git)
-- [fivetran/linkedin](https://github.com/dbt-labs/dbt-project-evaluator.git)
-- [fivetran/microsoft_ads](https://github.com/fivetran/dbt_microsoft_ads.git)
-- [fivetran/pendo](https://github.com/fivetran/dbt_pendo.git)
-- [fivetran/qualtrics](https://github.com/fivetran/dbt_qualtrics.git)
-- [fivetran/salesforce](https://github.com/fivetran/dbt_salesforce.git)
-- [fivetran/salesforce_formula_utils](https://github.com/fivetran/dbt_salesforce_formula_utils.git)
-- [fivetran/social_media_reporting](https://github.com/fivetran/dbt_social_media_reporting.git)
-- [fivetran/zendesk](https://github.com/fivetran/dbt_zendesk.git)
-- [GJMcClintock/dbt_tld](https://github.com/GJMcClintock/dbt_tld.git)
-- [godatadriven/dbt_date](https://github.com/godatadriven/dbt-date.git)
-- [kristeligt-dagblad/dbt_ml](https://github.com/kristeligt-dagblad/dbt_ml.git)
-- [LewisDavies/upstream_prod](https://github.com/LewisDavies/upstream-prod.git) (versions 0.9.6 and above)
-- [metaplane/dbt_expectations](https://github.com/metaplane/dbt-expectations.git)
-- [Montreal-Analytics/snowflake_utils](https://github.com/Montreal-Analytics/dbt-snowflake-utils.git)
-- [Snowflake-Labs/dbt_semantic_view](https://github.com/Snowflake-Labs/dbt_semantic_view)
+| Package | Repository | Notes |
+|---------|------------|-------|
+| AxelThevenot/dbt_assertions | [GitHub](https://github.com/AxelThevenot/dbt-assertions) | |
+| Datavault-UK/automate_dv | [GitHub](https://github.com/Datavault-UK/dbtvault.git) | |
+| dbt-labs/audit_helper | [GitHub](https://github.com/dbt-labs/dbt-audit-helper.git) | |
+| dbt-labs/codegen | [GitHub](https://github.com/dbt-labs/dbt-codegen.git) | |
+| dbt-labs/dbt_project_evaluator | [GitHub](https://github.com/dbt-labs/dbt-project-evaluator.git) | Versions 1.1.1 and above |
+| dbt-labs/dbt_utils | [GitHub](https://github.com/dbt-labs/dbt-utils.git) | |
+| elementary-data/elementary | [GitHub](https://github.com/elementary-data/dbt-data-reliability.git) | |
+| entechlog/dbt_snow_mask | [GitHub](https://github.com/entechlog/dbt-snow-mask.git) | |
+| fivetran/ad_reporting | [GitHub](https://github.com/fivetran/dbt_ad_reporting.git) | |
+| fivetran/facebook_ads | [GitHub](https://github.com/fivetran/dbt_facebook_ads.git) | |
+| fivetran/fivetran_log | [GitHub](https://github.com/fivetran/dbt_fivetran_log.git) | |
+| fivetran/fivetran_utils | [GitHub](https://github.com/fivetran/dbt_fivetran_utils.git) | |
+| fivetran/google_ads | [GitHub](https://github.com/fivetran/dbt_google_ads.git) | |
+| fivetran/hubspot | [GitHub](https://github.com/fivetran/dbt_hubspot.git) | |
+| fivetran/jira | [GitHub](https://github.com/fivetran/dbt_jira.git) | |
+| fivetran/linkedin | [GitHub](https://github.com/dbt-labs/dbt-project-evaluator.git) | |
+| fivetran/microsoft_ads | [GitHub](https://github.com/fivetran/dbt_microsoft_ads.git) | |
+| fivetran/pendo | [GitHub](https://github.com/fivetran/dbt_pendo.git) | |
+| fivetran/qualtrics | [GitHub](https://github.com/fivetran/dbt_qualtrics.git) | |
+| fivetran/salesforce | [GitHub](https://github.com/fivetran/dbt_salesforce.git) | |
+| fivetran/salesforce_formula_utils | [GitHub](https://github.com/fivetran/dbt_salesforce_formula_utils.git) | |
+| fivetran/social_media_reporting | [GitHub](https://github.com/fivetran/dbt_social_media_reporting.git) | |
+| fivetran/zendesk | [GitHub](https://github.com/fivetran/dbt_zendesk.git) | |
+| GJMcClintock/dbt_tld | [GitHub](https://github.com/GJMcClintock/dbt_tld.git) | |
+| godatadriven/dbt_date | [GitHub](https://github.com/godatadriven/dbt-date.git) | |
+| kristeligt-dagblad/dbt_ml | [GitHub](https://github.com/kristeligt-dagblad/dbt_ml.git) | |
+| LewisDavies/upstream_prod | [GitHub](https://github.com/LewisDavies/upstream-prod.git) | Versions 0.9.6 and above |
+| metaplane/dbt_expectations | [GitHub](https://github.com/metaplane/dbt-expectations.git) | |
+| Montreal-Analytics/snowflake_utils | [GitHub](https://github.com/Montreal-Analytics/dbt-snowflake-utils.git) | |
+| Snowflake-Labs/dbt_semantic_view | [GitHub](https://github.com/Snowflake-Labs/dbt_semantic_view) | |
 
 Additionally, the Fivetran `source` and `transformation` packages have been combined into a single package. If you manually installed source packages like `fivetran/github_source`, you need to ensure `fivetran/github` is installed and deactivate the transformation models.
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
This PR converts the "Package Support" section on the Fusion supported features page from a bulleted list to a 3-column table.

The change improves the readability and scannability of the supported packages, making it easier to quickly identify the package, its repository, and any specific notes (like version requirements).

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).

---
[Slack Thread](https://dbt-labs.slack.com/archives/C0A16RWFC4E/p1764844786674809?thread_ts=1764844786.674809&cid=C0A16RWFC4E)

<a href="https://cursor.com/background-agent?bcId=bc-98894ea4-4eee-478d-9dea-ba7e7db47bef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-98894ea4-4eee-478d-9dea-ba7e7db47bef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

