### PR TITLE
fix manual install link 

### DIFF
--- a/website/snippets/_install-dbt-extension.md
+++ b/website/snippets/_install-dbt-extension.md
@@ -18,7 +18,7 @@ To use the extension, you must meet the following prerequisites:
 
 | Prerequisite | Details |
 | --- | --- |
-| **<Constant name="fusion_engine" />**  | The [dbt VS Code extension](https://marketplace.visualstudio.com/items?itemName=dbtLabsInc.dbt&ssr=false#overview) requires the <Constant name="fusion_engine" /> binary (a small executable program). The extension will prompt you to install it, or you can [install it manually](#install-fusion-manually) at any time. <br /><br />[Register your email](#register-the-extension) within 14 days of installing the dbt extension.  Free for up to 15 users.  |
+| **<Constant name="fusion_engine" />**  | The [dbt VS Code extension](https://marketplace.visualstudio.com/items?itemName=dbtLabsInc.dbt&ssr=false#overview) requires the <Constant name="fusion_engine" /> binary (a small executable program). The extension will prompt you to install it, or you can [install it manually](#install-the-dbt-fusion-engine-from-the-command-line-if-you-havent-already) at any time. <br /><br />[Register your email](#register-the-extension) within 14 days of installing the dbt extension.  Free for up to 15 users.  |
 | **Project files** | - You need a `profiles.yml` configuration file.<br /><br />⁃ You _may_ need to [download](#register-with-dbt_cloudyml) a `dbt_cloud.yml` file depending on your [registration path](#choose-your-registration-path).<br /><br />⁃ You don't need a <Constant name="dbt_platform" /> project to use the extension. |
 | **Editor** | [VS Code](https://code.visualstudio.com/), [Cursor](https://www.cursor.com/en), or [Windsurf](https://windsurf.com/editor) code editor. |
 | **Operating systems** | macOS, Windows, or Linux-based computer. |
@@ -35,15 +35,14 @@ To install the dbt VS Code extension, follow these steps in your editor of choic
     <Lightbox src="/img/docs/extension/dbt-extension-statusbar.png" width="60%" title="If you see the 'dbt Extension` label, the extension is activated"/>
 3. Once the dbt extension is activated, it will automatically begin downloading the correct dbt Language Server (<Term id="lsp"/>) for your operating system.
     <Lightbox src="/img/docs/extension/extension-lsp-download.png" width="60%" title="The dbt Language Server will be installed automatically"/>
-4. If the dbt Fusion engine is not already installed on your machine, the extension will prompt you to download and install it. Follow the steps shown in the notification to complete the installation or [install it manually from the command line](#install-fusion-manually).
+4. If the dbt Fusion engine is not already installed on your machine, the extension will prompt you to download and install it. Follow the steps shown in the notification to complete the installation or [install it manually from the command line](#install-the-dbt-fusion-engine-from-the-command-line-if-you-havent-already).
     <Lightbox src="/img/docs/extension/install-dbt-fusion-engine.png" width="60%" title="Follow the prompt to install the dbt Fusion engine"/>
 5. Run the VS Code extension [upgrade tool](#upgrade-to-fusion) to ensure your dbt project is Fusion ready and help you fix any errors and deprecations.
 6. (Optional) If you're new to the extension or VS Code/Cursor, you [can set your local environment](/docs/configure-dbt-extension) to mirror your <Constant name="dbt_platform" /> environment and [set any environment variables](/docs/configure-dbt-extension#configure-environment-variables) locally to use the VS Code extension features.
 
 You're all set up with the dbt extension! The next steps are:
 - Follow the [getting started](#getting-started) section to begin the terminal onboarding workflow and configure your set up. If you encounter any parsing errors, you can also run the [`dbt-autofix` tool](https://github.com/dbt-labs/dbt-autofix?tab=readme-ov-file#installation) to resolve them.
-- <Expandable alt_header="Install the dbt Fusion engine from the command line, if you haven't already.">
-
+- <Expandable alt_header="Install the dbt Fusion engine from the command line, if you haven't already." > 
     <FusionManualInstall />
   3. Follow the [getting started](/docs/install-dbt-extension#getting-started) guide to get started with the extension. You can get started using one of these methods:
       - Running `dbtf init` to use terminal onboarding.

--- a/website/src/components/expandable/index.js
+++ b/website/src/components/expandable/index.js
@@ -64,10 +64,22 @@ function Expandable({ children, alt_header = null, lifecycle, is_open = false })
 
   // Auto-expand when linked via hash (URL fragment)
   useEffect(() => {
-    if (window.location.hash === `#${anchorId}`) {
-      setIsOpen(true);
-      detailsRef.current?.scrollIntoView({ behavior: 'smooth' });
-    }
+    const checkHash = () => {
+      if (window.location.hash === `#${anchorId}`) {
+        setIsOpen(true);
+        detailsRef.current?.scrollIntoView({ behavior: 'smooth' });
+      }
+    };
+
+    // Check on mount
+    checkHash();
+
+    // Listen for hash changes (for anchor links on the same page)
+    window.addEventListener('hashchange', checkHash);
+
+    return () => {
+      window.removeEventListener('hashchange', checkHash);
+    };
   }, [anchorId]);
 
   // Observe search highlight and auto-expand


### PR DESCRIPTION
this pr fixes the following:
- install manually sentence links to a non-existent link. udpated to correct anchorlink
- makes it possible for expandable to automatically open whenever a user clicks on an anchorlink that goes to an expandable