### PR TITLE
Fix - Code block highlighting

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -35,7 +35,7 @@
         "mobx": "^6.3.9",
         "node-polyfill-webpack-plugin": "^3.0.0",
         "papaparse": "^5.3.2",
-        "prism-react-renderer": "^2.3.1",
+        "prism-react-renderer": "^2.4.1",
         "query-string": "^8.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -27525,9 +27525,10 @@
       }
     },
     "node_modules/prism-react-renderer": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-2.4.0.tgz",
-      "integrity": "sha512-327BsVCD/unU4CNLZTWVHyUHKnsqcvj2qbPlQ8MiBE2eq2rgctjigPA1Gp9HLF83kZ20zNN6jgizHJeEsyFYOw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-2.4.1.tgz",
+      "integrity": "sha512-ey8Ls/+Di31eqzUxC46h8MksNuGx/n0AAC8uKpwFau4RPDYLuE3EXTp8N8G2vX2N7UC/+IXeNUnlWBGGcAG+Ig==",
+      "license": "MIT",
       "dependencies": {
         "@types/prismjs": "^1.26.0",
         "clsx": "^2.0.0"

--- a/website/package.json
+++ b/website/package.json
@@ -39,7 +39,7 @@
     "mobx": "^6.3.9",
     "node-polyfill-webpack-plugin": "^3.0.0",
     "papaparse": "^5.3.2",
-    "prism-react-renderer": "^2.3.1",
+    "prism-react-renderer": "^2.4.1",
     "query-string": "^8.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -386,6 +386,10 @@ h3 {
   padding-top: 2rem !important;
 }
 
+/* Inline code styling
+   IMPORTANT: Scoped to :not(pre) > code to prevent styling fenced code blocks.
+   Without this scope, inline code styles can briefly apply to code blocks if
+   Prism/CodeBlock CSS chunks load late during navigation, causing color/background flashes. */
 :not(pre) > code {
   border: none;
   background-color: rgba(246, 245, 255, 1);
@@ -461,6 +465,15 @@ ul.table-of-contents .hash-link::before {
 
 pre {
   font-size: 14px !important;
+}
+
+/* Code blocks: Ensure Prism token lines always render as block-level elements.
+   This prevents the "single unwrapped line" flash that can occur on first load or
+   client-side navigation when CodeBlock CSS chunks haven't loaded yet. */
+.theme-code-block .token-line,
+.prism-code .token-line,
+pre[class*="language-"] .token-line {
+  display: block;
 }
 
 a.code-link {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -386,7 +386,7 @@ h3 {
   padding-top: 2rem !important;
 }
 
-code {
+:not(pre) > code {
   border: none;
   background-color: rgba(246, 245, 255, 1);
   color: rgba(61, 24, 154, 1);
@@ -410,7 +410,7 @@ code {
   font-size: var(--text-sm);
 }
 
-a code {
+a > code {
   color: rgba(61, 24, 154, 1);
 }
 

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -10,12 +10,6 @@ import Link from '@docusaurus/Link';
 import BlogPostCard from '@site/src/components/blogPostCard';
 import StructuredData from '@site/src/components/StructuredData';
 
-const bannerAnimation = require('@site/static/img/banner-white.svg');
-
-function getBanner() {
-  return { __html: bannerAnimation };
-}
-
 function Home() {
   // Use same date formatting as in theme's BlogPostItem component
   const dateTimeFormat = useDateTimeFormat({
@@ -311,11 +305,6 @@ function Home() {
             </div>
           </section>
         </div>
-
-        <div
-          className="banner-animation"
-          dangerouslySetInnerHTML={getBanner()}
-        ></div>
       </Layout>
     </>
   );


### PR DESCRIPTION
## What are you changing in this pull request and why?

This PR includes a small set of targeted changes aimed at eliminating intermittent unstyled code rendering. While I wasn’t able to reliably reproduce the issue locally or across browsers, these updates address likely root causes with minimal risk and surface area.

### Summary of changes

1. **Upgrade `prism-react-renderer`**  
   - Bumped from `^2.3.1` → `^2.4.1` to pick up minor fixes and improvements related to token rendering.

2. **Tighten CSS scoping for code elements**  
   - Updated the `code` selector to `:not(pre) > code` to prevent inline code styles from leaking into fenced code blocks  
   - Changed `a code` to `a > code` for more explicit targeting  
   - Ensured token lines always render as block-level elements to prevent occasional single-line “flash” during render

3. **Remove homepage banner animation**  
   - Removed an animation that caused an object module flash on load  
   - While not directly tied to the code rendering issue, this animation is no longer needed and removing it reduces visual instability on page load

## Preview Links
https://docs-getdbt-com-git-fix-code-block-syntax-dbt-labs.vercel.app/reference/resource-properties/freshness

https://docs-getdbt-com-git-fix-code-block-syntax-dbt-labs.vercel.app/best-practices/how-we-mesh/mesh-6-coordinate-versions


## Testing
- Verify code blocks render correctly on initial page load
- Verify code blocks don't flash during client-side navigation
- Verify inline code styling still works correctly
- Verify homepage loads without announcement  banner `[Object module]` flash

