### PR TITLE
updated fusion compatibility matrix table

### DIFF
--- a/website/docs/docs/fusion/supported-features.md
+++ b/website/docs/docs/fusion/supported-features.md
@@ -51,7 +51,6 @@ If you're not sure what features are available, check out the following table.
 | **Category / Capability** | **dbt Core**<br /><small>(self-hosted)</small> | **Fusion CLI**<br/><small>(self-hosted)</small> | **VS Code <br />+ Fusion** | **<Constant name="dbt_platform" />*** | **Requires <br />`static_analysis`** |
 |:--------------|:--------------:|:---------------:|:-------------:|:-------------:|:--------------:|
 | **Engine performance** |  |  |  |  |  |
-| SQL transformation | ✅ | ✅ | ✅ | ✅ | ❌ |
 | SQL rendering | ✅ | ✅ | ✅ | ✅ | ❌ |
 | SQL parsing and compilation (SQL understanding) | ❌ | ✅ | ✅ | ✅ | ✅ |
 | Uses the <Constant name="fusion_engine"/> | ❌ <br /><small>(Built on Python)</small> | ✅ | ✅ | ✅ | ❌ |

--- a/website/docs/docs/fusion/supported-features.md
+++ b/website/docs/docs/fusion/supported-features.md
@@ -45,30 +45,32 @@ Note that we have removed some deprecated features and introduced more rigorous 
 
 If you're not sure what features are available, check out the following table. 
 
-> ✅ = Available | 🟡 = Partial / at compile-time only | ❌ = Not available | Coming soon = Not yet available
+> ✅ = Available | 🟡 = Partial / at compile-time only | ❌ = Not available | Coming soon = Not yet available.
+> Some features need you to configure [`static_analysis`](/docs/fusion/new-concepts#configuring-static_analysis) in order to work.
 
-| **Category / Capability** | **dbt Core**<br /><small>(self-hosted)</small> | **Fusion CLI**<br/><small>(self-hosted)</small> | **VS Code <br />+ Fusion** | **<Constant name="dbt_platform" />*** |
-|:---------------------------|:--------------------:|:--------------------:|:------------------:|:----------------------:|
-| **Engine performance** |  |  |  |  |
-| SQL compilation | ✅ | ✅ | ✅ | ✅ |
-| SQL compilation and parsing (SQL understanding) | ❌ | ✅ | ✅ | ✅ |
-| Uses the <Constant name="fusion_engine"/> | ❌ <br /><small>(Built on Python)</small> | ✅ | ✅ | ✅ |
-| Up to 30x faster parse / compile | ❌ | ✅ | ✅ | ✅ |
-| Incremental compilation | ❌ | ❌ | ✅ | ✅ |
-| **Editor and development experience** |  |  |  |  |
-| IntelliSense / autocomplete / hover info | ❌ | ❌ | ✅ | ✅ |
-| Inline errors (on save / in editor) | ❌ | 🟡 | ✅ | ✅ |
-| Live CTE previews / compiled SQL view | ❌ | ❌ | ✅ | ✅ |
-| Refactoring tools (rename model / column) | ❌ | ❌ | ✅ | Coming soon |
-| Go-to definition / references | ❌ | ❌ | ✅ | Coming soon |
-| Column-level lineage (in editor) | ❌ | ❌ | ✅ | Coming soon |
-| Developer compare changes | ❌ | ❌  | Coming soon | Coming soon |
-| **Platform and governance** |  |  |  |  |
-| Advanced CI compare changes | ❌ | ❌  | ✅ | ✅ |
-| dbt Mesh | ❌ | ❌  | ✅ | ✅ |
-| State-aware orchestration (SAO) | ❌ | ❌ | ❌ | ✅ |
-| Governance (PII / PHI tracking) | ❌ | ❌ | ❌ | Coming soon |
-| CI/CD cost optimization (Slimmer CI) | ❌ | ❌ | ❌ | Coming soon |
+| **Category / Capability** | **dbt Core**<br /><small>(self-hosted)</small> | **Fusion CLI**<br/><small>(self-hosted)</small> | **VS Code <br />+ Fusion** | **<Constant name="dbt_platform" />*** | **Requires <br />`static_analysis`** |
+|:--------------|:--------------:|:---------------:|:-------------:|:-------------:|:--------------:|
+| **Engine performance** |  |  |  |  |  |
+| SQL transformation | ✅ | ✅ | ✅ | ✅ | ❌ |
+| SQL rendering | ✅ | ✅ | ✅ | ✅ | ❌ |
+| SQL parsing and compilation  (SQL understanding) | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Uses the <Constant name="fusion_engine"/> | ❌ <br /><small>(Built on Python)</small> | ✅ | ✅ | ✅ | ❌ |
+| Up to 30x faster parse / compile | ❌ | ✅ | ✅ | ✅ | ❌ |
+| **Editor and development experience** |  |  |  |  |  |
+| IntelliSense / autocomplete / hover info | ❌ | ❌ | ✅ | ✅ | ✅ |
+| Inline errors (on save / in editor) | ❌ | 🟡 | ✅ | ✅ | ✅ |
+| Live CTE previews / compiled SQL view | ❌ | ❌ | ✅ | ✅ | 🟡 <br /><small>(Live CTE previews only)</small> |
+| Refactoring tools (rename model / column) | ❌ | ❌ | ✅ | Coming soon | 🟡 <br /><small>(Column refactoring only)</small> |
+| Go-to definition / references | ❌ | ❌ | ✅ | Coming soon | 🟡 <br /><small>(Column go-to definition only)</small> |
+| Column-level lineage (in editor) | ❌ | ❌ | ✅ | Coming soon | ✅ |
+| Developer compare changes | ❌ | ❌  | Coming soon | Coming soon | ❌ |
+| **Platform and governance** |  |  |  |  |  |
+| Advanced CI compare changes | ❌ | ❌  | ✅ | ✅ | ❌ |
+| dbt Mesh | ❌ | ❌  | ✅ | ✅ | ❌ |
+| Efficient testing | ❌ | ❌ | ❌ | ✅ | ✅ |
+| State-aware orchestration (SAO) | ❌ | ❌ | ❌ | ✅ | ❌ |
+| Governance (PII / PHI tracking) | ❌ | ❌ | ❌ | Coming soon | ✅ |
+| CI/CD cost optimization (Slimmer CI) | ❌ | ❌ | ❌ | Coming soon | ✅ |
 
 *Support for other <Constant name="dbt_platform" /> tools, like <Constant name="semantic_layer" /> and <Constant name="explorer" />, is coming soon.
 

--- a/website/docs/docs/fusion/supported-features.md
+++ b/website/docs/docs/fusion/supported-features.md
@@ -43,10 +43,9 @@ Note that we have removed some deprecated features and introduced more rigorous 
 - To learn about the <Term id="lsp"/> features supported across the <Constant name="dbt_platform"/>, refer to [About dbt LSP](/docs/about-dbt-lsp).
 - To stay up-to-date on the latest features and capabilities, check out the [Fusion diaries](https://github.com/dbt-labs/dbt-fusion/discussions).
 
-If you're not sure what features are available, check out the following table. 
+Some features need you to configure [`static_analysis`](/docs/fusion/new-concepts#configuring-static_analysis) in order to work. If you're not sure what features are available, check out the following table.  
 
 > ✅ = Available | 🟡 = Partial/at compile-time only | ❌ = Not available | Coming soon = Not yet available.
-> Some features need you to configure [`static_analysis`](/docs/fusion/new-concepts#configuring-static_analysis) in order to work.
 
 | **Category/Capability** | **dbt Core**<br /><small>(self-hosted)</small> | **Fusion CLI**<br/><small>(self-hosted)</small> | **VS Code <br />+ Fusion** | **<Constant name="dbt_platform" />*** | **Requires <br />`static_analysis`** |
 |:--------------|:--------------:|:---------------:|:-------------:|:-------------:|:--------------:|

--- a/website/docs/docs/fusion/supported-features.md
+++ b/website/docs/docs/fusion/supported-features.md
@@ -48,18 +48,18 @@ If you're not sure what features are available, check out the following table.
 > ✅ = Available | 🟡 = Partial/at compile-time only | ❌ = Not available | Coming soon = Not yet available.
 > Some features need you to configure [`static_analysis`](/docs/fusion/new-concepts#configuring-static_analysis) in order to work.
 
-| **Category / Capability** | **dbt Core**<br /><small>(self-hosted)</small> | **Fusion CLI**<br/><small>(self-hosted)</small> | **VS Code <br />+ Fusion** | **<Constant name="dbt_platform" />*** | **Requires <br />`static_analysis`** |
+| **Category/Capability** | **dbt Core**<br /><small>(self-hosted)</small> | **Fusion CLI**<br/><small>(self-hosted)</small> | **VS Code <br />+ Fusion** | **<Constant name="dbt_platform" />*** | **Requires <br />`static_analysis`** |
 |:--------------|:--------------:|:---------------:|:-------------:|:-------------:|:--------------:|
 | **Engine performance** |  |  |  |  |  |
 | SQL rendering | ✅ | ✅ | ✅ | ✅ | ❌ |
 | SQL parsing and compilation (SQL understanding) | ❌ | ✅ | ✅ | ✅ | ✅ |
 | Uses the <Constant name="fusion_engine"/> | ❌ <br /><small>(Built on Python)</small> | ✅ | ✅ | ✅ | ❌ |
-| Up to 30x faster parse / compile | ❌ | ✅ | ✅ | ✅ | ❌ |
+| Up to 30x faster parse/compile | ❌ | ✅ | ✅ | ✅ | ❌ |
 | **Editor and development experience** |  |  |  |  |  |
-| IntelliSense/autocomplete / hover info | ❌ | ❌ | ✅ | ✅ | ✅ |
+| IntelliSense/autocomplete/hover info | ❌ | ❌ | ✅ | ✅ | ✅ |
 | Inline errors (on save/in editor) | ❌ | 🟡 | ✅ | ✅ | ✅ |
 | Live CTE previews/compiled SQL view | ❌ | ❌ | ✅ | ✅ | 🟡 <br /><small>(Live CTE previews only)</small> |
-| Refactoring tools (rename model / column) | ❌ | ❌ | ✅ | Coming soon | 🟡 <br /><small>(Column refactoring only)</small> |
+| Refactoring tools (rename model/column) | ❌ | ❌ | ✅ | Coming soon | 🟡 <br /><small>(Column refactoring only)</small> |
 | Go-to definition/references/macro | ❌ | ❌ | ✅ | Coming soon | 🟡 <br /><small>(Column go-to definition only)</small> |
 | Column-level lineage (in editor) | ❌ | ❌ | ✅ | Coming soon | ✅ |
 | Developer compare changes | ❌ | ❌  | Coming soon | Coming soon | ❌ |

--- a/website/docs/docs/fusion/supported-features.md
+++ b/website/docs/docs/fusion/supported-features.md
@@ -45,7 +45,7 @@ Note that we have removed some deprecated features and introduced more rigorous 
 
 If you're not sure what features are available, check out the following table. 
 
-> ✅ = Available | 🟡 = Partial / at compile-time only | ❌ = Not available | Coming soon = Not yet available.
+> ✅ = Available | 🟡 = Partial/at compile-time only | ❌ = Not available | Coming soon = Not yet available.
 > Some features need you to configure [`static_analysis`](/docs/fusion/new-concepts#configuring-static_analysis) in order to work.
 
 | **Category / Capability** | **dbt Core**<br /><small>(self-hosted)</small> | **Fusion CLI**<br/><small>(self-hosted)</small> | **VS Code <br />+ Fusion** | **<Constant name="dbt_platform" />*** | **Requires <br />`static_analysis`** |
@@ -53,13 +53,13 @@ If you're not sure what features are available, check out the following table.
 | **Engine performance** |  |  |  |  |  |
 | SQL transformation | ✅ | ✅ | ✅ | ✅ | ❌ |
 | SQL rendering | ✅ | ✅ | ✅ | ✅ | ❌ |
-| SQL parsing and compilation  (SQL understanding) | ❌ | ✅ | ✅ | ✅ | ✅ |
+| SQL parsing and compilation (SQL understanding) | ❌ | ✅ | ✅ | ✅ | ✅ |
 | Uses the <Constant name="fusion_engine"/> | ❌ <br /><small>(Built on Python)</small> | ✅ | ✅ | ✅ | ❌ |
 | Up to 30x faster parse / compile | ❌ | ✅ | ✅ | ✅ | ❌ |
 | **Editor and development experience** |  |  |  |  |  |
-| IntelliSense / autocomplete / hover info | ❌ | ❌ | ✅ | ✅ | ✅ |
-| Inline errors (on save / in editor) | ❌ | 🟡 | ✅ | ✅ | ✅ |
-| Live CTE previews / compiled SQL view | ❌ | ❌ | ✅ | ✅ | 🟡 <br /><small>(Live CTE previews only)</small> |
+| IntelliSense/autocomplete / hover info | ❌ | ❌ | ✅ | ✅ | ✅ |
+| Inline errors (on save/in editor) | ❌ | 🟡 | ✅ | ✅ | ✅ |
+| Live CTE previews/compiled SQL view | ❌ | ❌ | ✅ | ✅ | 🟡 <br /><small>(Live CTE previews only)</small> |
 | Refactoring tools (rename model / column) | ❌ | ❌ | ✅ | Coming soon | 🟡 <br /><small>(Column refactoring only)</small> |
 | Go-to definition/references/macro | ❌ | ❌ | ✅ | Coming soon | 🟡 <br /><small>(Column go-to definition only)</small> |
 | Column-level lineage (in editor) | ❌ | ❌ | ✅ | Coming soon | ✅ |
@@ -69,7 +69,7 @@ If you're not sure what features are available, check out the following table.
 | dbt Mesh | ❌ | ❌  | ✅ | ✅ | ❌ |
 | Efficient testing | ❌ | ❌ | ❌ | ✅ | ✅ |
 | State-aware orchestration (SAO) | ❌ | ❌ | ❌ | ✅ | ❌ |
-| Governance (PII / PHI tracking) | ❌ | ❌ | ❌ | Coming soon | ✅ |
+| Governance (PII/PHI tracking) | ❌ | ❌ | ❌ | Coming soon | ✅ |
 | CI/CD cost optimization (Slimmer CI) | ❌ | ❌ | ❌ | Coming soon | ✅ |
 
 *Support for other <Constant name="dbt_platform" /> tools, like <Constant name="semantic_layer" /> and <Constant name="explorer" />, is coming soon.

--- a/website/docs/docs/fusion/supported-features.md
+++ b/website/docs/docs/fusion/supported-features.md
@@ -61,7 +61,7 @@ If you're not sure what features are available, check out the following table.
 | Inline errors (on save / in editor) | ❌ | 🟡 | ✅ | ✅ | ✅ |
 | Live CTE previews / compiled SQL view | ❌ | ❌ | ✅ | ✅ | 🟡 <br /><small>(Live CTE previews only)</small> |
 | Refactoring tools (rename model / column) | ❌ | ❌ | ✅ | Coming soon | 🟡 <br /><small>(Column refactoring only)</small> |
-| Go-to definition / references | ❌ | ❌ | ✅ | Coming soon | 🟡 <br /><small>(Column go-to definition only)</small> |
+| Go-to definition/references/macro | ❌ | ❌ | ✅ | Coming soon | 🟡 <br /><small>(Column go-to definition only)</small> |
 | Column-level lineage (in editor) | ❌ | ❌ | ✅ | Coming soon | ✅ |
 | Developer compare changes | ❌ | ❌  | Coming soon | Coming soon | ❌ |
 | **Platform and governance** |  |  |  |  |  |

--- a/website/docs/docs/fusion/supported-features.md
+++ b/website/docs/docs/fusion/supported-features.md
@@ -45,7 +45,7 @@ Note that we have removed some deprecated features and introduced more rigorous 
 
 Some features need you to configure [`static_analysis`](/docs/fusion/new-concepts#configuring-static_analysis) in order to work. If you're not sure what features are available, check out the following table.  
 
-> ✅ = Available | 🟡 = Partial/at compile-time only | ❌ = Not available | Coming soon = Not yet available.
+> ✅ = Available | 🟡 = Partial/at compile-time only | ❌ = Not available | Coming soon = Not yet available
 
 | **Category/Capability** | **dbt Core**<br /><small>(self-hosted)</small> | **Fusion CLI**<br/><small>(self-hosted)</small> | **VS Code <br />+ Fusion** | **<Constant name="dbt_platform" />*** | **Requires <br />`static_analysis`** |
 |:--------------|:--------------:|:---------------:|:-------------:|:-------------:|:--------------:|


### PR DESCRIPTION
this pr adds a "requires `static_analysis`" column to the fusion supported features table to indicate which features require static analysis.


- added a new column "Requires `static_analysis`" to the features and capabilities table
- marked features that require static analysis in that column
- added a note above the table explaining that some features require `static_analysis` config
- updated the column header to use a shorter format: "Requires `static_analysis`"

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-fix-update-fusion-table-dbt-labs.vercel.app/docs/fusion/supported-features

<!-- end-vercel-deployment-preview -->