### PR TITLE
Incremental model full refresh clarification

### DIFF
--- a/website/docs/docs/build/incremental-models.md
+++ b/website/docs/docs/build/incremental-models.md
@@ -166,7 +166,7 @@ To force dbt to rebuild the entire incremental model from scratch, use the `--fu
 $ dbt run --full-refresh --select my_incremental_model+
 ```
 
-The trailing `+` in the command above will also run all downstream models that depend on `my_incremental_model`. **Important:** If any of those downstream dependencies are also incremental models, they will be fully refreshed as well. This ensures consistency across your incremental model lineage when the logic changes.
+The trailing `+` in the command above will also run all downstream models that depend on `my_incremental_model`. If any of those downstream dependencies are also incremental models, they will be fully refreshed as well. 
 
 You can optionally use the [`full_refresh config`](/reference/resource-configs/full_refresh) to set a resource to always or never full-refresh at the project or resource level. If specified as true or false, the `full_refresh` config will take precedence over the presence or absence of the `--full-refresh` flag.
 

--- a/website/docs/docs/build/incremental-models.md
+++ b/website/docs/docs/build/incremental-models.md
@@ -166,7 +166,7 @@ To force dbt to rebuild the entire incremental model from scratch, use the `--fu
 $ dbt run --full-refresh --select my_incremental_model+
 ```
 
-It's also advisable to rebuild any downstream models, as indicated by the trailing `+`.
+The trailing `+` in the command above will also run all downstream models that depend on `my_incremental_model`. **Important:** If any of those downstream dependencies are also incremental models, they will be fully refreshed as well. This ensures consistency across your incremental model lineage when the logic changes.
 
 You can optionally use the [`full_refresh config`](/reference/resource-configs/full_refresh) to set a resource to always or never full-refresh at the project or resource level. If specified as true or false, the `full_refresh` config will take precedence over the presence or absence of the `--full-refresh` flag.
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
This PR clarifies the behavior of the `dbt run --full-refresh --select my_incremental_model+` command in the incremental models documentation.

The update explicitly states that:
- The `+` selector will run all downstream models.
- If any of these downstream dependencies are also incremental models, they will be fully refreshed as well.

This clarification ensures users understand that `--full-refresh` propagates through the entire selected lineage, guaranteeing consistency when changes are made.

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).

---
[Slack Thread](https://dbt-labs.slack.com/archives/C02NCQ9483C/p1765527717487199?thread_ts=1765527717.487199&cid=C02NCQ9483C)

<a href="https://cursor.com/background-agent?bcId=bc-23d6ca10-edf1-469d-bad9-c3ab3b727c7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-23d6ca10-edf1-469d-bad9-c3ab3b727c7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

