### PR TITLE
Docs materialization precedence comment

### DIFF
--- a/website/docs/reference/resource-configs/materialized.md
+++ b/website/docs/reference/resource-configs/materialized.md
@@ -90,4 +90,5 @@ Materializations are implemented following this "drop through" life cycle:
 4. If there are no configuration changes, perform the default action for that type (e.g. apply refresh for a materialized view).
 5. Determine whether to apply the configuration changes according to the `on_configuration_change` setting.
 
+<!-- this is a comment tes -->
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
Adds a specific test comment `<!-- this is a comment tes -->` to the end of `website/docs/reference/resource-configs/materialized.md`. This PR was created to fulfill a direct request to add this comment and does not address the broader user feedback regarding the accuracy of the 'creation-precedence' documentation.

## Checklist
- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).

---
<a href="https://cursor.com/background-agent?bcId=bc-e5f92fe7-865e-432b-ac5f-bb8abc719e05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e5f92fe7-865e-432b-ac5f-bb8abc719e05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

