### PR TITLE
Add December 2025 compatible release notes

### DIFF
--- a/website/docs/docs/dbt-versions/compatible-track-changelog.md
+++ b/website/docs/docs/dbt-versions/compatible-track-changelog.md
@@ -20,10 +20,12 @@ This compatible release includes functionality from the following versions of db
 
 ```
 dbt-core==1.10.15
+
 # shared interfaces
 dbt-adapters==1.16.7
 dbt-common==1.33.0
 dbt-semantic-interfaces==0.9.0
+
 # adapters
 dbt-athena==1.9.5
 dbt-bigquery==1.10.3

--- a/website/docs/docs/dbt-versions/compatible-track-changelog.md
+++ b/website/docs/docs/dbt-versions/compatible-track-changelog.md
@@ -43,7 +43,7 @@ dbt-trino==1.9.3
 ```
 
 Changelogs:
-- [dbt-core 1.10.13](https://github.com/dbt-labs/dbt-core/blob/1.10.latest/CHANGELOG.md#dbt-core-11013---september-25-2025)
+- [dbt-core 1.10.15](https://github.com/dbt-labs/dbt-core/blob/1.10.latest/CHANGELOG.md#dbt-core-11015---november-12-2025)
 - [dbt-adapters 1.16.7](https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-adapters/CHANGELOG.md#dbt-adapters-1166---september-03-2025)
 - [dbt-common 1.33.0](https://github.com/dbt-labs/dbt-common/blob/main/CHANGELOG.md#dbt-common-1330---october-20-2025)
 - [dbt-athena 1.9.5](https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-athena/CHANGELOG.md#dbt-athena-194---april-28-2025)

--- a/website/docs/docs/dbt-versions/compatible-track-changelog.md
+++ b/website/docs/docs/dbt-versions/compatible-track-changelog.md
@@ -10,6 +10,53 @@ Each monthly "Compatible" release includes functionality matching up-to-date ope
 
 For more information, see [release tracks](/docs/dbt-versions/cloud-release-tracks).
 
+## December 2025
+
+Release date: December 9, 2025
+
+### dbt cloud-based platform
+
+This compatible release includes functionality from the following versions of dbt Core OSS:
+
+```
+dbt-core==1.10.15
+# shared interfaces
+dbt-adapters==1.16.7
+dbt-common==1.33.0
+dbt-semantic-interfaces==0.9.0
+# adapters
+dbt-athena==1.9.5
+dbt-bigquery==1.10.3
+dbt-databricks==1.10.15
+dbt-extractor==0.6.0
+dbt-fabric==1.9.4
+dbt-postgres==1.9.1
+dbt-redshift==1.9.5
+dbt-sl-sdk[sync]==0.13.0
+dbt-snowflake==1.10.3
+dbt-spark==1.9.3
+dbt-synapse==1.8.4
+dbt-teradata==1.10.0
+dbt-trino==1.9.3
+```
+
+Changelogs:
+- [dbt-core 1.10.13](https://github.com/dbt-labs/dbt-core/blob/1.10.latest/CHANGELOG.md#dbt-core-11013---september-25-2025)
+- [dbt-adapters 1.16.7](https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-adapters/CHANGELOG.md#dbt-adapters-1166---september-03-2025)
+- [dbt-common 1.33.0](https://github.com/dbt-labs/dbt-common/blob/main/CHANGELOG.md#dbt-common-1330---october-20-2025)
+- [dbt-athena 1.9.5](https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-athena/CHANGELOG.md#dbt-athena-194---april-28-2025)
+- [dbt-bigquery 1.10.3](https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-bigquery/CHANGELOG.md#dbt-bigquery-1101---july-29-2025)
+- [dbt-databricks 1.10.15](https://github.com/databricks/dbt-databricks/blob/1.10.latest/CHANGELOG.md#dbt-databricks-11015-nov-17-2025)
+- [dbt-fabric 1.9.4](https://github.com/microsoft/dbt-fabric/releases/tag/v1.9.4)
+- [dbt-postgres 1.9.1](https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-postgres/CHANGELOG.md#changelog)
+- [dbt-redshift 1.9.5](https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-redshift/CHANGELOG.md#dbt-redshift-195---may-13-2025)
+- [dbt-snowflake 1.10.3](http://github.com/dbt-labs/dbt-adapters/blob/main/dbt-snowflake/CHANGELOG.md)
+- [dbt-spark 1.9.3](https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-spark/CHANGELOG.md#dbt-spark-193---july-16-2025)
+- [dbt-synapse 1.8.4](https://github.com/microsoft/dbt-synapse/blob/v1.8.latest/CHANGELOG.md)
+- [dbt-teradata 1.10.0](https://github.com/Teradata/dbt-teradata/releases/tag/v1.10.0)
+- [dbt-trino 1.9.3](https://github.com/starburstdata/dbt-trino/blob/master/CHANGELOG.md#dbt-trino-193---july-22-2025)
+
+
 ## October 2025
 
 Release date: October 23, 2025


### PR DESCRIPTION
## What are you changing in this pull request and why?

Adding December 2025 compatible release notes in preparation for release!

## Checklist
- [X] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [X] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [X] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).
<!--
PRE-RELEASE VERSION OF dbt (if so, uncomment):
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
<!-- 
ADDING OR REMOVING PAGES (if so, uncomment):
- [ ] Add/remove page in `website/sidebars.js`
- [ ] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages
-->
