### PR TITLE
clarify group permission 

### DIFF
--- a/website/docs/docs/deploy/job-notifications.md
+++ b/website/docs/docs/deploy/job-notifications.md
@@ -146,7 +146,7 @@ If you're logged out or the Slack app/website is closed, you must authenticate b
 Configuring Slack notifications at the account level is currently available in private beta. To request access, contact your account manager.
 :::
 
-Integrate Slack with <Constant name="dbt_platform" /> at the account level to receive job notifications in Slack. dbt integrates with Slack via OAuth to ensure secure authentication. Only refer to these instructions if you have access to the private beta feature.
+Integrate Slack with <Constant name="dbt_platform" /> at the account level to receive job notifications in Slack. A single <Constant name="dbt_platform" /> account can integrate with one Slack workspace. dbt integrates with Slack via OAuth to ensure secure authentication. Only refer to these instructions if you have access to the private beta feature.
 
 ### Prerequisites
 
@@ -154,7 +154,7 @@ Integrate Slack with <Constant name="dbt_platform" /> at the account level to re
 - A <Constant name="dbt_platform"/> account admin must link the Slack app at the account level.
 - To install the Slack app to a workspace, your Slack org must permit app installations. In some orgs this requires a Slack admin approval.
 
-After an account admin links the Slack app for the account, [any licensed user](/docs/cloud/manage-access/seats-and-users) in the account can configure Slack job notifications.
+After an account admin links the Slack app for the account, [any licensed user](/docs/cloud/manage-access/seats-and-users) in the account can configure Slack job notifications so long as they are assigned to a [group](/docs/cloud/manage-access/about-user-access#groups) with **Account Admin**, **Owner**, or **Member** permissions. IT licenses don't have access to configure Slack job notifications.
 
 **Channels supported:**
   - Public channels are supported by default

--- a/website/docs/reference/commands/debug.md
+++ b/website/docs/reference/commands/debug.md
@@ -67,11 +67,13 @@ Options:
                 database object in the current environment.
 
  --indirect-selection [eager|cautious|buildable|empty]
-                Choose which tests to select that are
-                adjacent to selected resources. Eager is
-                most inclusive, cautious is most exclusive,
-                and buildable is in between. Empty includes
-                no tests at all.
+                Controls which tests run based on their
+                relationships to selected models in your DAG.
+                Eager (default) is most inclusive and runs
+                tests that reference your selected models.
+                Cautious is most exclusive and only runs tests
+                that exclusively reference selected models.
+                Buildable is in between. Empty runs no tests.
 
  --log-cache-events / --no-log-cache-events
                 Enable verbose logging for relational cache

--- a/website/docs/reference/global-configs/indirect-selection.md
+++ b/website/docs/reference/global-configs/indirect-selection.md
@@ -6,7 +6,13 @@ sidebar: "Indirect selection"
 
 import IndirSelect from '/snippets/_indirect-selection-definitions.md';
 
-Use the `--indirect-selection` flag to `dbt test` or `dbt build` to configure which tests to run for the nodes you specify. You can set this as a CLI flag or an environment variable. In dbt Core, you can also configure user configurations in [YAML selectors](/reference/node-selection/yaml-selectors) or in the `flags:` block of `dbt_project.yml`, which sets project-level flags.
+**Indirect selection** determines which tests to run when you select models or other resources. It applies to tests that are related to your selected resources through relationships in your DAG &mdash; for example, tests on upstream or downstream models, or tests that reference multiple models.
+
+Use the `--indirect-selection` flag with `dbt test` or `dbt build` to configure this behavior. You can set this as a CLI flag or an environment variable. In dbt Core, you can also configure user configurations in [YAML selectors](/reference/node-selection/yaml-selectors) or in the `flags:` block of `dbt_project.yml`, which sets project-level flags.
+
+:::tip Indirect selection happens by default
+Even without explicitly using the `--indirect-selection` flag, dbt uses indirect selection when you run commands like `dbt test --select "stg_customers+"`. The default mode is `eager`, which runs all tests that reference your selected models. For example, `dbt test --select fct_orders` will run tests on `fct_orders`, but also tests in upstream models like `fct_order_items` if those tests reference `fct_orders`.
+:::
 
 When all flags are set, the order of precedence is as follows. Refer to [About global configs](/reference/global-configs/about-global-configs) for more details:
 
@@ -14,7 +20,7 @@ When all flags are set, the order of precedence is as follows. Refer to [About g
 1. Environment variables
 1. User configurations
 
-You can set the flag to: `empty`, `buildable`, `cautious`, or `eager` (default). By default, dbt indirectly selects all tests if they touch any resource you select. Learn more about these options in [Indirect selection in Test selection examples](/reference/node-selection/test-selection-examples?indirect-selection-mode=eager#indirect-selection).
+You can set the flag to: `empty`, `buildable`, `cautious`, or `eager` (default). Learn more about these options in [Indirect selection in Test selection examples](/reference/node-selection/test-selection-examples?indirect-selection-mode=eager#indirect-selection).
 
 <IndirSelect features={'/snippets/indirect-selection-definitions.md'}/>
 

--- a/website/docs/reference/node-selection/test-selection-examples.md
+++ b/website/docs/reference/node-selection/test-selection-examples.md
@@ -11,7 +11,7 @@ Test selection works a little differently from other resource selection. This ma
 
 Like all resource types, tests can be selected **directly**, by methods and operators that capture one of their attributes: their name, properties, tags, etc.
 
-Unlike other resource types, tests can also be selected **indirectly**. If a selection method or operator includes a test's parent(s), the test will also be selected. [See below](#indirect-selection) for more details.
+Unlike other resource types, tests can also be selected **indirectly** through relationships in your DAG. When you select a model, dbt automatically determines which related tests to run based on how those tests reference models in your project. For example, when you run `dbt test --select fct_orders`, dbt uses **indirect selection** to include tests on upstream models (like `fct_order_items`) that reference `fct_orders`, in addition to tests directly on `fct_orders` itself. [See below](#indirect-selection) for more details on controlling this behavior.
 
 Test selection is powerful, and we know it can be tricky. To that end, we've included lots of examples below:
 

--- a/website/snippets/_indirect-selection-definitions.md
+++ b/website/snippets/_indirect-selection-definitions.md
@@ -1,24 +1,31 @@
-You can use the following modes to configure the behavior when performing indirect selection (with `eager` mode as the default). Test exclusion is always greedy: if ANY parent is explicitly excluded, the test will be excluded as well.
+**Indirect selection modes** control which tests run based on the models you select and their relationships in your DAG. These modes determine how dbt handles tests that reference your selected models, either directly or through upstream/downstream relationships.
+
+You can use the following modes (with `eager` as the default). Test exclusion is always greedy: if ANY parent is explicitly excluded, the test will be excluded as well.
 
 :::tip Building subsets of a DAG
 The `buildable` and `cautious` modes can be useful when you're only building a subset of your DAG, and you want to avoid test failures in `eager` mode caused by unbuilt resources. You can also achieve this with [deferral](/reference/node-selection/defer).
 :::
 
+#### Eager mode (default)
 
+**Most inclusive.** Runs tests if ANY of the parent nodes are selected, regardless of whether all dependencies are met. This includes ANY tests that reference the selected nodes, even if they also reference other unselected nodes. 
 
-#### Eager mode
+For example, if you run `dbt test --select fct_orders`, eager mode will run:
+- Tests directly on `fct_orders`
+- Tests in upstream models (like `fct_order_items`) that reference `fct_orders` 
+- Tests in downstream models that reference `fct_orders`
 
-By default, runs tests if any of the parent nodes are selected, regardless of whether all dependencies are met. This includes ANY tests that reference the selected nodes. Models will be built if they depend on the selected model. In this mode, any tests depending on unbuilt resources will raise an error.
+Models will be built if they depend on the selected model. In this mode, any tests depending on unbuilt resources will raise an error.
 
 #### Buildable mode
 
-Only runs tests that refer to selected nodes (or their ancestors). This mode is slightly more inclusive than `cautious` by including tests whose references are each within the selected nodes (or their ancestors). This mode is useful when a test depends on a model _and_ a direct ancestor of that model, like confirming an aggregation has the same totals as its input.
+**Middle ground.** Only runs tests that refer to selected nodes (or their ancestors). This mode is slightly more inclusive than `cautious` by including tests whose references are each within the selected nodes (or their ancestors). This mode is useful when a test depends on a model _and_ a direct ancestor of that model, like confirming an aggregation has the same totals as its input.
 
 #### Cautious mode
 
-Ensures that tests are executed and models are built only when all necessary dependencies of the selected models are met. Restricts tests to only those that exclusively reference selected nodes. Tests will only be executed if all the nodes they depend on are selected, which prevents tests from running if one or more of its parent nodes are unselected and, consequently, unbuilt.
+**Most exclusive.** Ensures that tests are executed and models are built only when all necessary dependencies of the selected models are met. Restricts tests to only those that exclusively reference selected nodes. Tests will only be executed if all the nodes they depend on are selected, which prevents tests from running if one or more of its parent nodes are unselected and, consequently, unbuilt.
 
 #### Empty mode
 
-Restricts the build to only the selected node and ignores any indirect dependencies, including tests. It doesn't execute any tests, whether they are directly attached to the selected node or not. The empty mode does not include any tests and is automatically used for [interactive compilation](/reference/commands/compile#interactive-compile).
+**No tests.** Restricts the build to only the selected node and ignores any indirect dependencies, including tests. It doesn't execute any tests, whether they are directly attached to the selected node or not. The empty mode does not include any tests and is automatically used for [interactive compilation](/reference/commands/compile#interactive-compile).
 


### PR DESCRIPTION
this pr clarifies the permission requirements for configuring Slack job notifications at the account level. The current text says "any licensed user" can configure notifications, but this needs to specify that only certain roles (Account Admin, Owner, Member) have the necessary permissions.

[raised in internal slack](https://dbt-labs.slack.com/archives/C0A91LET5CG/p1769508699429769?thread_ts=1768903808.377659&cid=C0A91LET5CG)

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-clarify-user-permission-dbt-labs.vercel.app/docs/deploy/job-notifications
- https://docs-getdbt-com-git-update-clarify-user-permission-dbt-labs.vercel.app/reference/commands/debug
- https://docs-getdbt-com-git-update-clarify-user-permission-dbt-labs.vercel.app/reference/global-configs/indirect-selection
- https://docs-getdbt-com-git-update-clarify-user-permission-dbt-labs.vercel.app/reference/node-selection/test-selection-examples

<!-- end-vercel-deployment-preview -->