### PR TITLE
add lifecycle to fusion page

### DIFF
--- a/website/docs/docs/fusion/fusion.md
+++ b/website/docs/docs/fusion/fusion.md
@@ -7,6 +7,7 @@ pagination_next: "docs/fusion/about-fusion"
 pagination_prev: "docs/introduction"
 ---
 
+# dbt Fusion engine <Lifecycle status="preview" />
 
 <IntroText><Constant name="fusion_engine" /> is the next-generation engine built in Rust, that powers development across the <Constant name="dbt_platform" /> (formerly dbt Cloud), and local development in VS Code and Cursor, and the CLI.</IntroText>
 


### PR DESCRIPTION
this pr adds lifecyle status to make it clear that fusion is preview

raised in docs user feedback widget
https://dbtlabs.atlassian.net/browse/PRODDOCS-486?atlOrigin=eyJpIjoiZjU0Zjg5OThlZmE3NGQ1NTliOTBjOWZmYzliNmMyYTgiLCJwIjoiaiJ9

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-fix-add-lifecycle-dbt-labs.vercel.app/docs/fusion/fusion

<!-- end-vercel-deployment-preview -->