### PR TITLE
add tabs to tags page 

### DIFF
--- a/website/docs/reference/resource-configs/tags.md
+++ b/website/docs/reference/resource-configs/tags.md
@@ -543,7 +543,7 @@ Tags accumulate hierarchically. The [earlier example](/reference/resource-config
 
 ### Applying tags to specific columns and tests
 
-Tags can also be applied to specific columns in a resource and to tests.
+You can also apply tags to specific columns in a resource, and to tests.
 
 <File name='models/properties.yml'>
 

--- a/website/docs/reference/resource-configs/tags.md
+++ b/website/docs/reference/resource-configs/tags.md
@@ -6,101 +6,305 @@ datatype: string | [string]
 ---
 
 <Tabs
-  defaultValue="project-yaml"
+  defaultValue="models"
   values={[
-    { label: 'Project file', value: 'project-yaml', },
-    { label: 'Property file', value: 'other-yaml', },
-    { label: 'SQL file config', value: 'config', },
+    { label: 'Models', value: 'models', },
+    { label: 'Seeds', value: 'seeds', },
+    { label: 'Snapshots', value: 'snapshots', },
+    { label: 'Saved queries', value: 'saved queries', },
+    { label: 'Sources', value: 'sources', },
+    { label: 'Exposures', value: 'exposures', },
+    { label: 'Tests', value: 'tests', },
   ]
 }>
-<TabItem value="project-yaml">
+<TabItem value="models">
 
 <File name='dbt_project.yml'>
 
 <VersionBlock firstVersion="1.9">
 
 ```yml
-
-[models](/reference/model-configs):
-  [<resource-path>](/reference/resource-configs/resource-path):
-    +tags: <string> | [<string>] # Supports single strings or list of strings
-
-[snapshots](/reference/snapshot-configs):
+models:
   [<resource-path>](/reference/resource-configs/resource-path):
     +tags: <string> | [<string>]
-
-[seeds](/reference/seed-configs):
-  [<resource-path>](/reference/resource-configs/resource-path):
-    +tags: <string> | [<string>]
-
-[saved-queries:](/docs/build/saved-queries)
-  [<resource-path>](/reference/resource-configs/resource-path):
-    +tags: <string> | [<string>]
-
 ```
-</VersionBlock>
 
+</VersionBlock>
 
 </File>
-</TabItem>
 
-<TabItem value="other-yaml">
-
-<VersionBlock firstVersion="1.9">
-
-The following examples show how to add tags to dbt resources in YAML files. Replace `resource_type` with `exposures`, `models`, `snapshots`, `seeds`, or `saved_queries` as appropriate.
-</VersionBlock>
-
-<File name='resource_type/properties.yml'>
+<File name='models/properties.yml'>
 
 ```yaml
-resource_type:
-  - name: resource_name
+models:
+  - name: model_name
     config:
-      tags: <string> | [<string>] # Supports single strings or list of strings
-    # Optional: Add the following specific properties for models
+      tags: <string> | [<string>]
     columns:
       - name: column_name
         config:
           tags: <string> | [<string>] # changed to config in v1.10 and backported to 1.9
         data_tests:
-          test-name:
-            config:
-              tags: "single-string" # Supports single string 
-              tags: ["string-1", "string-2"] # Supports list of strings
+          - test_name:
+              config:
+                tags: <string> | [<string>]
 ```
 
 </File>
 
-To apply tags to a model in your `models/` directory, add the `config` property similar to the following example:
+<File name='models/<modelname>.sql'>
 
-<File name='models/model.yml'>
-
-```yaml
-models:
-  - name: my_model
-    description: A model description
-    config:
-      tags: ['example_tag']
-```
-
-</File>
-
-</TabItem>
-
-<TabItem value="config">
-
-<File name='models/model.sql'>
 ```sql
 {{ config(
     tags="<string>" | ["<string>"]
 ) }}
+
+select ...
 ```
+
 </File>
 
 </TabItem>
+
+<TabItem value="seeds">
+
+<File name='dbt_project.yml'>
+
+<VersionBlock firstVersion="1.9">
+
+```yml
+seeds:
+  [<resource-path>](/reference/resource-configs/resource-path):
+    +tags: <string> | [<string>]
+```
+
+</VersionBlock>
+
+</File>
+
+<File name='seeds/properties.yml'>
+
+```yaml
+seeds:
+  - name: seed_name
+    config:
+      tags: <string> | [<string>]
+    columns:
+      - name: column_name
+        config:
+          tags: <string> | [<string>] # changed to config in v1.10 and backported to 1.9
+        data_tests:
+          - test_name:
+              config:
+                tags: <string> | [<string>]
+```
+
+</File>
+
+</TabItem>
+
+<TabItem value="snapshots">
+
+<File name='dbt_project.yml'>
+
+<VersionBlock firstVersion="1.9">
+
+```yml
+snapshots:
+  [<resource-path>](/reference/resource-configs/resource-path):
+    +tags: <string> | [<string>]
+```
+
+</VersionBlock>
+
+</File>
+
+<VersionBlock firstVersion="1.9">
+
+<File name='snapshots/properties.yml'>
+
+```yaml
+snapshots:
+  - name: snapshot_name
+    config:
+      tags: <string> | [<string>]
+```
+
+</File>
+
+</VersionBlock>
+
+<File name='snapshots/<filename>.sql'>
+
+```sql
+{% snapshot snapshot_name %}
+
+{{ config(
+    tags="<string>" | ["<string>"]
+) }}
+
+select ...
+
+{% endsnapshot %}
+```
+
+</File>
+
+</TabItem>
+
+<TabItem value="saved queries">
+
+<File name='dbt_project.yml'>
+
+<VersionBlock firstVersion="1.9">
+
+```yml
+saved-queries:
+  [<resource-path>](/reference/resource-configs/resource-path):
+    +tags: <string> | [<string>]
+```
+
+</VersionBlock>
+
+</File>
+
+<File name='models/semantic_models.yml'>
+
+```yaml
+saved_queries:
+  - name: saved_query_name
+    config:
+      tags: <string> | [<string>]
+```
+
+</File>
+
+</TabItem>
+
+<TabItem value="sources">
+
+<File name='dbt_project.yml'>
+
+<VersionBlock firstVersion="1.9">
+
+```yml
+sources:
+  [<resource-path>](/reference/resource-configs/resource-path):
+    +tags: <string> | [<string>]
+```
+
+</VersionBlock>
+
+</File>
+
+<File name='models/properties.yml'>
+
+```yaml
+sources:
+  - name: source_name
+    config:
+      tags: <string> | [<string>] # changed to config in v1.10
+    tables:
+      - name: table_name
+        config:
+          tags: <string> | [<string>] # changed to config in v1.10
+        columns:
+          - name: column_name
+            config:
+              tags: <string> | [<string>] # changed to config in v1.10 and backported to 1.9
+            data_tests:
+              - test_name:
+                  config:
+                    tags: <string> | [<string>]
+```
+
+</File>
+
+Note that for backwards compatibility, `tags` is supported as a top-level key for sources, but without the capabilities of config inheritance.
+
+</TabItem>
+
+<TabItem value="exposures">
+
+<File name='dbt_project.yml'>
+
+<VersionBlock firstVersion="1.9">
+
+```yml
+exposures:
+  [<resource-path>](/reference/resource-configs/resource-path):
+    +tags: <string> | [<string>]
+```
+
+</VersionBlock>
+
+</File>
+
+<File name='models/exposures.yml'>
+
+```yaml
+exposures:
+  - name: exposure_name
+    config:
+      tags: <string> | [<string>] # changed to config in v1.10
+```
+
+</File>
+
+Note that for backwards compatibility, `tags` is supported as a top-level key for exposures, but without the capabilities of config inheritance.
+
+</TabItem>
+
+<TabItem value="tests">
+
+<File name='dbt_project.yml'>
+
+<VersionBlock firstVersion="1.9">
+
+```yml
+data_tests:
+  [<resource-path>](/reference/resource-configs/resource-path):
+    +tags: <string> | [<string>]
+```
+
+</VersionBlock>
+
+</File>
+
+<File name='models/properties.yml'>
+
+```yaml
+models:
+  - name: model_name
+    columns:
+      - name: column_name
+        data_tests:
+          - test_name:
+              config:
+                tags: <string> | [<string>]
+```
+
+</File>
+
+<File name='tests/<filename>.sql'>
+
+```sql
+{% test test_name() %}
+
+{{ config(
+    tags="<string>" | ["<string>"]
+) }}
+
+select ...
+
+{% endtest %}
+```
+
+</File>
+
+</TabItem>
+
 </Tabs>
-Note that for backwards compatibility, `tags` is supported as a top-level key, but without the capabilities of config inheritance.
 
 ## Definition
 Apply a tag (or list of tags) to a resource.
@@ -133,7 +337,7 @@ Refer to [usage notes](#usage-notes) for more information.
 
 ## Examples
 
-The following examples show how to apply tags to resources in your project. You can configure tags in the `dbt_project.yml`, `schema.yml`, or SQL files.
+The following examples show how to apply tags to resources in your project. You can configure tags in the `dbt_project.yml`, property files, or SQL files.
 
 ### Use tags to run parts of your project
 
@@ -259,7 +463,7 @@ This following example shows how to apply a tag to a saved query in the `dbt_pro
 <File name='dbt_project.yml'>
 
 ```yml
-[saved-queries](/docs/build/saved-queries):
+saved-queries:
   jaffle_shop:
     customer_order_metrics:
       +tags: order_metrics
@@ -337,49 +541,63 @@ Tags accumulate hierarchically. The [earlier example](/reference/resource-config
 | models/marts/dim_customers.sql   | `contains_pii`, `hourly`, `published` |
 | models/metrics/daily_metrics.sql | `contains_pii`, `daily`, `published`  |
 
-### Other resource types
+### Applying tags to specific columns and tests
 
-Tags can also be applied to [sources](/docs/build/sources), [exposures](/docs/build/exposures), and even _specific columns_ in a resource.
-These resources do not yet support the `config` property, so you'll need to specify
-the tags as a top-level key instead.
+Tags can also be applied to specific columns in a resource and to tests.
 
-<File name='models/schema.yml'>
+<File name='models/properties.yml'>
 
 ```yml
-
-exposures:
-  - name: my_exposure
-    config:
-      tags: ['exposure_tag'] # changed to config in v1.10
-    ...
-
-sources:
-  - name: source_name
-    config:
-      tags: ['top_level'] # changed to config in v1.10
-
-    tables:
-      - name: table_name
+models:
+  - name: my_model
+    columns:
+      - name: column_name
         config:
-          tags: ['table_level'] # changed to config in v1.10
-
-        columns:
-          - name: column_name
-            config:
-              tags: ['column_level'] # changed to config in v1.10 and backported to 1.9
-            data_tests:
-              - unique:
-                config:
-                  tags: ['test_level'] # changed to config in v1.10
+          tags: ['column_level'] # changed to config in v1.10 and backported to 1.9
+        data_tests:
+          - unique:
+              config:
+                tags: ['test_level'] # changed to config in v1.10
 ```
 
 </File>
 
-
-In the example above, the `unique` test would be selected by any of these four tags:
+In the example above, the `unique` test would be selected by either of these tags:
 ```bash
-dbt test --select tag:top_level
-dbt test --select tag:table_level
 dbt test --select tag:column_level
 dbt test --select tag:test_level
 ```
+
+### Backwards compatibility for sources and exposures
+
+For backwards compatibility, `tags` is supported as a top-level key for sources and exposures (prior to dbt v1.10), but without the capabilities of config inheritance.
+
+<File name='models/properties.yml'>
+
+```yml
+exposures:
+  - name: my_exposure
+    tags: ['exposure_tag'] # top-level key (legacy)
+    # OR use config (v1.10+)
+    config:
+      tags: ['exposure_tag']
+
+sources:
+  - name: source_name
+    tags: ['top_level'] # top-level key (legacy)
+    # OR use config (v1.10+)
+    config:
+      tags: ['top_level']
+    tables:
+      - name: table_name
+        tags: ['table_level'] # top-level key (legacy)
+        # OR use config (v1.10+)
+        config:
+          tags: ['table_level']
+        columns:
+          - name: column_name
+            config:
+              tags: ['column_level'] # changed to config in v1.10 and backported to 1.9
+```
+
+</File>


### PR DESCRIPTION
## What are you changing in this pull request and why?
This PR refactors the `tags` configuration page (`website/docs/reference/resource-configs/tags.md`) to use resource-type tabs instead of placement-based tabs.

The change aims to improve consistency and user experience by aligning the `tags` page with other resource configuration pages (e.g., `meta`, `enabled`, `group`).
Resolves #3958


## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [x] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).

---
<a href="https://cursor.com/background-agent?bcId=bc-88330e7e-55d4-4066-8567-a25fc359709f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-88330e7e-55d4-4066-8567-a25fc359709f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

