### PR TITLE
add --target flag examples

### DIFF
--- a/website/docs/reference/dbt-jinja-functions/target.md
+++ b/website/docs/reference/dbt-jinja-functions/target.md
@@ -53,7 +53,7 @@ Some configurations are shared between all adapters, while others are adapter-sp
 
 ## Using the --target flag
 
-The active target (and its associated `target.name` value) can be set using the `--target` flag when running dbt commands:
+Use the `--target` flag when running dbt commands to set the active target and its associated `target.name` value:
 
 ```bash
 dbt run --target dev

--- a/website/docs/reference/dbt-jinja-functions/target.md
+++ b/website/docs/reference/dbt-jinja-functions/target.md
@@ -12,7 +12,7 @@ The `target` variable contains information about your connection to the warehous
    - **[<Constant name="orchestrator" />](/docs/deploy/job-scheduler)**: `target.name` is defined per job as described in [Custom target names](/docs/build/custom-target-names). For other attributes, values are defined by the deployment connection. To check these values, click **Deploy** and select **Environments**. Then, select the relevant deployment environment, and click **Settings**.
    - **[<Constant name="cloud_ide" />](/docs/cloud/studio-ide/develop-in-studio)**: These values are defined by your connection and credentials. To edit these values, click on your account name in the left side menu and select **Account settings**. Then, click **Credentials**. Select and edit a project to set up the credentials and target name.
 
-Some configurations are shared between all adapters, while others are adapter-specific.
+Some configurations are shared between all adapters, while others are adapter-specific. You can also use the [`--target` flag](#using-the---target-flag) to set the active target when running dbt commands.
 
 ## Common
 | Variable | Example | Description |
@@ -51,6 +51,20 @@ Some configurations are shared between all adapters, while others are adapter-sp
 | `target.project` | abc-123 | The project specified in the active profile |
 | `target.dataset` | dbt_alice | The dataset the active profile |
 
+## Using the --target flag
+
+The active target (and its associated `target.name` value) can be set using the `--target` flag when running dbt commands:
+
+```bash
+dbt run --target dev
+```
+
+```bash
+dbt run --target prod
+```
+
+You can use the `--target` flag with any dbt command to override the default target specified in your `profiles.yml` file. This is useful for running the same dbt project against different environments (like dev, staging, or prod) without changing your configuration files.
+
 ## Examples
 
 ### Use `target.name` to limit data in dev
@@ -84,15 +98,3 @@ sources:
       {%- endif -%}
     schema: source_schema
 ```
-
-To specify which target to use when running dbt commands, use the `--target` flag:
-
-```bash
-dbt run --target dev
-```
-
-```bash
-dbt run --target prod
-```
-
-You can use the `--target` flag with any dbt command to override the default target specified in your `profiles.yml` file. This is useful for running the same dbt project against different environments (like dev, staging, or prod) without changing your configuration files.

--- a/website/docs/reference/dbt-jinja-functions/target.md
+++ b/website/docs/reference/dbt-jinja-functions/target.md
@@ -84,3 +84,15 @@ sources:
       {%- endif -%}
     schema: source_schema
 ```
+
+To specify which target to use when running dbt commands, use the `--target` flag:
+
+```bash
+dbt run --target dev
+```
+
+```bash
+dbt run --target prod
+```
+
+You can use the `--target` flag with any dbt command to override the default target specified in your `profiles.yml` file. This is useful for running the same dbt project against different environments (like dev, staging, or prod) without changing your configuration files.

--- a/website/docs/reference/global-configs/about-global-configs.md
+++ b/website/docs/reference/global-configs/about-global-configs.md
@@ -45,7 +45,7 @@ dbt run --target prod
 dbt build --target staging
 ```
 
-This allows you to run the same dbt project against different environments without modifying your configuration files. The target must be defined in your `profiles.yml` file. Learn more about [connection profiles and targets](/docs/core/connect-data-platform/connection-profiles).
+The `--target` flag allows you to run the same dbt project against different environments without modifying your configuration files. Define the target in your `profiles.yml` file. Learn more about [connection profiles and targets](/docs/core/connect-data-platform/connection-profiles#understanding-targets-in-profiles).
 
 <FilterableTable>
 

--- a/website/docs/reference/global-configs/about-global-configs.md
+++ b/website/docs/reference/global-configs/about-global-configs.md
@@ -37,7 +37,7 @@ Because the values of `flags` can differ across invocations, we strongly advise 
 
 ### Common flag examples
 
-The `--target` flag is commonly used to specify which target (environment) to use when running dbt commands. For example:
+Use the `--target` flag to specify which target (environment) to use when running dbt commands. For example:
 
 ```bash
 dbt run --target dev

--- a/website/docs/reference/global-configs/about-global-configs.md
+++ b/website/docs/reference/global-configs/about-global-configs.md
@@ -35,7 +35,17 @@ on-run-start:
 ## Available flags
 Because the values of `flags` can differ across invocations, we strongly advise against using `flags` as an input to configurations or dependencies (`ref` + `source`) that dbt resolves [during parsing](/reference/parsing#known-limitations).
 
+### Common flag examples
 
+The `--target` flag is commonly used to specify which target (environment) to use when running dbt commands. For example:
+
+```bash
+dbt run --target dev
+dbt run --target prod
+dbt build --target staging
+```
+
+This allows you to run the same dbt project against different environments without modifying your configuration files. The target must be defined in your `profiles.yml` file. Learn more about [connection profiles and targets](/docs/core/connect-data-platform/connection-profiles).
 
 <FilterableTable>
 

--- a/website/snippets/_connection-profiles.md
+++ b/website/snippets/_connection-profiles.md
@@ -95,6 +95,20 @@ You may also have a `prod` target within your profile, which creates the objects
 
 If you do have multiple targets in your profile, and want to use a target other than the default, you can do this using the `--target` option when issuing a dbt command.
 
+For example, to run against your `prod` target instead of the default `dev` target:
+
+```bash
+dbt run --target prod
+```
+
+You can use the `--target` flag with any dbt command, such as:
+
+```bash
+dbt build --target prod
+dbt test --target dev
+dbt compile --target qa
+```
+
 ### Overriding profiles and targets
 
 When running dbt commands, you can specify which profile and target to use from the CLI using the `--profile` and `--target` [flags](/reference/global-configs/about-global-configs#available-flags). These flags override what’s defined in your `dbt_project.yml` as long as the specified profile and target are already defined in your `profiles.yml` file.

--- a/website/snippets/_connection-profiles.md
+++ b/website/snippets/_connection-profiles.md
@@ -93,7 +93,7 @@ A typical profile for an analyst using dbt locally will have a target named `dev
 
 You may also have a `prod` target within your profile, which creates the objects in your production schema. However, since it's often desirable to perform production runs on a schedule, we recommend deploying your dbt project to a separate machine other than your local machine. Most dbt users only have a `dev` target in their profile on their local machine.
 
-If you do have multiple targets in your profile, and want to use a target other than the default, you can do this using the `--target` option when issuing a dbt command.
+If you do have multiple targets in your profile, and want to use a target other than the default, you can do this using the `--target` flag when running a dbt command.
 
 For example, to run against your `prod` target instead of the default `dev` target:
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
This PR resolves issue #5042 by adding simple, practical examples of using the `--target` flag in dbt commands across relevant documentation pages.

The changes aim to clarify how to specify different targets (environments) when executing dbt commands, enhancing the user's understanding of this core functionality.

Examples have been added to:
*   `website/docs/reference/dbt-jinja-functions/target.md`
*   `website/snippets/_connection-profiles.md`
*   `website/docs/reference/global-configs/about-global-configs.md`

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).

---
<a href="https://cursor.com/background-agent?bcId=bc-0ff39d3b-8d11-4014-a4de-201adfbf5373"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0ff39d3b-8d11-4014-a4de-201adfbf5373"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

