### PR TITLE
Cloud cli host flag clarification

### DIFF
--- a/website/docs/reference/commands/cmd-docs.md
+++ b/website/docs/reference/commands/cmd-docs.md
@@ -94,7 +94,7 @@ dbt docs serve --port 8001
 You may specify a different host using the `--host` flag.
 
 :::info Note
-The `--host` flag is only available in [<Constant name="core" />](/docs/core/installation-overview). It is not supported in the [<Constant name="cloud_cli" />](/docs/cloud/cloud-cli-installation).
+The `--host` flag is only available in [<Constant name="core" />](/docs/core/installation-overview). It's not supported in the [<Constant name="cloud_cli" />](/docs/cloud/cloud-cli-installation).
 :::
 
 **Example**:

--- a/website/docs/reference/commands/cmd-docs.md
+++ b/website/docs/reference/commands/cmd-docs.md
@@ -94,7 +94,7 @@ dbt docs serve --port 8001
 You may specify a different host using the `--host` flag.
 
 :::info Note
-The `--host` flag is only available in [<Constant name="core" />](/docs/core/installation-overview). It's not supported in the [<Constant name="cloud_cli" />](/docs/cloud/cloud-cli-installation).
+The `--host` flag is only available in [local CLI](/docs/core/installation-overview). It's not supported in [<Constant name="fusion"/>](/docs/fusion/supported-features#limitations) and  [<Constant name="cloud_cli" />](/docs/cloud/cloud-cli-installation).
 :::
 
 **Example**:

--- a/website/docs/reference/commands/cmd-docs.md
+++ b/website/docs/reference/commands/cmd-docs.md
@@ -93,6 +93,10 @@ dbt docs serve --port 8001
 
 You may specify a different host using the `--host` flag.
 
+:::info Note
+The `--host` flag is only available in [<Constant name="core" />](/docs/core/installation-overview). It is not supported in the [<Constant name="cloud_cli" />](/docs/cloud/cloud-cli-installation).
+:::
+
 **Example**:
 
 ```shell

--- a/website/docs/reference/commands/cmd-docs.md
+++ b/website/docs/reference/commands/cmd-docs.md
@@ -94,7 +94,7 @@ dbt docs serve --port 8001
 You may specify a different host using the `--host` flag.
 
 :::info Note
-The `--host` flag is only available in [local CLI](/docs/core/installation-overview). It's not supported in [<Constant name="fusion"/>](/docs/fusion/supported-features#limitations) and  [<Constant name="cloud_cli" />](/docs/cloud/cloud-cli-installation).
+The `--host` flag is only available in [local CLI](/docs/core/installation-overview). It's not supported in the [<Constant name="cloud_cli" />](/docs/cloud/cloud-cli-installation).
 :::
 
 **Example**:

--- a/website/docs/reference/commands/cmd-docs.md
+++ b/website/docs/reference/commands/cmd-docs.md
@@ -94,7 +94,7 @@ dbt docs serve --port 8001
 You may specify a different host using the `--host` flag.
 
 :::info Note
-The `--host` flag is only available in [local CLI](/docs/core/installation-overview). It's not supported in the [<Constant name="cloud_cli" />](/docs/cloud/cloud-cli-installation).
+The `--host` flag is only available in the [local CLI](/docs/core/installation-overview). It's not supported in the [<Constant name="cloud_cli" />](/docs/cloud/cloud-cli-installation).
 :::
 
 **Example**:

--- a/website/docs/reference/commands/cmd-docs.md
+++ b/website/docs/reference/commands/cmd-docs.md
@@ -94,7 +94,7 @@ dbt docs serve --port 8001
 You may specify a different host using the `--host` flag.
 
 :::info Note
-The `--host` flag is only available in the [local CLI](/docs/core/installation-overview). It's not supported in the [<Constant name="cloud_cli" />](/docs/cloud/cloud-cli-installation).
+The `--host` flag is only available in the [<Constant name="core"/>](/docs/core/installation-overview). It's not supported in the [<Constant name="cloud_cli" />](/docs/cloud/cloud-cli-installation).
 :::
 
 **Example**:


### PR DESCRIPTION
## What are you changing in this pull request and why?
This PR clarifies that the `--host` flag for `dbt docs serve` is only supported in dbt Core and not in the dbt Cloud CLI. A note has been added to the documentation to prevent user confusion regarding its availability.

Resolves #7983


## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [x] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).

---
<a href="https://cursor.com/background-agent?bcId=bc-2131cf66-f86f-4c86-811c-7a5ee17b60e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2131cf66-f86f-4c86-811c-7a5ee17b60e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

