### PR TITLE
Fix property name in data formats documentation

### DIFF
--- a/website/docs/reference/resource-properties/data-formats.md
+++ b/website/docs/reference/resource-properties/data-formats.md
@@ -27,7 +27,7 @@ unit_tests:
         format: dict
         rows:
           - {id: 1, name: gerda}
-          - {id: 2, b: michelle}    
+          - {id: 2, name: michelle}    
 
 ```
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
I'm _guessing_ this was a typo, so fixing it.

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-dbeatty10-patch-3-dbt-labs.vercel.app/reference/resource-properties/data-formats

<!-- end-vercel-deployment-preview -->