### PR TITLE
Fusion environment variables

### DIFF
--- a/website/docs/docs/configure-dbt-extension.md
+++ b/website/docs/docs/configure-dbt-extension.md
@@ -125,11 +125,17 @@ The following steps will explain how to configure environment variables using Po
 
 #### Configure in the VS Code extension settings
 
-To use the dbt extension menu actions/buttons, you can configure environment variables directly in the [VS Code User Settings](vscode://settings/dbt.environmentVariables) interface or in any `.env` file at the root level. This includes both your custom variables and any automatic [<Constant name="dbt_platform"/> variables](/docs/build/environment-variables) (like `DBT_CLOUD_ENVIRONMENT_NAME`) that your project depends on.
+To use the dbt extension menu actions/buttons, you can configure environment variables directly in the [VS Code User Settings](vscode://settings/dbt.environmentVariables) interface or in a `.env` file in your current working directory. This includes both your custom variables and any automatic [<Constant name="dbt_platform"/> variables](/docs/build/environment-variables) (like `DBT_CLOUD_ENVIRONMENT_NAME`) that your project depends on.
 
-- Configure variables in the VS Code **User Settings** or in any `.env` file to have them recognized by the extension. For example, when using <Term id="lsp" /> -powered features, "Show build menu," and more.
+- Configure variables in the VS Code **User Settings** or in a `.env` file to have them recognized by the extension. For example, when using <Term id="lsp" /> -powered features, "Show build menu," and more.
 - VS Code does not inherit variables set by the VS Code terminal or external shells.
 - The terminal uses system environmental variables, and does not inherit variables set in the dbt VS Code extension config. For example, running a dbt command in the terminal won't fetch or use the dbt VS Code extension variables.
+
+:::info `.env` file support
+Both the <Constant name="fusion"/> CLI and the dbt VS Code extension automatically load environment variables from a `.env` file in your current working directory. The `.env` file provides a convenient way to set environment variables that work across both the CLI and the extension.
+
+**Precedence order**: Environment variables set directly in your shell (such as `export DBT_ENV_VAR=value`) take precedence over values defined in the `.env` file.
+:::
 
 To configure environment variables in VS Code/Cursor:
 
@@ -146,7 +152,7 @@ To configure environment variables in VS Code/Cursor:
 </TabItem>
 
 <TabItem value="env-file" label="Open .env file">
-1. In your dbt project, create a `.env` file at the root level (same level as your `dbt_project.yml` file).
+1. Create a `.env` file in your current working directory. This is typically at the root level of your dbt project (same level as your `dbt_project.yml` file).
 2. Add your environment variables to the file. For example:
     ```env
     DBT_ENV_VAR1=my_value
@@ -155,6 +161,10 @@ To configure environment variables in VS Code/Cursor:
 3. Save the file.
 4. Reload the VS Code extension to apply the changes.
 5. Verify the changes by running a dbt command using the extension menu button on the top right corner and checking the output.
+
+:::tip
+The `.env` file is automatically loaded by both the <Constant name="fusion"/> CLI and the VS Code extension. This means environment variables you define in `.env` will be available when running dbt commands in the terminal as well as when using the extension's menu actions.
+:::
 </TabItem>
 
 <!-- commenting out as this might not be the best way to configure environment variables and we're recommending the .env file instead https://github.com/dbt-labs/dbt-core/issues/12106

--- a/website/docs/docs/fusion/install-fusion-cli.md
+++ b/website/docs/docs/fusion/install-fusion-cli.md
@@ -59,7 +59,7 @@ The Fusion install automatically includes adapters outlined in the [Fusion requi
          schema: "{{ env_var('DBT_MY_SCHEMA') }}"
    ```
 
-3. Run your dbt commands normally. <Constant name="fusion"/> will automatically load the variables from the `.env` file.
+3. Try running your dbt commands normally, <Constant name="fusion"/> will automatically load the variables from the `.env` file.
 
 ### Precedence order
 

--- a/website/docs/docs/fusion/install-fusion-cli.md
+++ b/website/docs/docs/fusion/install-fusion-cli.md
@@ -34,6 +34,48 @@ dbtf system uninstall
 
 The Fusion install automatically includes adapters outlined in the [Fusion requirements](/docs/fusion/supported-features#requirements). Other adapters will be available at a later date.
 
+## Environment variables
+
+<Constant name="fusion"/> automatically loads environment variables from a `.env` file in your current working directory. This provides a convenient way to manage credentials and configuration without hardcoding them in your `profiles.yml` or exposing them in your shell history.
+
+### Using .env files
+
+1. Create a `.env` file in your current working directory (typically at the root of your dbt project):
+   ```env
+   DBT_MY_DATABASE=my_database
+   DBT_MY_SCHEMA=my_schema
+   DBT_SECRET_KEY=my_secret_value
+   ```
+
+2. Reference these variables in your `profiles.yml` using the [`env_var` Jinja function](/reference/dbt-jinja-functions/env_var):
+   ```yaml
+   my_profile:
+     target: dev
+     outputs:
+       dev:
+         type: snowflake
+         account: my_account
+         database: "{{ env_var('DBT_MY_DATABASE') }}"
+         schema: "{{ env_var('DBT_MY_SCHEMA') }}"
+   ```
+
+3. Run your dbt commands normally. <Constant name="fusion"/> will automatically load the variables from the `.env` file.
+
+### Precedence order
+
+When the same environment variable is defined in multiple places, <Constant name="fusion"/> uses the following precedence order (highest to lowest):
+
+1. **Shell environment** &mdash; Variables set directly in your shell (for example, `export DBT_MY_VAR=value`)
+2. **`.env` file** &mdash; Variables defined in the `.env` file in your current working directory
+
+This means shell environment variables always override values from the `.env` file.
+
+:::tip
+Add `.env` to your `.gitignore` file to prevent sensitive credentials from being committed to version control. The `dbt init` command automatically includes `.env` in the generated `.gitignore` file.
+:::
+
+For more details on managing environment variables across different development environments, refer to [Configure your local environment](/docs/configure-dbt-extension#set-environment-variables-locally).
+
 
 ## Troubleshooting
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
This PR documents the new `.env` file loading behavior for the Fusion CLI and the dbt VS Code extension.

Specifically:
- `configure-dbt-extension.md`: Updated to clarify that both Fusion CLI and the VS Code extension load `.env` files from the current working directory, and documented environment variable precedence.
- `install-fusion-cli.md`: Added a new "Environment variables" section detailing `.env` file support, usage instructions, and precedence for Fusion CLI.

This change addresses the need to clearly communicate how environment variables are handled, as discussed in [dbt-labs/dbt-fusion#946](https://github.com/dbt-labs/dbt-fusion/issues/946) and the related [Slack thread](https://dbt-labs.slack.com/archives/C08USPUN8F4/p1768928341827979?thread_ts=1768327971.230579&cid=C08USPUN8F4).

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [x] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).

---
[Slack Thread](https://dbt-labs.slack.com/archives/C0A16RWFC4E/p1769015775151669?thread_ts=1769015775.151669&cid=C0A16RWFC4E)

<a href="https://cursor.com/background-agent?bcId=bc-d5f6cd70-c1ab-4531-bfb4-1139f3cd4fba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d5f6cd70-c1ab-4531-bfb4-1139f3cd4fba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

