### PR TITLE
adds cursor agent mode callout

### DIFF
--- a/website/docs/docs/about-dbt-extension.md
+++ b/website/docs/docs/about-dbt-extension.md
@@ -91,6 +91,8 @@ The following are currently known limitations of the dbt extension:
 
 - **Renaming models:** When a model file is renamed, the dbt extension will apply edits to update all `ref()` calls that reference the renamed model. Due to limitations of VS Code's Language Server Client, we are not able to auto-save these edit files. As a result, you may see that renaming a model file results in compiler errors in your project. To fix these errors, you must either manually save each file that was edited by the dbt extension, or click **File** --> **Save All** to save all edited files.
 
+- **Using Cursor's Agent mode:** When using the dbt extension in Cursor, lineage visualization works best in Editor mode and doesn't render in Agent mode. If you're working in Agent mode and need to view lineage, switch to Editor mode to access the full lineage tab functionality.
+
 
 ## Support
 

--- a/website/docs/docs/dbt-extension-features.md
+++ b/website/docs/docs/dbt-extension-features.md
@@ -122,6 +122,11 @@ Usage:
 
 See lineage at the column or table level as you develop — no context switching or breaking flow.
 
+:::tip Using the lineage tab in Cursor
+
+If you're using the dbt VS Code extension in Cursor, the lineage tab works best in Editor mode and doesn't render in Agent mode. If you're in Agent mode and the lineage tab isn't rendering, just switch to Editor mode to view your project's table and column lineage.
+:::
+
 View table lineage:
 - Open the **Lineage** tab in your editor. It will reflect table lineage focused on the currently-open file.
 - Double-click nodes to open the files in your editor.

--- a/website/docs/docs/dbt-extension-features.md
+++ b/website/docs/docs/dbt-extension-features.md
@@ -21,6 +21,7 @@ The following extension features help you get more done, fast:
 - **[Hover insights](#hover-insights):** See context on tables, columns, and functions without leaving your code. Simply hover over any SQL element to see details like column names and data types.
 - **[Live CTE previews](#live-preview-for-models-and-ctes):** Preview a CTE’s output directly from inside your dbt model for faster validation and debugging.
 - **[Rich lineage in context](#rich-lineage-in-context):** See lineage at the column or table level as you develop with no context switching or breaking the flow.
+  - If you use Cursor, the lineage tab works best in Editor mode and doesn't render in Agent mode. If you're in Agent mode and the lineage tab isn't rendering, just switch to Editor mode to view your project's table and column lineage.
 - **[View compiled code](#view-compiled-code):** Get a live view of the SQL code your models will build alongside your dbt code.
 - **[Build flexibly](#build-flexibly):** Use the command palette to build models with complex selectors.
  

--- a/website/docs/docs/fusion/supported-features.md
+++ b/website/docs/docs/fusion/supported-features.md
@@ -91,6 +91,7 @@ If your project is using any of the features listed in the following table, you 
 - Models that leverage specific materialization features may be unable to run or may be missing some desirable configurations.
 - Tooling that expects dbt Core's exact log output. Fusion's logging system is currently unstable and incomplete.
 - Workflows built around complementary features of the dbt platform (like model-level notifications, Advanced CI, and Semantic Layer) that Fusion does not yet support.
+- When using the dbt VS Code extension in Cursor, lineage visualization works best in Editor mode and doesn't render in Agent mode. If you're working in Agent mode and need to view lineage, switch to Editor mode to access the full lineage tab functionality.
 
 :::note
 We have been moving quickly to implement many of these features ahead of General Availability. Read more about [the path to GA](/blog/dbt-fusion-engine-path-to-ga), and track our progress in the [`dbt-fusion` milestones](https://github.com/dbt-labs/dbt-fusion/milestones).

--- a/website/docs/docs/fusion/supported-features.md
+++ b/website/docs/docs/fusion/supported-features.md
@@ -50,7 +50,7 @@ Some features need you to configure [`static_analysis`](/docs/fusion/new-concept
 | **Category/Capability** | **dbt Core**<br /><small>(self-hosted)</small> | **Fusion CLI**<br/><small>(self-hosted)</small> | **VS Code <br />+ Fusion** | **<Constant name="dbt_platform" />*** | **Requires <br />`static_analysis`** |
 |:--------------|:--------------:|:---------------:|:-------------:|:-------------:|:--------------:|
 | **Engine performance** |  |  |  |  |  |
-| SQL rendering | ✅ | ✅ | ✅ | ✅ | ❌ |
+| <Term id="sql-rendering" /> | ✅ | ✅ | ✅ | ✅ | ❌ |
 | SQL parsing and compilation (SQL understanding) | ❌ | ✅ | ✅ | ✅ | ✅ |
 | Uses the <Constant name="fusion_engine"/> | ❌ <br /><small>(Built on Python)</small> | ✅ | ✅ | ✅ | ❌ |
 | Up to 30x faster parse/compile | ❌ | ✅ | ✅ | ✅ | ❌ |

--- a/website/docs/terms/hover-terms.md
+++ b/website/docs/terms/hover-terms.md
@@ -129,7 +129,7 @@ sql-expression:
 
 sql-rendering:
   displayText: SQL rendering  
-  hoverSnippet: The dbt Core engine takes SQL with Jinja, and renders out all the macros present in the model to produce SQL ready to execute against the database. For SQL compilation and parsing capabilities, use the Fusion engine instead to better understand your SQL structure.
+  hoverSnippet: The dbt Core engine takes SQL with Jinja, and renders all the macros present in the model to produce SQL that is ready to run against the database. For SQL parsing and compilation capabilities, use the Fusion engine instead to better understand your SQL structure.
 
 subquery:
   displayText: subquery

--- a/website/docs/terms/hover-terms.md
+++ b/website/docs/terms/hover-terms.md
@@ -127,6 +127,10 @@ sql-expression:
   displayText: SQL expression
   hoverSnippet: A SQL expression is a combination of columns, values, operators, and functions that evaluates to a single value.
 
+sql-rendering:
+  displayText: SQL rendering  
+  hoverSnippet: The dbt Core engine takes SQL with Jinja, and renders out all the macros present in the model to produce SQL ready to execute against the database. For SQL compilation and parsing capabilities, use the Fusion engine instead to better understand your SQL structure.
+
 subquery:
   displayText: subquery
   hoverSnippet: A subquery is a query within another query. Subqueries are often used when you need to process data in multiple steps.

--- a/website/snippets/_fusion-troubleshooting.md
+++ b/website/snippets/_fusion-troubleshooting.md
@@ -8,6 +8,11 @@ import DbtDirectoryFaq from '/snippets/_dbt-directory-faq.md';
 
 </Expandable>
 
+<Expandable alt_header="I can't see the lineage tab in Cursor">
+
+If you're using the dbt VS Code extension in Cursor, the lineage tab works best in Editor mode and doesn't render in Agent mode. If you're in Agent mode and the lineage tab isn't rendering, just switch to Editor mode to view your project's table and column lineage.
+</Expandable>
+
 <Expandable  alt_header="dbt platform configurations">
 
 If you're a cloud-based dbt platform user who has the `dbt-cloud:` config in the `dbt_project.yml` file and are also using dbt Mesh, you must have the project ID configured:


### PR DESCRIPTION
this pr adds a callout explaining the lineage tab isn't rendered when using cursor in agent mode 

also adds a term id for sql rendering

raised internally: https://dbt-labs.slack.com/archives/C02NCQ9483C/p1765439792152899

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-vsce-dbt-labs.vercel.app/docs/about-dbt-extension
- https://docs-getdbt-com-git-update-vsce-dbt-labs.vercel.app/docs/dbt-extension-features
- https://docs-getdbt-com-git-update-vsce-dbt-labs.vercel.app/docs/fusion/supported-features

<!-- end-vercel-deployment-preview -->