### PR TITLE
Fix numbered list on dbt extension page

### DIFF
--- a/website/snippets/_install-dbt-extension.md
+++ b/website/snippets/_install-dbt-extension.md
@@ -169,7 +169,7 @@ Follow these steps to download the `dbt_cloud.yml` file:
     - macOS/Linux: `~/.dbt/`
     - Windows: `C:\Users\[username]\.dbt\`
 
-For detailed instructions on how to create a `.dbt` directory and move the file, see [this FAQ](#how-to-create-a-dbt-directory-in-root-and-move-dbt_cloudyml-file).
+   For detailed instructions on how to create a `.dbt` directory and move the file, see [this FAQ](#how-to-create-a-dbt-directory-in-root-and-move-dbt_cloudyml-file).
 7. Then go back to VS Code and open the command palette (`Ctrl + Shift + P` (Windows/Linux) or `Cmd + Shift + P` (macOS)).  
 8. Run `dbt: Register dbt extension` to complete registration.
 9. If you run into any issues, reach out to [support](/docs/dbt-support) &mdash; we're here to help!

--- a/website/snippets/_install-dbt-extension.md
+++ b/website/snippets/_install-dbt-extension.md
@@ -164,13 +164,9 @@ Follow these steps to download the `dbt_cloud.yml` file:
 4. In the **Set up your credentials** section, click **Download credential**s to download the `dbt_cloud.yml` file.
 5. Download the `dbt_cloud.yml` file to complete registration.
 <Lightbox src="/img/docs/extension/download-registration-2.png" width="70%" title="Download the dbt_cloud.yml file to complete registration."/>
-
-6. Move the downloaded `dbt_cloud.yml` file to your dbt directory:
+6. Move the downloaded `dbt_cloud.yml` file into your system’s dbt folder. If you need help creating/moving the `.dbt` directory, see [this FAQ](#how-to-create-a-dbt-directory-in-root-and-move-dbt_cloudyml-file).
     - macOS/Linux: `~/.dbt/`
     - Windows: `C:\Users\[username]\.dbt\`
-
-   For detailed instructions on how to create a `.dbt` directory and move the file, see [this FAQ](#how-to-create-a-dbt-directory-in-root-and-move-dbt_cloudyml-file).
-
 7. Then go back to VS Code and open the command palette (`Ctrl + Shift + P` (Windows/Linux) or `Cmd + Shift + P` (macOS)).  
 8. Run `dbt: Register dbt extension` to complete registration.
 9. If you run into any issues, reach out to [support](/docs/dbt-support) &mdash; we're here to help!

--- a/website/snippets/_install-dbt-extension.md
+++ b/website/snippets/_install-dbt-extension.md
@@ -170,6 +170,7 @@ Follow these steps to download the `dbt_cloud.yml` file:
     - Windows: `C:\Users\[username]\.dbt\`
 
    For detailed instructions on how to create a `.dbt` directory and move the file, see [this FAQ](#how-to-create-a-dbt-directory-in-root-and-move-dbt_cloudyml-file).
+
 7. Then go back to VS Code and open the command palette (`Ctrl + Shift + P` (Windows/Linux) or `Cmd + Shift + P` (macOS)).  
 8. Run `dbt: Register dbt extension` to complete registration.
 9. If you run into any issues, reach out to [support](/docs/dbt-support) &mdash; we're here to help!


### PR DESCRIPTION
## What are you changing in this pull request and why?
This PR fixes a broken numbered list on the "Install dbt Extension" page, specifically in the "Download the `dbt_cloud.yml` file" section.

The issue was caused by a paragraph following item 6 that was not properly indented, which broke the markdown numbered list and caused items 7, 8, and 9 to restart numbering.

By adding 3 spaces of indentation to the explanatory text after step 6, the content is correctly associated with step 6, allowing the subsequent steps (7, 8, and 9) to continue with the correct numbering.

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).

---
[Slack Thread](https://dbt-labs.slack.com/archives/C0A16RWFC4E/p1764933593330559?thread_ts=1764933593.330559&cid=C0A16RWFC4E)

<a href="https://cursor.com/background-agent?bcId=bc-d439f96d-720f-43b3-867d-c47741a181a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d439f96d-720f-43b3-867d-c47741a181a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

