### PR TITLE
fix platform configs link

### DIFF
--- a/website/docs/reference/references-overview.md
+++ b/website/docs/reference/references-overview.md
@@ -23,7 +23,7 @@ Learn how to add more configurations to your dbt project or adapter, use propert
 <Card
     title="Platform-specific configurations"
     body="Learn how to optimize performance with data platform-specific configurations in dbt and dbt Core."
-    link="/reference/resource-configs/postgres-configs"
+    link="/reference/resource-configs/resource-configs"
     icon="computer"/>
 
 <Card


### PR DESCRIPTION
this pr fixes the platform specific link n the ref overview page

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-fix-link-to-platform-dbt-labs.vercel.app/reference/references-overview

<!-- end-vercel-deployment-preview -->