### PR TITLE
Documentation update constraints prerequisites

### DIFF
--- a/website/docs/reference/resource-properties/constraints.md
+++ b/website/docs/reference/resource-properties/constraints.md
@@ -12,7 +12,7 @@ When enforced, a constraint guarantees that you will never see invalid data in t
 Before using constraints, ensure the following requirements are met:
 
 - **You use supported materializations** &mdash; Constraints only work on `table` and `incremental` models. Constraints are never applied on `ephemeral` models or those materialized as `view`. 
-- **Contract enforcement** &mdash; To use constraints, your model must declare and enforce a [contract](/reference/resource-configs/contract). This means you need to explicitly define the `data_type` for every column in your model's schema configuration.
+- **You enforce a contract** &mdash; To use constraints, your model must declare and enforce a [contract](/reference/resource-configs/contract). This means you need to explicitly define the `data_type` for every column in your model's schema configuration.
 
 ## Defining constraints
 

--- a/website/docs/reference/resource-properties/constraints.md
+++ b/website/docs/reference/resource-properties/constraints.md
@@ -11,8 +11,8 @@ When enforced, a constraint guarantees that you will never see invalid data in t
 
 Before using constraints, ensure the following requirements are met:
 
-- **Supported materializations** &mdash; Only `table` and `incremental` models support applying and enforcing constraints. Constraints are never applied on `ephemeral` models or those materialized as `view`.
-- **Contract enforcement** &mdash; Constraints require the declaration and enforcement of a model [contract](/reference/resource-configs/contract). This means you need to explicitly define the `data_type` for every column in your model's schema configuration.
+- **You use supported materializations** &mdash; Constraints only work on `table` and `incremental` models. Constraints are never applied on `ephemeral` models or those materialized as `view`. 
+- **Contract enforcement** &mdash; To use constraints, your model must declare and enforce a [contract](/reference/resource-configs/contract). This means you need to explicitly define the `data_type` for every column in your model's schema configuration.
 
 ## Defining constraints
 

--- a/website/docs/reference/resource-properties/constraints.md
+++ b/website/docs/reference/resource-properties/constraints.md
@@ -7,9 +7,12 @@ Constraints are a feature of many data platforms. When specified, the platform w
 
 When enforced, a constraint guarantees that you will never see invalid data in the table materialized by your model. Enforcement varies significantly by data platform.
 
-Constraints require the declaration and enforcement of a model [contract](/reference/resource-configs/contract).
+## Prerequisites
 
-**Constraints are never applied on `ephemeral` models or those materialized as `view`**. Only `table` and `incremental` models support applying and enforcing constraints.
+Before using constraints, ensure the following requirements are met:
+
+- **Supported materializations** &mdash; Only `table` and `incremental` models support applying and enforcing constraints. Constraints are never applied on `ephemeral` models or those materialized as `view`.
+- **Contract enforcement** &mdash; Constraints require the declaration and enforcement of a model [contract](/reference/resource-configs/contract). This means you need to explicitly define the `data_type` for every column in your model's schema configuration.
 
 ## Defining constraints
 
@@ -44,6 +47,7 @@ models:
     
     # required
     config:
+      materialized: table
       contract: {enforced: true}
     
     # model-level constraints


### PR DESCRIPTION
## What are you changing in this pull request and why?
This PR adds a new "Prerequisites" section to the constraints documentation page (`reference/resource-properties/constraints.md`).

The changes clarify:
*   Only `table` and `incremental` models support applying and enforcing constraints.
*   Constraints require a [contract](/reference/resource-configs/contract), necessitating explicit `data_type` definitions for all columns.

Additionally, `materialized: table` has been added to the first `models/schema.yml` code example for consistency and clarity.

These updates aim to provide clearer guidance and address common user confusion regarding the requirements for using constraints.

### Testing
Testing in jaffle shop project:
- DDL &mdash; 
```create or replace transient  table analytics.dbt_mwong.stg_customers
    
  (
    customer_id varchar not null primary key,
    customer_name varchar
    
    )
```
- config &mdash;
```models:
  - name: stg_customers
    description: Customer data with basic cleaning and transformation applied, one row per customer.
    config:
      contract:
        enforced: true
      materialized: table
```

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).

---
[Slack Thread](https://dbt-labs.slack.com/archives/C05FWBP9X1U/p1767325449317279?thread_ts=1767325449.317279&cid=C05FWBP9X1U)

<a href="https://cursor.com/background-agent?bcId=bc-679ff261-1ffe-4840-82e9-d91914023f34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-679ff261-1ffe-4840-82e9-d91914023f34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

