### PR TITLE
Remove cost remediation FAQ

### DIFF
--- a/website/docs/faqs/Accounts/_account-specific-features.md
+++ b/website/docs/faqs/Accounts/_account-specific-features.md
@@ -115,20 +115,6 @@ PrivateLink provides a secure and private connection between your organization's
 
 IP restrictions (IP allowlist/blocklist) let organizations control which IPs can access their <Constant name="cloud" /> account.
 
-## Cost remediation tooling <Lifecycle status="Enterprise+"/>
-
-Cost remediation tooling helps organizations identify and resolve inefficiencies that lead to unnecessary data platform expenses &mdash; especially in cloud data warehouses.
-
-Cost remediation is one of the three pillars of managing costs:
-
-- Monitoring (to see costs)
-
-- Avoidance (to prevent costs)
-
-- Remediation (to fix existing issues)
-
-It identifies cost inefficiencies, suggests optimizations, streamlines issue resolution through workflows, and aims to automate fixes with minimal effort.
-
 ## Projects and run slots 
 
 The number of projects and run slots available to your organization varies based on your selected plan tier. For detailed information, please refer to our [pricing page](https://www.getdbt.com/pricing).


### PR DESCRIPTION
## What are you changing in this pull request and why?
This PR removes the "Cost remediation tooling" section from the Account-specific features FAQ page (`website/docs/faqs/Accounts/_account-specific-features.md`). This section, including its header, description, and the three pillars of cost management, is being removed as it is no longer relevant for this FAQ.

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).

---
[Slack Thread](https://dbt-labs.slack.com/archives/C0A16RWFC4E/p1765304560905509?thread_ts=1765304560.905509&cid=C0A16RWFC4E)

<a href="https://cursor.com/background-agent?bcId=bc-1842ff61-9dc1-41bc-8469-f612ae1407f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1842ff61-9dc1-41bc-8469-f612ae1407f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

