### PR TITLE
Add Starter plan to Discovery API prerequisites

### DIFF
--- a/website/constants.js
+++ b/website/constants.js
@@ -22,8 +22,4 @@ export const CONSTANTS = {
   mesh: 'Mesh',
   orchestrator: 'Orchestrator',
   copilot: 'Copilot',
-  semantic_layer: 'Semantic Layer',
-  starter_plan: 'Starter',
-  enterprise_plan: 'Enterprise',
-  enterprise_plus_plan: 'Enterprise+',
 }

--- a/website/constants.js
+++ b/website/constants.js
@@ -22,4 +22,5 @@ export const CONSTANTS = {
   mesh: 'Mesh',
   orchestrator: 'Orchestrator',
   copilot: 'Copilot',
+  semantic_layer: 'Semantic Layer',
 }

--- a/website/constants.js
+++ b/website/constants.js
@@ -23,4 +23,7 @@ export const CONSTANTS = {
   orchestrator: 'Orchestrator',
   copilot: 'Copilot',
   semantic_layer: 'Semantic Layer',
+  starter_plan: 'Starter',
+  enterprise_plan: 'Enterprise',
+  enterprise_plus_plan: 'Enterprise+',
 }

--- a/website/snippets/metadata-api-prerequisites.md
+++ b/website/snippets/metadata-api-prerequisites.md
@@ -1,5 +1,5 @@
 ## Prerequisites
 
 - <Constant name="cloud" /> [multi-tenant](/docs/cloud/about-cloud/tenancy#multi-tenant) or [single tenant](/docs/cloud/about-cloud/tenancy#single-tenant) account
-- You must be on an [Enterprise or Enterprise+ plan](https://www.getdbt.com/pricing/)
+- You must be on a <Constant name="starter_plan" />, <Constant name="enterprise_plan" />, or <Constant name="enterprise_plus_plan" /> [plan](https://www.getdbt.com/pricing/)
 - Your projects must be on a <Constant name="cloud" /> [release tracks](/docs/dbt-versions/cloud-release-tracks) or dbt version 1.0 or later. Refer to [Upgrade dbt version in Cloud](/docs/dbt-versions/upgrade-dbt-version-in-cloud) to upgrade.

--- a/website/snippets/metadata-api-prerequisites.md
+++ b/website/snippets/metadata-api-prerequisites.md
@@ -1,5 +1,5 @@
 ## Prerequisites
 
 - <Constant name="cloud" /> [multi-tenant](/docs/cloud/about-cloud/tenancy#multi-tenant) or [single tenant](/docs/cloud/about-cloud/tenancy#single-tenant) account
-- You must be on a <Constant name="starter_plan" />, <Constant name="enterprise_plan" />, or <Constant name="enterprise_plus_plan" /> [plan](https://www.getdbt.com/pricing/)
+-- You must be on a [Starter, Enterprise, or Enterprise+ plan](https://www.getdbt.com/pricing/)
 - Your projects must be on a <Constant name="cloud" /> [release tracks](/docs/dbt-versions/cloud-release-tracks) or dbt version 1.0 or later. Refer to [Upgrade dbt version in Cloud](/docs/dbt-versions/upgrade-dbt-version-in-cloud) to upgrade.

--- a/website/snippets/metadata-api-prerequisites.md
+++ b/website/snippets/metadata-api-prerequisites.md
@@ -1,5 +1,5 @@
 ## Prerequisites
 
 - <Constant name="cloud" /> [multi-tenant](/docs/cloud/about-cloud/tenancy#multi-tenant) or [single tenant](/docs/cloud/about-cloud/tenancy#single-tenant) account
--- You must be on a [Starter, Enterprise, or Enterprise+ plan](https://www.getdbt.com/pricing/)
+- You must be on a [Starter, Enterprise, or Enterprise+ plan](https://www.getdbt.com/pricing/)
 - Your projects must be on a <Constant name="cloud" /> [release tracks](/docs/dbt-versions/cloud-release-tracks) or dbt version 1.0 or later. Refer to [Upgrade dbt version in Cloud](/docs/dbt-versions/upgrade-dbt-version-in-cloud) to upgrade.


### PR DESCRIPTION

- Updated metadata-api-prerequisites.md to include Starter plan alongside Enterprise and Enterprise+ using constant variables
- All three plans are now displayed on the same row

