### PR TITLE
Guide step behavior

### DIFF
--- a/website/src/components/quickstartTOC/index.js
+++ b/website/src/components/quickstartTOC/index.js
@@ -141,9 +141,21 @@ function QuickstartTOC() {
       item.classList.toggle(clsx(style.active), isActive);
     });
 
-    // Scroll to the top of the page when the user clicks next
-    if (window.scrollY > 0) {
-      window.scrollTo(0, 0);
+    // Scroll to the active step content area, accounting for fixed navbar
+    const activeStepWrapper = document.querySelector(
+      `.${style.stepWrapper}[data-step='${activeStep}']`
+    );
+    if (activeStepWrapper) {
+      const navbarHeight = parseInt(
+        getComputedStyle(document.documentElement).getPropertyValue('--ifm-navbar-height') || '85'
+      );
+      const elementPosition = activeStepWrapper.getBoundingClientRect().top + window.scrollY;
+      const offsetPosition = elementPosition - navbarHeight - 20; // Extra 20px padding
+
+      window.scrollTo({
+        top: offsetPosition,
+        behavior: 'smooth'
+      });
     }
 
     // Set local storage to the active step


### PR DESCRIPTION
## What are you changing in this pull request and why?

Changes the behavior so that when a user navigates between guide steps, they are reset to the top of the H2 section and not the whole page.

Closes [Jira PRODDOCS-370](https://dbtlabs.atlassian.net/browse/PRODDOCS-370?atlOrigin=eyJpIjoiZWViOGMzYjIyZDA5NDRhZDhlODZiOGY3NWI5OTI2NjEiLCJwIjoiaiJ9)

## Checklist
<!-- Ensure your PR meets the following items. Feel free to add additiona checklist items to the list if additional checks need to happen before the PR is merged, such as:
- [ ] Needs technical review
- [ ] Change base branch
- [ ] Merge on xyz date
-->
- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).
<!--
PRE-RELEASE VERSION OF dbt (if so, uncomment):
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
<!-- 
ADDING OR REMOVING PAGES (if so, uncomment):
- [ ] Add/remove page in `website/sidebars.js`
- [ ] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages
-->
