### PR TITLE
add clarification slack job notifis

### DIFF
--- a/website/docs/docs/deploy/job-notifications.md
+++ b/website/docs/docs/deploy/job-notifications.md
@@ -143,10 +143,12 @@ If you're logged out or the Slack app/website is closed, you must authenticate b
 
 ## Slack notifications (account) <Lifecycle status="private_beta" />  {#slack-notifications-account}
 :::info
-Configuring Slack notifications at the account level is currently available in private beta. To request access, contact your account manager.
+Configuring Slack notifications at the account level is currently available in private beta. To request access, contact your account manager. Only refer to these instructions if you have access to the private beta feature.
 :::
 
-Integrate Slack with <Constant name="dbt_platform" /> at the account level to receive job notifications in Slack. dbt integrates with Slack via OAuth to ensure secure authentication. Only refer to these instructions if you have access to the private beta feature.
+Integrate Slack with <Constant name="dbt_platform" /> at the account level to receive job notifications in Slack. 
+
+A single <Constant name="dbt_platform" /> account can integrate with one Slack workspace. dbt integrates with Slack via OAuth to ensure secure authentication. 
 
 ### Prerequisites
 
@@ -154,7 +156,7 @@ Integrate Slack with <Constant name="dbt_platform" /> at the account level to re
 - A <Constant name="dbt_platform"/> account admin must link the Slack app at the account level.
 - To install the Slack app to a workspace, your Slack org must permit app installations. In some orgs this requires a Slack admin approval.
 
-After an account admin links the Slack app for the account, [any licensed user](/docs/cloud/manage-access/seats-and-users) in the account can configure Slack job notifications.
+After an account admin links the Slack app for the account, [any licensed user](/docs/cloud/manage-access/seats-and-users) in the account can configure Slack job notifications so long as they are assigned to a [group](/docs/cloud/manage-access/about-user-access#groups) with **Account Admin**, **Owner**, or **Member** permissions. IT licenses don't have access to configure Slack job notifications.
 
 **Channels supported:**
   - Public channels are supported by default

--- a/website/docs/docs/deploy/job-notifications.md
+++ b/website/docs/docs/deploy/job-notifications.md
@@ -146,9 +146,9 @@ If you're logged out or the Slack app/website is closed, you must authenticate b
 Configuring Slack notifications at the account level is currently available in private beta. To request access, contact your account manager. Only refer to these instructions if you have access to the private beta feature.
 :::
 
-Integrate Slack with <Constant name="dbt_platform" /> at the account level to receive job notifications in Slack. 
+Integrate Slack with <Constant name="dbt_platform" /> at the account level to receive job notifications in Slack. dbt integrates with Slack via OAuth to ensure secure authentication. 
 
-A single <Constant name="dbt_platform" /> account can integrate with one Slack workspace. dbt integrates with Slack via OAuth to ensure secure authentication. 
+A single <Constant name="dbt_platform" /> account can integrate with one Slack workspace. 
 
 ### Prerequisites
 


### PR DESCRIPTION
this pr clarifies the permission requirements for configuring Slack job notifications at the account level. The current text says "any licensed user" can configure notifications, but this needs to specify that only certain roles (Account Admin, Owner, Member) have the necessary permissions.

raised in internal slack

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-clarify-slack-config-dbt-labs.vercel.app/docs/deploy/job-notifications

<!-- end-vercel-deployment-preview -->