### PR TITLE
dbt copilot documentation

### DIFF
--- a/website/docs/docs/cloud/enable-dbt-copilot.md
+++ b/website/docs/docs/cloud/enable-dbt-copilot.md
@@ -18,8 +18,10 @@ This page explains how to enable <Constant name="copilot" /> in <Constant name="
 - Must have a [<Constant name="cloud" /> Starter, Enterprise, or Enterprise+ account](https://www.getdbt.com/pricing).
   - Certain features like [BYOK](#bringing-your-own-openai-api-key-byok), [natural prompts in Canvas](/docs/cloud/build-canvas-copilot), and more are only available on Enterprise and Enterprise+ plans.
 - Development environment is on a supported [release track](/docs/dbt-versions/cloud-release-tracks) to receive ongoing updates.
-- By default, <Constant name="copilot" /> deployments use a central OpenAI API key managed by dbt Labs. Alternatively, you can [bring your own OpenAI API key](#bringing-your-own-openai-api-key-byok)(BYOK).
-  - For BYOK, make sure to enable the latest text generation models as well as the `text-embedding-3-small` model.
+- By default, <Constant name="copilot" /> deployments use a central OpenAI API key managed by dbt Labs. Alternatively, you can [bring your own OpenAI API key](#bringing-your-own-openai-api-key-byok) (BYOK).
+  - For BYOK, ensure your API key has access to the required models:
+    - **Text generation models**: GPT-4 or later (GPT-4o, GPT-4 Turbo, or o1 models)
+    - **Embedding model**: `text-embedding-3-small`
 - Opt-in to AI features by following the steps in the next section in your **Account settings**.
 
 ## Enable dbt Copilot
@@ -72,23 +74,41 @@ To configure the AI integration in your <Constant name="cloud" /> account, a <Co
   <TabItem value="openai" label="OpenAI">
   Bringing your own OpenAI key is available for Enterprise or Enterprise+ plans.
 
+  **Prerequisites**:
+  - Ensure your OpenAI API key has access to the required models:
+    - **Text generation models**: GPT-4 or later (GPT-4o, GPT-4 Turbo, or o1 models)
+    - **Embedding model**: `text-embedding-3-small`
+
   1. Select the toggle for **OpenAI** to use your own OpenAI key.
   2. Enter the API key.
   3. Click **Save**.
-    <Lightbox src="/img/docs/dbt-cloud/account-integration-openai.png" width="85%" title="Example of the OpenAI integration page" />
+  
+  <Lightbox src="/img/docs/dbt-cloud/account-integration-openai.png" width="85%" title="Example of the OpenAI integration page" />
 
   </TabItem>
 
   <TabItem value="azure" label="Azure OpenAI">
   Bringing your own Azure OpenAI key is available for Enterprise or Enterprise+ plans.
 
-  To learn about deploying your own OpenAI model on Azure, refer to [Deploy models on Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-studio/how-to/deploy-models-openai). Configure credentials for your Azure OpenAI deployment in <Constant name="cloud" /> the following way:
+  To learn about deploying your own OpenAI model on Azure, refer to [Deploy models on Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-studio/how-to/deploy-models-openai). 
+  
+  **Prerequisites**:
+  - Deploy a text generation model in Azure OpenAI (GPT-4, GPT-4o, GPT-4 Turbo, or o1 models)
+  - Deploy the `text-embedding-3-small` embedding model in Azure OpenAI
+  - Note the deployment names for both models
+  
+  Configure credentials for your Azure OpenAI deployment in <Constant name="cloud" /> the following way:
 
   1. Locate your Azure OpenAI configuration in your Azure Deployment details page.
   2. Enter your Azure OpenAI API key.
-  3. Enter the **Endpoint**, **API Version**, and **Deployment / Model Name**.
-  4. Click **Save**.
+  3. Enter the **Endpoint** (your Azure OpenAI resource endpoint URL).
+  4. Enter the **API Version** (for example, `2024-02-15-preview` or later).
+  5. Enter the **Deployment / Model Name** (the deployment name you created in Azure for your text generation model).
+  6. Click **Save**.
+  
   <Lightbox src="/img/docs/dbt-cloud/account-integration-azure-manual.png" width="85%" title="Example of Azure OpenAI integration section" />
+  
+  **Note**: Currently, you only need to configure the text generation model deployment. The embedding model will be supported in future releases, but ensure you have it deployed and ready in your Azure OpenAI resource.
 
   </TabItem>
   </Tabs>


### PR DESCRIPTION
## What are you changing in this pull request and why?
This PR clarifies the model requirements and configuration steps for dbt Copilot's AI integrations, specifically for Bring Your Own Key (BYOK) setups with OpenAI and Azure OpenAI.

The changes aim to provide clearer guidance for users, reducing potential confusion about which models are required (e.g., GPT-4 or later for text generation, `text-embedding-3-small` for embeddings) and how to properly configure them, especially for Azure OpenAI. This update addresses common user questions and improves the overall setup experience.

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).

---
<a href="https://cursor.com/background-agent?bcId=bc-ebbc8030-026e-4d81-9471-510ee6190a5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ebbc8030-026e-4d81-9471-510ee6190a5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

