### PR TITLE
Config code example update

### DIFF
--- a/website/docs/reference/resource-configs/spark-configs.md
+++ b/website/docs/reference/resource-configs/spark-configs.md
@@ -125,7 +125,8 @@ If no `partition_by` is specified, then the `insert_overwrite` strategy will ato
 {{ config(
     materialized='incremental',
     partition_by=['date_day'],
-    file_format='parquet'
+    file_format='parquet',
+    incremental_strategy='insert_overwrite'
 ) }}
 
 /*


### PR DESCRIPTION
## What are you changing in this pull request and why?
This PR updates the Spark `insert_overwrite` incremental strategy example in `spark-configs.md`. The `incremental_strategy='insert_overwrite'` configuration is explicitly added to the `config` block. This clarifies to users the need to specify this strategy for Spark `insert_overwrite` models, making the example more complete and explicit.

Resolves https://github.com/dbt-labs/docs.getdbt.com/issues/3366


## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [x] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).

---
<a href="https://cursor.com/background-agent?bcId=bc-26c44ffc-08ba-4ebb-8f50-39555fdeef06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-26c44ffc-08ba-4ebb-8f50-39555fdeef06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

