### PR TITLE
Documentation parameter syntax update

### DIFF
--- a/website/docs/docs/build/conversion-metrics.md
+++ b/website/docs/docs/build/conversion-metrics.md
@@ -17,7 +17,7 @@ Conversion metrics are different from [ratio metrics](/docs/build/ratio) because
 The specification for conversion metrics is as follows:
 
 :::tip
-Note that we use the double colon (::) to indicate whether a parameter is nested within another parameter. So for example, `query_params::metrics` means the `metrics` parameter is nested under `query_params`.
+Note that we use dot notation (`.`) to indicate whether a parameter is nested within another parameter. For example, `base_measure.name` means the `name` parameter is nested under `base_measure`.
 :::
 
 | Parameter | Description | Required | Type |
@@ -31,14 +31,14 @@ Note that we use the double colon (::) to indicate whether a parameter is nested
 | `entity` | The entity for each conversion event. | Required | String |  
 | `calculation` | Method of calculation. Either `conversion_rate` or `conversions`. Defaults to `conversion_rate`.  | Optional | String |
 | `base_measure` | A list of base measure inputs. | Required | Dict |
-| `base_measure:name` | The base conversion event measure. |  Required | String |
-| `base_measure:fill_nulls_with` | Set the value in your metric definition instead of null (such as zero). | Optional | Integer |
-| `base_measure:join_to_timespine` | Boolean that indicates if the aggregated measure should be joined to the time spine table to fill in missing dates. Default `false`. | Optional | Boolean |
-| `base_measure:filter` | Optional `filter` used to apply to the base measure. | Optional | String |
+| `base_measure.name` | The base conversion event measure. |  Required | String |
+| `base_measure.fill_nulls_with` | Set the value in your metric definition instead of null (such as zero). | Optional | Integer |
+| `base_measure.join_to_timespine` | Boolean that indicates if the aggregated measure should be joined to the time spine table to fill in missing dates. Default `false`. | Optional | Boolean |
+| `base_measure.filter` | Optional `filter` used to apply to the base measure. | Optional | String |
 | `conversion_measure` | A list of conversion measure inputs. | Required | Dict |
-| `conversion_measure:name` | The base conversion event measure.| Required | String |
-| `conversion_measure:fill_nulls_with` | Set the value in your metric definition instead of null (such as zero). | Optional | Integer |
-| `conversion_measure:join_to_timespine` | Boolean that indicates if the aggregated measure should be joined to the time spine table to fill in missing dates. Default `false`. | Optional | Boolean |  
+| `conversion_measure.name` | The base conversion event measure.| Required | String |
+| `conversion_measure.fill_nulls_with` | Set the value in your metric definition instead of null (such as zero). | Optional | Integer |
+| `conversion_measure.join_to_timespine` | Boolean that indicates if the aggregated measure should be joined to the time spine table to fill in missing dates. Default `false`. | Optional | Boolean |  
 | `window` | The time window for the conversion event, such as 7 days, 1 week, 3 months. Defaults to infinity. | Optional | String |
 | `constant_properties` | List of constant properties.  | Optional | List |
 | `base_property` | The property from the base semantic model that you want to hold constant.  |  Optional | String |

--- a/website/docs/docs/build/cumulative-metrics.md
+++ b/website/docs/docs/build/cumulative-metrics.md
@@ -11,7 +11,7 @@ Cumulative metrics aggregate a measure over a given accumulation window. If no w
 Cumulative metrics are useful for calculating things like weekly active users, or month-to-date revenue. The parameters, description, and types for cumulative metrics are: 
 
 :::tip
-Note that we use the double colon (::) to indicate whether a parameter is nested within another parameter. So for example, `measure::name` means the `name` parameter is nested under `measure`.
+Note that we use dot notation (`.`) to indicate whether a parameter is nested within another parameter. For example, `measure.name` means the `name` parameter is nested under `measure`.
 :::
 
 ## Parameters
@@ -24,21 +24,21 @@ Note that we use the double colon (::) to indicate whether a parameter is nested
 | `description`       | The description of the metric.     | Optional  | String |
 | `type`    | The type of the metric (cumulative, derived, ratio, or simple).       | Required  | String |  
 | `label`     | Required string that defines the display value in downstream tools. Accepts plain text, spaces, and quotes (such as `orders_total` or `"orders_total"`).  | Required  | String |
-| `type_params`    | The type parameters of the metric. Supports nested parameters indicated by the double colon, such as `type_params::measure`.  | Required  | Dict |
-| `type_params::measure`   | The measure associated with the metric. Supports both shorthand (string) and object syntax. The shorthand is used if only the name is needed, while the object syntax allows specifying additional attributes. | Required  | Dict |
-| `measure::name`    | The name of the measure being referenced. Required if using object syntax for `type_params::measure`.  | Optional  | String |
-| `measure::fill_nulls_with`     | Sets a value (for example, 0) to replace nulls in the metric definition.    | Optional  | Integer |
-| `measure::join_to_timespine` | Boolean indicating if the aggregated measure should be joined to the time spine table to fill in missing dates. Default is `false`. | Optional  | Boolean |
-| `type_params::cumulative_type_params`     | Configures the attributes like `window`, `period_agg`, and `grain_to_date` for cumulative metrics. | Optional  | Dict |
-| `cumulative_type_params::window`      | Specifies the accumulation window, such as `1 month`, `7 days`, or `1 year`. Cannot be used with `grain_to_date`.   | Optional  | String |
-| `cumulative_type_params::grain_to_date`   | Sets the accumulation grain, such as `month`, restarting accumulation at the beginning of each specified grain period. Cannot be used with `window`. | Optional  | String |
-| `cumulative_type_params::period_agg`  | Defines how to aggregate the cumulative metric when summarizing data to a different granularity: `first`, `last`, or `average`. Defaults to `first` if `window` is not specified. | Optional  | String |
+| `type_params`    | The type parameters of the metric. Supports nested parameters indicated by dot notation, such as `type_params.measure`.  | Required  | Dict |
+| `type_params.measure`   | The measure associated with the metric. Supports both shorthand (string) and object syntax. The shorthand is used if only the name is needed, while the object syntax allows specifying additional attributes. | Required  | Dict |
+| `measure.name`    | The name of the measure being referenced. Required if using object syntax for `type_params.measure`.  | Optional  | String |
+| `measure.fill_nulls_with`     | Sets a value (for example, 0) to replace nulls in the metric definition.    | Optional  | Integer |
+| `measure.join_to_timespine` | Boolean indicating if the aggregated measure should be joined to the time spine table to fill in missing dates. Default is `false`. | Optional  | Boolean |
+| `type_params.cumulative_type_params`     | Configures the attributes like `window`, `period_agg`, and `grain_to_date` for cumulative metrics. | Optional  | Dict |
+| `cumulative_type_params.window`      | Specifies the accumulation window, such as `1 month`, `7 days`, or `1 year`. Cannot be used with `grain_to_date`.   | Optional  | String |
+| `cumulative_type_params.grain_to_date`   | Sets the accumulation grain, such as `month`, restarting accumulation at the beginning of each specified grain period. Cannot be used with `window`. | Optional  | String |
+| `cumulative_type_params.period_agg`  | Defines how to aggregate the cumulative metric when summarizing data to a different granularity: `first`, `last`, or `average`. Defaults to `first` if `window` is not specified. | Optional  | String |
 
 </VersionBlock>
 
-<Expandable alt_header="Explanation of type_params::measure">
+<Expandable alt_header="Explanation of type_params.measure">
   
-The`type_params::measure` configuration can be written in different ways:
+The `type_params.measure` configuration can be written in different ways:
 - Shorthand syntax &mdash;  To only specify the name of the measure, use a simple string value. This is a shorthand approach when no other attributes are required.
   ```yaml
   type_params:

--- a/website/docs/docs/build/saved-queries.md
+++ b/website/docs/docs/build/saved-queries.md
@@ -15,7 +15,7 @@ Saved queries serve as the foundational building block, allowing you to [configu
 To create a saved query, refer to the following table parameters.
 
 :::tip
-Note that we use the double colon (::) to indicate whether a parameter is nested within another parameter. So for example, `query_params::metrics` means the `metrics` parameter is nested under `query_params`.
+Note that we use dot notation (`.`) to indicate whether a parameter is nested within another parameter. For example, `query_params.metrics` means the `metrics` parameter is nested under `query_params`.
 :::
 
 <!-- For versions 1.9 and higher -->
@@ -27,19 +27,19 @@ Note that we use the double colon (::) to indicate whether a parameter is nested
 | `description`     | String      | Required     | A description of the saved query.     |
 | `label`     | String      | Required     | The display name for your saved query. This value will be shown in downstream tools.    |
 | `config`     | String      |  Optional     |  Use the [`config`](/reference/resource-properties/config) property to specify configurations for your saved query. Supports `cache`, [`enabled`](/reference/resource-configs/enabled), `export_as`, [`group`](/reference/resource-configs/group), [`meta`](/reference/resource-configs/meta), [`tags`](/reference/resource-configs/tags), and [`schema`](/reference/resource-configs/schema)  configurations.   |
-| `config::cache::enabled`     | Object      | Optional     |  An object with a sub-key used to specify if a saved query should populate the [cache](/docs/use-dbt-semantic-layer/sl-cache). Accepts sub-key `true` or `false`. Defaults to `false` |
+| `config.cache.enabled`     | Object      | Optional     |  An object with a sub-key used to specify if a saved query should populate the [cache](/docs/use-dbt-semantic-layer/sl-cache). Accepts sub-key `true` or `false`. Defaults to `false` |
 | `limit`     | Integer    | Optional     |  The maximum number of rows to return. |
 | `order_by`  | String     | Optional     |  The metrics and group bys to order the query by. |
 | `query_params`       | Structure   | Required     | Contains the query parameters. |
-| `query_params::metrics`   | List or String   | Optional    | A list of the metrics to be used in the query as specified in the command line interface. |
-| `query_params::group_by`    | List or String          | Optional    | A list of the Entities and Dimensions to be used in the query, which include the `Dimension` or `TimeDimension`. |
-| `query_params::where`        | List or String | Optional  | A list of strings that may include the `Dimension` or `TimeDimension` objects. |
+| `query_params.metrics`   | List or String   | Optional    | A list of the metrics to be used in the query as specified in the command line interface. |
+| `query_params.group_by`    | List or String          | Optional    | A list of the Entities and Dimensions to be used in the query, which include the `Dimension` or `TimeDimension`. |
+| `query_params.where`        | List or String | Optional  | A list of strings that may include the `Dimension` or `TimeDimension` objects. |
 | `exports`     | List or Structure | Optional    | A list of exports to be specified within the exports structure.     |
-| `exports::name`       | String               | Required     | Name of the export object.      |
-| `exports::config`     | List or Structure     | Required     | A [`config`](/reference/resource-properties/config) property for any parameters specifying the export.  |
-| `exports::config::export_as` | String    | Required     | The type of export to run. Options include table or view currently and cache in the near future.   |
-| `exports::config::schema`   | String   | Optional    | The [schema](/reference/resource-configs/schema) for creating the table or view. This option cannot be used for caching.   |
-| `exports::config::alias`  | String     | Optional    | The table [alias](/reference/resource-configs/alias) used to write to the table or view.  This option cannot be used for caching.  | 
+| `exports.name`       | String               | Required     | Name of the export object.      |
+| `exports.config`     | List or Structure     | Required     | A [`config`](/reference/resource-properties/config) property for any parameters specifying the export.  |
+| `exports.config.export_as` | String    | Required     | The type of export to run. Options include table or view currently and cache in the near future.   |
+| `exports.config.schema`   | String   | Optional    | The [schema](/reference/resource-configs/schema) for creating the table or view. This option cannot be used for caching.   |
+| `exports.config.alias`  | String     | Optional    | The table [alias](/reference/resource-configs/alias) used to write to the table or view.  This option cannot be used for caching.  | 
 
 </VersionBlock>
 

--- a/website/docs/docs/build/simple.md
+++ b/website/docs/docs/build/simple.md
@@ -12,7 +12,7 @@ Simple metrics are metrics that directly reference a single measure, without any
  The parameters, description, and type for simple metrics are:
 
 :::tip
-Note that we use the double colon (::) to indicate whether a parameter is nested within another parameter. So for example, `query_params::metrics` means the `metrics` parameter is nested under `query_params`.
+Note that we use dot notation (`.`) to indicate whether a parameter is nested within another parameter. For example, `measure.name` means the `name` parameter is nested under `measure`.
 :::
 
 
@@ -24,11 +24,11 @@ Note that we use the double colon (::) to indicate whether a parameter is nested
 | `label` | Defines the display value in downstream tools. Accepts plain text, spaces, and quotes (such as `orders_total` or `"orders_total"`). | Required | String |
 | `type_params` | The type parameters of the metric. | Required | Dict |
 | `measure` | A list of measure inputs. | Required | List |
-| `measure:name` | The measure you're referencing. | Required | String |
-| `measure:alias` | Optional [`alias`](/reference/resource-configs/alias) to rename the measure. | Optional | String |
-| `measure:filter` | Optional `filter` applied to the measure. | Optional | String |
-| `measure:fill_nulls_with` | Set the value in your metric definition instead of null (such as zero). | Optional | Integer |
-| `measure:join_to_timespine` | Indicates if the aggregated measure should be joined to the time spine table to fill in missing dates. Default `false`. | Optional | Boolean |
+| `measure.name` | The measure you're referencing. | Required | String |
+| `measure.alias` | Optional [`alias`](/reference/resource-configs/alias) to rename the measure. | Optional | String |
+| `measure.filter` | Optional `filter` applied to the measure. | Optional | String |
+| `measure.fill_nulls_with` | Set the value in your metric definition instead of null (such as zero). | Optional | Integer |
+| `measure.join_to_timespine` | Indicates if the aggregated measure should be joined to the time spine table to fill in missing dates. Default `false`. | Optional | Boolean |
 
 The following displays the complete specification for simple metrics, along with an example.
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
This PR standardizes the notation for nested parameters in the documentation. Previously, nested parameters were sometimes indicated by double colons (`::`) or colons (`:`). This change updates all such instances to use dot notation (`.`), improving consistency and readability across the docs. For example, `query_params::metrics` is now `query_params.metrics`.

discussed and follow up from https://github.com/dbt-labs/docs.getdbt.com/pull/8309#discussion_r2634379297

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).

---
<a href="https://cursor.com/background-agent?bcId=bc-6eb97f73-0ce4-48cb-b127-6b55bbc67523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6eb97f73-0ce4-48cb-b127-6b55bbc67523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

