### PR TITLE
Special environment variables override

### DIFF
--- a/website/docs/docs/build/environment-variables.md
+++ b/website/docs/docs/build/environment-variables.md
@@ -103,7 +103,7 @@ While all environment variables are encrypted at rest in <Constant name="cloud" 
 
 ### Special environment variables
 
-<Constant name="cloud" /> has a number of pre-defined variables built in. Variables are set automatically and cannot be changed. This means that the order of precedence for overriding environment variables don't apply to these pre-defined variables at the project, environment, or job level.
+<Constant name="cloud" /> has a number of pre-defined variables built in. Variables are set automatically and cannot be changed. This means that the order of precedence for overriding environment variables doesn't apply to these pre-defined variables at the project, environment, or job level.
 
 #### Studio IDE details
 

--- a/website/docs/docs/build/environment-variables.md
+++ b/website/docs/docs/build/environment-variables.md
@@ -103,7 +103,7 @@ While all environment variables are encrypted at rest in <Constant name="cloud" 
 
 ### Special environment variables
 
-<Constant name="cloud" /> has a number of pre-defined variables built in. Variables are set automatically and cannot be changed.
+<Constant name="cloud" /> has a number of pre-defined variables built in. Variables are set automatically and cannot be changed. Consequently, the order of precedence to override environment variables will not apply to the following pre-defined variables.
 
 #### Studio IDE details
 

--- a/website/docs/docs/build/environment-variables.md
+++ b/website/docs/docs/build/environment-variables.md
@@ -103,7 +103,7 @@ While all environment variables are encrypted at rest in <Constant name="cloud" 
 
 ### Special environment variables
 
-<Constant name="cloud" /> has a number of pre-defined variables built in. Variables are set automatically and cannot be changed. Consequently, the order of precedence to override environment variables will not apply to the following pre-defined variables.
+<Constant name="cloud" /> has a number of pre-defined variables built in. Variables are set automatically and cannot be changed. This means that the order of precedence for overriding environment variables don't apply to these pre-defined variables at the project, environment, or job level.
 
 #### Studio IDE details
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
This PR adds a clarifying sentence to the "Special environment variables" section of the `environment-variables.md` page. The change explicitly states that the usual order of precedence for overriding environment variables does not apply to these pre-defined dbt Cloud variables, addressing potential confusion about their immutability.

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).

---
[Slack Thread](https://dbt-labs.slack.com/archives/C02NCQ9483C/p1769074734490889?thread_ts=1769074734.490889&cid=C02NCQ9483C)

<a href="https://cursor.com/background-agent?bcId=bc-970e0971-1bbf-411f-bb35-c6a7ebe9725b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-970e0971-1bbf-411f-bb35-c6a7ebe9725b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

