### PR TITLE
Update package documentation link

### DIFF
--- a/website/docs/docs/fusion/fusion-readiness.md
+++ b/website/docs/docs/fusion/fusion-readiness.md
@@ -29,7 +29,7 @@ You must resolve deprecations while your projects are on a <Constant name="core"
 
 ### 3. Validate and upgrade your dbt packages
 
-The most commonly used dbt Labs managed packages (such as `dbt_utils` and `dbt_project_evaluator`) are already compatible with <Constant name="fusion" />, as are a large number of external and community packages. We list many known supported packages [here](https://docs.getdbt.com/docs/fusion/supported-features#package-support), but more exist. 
+The most commonly used dbt Labs managed packages (such as `dbt_utils` and `dbt_project_evaluator`) are already compatible with <Constant name="fusion" />, as are a large number of external and community packages. Review [the dbt package hub](https://hub.getdbt.com) to see verified <Constant name="fusion" />-compatible packages by checking that the `require-dbt-version` configuration includes `2.0.0` or higher. Refer to [package support](/docs/fusion/supported-features#package-support) for more information.
 
 - [ ] Make sure that all of your packages are upgraded to the most recent version, many of which contain enhancements to support <Constant name="fusion" />. 
 - [ ] Check package repositories to make sure they're compatible with <Constant name="fusion" />. If a package you use is not yet compatible, we recommend opening an issue with the maintainer, making the contribution yourself, or removing the package temporarily before you upgrade.

--- a/website/docs/docs/fusion/supported-features.md
+++ b/website/docs/docs/fusion/supported-features.md
@@ -100,12 +100,13 @@ import FusionFeatures from '/snippets/_fusion-missing-features.md';
 
 <FusionFeatures />
 
-import AboutFusion from '/snippets/_about-fusion.md';
-
-<AboutFusion />
-
-### Package support
+## Package support
 
 import FusionPackages from '/snippets/_fusion-supported-packages.md';
 
 <FusionPackages />
+
+import AboutFusion from '/snippets/_about-fusion.md';
+
+<AboutFusion />
+

--- a/website/docs/guides/fusion-upgrade-prepare.md
+++ b/website/docs/guides/fusion-upgrade-prepare.md
@@ -12,7 +12,7 @@ import FusionAdapters from '/snippets/_fusion-dwh.md';
 
 ## Introduction <Lifecycle status="private_preview" />
 
-:::Important private preview
+:::info private preview
 
 The <Constant name="fusion_engine" /> is available as a private preview for all tiers of <Constant name="dbt_platform" /> accounts. dbt Labs is enabling <Constant name="fusion" /> only on accounts that have eligible projects. Following the steps outlined in this guide doesn't guarantee <Constant name="fusion" /> eligibility.
 

--- a/website/docs/guides/fusion-upgrade-prepare.md
+++ b/website/docs/guides/fusion-upgrade-prepare.md
@@ -249,9 +249,9 @@ packages:
 
 ### Step 2: Check compatibility and find the latest package versions
 
-Review the [supported packages list](/docs/fusion/supported-features#package-support) to see verified <Constant name="fusion" />-compatible packages.
+Review [the dbt package hub](https://hub.getdbt.com) to see verified <Constant name="fusion" />-compatible packages by checking that the `require-dbt-version` configuration includes `2.0.0` or higher. Refer to [package support](/docs/fusion/supported-features#package-support) for more information.
 
-For packages not on this list:
+For packages that aren't <Constant name="fusion" />-compatible:
    - Visit the package's GitHub repository.
    - Check the README or recent releases for <Constant name="fusion" /> compatibility information.
    - Look for issues or discussions about <Constant name="fusion" /> support.
@@ -267,7 +267,7 @@ For Hub packages, you can use version ranges to stay up-to-date:
 ```yaml
 packages:
   - package: dbt-labs/dbt_utils
-    version: [">=1.0.0", "<2.0.0"]  # Gets latest 1.x version
+    version: [">=1.0.0", "<3.0.0"]  # Gets latest 1.x or 2.x version
 ```
 
 ### Step 3: Update your package versions

--- a/website/snippets/_fusion-supported-packages.md
+++ b/website/snippets/_fusion-supported-packages.md
@@ -1,4 +1,4 @@
 To determine if a package is compatible with the <Constant name="fusion_engine" />, visit the [dbt package hub](https://hub.getdbt.com/) and review the package's [`require-dbt-version` configuration](/reference/project-configs/require-dbt-version#pin-to-a-range). 
 - Packages with a `require-dbt-version` that equals or contains `2.0` are compatible with <Constant name="fusion"/>. For example, `require-dbt-version: ">=1.10.0,<3.0.0"`
-- Additionally, the Fivetran `source` and `transformation` packages have been combined into a single package. If you manually installed source packages like `fivetran/github_source`, you need to ensure `fivetran/github` is installed and deactivate the transformation models.
+- The Fivetran `source` and `transformation` packages have been combined into a single package. If you manually installed source packages like `fivetran/github_source`, you need to ensure `fivetran/github` is installed and deactivate the transformation models.
 - Package maintainers that would like make their package compatible with <Constant name="fusion"/> can refer to the [Fusion package upgrade guide](/guides/fusion-package-compat) for instructions.

--- a/website/snippets/_fusion-supported-packages.md
+++ b/website/snippets/_fusion-supported-packages.md
@@ -1,4 +1,6 @@
-To determine if a package is compatible with the <Constant name="fusion_engine" />, visit the [dbt package hub](https://hub.getdbt.com/) and review the package's [`require-dbt-version` configuration](/reference/project-configs/require-dbt-version#pin-to-a-range). 
+To determine if a package is compatible with the <Constant name="fusion_engine" />, visit the [dbt package hub](https://hub.getdbt.com/) and review the package's [`require-dbt-version` configuration](/reference/project-configs/require-dbt-version#pin-to-a-range). For the second part, maybe something like:
+
+Even if a package doesn't reflect compatibility in the package hub, it may still work with Fusion.  Work with package maintainers to track updates, and thoroughly test packages that aren't clearly compatible before deploying.
 - Packages with a `require-dbt-version` that equals or contains `2.0` are compatible with <Constant name="fusion"/>. For example, `require-dbt-version: ">=1.10.0,<3.0.0"`
 - The Fivetran `source` and `transformation` packages have been combined into a single package. If you manually installed source packages like `fivetran/github_source`, you need to ensure `fivetran/github` is installed and deactivate the transformation models.
 - Package maintainers who would like to make their package compatible with <Constant name="fusion"/> can refer to the [Fusion package upgrade guide](/guides/fusion-package-compat) for instructions.

--- a/website/snippets/_fusion-supported-packages.md
+++ b/website/snippets/_fusion-supported-packages.md
@@ -1,6 +1,6 @@
 To determine if a package is compatible with the <Constant name="fusion_engine" />, visit the [dbt package hub](https://hub.getdbt.com/) and review the package's [`require-dbt-version` configuration](/reference/project-configs/require-dbt-version#pin-to-a-range). For the second part, maybe something like:
 
 Even if a package doesn't reflect compatibility in the package hub, it may still work with Fusion.  Work with package maintainers to track updates, and thoroughly test packages that aren't clearly compatible before deploying.
-- Packages with a `require-dbt-version` that equals or contains `2.0` are compatible with <Constant name="fusion"/>. For example, `require-dbt-version: ">=1.10.0,<3.0.0"`
+- Packages with a `require-dbt-version` that equals or contains `2.0.0` are compatible with <Constant name="fusion"/>. For example, `require-dbt-version: ">=1.10.0,<3.0.0"`
 - The Fivetran `source` and `transformation` packages have been combined into a single package. If you manually installed source packages like `fivetran/github_source`, you need to ensure `fivetran/github` is installed and deactivate the transformation models.
 - Package maintainers who would like to make their package compatible with <Constant name="fusion"/> can refer to the [Fusion package upgrade guide](/guides/fusion-package-compat) for instructions.

--- a/website/snippets/_fusion-supported-packages.md
+++ b/website/snippets/_fusion-supported-packages.md
@@ -1,5 +1,4 @@
-To determine if a package is compatible with the <Constant name="fusion_engine" />, visit the [dbt package hub](https://hub.getdbt.com/) and review the package's `require-dbt-version` configuration. Packages with a `require-dbt-version` that equals or contains `2.0` are compatible with <Constant name="fusion"/>.
-
-Additionally, the Fivetran `source` and `transformation` packages have been combined into a single package. If you manually installed source packages like `fivetran/github_source`, you need to ensure `fivetran/github` is installed and deactivate the transformation models.
-
-Package maintainers that would like make their package compatible with <Constant name="fusion"/> can refer to the [Fusion package upgrade guide](/guides/fusion-package-compat) for instructions.
+To determine if a package is compatible with the <Constant name="fusion_engine" />, visit the [dbt package hub](https://hub.getdbt.com/) and review the package's [`require-dbt-version` configuration](/reference/project-configs/require-dbt-version#pin-to-a-range). 
+- Packages with a `require-dbt-version` that equals or contains `2.0` are compatible with <Constant name="fusion"/>. For example, `require-dbt-version: ">=1.10.0,<3.0.0"`
+- Additionally, the Fivetran `source` and `transformation` packages have been combined into a single package. If you manually installed source packages like `fivetran/github_source`, you need to ensure `fivetran/github` is installed and deactivate the transformation models.
+- Package maintainers that would like make their package compatible with <Constant name="fusion"/> can refer to the [Fusion package upgrade guide](/guides/fusion-package-compat) for instructions.

--- a/website/snippets/_fusion-supported-packages.md
+++ b/website/snippets/_fusion-supported-packages.md
@@ -1,4 +1,4 @@
 To determine if a package is compatible with the <Constant name="fusion_engine" />, visit the [dbt package hub](https://hub.getdbt.com/) and review the package's [`require-dbt-version` configuration](/reference/project-configs/require-dbt-version#pin-to-a-range). 
 - Packages with a `require-dbt-version` that equals or contains `2.0` are compatible with <Constant name="fusion"/>. For example, `require-dbt-version: ">=1.10.0,<3.0.0"`
 - The Fivetran `source` and `transformation` packages have been combined into a single package. If you manually installed source packages like `fivetran/github_source`, you need to ensure `fivetran/github` is installed and deactivate the transformation models.
-- Package maintainers that would like make their package compatible with <Constant name="fusion"/> can refer to the [Fusion package upgrade guide](/guides/fusion-package-compat) for instructions.
+- Package maintainers who would like to make their package compatible with <Constant name="fusion"/> can refer to the [Fusion package upgrade guide](/guides/fusion-package-compat) for instructions.

--- a/website/snippets/_fusion-supported-packages.md
+++ b/website/snippets/_fusion-supported-packages.md
@@ -1,35 +1,4 @@
-The following packages are verified and supported on the <Constant name="fusion_engine" />:
-
-- [AxelThevenot/dbt_assertions](https://github.com/AxelThevenot/dbt-assertions)
-- [Datavault-UK/automate_dv](https://github.com/Datavault-UK/dbtvault.git)
-- [dbt-labs/audit_helper](https://github.com/dbt-labs/dbt-audit-helper.git)
-- [dbt-labs/codegen](https://github.com/dbt-labs/dbt-codegen.git)
-- [dbt-labs/dbt_project_evaluator](https://github.com/dbt-labs/dbt-project-evaluator.git) (versions 1.1.1 and above)
-- [dbt-labs/dbt_utils](https://github.com/dbt-labs/dbt-utils.git)
-- [elementary-data/elementary](https://github.com/elementary-data/dbt-data-reliability.git)
-- [entechlog/dbt_snow_mask](https://github.com/entechlog/dbt-snow-mask.git)
-- [fivetran/ad_reporting](https://github.com/fivetran/dbt_ad_reporting.git)
-- [fivetran/facebook_ads](https://github.com/fivetran/dbt_facebook_ads.git)
-- [fivetran/fivetran_log](https://github.com/fivetran/dbt_fivetran_log.git)
-- [fivetran/fivetran_utils](https://github.com/fivetran/dbt_fivetran_utils.git)
-- [fivetran/google_ads](https://github.com/fivetran/dbt_google_ads.git)
-- [fivetran/hubspot](https://github.com/fivetran/dbt_hubspot.git)
-- [fivetran/jira](https://github.com/fivetran/dbt_jira.git)
-- [fivetran/linkedin](https://github.com/dbt-labs/dbt-project-evaluator.git)
-- [fivetran/microsoft_ads](https://github.com/fivetran/dbt_microsoft_ads.git)
-- [fivetran/pendo](https://github.com/fivetran/dbt_pendo.git)
-- [fivetran/qualtrics](https://github.com/fivetran/dbt_qualtrics.git)
-- [fivetran/salesforce](https://github.com/fivetran/dbt_salesforce.git)
-- [fivetran/salesforce_formula_utils](https://github.com/fivetran/dbt_salesforce_formula_utils.git)
-- [fivetran/social_media_reporting](https://github.com/fivetran/dbt_social_media_reporting.git)
-- [fivetran/zendesk](https://github.com/fivetran/dbt_zendesk.git)
-- [GJMcClintock/dbt_tld](https://github.com/GJMcClintock/dbt_tld.git)
-- [godatadriven/dbt_date](https://github.com/godatadriven/dbt-date.git)
-- [kristeligt-dagblad/dbt_ml](https://github.com/kristeligt-dagblad/dbt_ml.git)
-- [LewisDavies/upstream_prod](https://github.com/LewisDavies/upstream-prod.git) (versions 0.9.6 and above)
-- [metaplane/dbt_expectations](https://github.com/metaplane/dbt-expectations.git)
-- [Montreal-Analytics/snowflake_utils](https://github.com/Montreal-Analytics/dbt-snowflake-utils.git)
-- [Snowflake-Labs/dbt_semantic_view](https://github.com/Snowflake-Labs/dbt_semantic_view)
+To determine if a package is compatible with the <Constant name="fusion_engine" />, visit the [dbt package hub](https://hub.getdbt.com/) and review the package's `require-dbt-version` configuration. Packages with a `require-dbt-version` that equals or contains `2.0` are compatible with <Constant name="fusion"/>.
 
 Additionally, the Fivetran `source` and `transformation` packages have been combined into a single package. If you manually installed source packages like `fivetran/github_source`, you need to ensure `fivetran/github` is installed and deactivate the transformation models.
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
Per Connie, this PR removes the static list of Fusion-supported packages from `website/snippets/_fusion-supported-packages.md` since the current list isn't correct.

Instead of a static list, the content now directs users to the [dbt package hub](https://hub.getdbt.com/) to check a package's `require-dbt-version` configuration. Packages with `require-dbt-version` equal to or containing `2.0` are compatible with the Fusion engine.

This change provides a more maintainable and up-to-date method for users to determine package compatibility, reducing the need for manual updates to the documentation.

## Checklist
- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).

---
[Slack Thread](https://dbt-labs.slack.com/archives/C0A16RWFC4E/p1765221731684919?thread_ts=1765221731.684919&cid=C0A16RWFC4E)

<a href="https://cursor.com/background-agent?bcId=bc-0ec80798-6f64-4087-bc8d-51b87a4b61b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0ec80798-6f64-4087-bc8d-51b87a4b61b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

