### PR TITLE
Canvas git integration limitations

### DIFF
--- a/website/snippets/_canvas-prerequisites.md
+++ b/website/snippets/_canvas-prerequisites.md
@@ -9,8 +9,9 @@ Before using <Constant name="visual_editor" />, you should:
     - Snowflake
     - Trino
     - You can access the <Constant name="visual_editor" /> with adapters not listed, but some features may be missing at this time. 
-- Use [GitHub](/docs/cloud/git/connect-github), [GitLab](/docs/cloud/git/connect-gitlab), or [Azure DevOps](/docs/cloud/git/connect-azure-devops) as your <Constant name="git" /> provider, connected to dbt via HTTPS. SSH connections are not supported for <Constant name="visual_editor" /> at this time.
-  - <Constant name="visual_editor" /> doesn't support Git integration for GitHub self-hosted / on-premises deployments.
+- Use [GitHub](/docs/cloud/git/connect-github), [GitLab](/docs/cloud/git/connect-gitlab), or [Azure DevOps](/docs/cloud/git/connect-azure-devops) as your <Constant name="git" /> provider, connected to dbt via HTTPS.
+  - SSH connections aren't supported at this time.
+  - Git integration for GitHub self-hosted / on-premises deployments aren't supported at this time.
 - Have an existing <Constant name="cloud" /> project already created with a Staging or Production run completed.
 - Verify your Development environment is on a supported [release track](/docs/dbt-versions/cloud-release-tracks) to receive ongoing updates.
 - Have read-only access to the [Staging environment](/docs/deploy/deploy-environments#staging-environment) with the data to be able to execute `run` in the <Constant name="visual_editor" />. To customize the required access for the <Constant name="visual_editor" /> user group, refer to [Set up environment-level permissions](/docs/cloud/manage-access/environment-permissions-setup) for more information.

--- a/website/snippets/_canvas-prerequisites.md
+++ b/website/snippets/_canvas-prerequisites.md
@@ -10,6 +10,7 @@ Before using <Constant name="visual_editor" />, you should:
     - Trino
     - You can access the <Constant name="visual_editor" /> with adapters not listed, but some features may be missing at this time. 
 - Be using [GitHub](/docs/cloud/git/connect-github), [GitLab](/docs/cloud/git/connect-gitlab), or [Azure DevOps](/docs/cloud/git/connect-azure-devops) as your <Constant name="git" /> provider, connected to dbt via HTTPS. SSH connections are not supported for <Constant name="visual_editor" /> at this time.
+  - **Note:** <Constant name="git" /> integration is not available for <Constant name="visual_editor" /> on on-premises or single tenant deployments at this time.
 - Have an existing <Constant name="cloud" /> project already created with a Staging or Production run completed.
 - Verify your Development environment is on a supported [release track](/docs/dbt-versions/cloud-release-tracks) to receive ongoing updates.
 - Have read-only access to the [Staging environment](/docs/deploy/deploy-environments#staging-environment) with the data to be able to execute `run` in the <Constant name="visual_editor" />. To customize the required access for the <Constant name="visual_editor" /> user group, refer to [Set up environment-level permissions](/docs/cloud/manage-access/environment-permissions-setup) for more information.

--- a/website/snippets/_canvas-prerequisites.md
+++ b/website/snippets/_canvas-prerequisites.md
@@ -10,7 +10,7 @@ Before using <Constant name="visual_editor" />, you should:
     - Trino
     - You can access the <Constant name="visual_editor" /> with adapters not listed, but some features may be missing at this time. 
 - Use [GitHub](/docs/cloud/git/connect-github), [GitLab](/docs/cloud/git/connect-gitlab), or [Azure DevOps](/docs/cloud/git/connect-azure-devops) as your <Constant name="git" /> provider, connected to dbt via HTTPS. SSH connections are not supported for <Constant name="visual_editor" /> at this time.
-  - Note that <Constant name="visual_editor" /> doesn't support Git integration for on-premises or [single tenant deployments](/docs/cloud/about-cloud/tenancy) at this time.
+  - <Constant name="visual_editor" /> doesn't support Git integration for GitHub self-hosted / on-premises deployments.
 - Have an existing <Constant name="cloud" /> project already created with a Staging or Production run completed.
 - Verify your Development environment is on a supported [release track](/docs/dbt-versions/cloud-release-tracks) to receive ongoing updates.
 - Have read-only access to the [Staging environment](/docs/deploy/deploy-environments#staging-environment) with the data to be able to execute `run` in the <Constant name="visual_editor" />. To customize the required access for the <Constant name="visual_editor" /> user group, refer to [Set up environment-level permissions](/docs/cloud/manage-access/environment-permissions-setup) for more information.

--- a/website/snippets/_canvas-prerequisites.md
+++ b/website/snippets/_canvas-prerequisites.md
@@ -9,8 +9,8 @@ Before using <Constant name="visual_editor" />, you should:
     - Snowflake
     - Trino
     - You can access the <Constant name="visual_editor" /> with adapters not listed, but some features may be missing at this time. 
-- Be using [GitHub](/docs/cloud/git/connect-github), [GitLab](/docs/cloud/git/connect-gitlab), or [Azure DevOps](/docs/cloud/git/connect-azure-devops) as your <Constant name="git" /> provider, connected to dbt via HTTPS. SSH connections are not supported for <Constant name="visual_editor" /> at this time.
-  - **Note:** <Constant name="git" /> integration is not available for <Constant name="visual_editor" /> on on-premises or single tenant deployments at this time.
+- Use [GitHub](/docs/cloud/git/connect-github), [GitLab](/docs/cloud/git/connect-gitlab), or [Azure DevOps](/docs/cloud/git/connect-azure-devops) as your <Constant name="git" /> provider, connected to dbt via HTTPS. SSH connections are not supported for <Constant name="visual_editor" /> at this time.
+  - Note that <Constant name="visual_editor" /> doesn't support Git integration for on-premises or [single tenant deployments](/docs/cloud/about-cloud/tenancy) at this time.
 - Have an existing <Constant name="cloud" /> project already created with a Staging or Production run completed.
 - Verify your Development environment is on a supported [release track](/docs/dbt-versions/cloud-release-tracks) to receive ongoing updates.
 - Have read-only access to the [Staging environment](/docs/deploy/deploy-environments#staging-environment) with the data to be able to execute `run` in the <Constant name="visual_editor" />. To customize the required access for the <Constant name="visual_editor" /> user group, refer to [Set up environment-level permissions](/docs/cloud/manage-access/environment-permissions-setup) for more information.


### PR DESCRIPTION
## What are you changing in this pull request and why?
Added a note to the Canvas prerequisites page (`website/snippets/_canvas-prerequisites.md`) clarifying that Git integration for the Visual Editor (Canvas) is not supported for on-premises or single-tenant dbt Cloud deployments.

This change addresses a user query and provides important context regarding Canvas functionality limitations, as discussed in [this Slack thread](https://dbt-labs.slack.com/archives/C0697CMAR7H/p1767864719451839).

## Checklist
- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).

---
[Slack Thread](https://dbt-labs.slack.com/archives/C0A16RWFC4E/p1767889383985449?thread_ts=1767889383.985449&cid=C0A16RWFC4E)

<a href="https://cursor.com/background-agent?bcId=bc-565e96bc-cbd1-459e-a048-88ed0a61ce72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-565e96bc-cbd1-459e-a048-88ed0a61ce72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

