### PR TITLE
add trino to mf requirements

### DIFF
--- a/website/docs/docs/build/about-metricflow.md
+++ b/website/docs/docs/build/about-metricflow.md
@@ -18,7 +18,7 @@ Before you start, consider the following guidelines:
 
 - Define metrics in YAML and query them using these [new metric specifications](https://github.com/dbt-labs/dbt-core/discussions/7456).
 - You must be on [dbt version](/docs/dbt-versions/upgrade-dbt-version-in-cloud) 1.6 or higher to use MetricFlow. 
-- Use MetricFlow with Snowflake, BigQuery, Databricks, Postgres (<Constant name="core" /> only), Trino,or Redshift. 
+- Use MetricFlow with Snowflake, BigQuery, Databricks, Postgres (<Constant name="core" /> only), Trino, or Redshift. 
 - Discover insights and query your metrics using the [<Constant name="semantic_layer" />](/docs/use-dbt-semantic-layer/dbt-sl) and its diverse range of [available integrations](/docs/cloud-integrations/avail-sl-integrations). 
 
 ## MetricFlow

--- a/website/docs/docs/build/about-metricflow.md
+++ b/website/docs/docs/build/about-metricflow.md
@@ -12,11 +12,13 @@ This guide introduces MetricFlow's fundamental ideas for people new to this feat
 
 MetricFlow handles SQL query construction and defines the specification for dbt semantic models and metrics. It allows you to define metrics in your dbt project and query them with [MetricFlow commands](/docs/build/metricflow-commands) whether in <Constant name="cloud" /> or <Constant name="core" />.
 
+
+## Prerequisites
 Before you start, consider the following guidelines:
 
 - Define metrics in YAML and query them using these [new metric specifications](https://github.com/dbt-labs/dbt-core/discussions/7456).
 - You must be on [dbt version](/docs/dbt-versions/upgrade-dbt-version-in-cloud) 1.6 or higher to use MetricFlow. 
-- Use MetricFlow with Snowflake, BigQuery, Databricks, Postgres (<Constant name="core" /> only), or Redshift. 
+- Use MetricFlow with Snowflake, BigQuery, Databricks, Postgres (<Constant name="core" /> only), Trino,or Redshift. 
 - Discover insights and query your metrics using the [<Constant name="semantic_layer" />](/docs/use-dbt-semantic-layer/dbt-sl) and its diverse range of [available integrations](/docs/cloud-integrations/avail-sl-integrations). 
 
 ## MetricFlow

--- a/website/docs/docs/build/validation.md
+++ b/website/docs/docs/build/validation.md
@@ -17,8 +17,8 @@ The code that handles validation [can be found here](https://github.com/dbt-labs
 You can run validations from <Constant name="cloud" /> or the command line with the following [MetricFlow commands](/docs/build/metricflow-commands). In <Constant name="cloud" />, you need developer credentials to run `dbt sl validate-configs` in the IDE or CLI, and deployment credentials to run it in CI.
 
 ```bash
-dbt sl validate # <Constant name="cloud" /> users
-mf validate-configs # <Constant name="core" /> users
+dbt sl validate # dbt platform users
+mf validate-configs # dbt Core users
 ```
 
 ## Parsing


### PR DESCRIPTION
this pr adds trino to mf prerequst

[raised in dbt slack](https://dbt-labs.slack.com/archives/C02CCBBBR1D/p1768824216565209)

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-add-add-trino-dbt-labs.vercel.app/docs/build/about-metricflow
- https://docs-getdbt-com-git-add-add-trino-dbt-labs.vercel.app/docs/build/validation

<!-- end-vercel-deployment-preview -->