### PR TITLE
Improve Claude MCP documentation

### DIFF
--- a/website/docs/docs/dbt-ai/about-mcp.md
+++ b/website/docs/docs/dbt-ai/about-mcp.md
@@ -15,13 +15,6 @@ The MCP server provides access to the dbt CLI, [API](/docs/dbt-cloud-apis/overvi
 
 For more information on MCP, have a look at [Get started with the Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction).
 
-<!--TODO need to create>
-## Architecture
-
-There are two ways to access the dbt-mcp server: locally hosted or remotely hosted on the cloud-based dbt platform.
-
-<-->
-
 ## Server access
 
 You can use the dbt MCP server in two ways: locally or remotely. Choose the setup that best fits your workflow:

--- a/website/docs/docs/dbt-ai/integrate-mcp-claude.md
+++ b/website/docs/docs/dbt-ai/integrate-mcp-claude.md
@@ -108,7 +108,6 @@ To add advanced configurations:
 
 For debugging, you can find the Claude desktop logs at `~/Library/Logs/Claude` for Mac or `%APPDATA%\Claude\logs` for Windows.
 
-
 ## Claude Code
 
 You can set up Claude Code with both the local and remote `dbt-mcp` server. We recommend using the local `dbt-mcp` for more developer-focused workloads. See the [About MCP](/docs/dbt-ai/about-mcp#server-access) page for more more information about local and remote server features.
@@ -124,7 +123,8 @@ Prerequisites:
 1. Run one of these commands based on your use case. Be sure to update the commands for your specific needs:
 
 <Tabs>
-<TabItem value="CLI only">
+<TabItem value="cli" label="CLI only">
+
 For <Constant name="core" /> or <Constant name="fusion" /> only (no <Constant name="dbt_platform" />):
 
 ```shell
@@ -133,10 +133,12 @@ claude mcp add \
 -e DBT_PATH=/path/to/your/dbt/executable \
 -- uvx dbt-mcp
 ```
+
 </TabItem>
-<TabItem value="OAuth with dbt platform">
+<TabItem value="oauth" label="OAuth with dbt platform">
 
 For OAuth authentication (requires static subdomain). Find your static subdomain [these](/docs/cloud/about-cloud/regions-ip-addresses.md#server-access):
+
 ```shell
 claude mcp add dbt \
 -e DBT_HOST=your-host-with-subdoman \

--- a/website/docs/docs/dbt-ai/integrate-mcp-claude.md
+++ b/website/docs/docs/dbt-ai/integrate-mcp-claude.md
@@ -118,14 +118,12 @@ Prerequisites:
 - Complete the [local MCP setup](/docs/dbt-ai/setup-local-mcp).
 - Know your configuration method (OAuth <Constant name="dbt_core"/> or environment variables)
 
-### Claude Code setup
-
-1. Run one of these commands based on your use case. Be sure to update the commands for your specific needs:
+In your Claude Code set up, run one of these commands based on your use case. Be sure to update the commands for your specific needs:
 
 <Tabs>
 <TabItem value="cli" label="CLI only">
 
-For <Constant name="core" /> or <Constant name="fusion" /> only (no <Constant name="dbt_platform" />):
+For <Constant name="core" /> or <Constant name="fusion" /> only (no <Constant name="dbt_platform" /> account):
 
 ```shell
 claude mcp add dbt \
@@ -146,12 +144,23 @@ claude mcp add dbt \
 -e DBT_PATH=/path/to/your/dbt/executable \
 -- uvx dbt-mcp
 ```
+
+Replacing `your-host-with-subdomain`, `path/to/your/dbt/project`, and `path/to/your/dbt/executable` with your actual static subdomain, project path, and dbt executable path.
+
+For example, if your static subdomain is `abc123.us1.dbt.com`, your command would look like this:
+```shell
+claude mcp add dbt \
+-e DBT_HOST=abc123.us1.dbt.com \ ## this is the static subdomain
+-e DBT_PROJECT_DIR=/path/to/your/dbt/project \
+-e DBT_PATH=/path/to/your/dbt/executable \
+-- uvx dbt-mcp
+```
 </TabItem>
 </Tabs>
 
 #### Using an `.env` file
 
-If you prefer to manage environment variables in a separate file you can use the `--env-file` parameter from `uvx`:
+If you prefer to manage environment variables in a separate file, you can use the `--env-file` parameter from `uvx`:
 
 ```bash
 claude mcp add dbt -- uvx --env-file <path-to-.env-file> dbt-mcp

--- a/website/docs/docs/dbt-ai/integrate-mcp-claude.md
+++ b/website/docs/docs/dbt-ai/integrate-mcp-claude.md
@@ -138,7 +138,7 @@ claude mcp add \
 
 For OAuth authentication (requires static subdomain). Find your static subdomain [these](/docs/cloud/about-cloud/regions-ip-addresses.md#server-access):
 ```shell
-claude mcp add \
+claude mcp add dbt \
 -e DBT_HOST=your-host-with-subdoman \
 -e DBT_PROJECT_DIR=/path/to/your/dbt/project \
 -e DBT_PATH=/path/to/your/dbt/executable \

--- a/website/docs/docs/dbt-ai/integrate-mcp-claude.md
+++ b/website/docs/docs/dbt-ai/integrate-mcp-claude.md
@@ -137,11 +137,11 @@ claude mcp add \
 </TabItem>
 <TabItem value="oauth" label="OAuth with dbt platform">
 
-For OAuth authentication (requires static subdomain). Find your static subdomain [these](/docs/cloud/about-cloud/regions-ip-addresses.md#server-access):
+For OAuth authentication (requires static subdomain). Find your static subdomain [here](/docs/cloud/about-cloud/access-regions-ip-addresses):
 
 ```shell
 claude mcp add dbt \
--e DBT_HOST=your-host-with-subdoman \
+-e DBT_HOST=your-host-with-subdomain \
 -e DBT_PROJECT_DIR=/path/to/your/dbt/project \
 -e DBT_PATH=/path/to/your/dbt/executable \
 -- uvx dbt-mcp

--- a/website/docs/docs/dbt-ai/integrate-mcp-claude.md
+++ b/website/docs/docs/dbt-ai/integrate-mcp-claude.md
@@ -128,7 +128,7 @@ Prerequisites:
 For <Constant name="core" /> or <Constant name="fusion" /> only (no <Constant name="dbt_platform" />):
 
 ```shell
-claude mcp add \
+claude mcp add dbt \
 -e DBT_PROJECT_DIR=/path/to/your/dbt/project \
 -e DBT_PATH=/path/to/your/dbt/executable \
 -- uvx dbt-mcp

--- a/website/docs/docs/dbt-ai/integrate-mcp-claude.md
+++ b/website/docs/docs/dbt-ai/integrate-mcp-claude.md
@@ -9,94 +9,8 @@ import MCPExample from '/snippets/_mcp-config-files.md';
 import StaticSubdomainRequired from '/snippets/_static-subdomain-required.md';
 
 Claude is an AI assistant from Anthropic with two primary interfaces:
-- [Claude Code](https://www.anthropic.com/claude-code): A terminal/IDE tool for development
 - [Claude for desktop](https://claude.ai/download): A GUI with MCP support for file access and commands as well as basic coding features
-
-## Claude Code
-
-You can set up Claude Code with both the local and remote `dbt-mcp` server. We recommend using the local `dbt-mcp` for more developer-focused workloads. See the [About MCP](/docs/dbt-ai/about-mcp#server-access) page for more more information about local and remote server features.
-
-### Set up with local dbt MCP server
-
-Prerequisites:
-- Complete the [local MCP setup](/docs/dbt-ai/setup-local-mcp).
-- Know your configuration method (OAuth <Constant name="dbt_core"/> or environment variables)
-
-### Claude Code scopes
-
-By default, the MCP server is installed in the "local" scope, meaning that it will be active for Claude Code sessions in the current directory for the user who installed it.
-
-It is also possible to install the MCP server:
-- In the "user" scope, to have it installed for all Claude Code sessions, independently of the directory used
-- In the "project" scope, to create a config file that can be version controlled so that all developers of the same project can have the MCP server already installed
-
-To install it in the project scope, run the following and commit the `.mcp.json` file. Be sure to use an env var file path that is the same for all users.
-```bash
-claude mcp add dbt -s project -- uvx --env-file <path-to-.env-file> dbt-mcp
-```
-
-For more information on scopes, refer to [Understanding MCP server scopes](https://docs.anthropic.com/en/docs/claude-code/mcp#understanding-mcp-server-scopes).
-
-
-### Claude Code OAuth or environment variables setup
-
-The recommended method is to configure environment variables directly in Claude Code's configuration file without needing a separate `.env` file:
-
-1. Add the MCP server:
-
-  ```bash
-  claude mcp add dbt -- uvx dbt-mcp
-  ```
-2. Open the configuration editor:
-
-  ```bash
-  claude mcp edit dbt
-  ```
-
-3. In the configuration editor, add your environment variables based on your use case:
-
-<Tabs>
-<TabItem value="CLI only">
-
-For <Constant name="core" /> or <Constant name="fusion" /> only (no <Constant name="dbt_platform" />):
-```json
-{
-  "command": "uvx",
-  "args": ["dbt-mcp"],
-  "env": {
-    "DBT_PROJECT_DIR": "/path/to/your/dbt/project",
-    "DBT_PATH": "/path/to/your/dbt/executable"
-  }
-}
-```
-
-</TabItem>
-<TabItem value="OAuth with dbt platform">
-
-For OAuth authentication (requires static subdomain):
-```json
-{
-  "command": "uvx",
-  "args": ["dbt-mcp"],
-  "env": {
-    "DBT_HOST": "https://your-subdomain.us1.dbt.com",
-    "DBT_PROJECT_DIR": "/path/to/your/dbt/project",
-    "DBT_PATH": "/path/to/your/dbt/executable"
-  }
-}
-```
-
-</TabItem>
-</Tabs>
-
-#### Using an `.env` file
-
-If you prefer to manage environment variables in a separate file:
-
-```bash
-claude mcp add dbt -- uvx --env-file <path-to-.env-file> dbt-mcp
-```
-Replace `<path-to-.env-file>` with the full path to your `.env` file.
+- [Claude Code](https://www.anthropic.com/claude-code): A terminal/IDE tool for development
 
 ## Claude Desktop
 
@@ -116,7 +30,6 @@ To add advanced configurations:
 2. In the Settings window, navigate to the **Developer** tab in the left sidebar. This section contains options for configuring MCP servers and other developer features.
 3. Click the **Edit Config** button and open the configuration file with a text editor.
 4. Add your server configuration based on your use case. Choose the [correct JSON structure](https://modelcontextprotocol.io/quickstart/user#installing-the-filesystem-server) from the following options:
-
 
     <Expandable alt_header="Local MCP with OAuth">
 
@@ -195,6 +108,53 @@ To add advanced configurations:
 
 For debugging, you can find the Claude desktop logs at `~/Library/Logs/Claude` for Mac or `%APPDATA%\Claude\logs` for Windows.
 
+
+## Claude Code
+
+You can set up Claude Code with both the local and remote `dbt-mcp` server. We recommend using the local `dbt-mcp` for more developer-focused workloads. See the [About MCP](/docs/dbt-ai/about-mcp#server-access) page for more more information about local and remote server features.
+
+### Set up with local dbt MCP server
+
+Prerequisites:
+- Complete the [local MCP setup](/docs/dbt-ai/setup-local-mcp).
+- Know your configuration method (OAuth <Constant name="dbt_core"/> or environment variables)
+
+### Claude Code setup
+
+1. Run one of these commands based on your use case. Be sure to update the commands for your specific needs:
+
+<Tabs>
+<TabItem value="CLI only">
+For <Constant name="core" /> or <Constant name="fusion" /> only (no <Constant name="dbt_platform" />):
+
+```shell
+claude mcp add \
+-e DBT_PROJECT_DIR=/path/to/your/dbt/project \
+-e DBT_PATH=/path/to/your/dbt/executable \
+-- uvx dbt-mcp
+```
+</TabItem>
+<TabItem value="OAuth with dbt platform">
+
+For OAuth authentication (requires static subdomain). Find your static subdomain [these](/docs/cloud/about-cloud/regions-ip-addresses.md#server-access):
+```shell
+claude mcp add \
+-e DBT_HOST=your-host-with-subdoman \
+-e DBT_PROJECT_DIR=/path/to/your/dbt/project \
+-e DBT_PATH=/path/to/your/dbt/executable \
+-- uvx dbt-mcp
+```
+</TabItem>
+</Tabs>
+
+#### Using an `.env` file
+
+If you prefer to manage environment variables in a separate file you can use the `--env-file` parameter from `uvx`:
+
+```bash
+claude mcp add dbt -- uvx --env-file <path-to-.env-file> dbt-mcp
+```
+Replace `<path-to-.env-file>` with the full path to your `.env` file.
 
 ## Troubleshooting
 

--- a/website/snippets/_static-subdomain-required.md
+++ b/website/snippets/_static-subdomain-required.md
@@ -1,3 +1,3 @@
 :::info Static subdomains required
-Only accounts with static subdomains (for example, `abc123` in `abc123.us1.dbt.com`) can use OAuth with MCP servers. To find your account subdomain, navigate to **Account Settings** > **Account** > **Access URL**. If your account does not have a subdomain, contact support for more information.
+Only accounts with static subdomains (for example, `abc123` in `abc123.us1.dbt.com`) can use OAuth with MCP servers. Follow [these](/docs/cloud/about-cloud/regions-ip-addresses.md#server-access) instructions to find your account subdomain. If your account does not have a subdomain, contact support for more information.
 :::

--- a/website/snippets/_static-subdomain-required.md
+++ b/website/snippets/_static-subdomain-required.md
@@ -1,3 +1,3 @@
 :::info Static subdomains required
-Only accounts with static subdomains (for example, `abc123` in `abc123.us1.dbt.com`) can use OAuth with MCP servers. Follow [these](/docs/cloud/about-cloud/regions-ip-addresses.md#server-access) instructions to find your account subdomain. If your account does not have a subdomain, contact support for more information.
+Only accounts with static subdomains (for example, `abc123` in `abc123.us1.dbt.com`) can use OAuth with MCP servers. Follow [these](/docs/cloud/about-cloud/access-regions-ip-addresses) instructions to find your account subdomain. If your account does not have a subdomain, contact support for more information.
 :::


### PR DESCRIPTION
## What are you changing in this pull request and why?

This PR cleans up the Claude MCP docs:
- Reorganizes to put Claude Desktop ahead of Claude Code, better for business users
- Removes the `Claude Code scopes` section, which mainly documents Claude, not dbt MCP. We want to make our docs as easy as possible to read and maintain.
- Fixes the `claude` commands to be accurate with the latest version of the tool