### PR TITLE
Fix formatting of invalidate_hard_deletes in documentation

### DIFF
--- a/website/docs/reference/resource-configs/snapshots-jinja-legacy.md
+++ b/website/docs/reference/resource-configs/snapshots-jinja-legacy.md
@@ -57,7 +57,7 @@ Snapshot-specific configurations are applicable to only one dbt resource type ra
     [strategy](/reference/resource-configs/strategy)="timestamp" | "check",
     [updated_at](/reference/resource-configs/updated_at)="<column_name>",
     [check_cols](/reference/resource-configs/check_cols)=["<column_name>"] | "all"
-    [invalidate_hard_deletes](/reference/resource-configs/invalidate_hard_deletes) : true | false
+    [invalidate_hard_deletes](/reference/resource-configs/invalidate_hard_deletes)=true | false
 ) 
 }}
 


### PR DESCRIPTION
Documentation is using incorrect syntax for the {{ config() }} macro for the "invalidate_hard_deletes" option. Instead of a semi-colon, it should show an equal sign.

## What are you changing in this pull request and why?
Fixing incorrect syntax used in example in the "Snapshot specific configurations" section of the "Legacy snapshot configuration" page. Current documentation shows a semi-colon used for the "invalidate_hard_deletes" configuration setting when an equal sign should be used instead.

## Checklist
<!-- Ensure your PR meets the following items. Feel free to add additiona checklist items to the list if additional checks need to happen before the PR is merged, such as:
- [ ] Needs technical review
- [ ] Change base branch
- [ ] Merge on xyz date
-->
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).
<!--
PRE-RELEASE VERSION OF dbt (if so, uncomment):
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
<!-- 
ADDING OR REMOVING PAGES (if so, uncomment):
- [ ] Add/remove page in `website/sidebars.js`
- [ ] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages
-->
