### PR TITLE
Update docusaurus announcement bar with event details

### DIFF
--- a/website/blog/ctas.yml
+++ b/website/blog/ctas.yml
@@ -58,6 +58,6 @@
   url: https://www.getdbt.com/resources/webinars/speed-simplicity-cost-savings-experience-the-dbt-fusion-engine
 - name: ai_sl_mcp
   header: Live virtual event 
-  subheader: Join our virtual event on Dec 16 & 17: Delivering reliable AI with the dbt Semantic Layer and dbt MCP Server
+  subheader: Join our virtual event on Dec 16/17 to deliver reliable AI with the dbt Semantic Layer and dbt MCP Server
   button_text: Save your seat
   url: https://www.getdbt.com/resources/webinars/delivering-reliable-ai-with-the-dbt-semantic-layer-and-dbt-mcp-server

--- a/website/blog/ctas.yml
+++ b/website/blog/ctas.yml
@@ -56,7 +56,7 @@
   subheader: Experience the dbt Fusion engine with Tristan Handy and Elias DeFaria on October 28th
   button_text: Save your seat
   url: https://www.getdbt.com/resources/webinars/speed-simplicity-cost-savings-experience-the-dbt-fusion-engine
-- name: sl_mcp
+- name: ai_sl_mcp
   header: Live virtual event 
   subheader: Join our virtual event on Dec 16 & 17: Delivering reliable AI with the dbt Semantic Layer and dbt MCP Server
   button_text: Save your seat

--- a/website/blog/ctas.yml
+++ b/website/blog/ctas.yml
@@ -56,3 +56,8 @@
   subheader: Experience the dbt Fusion engine with Tristan Handy and Elias DeFaria on October 28th
   button_text: Save your seat
   url: https://www.getdbt.com/resources/webinars/speed-simplicity-cost-savings-experience-the-dbt-fusion-engine
+- name: sl_mcp
+  header: Live virtual event 
+  subheader: Join our virtual event on Dec 16 & 17: Delivering reliable AI with the dbt Semantic Layer and dbt MCP Server
+  button_text: Save your seat
+  url: https://www.getdbt.com/resources/webinars/delivering-reliable-ai-with-the-dbt-semantic-layer-and-dbt-mcp-server

--- a/website/blog/metadata.yml
+++ b/website/blog/metadata.yml
@@ -2,7 +2,7 @@
 featured_image: ""
 
 # This CTA lives in right sidebar on blog index
-featured_cta: "sl_mcp"
+featured_cta: "ai_sl_mcp"
 
 # Show or hide hero title, description, cta from blog index
 show_title: false

--- a/website/blog/metadata.yml
+++ b/website/blog/metadata.yml
@@ -2,7 +2,7 @@
 featured_image: ""
 
 # This CTA lives in right sidebar on blog index
-featured_cta: "fusion_engine"
+featured_cta: "sl_mcp"
 
 # Show or hide hero title, description, cta from blog index
 show_title: false

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -72,12 +72,12 @@ var siteSettings = {
     announcementBar: {
       id: "dbt-workshop",
       content:
-        "✨ Live virtual event - Smarter pipelines, 29% more efficient: How the dbt Fusion engine optimizes data work on December 3rd!",
+        "Join our virtual event on Dec 16 & 17: Delivering reliable AI with the dbt Semantic Layer and dbt MCP Server",
       isCloseable: true,
     },
     announcementBarActive: true,
     announcementBarLink:
-      "https://www.getdbt.com/resources/webinars/how-the-dbt-fusion-engine-optimizes-data-work",
+      "https://www.getdbt.com/resources/webinars/delivering-reliable-ai-with-the-dbt-semantic-layer-and-dbt-mcp-server",
     // Set community spotlight member on homepage
     // This is the ID for a specific file under docs/community/spotlight
     communitySpotlightMember: "original-dbt-athena-maintainers",


### PR DESCRIPTION
## What are you changing in this pull request and why?
This PR updates the Docusaurus announcement bar in `website/docusaurus.config.js` to promote the upcoming virtual event on Dec 16 & 17: "Delivering reliable AI with the dbt Semantic Layer and dbt MCP Server".

The `announcementBar.content` and `announcementBarLink` fields have been updated with the new event details and URL.

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).

---
[Slack Thread](https://dbt-labs.slack.com/archives/C02NCQ9483C/p1762220260257929?thread_ts=1762220260.257929&cid=C02NCQ9483C)

<a href="https://cursor.com/background-agent?bcId=bc-028b5147-ad9c-427f-b93c-0c8bead679f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-028b5147-ad9c-427f-b93c-0c8bead679f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

