### PR TITLE
Groups page description removal

### DIFF
--- a/website/docs/docs/build/groups.md
+++ b/website/docs/docs/build/groups.md
@@ -2,7 +2,6 @@
 title: "Add groups to your DAG"
 sidebar_label: "Groups"
 id: "groups"
-description: "When you define groups in dbt projects, you turn implicit relationships into an explicit grouping."
 keywords:
   - groups access mesh
 ---

--- a/website/snippets/_define-groups.md
+++ b/website/snippets/_define-groups.md
@@ -1,4 +1,4 @@
-Groups are defined in `.yml` files, nested under a `groups:` key. <VersionBlock firstVersion="1.10">You can add the `description` property and the `meta` config to add more information about the group.</VersionBlock>
+Groups are defined in `.yml` files, nested under a `groups:` key. <VersionBlock firstVersion="1.10">You can add the `meta` config to add more information about the group.</VersionBlock>
 
 
 <VersionBlock lastVersion="1.9">
@@ -26,7 +26,6 @@ groups:
     owner:
       # 'name' or 'email' is required; additional properties will no longer be allowed in a future release
       email: finance@jaffleshop.com
-    description: For the finance team # optional
     config:
       meta: # optional
         data_owner: Finance team


### PR DESCRIPTION
## What are you changing in this pull request and why?
This PR removes all mentions of the `description` field related to groups to align the documentation with current dbt functionality where `description` is not a valid property for groups.

Specifically, this includes:
- Removing the `description` field from the frontmatter of `groups.md`.
- Updating the `_define-groups.md` snippet to remove the mention of the `description` property.
- Removing the example `description` line from the YAML code block in the v1.10+ section.

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).

---
[Slack Thread](https://dbt-labs.slack.com/archives/C02NCQ9483C/p1766404123070749?thread_ts=1766404123.070749&cid=C02NCQ9483C)

<a href="https://cursor.com/background-agent?bcId=bc-b9b197e2-e20b-44a8-adce-5f5adbbc027a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b9b197e2-e20b-44a8-adce-5f5adbbc027a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

