### PR TITLE
BigQuery BigFrames documentation

### DIFF
--- a/website/docs/reference/resource-configs/bigquery-configs.md
+++ b/website/docs/reference/resource-configs/bigquery-configs.md
@@ -1191,7 +1191,7 @@ The BigQuery Python models also have the following additional configuration para
 | `enable_list_inference` | `<boolean>` | no       | `True`    | `True`, `False`  |
 | `intermediate_format`   | `<string>`  | no       | `parquet` | `parquet`, `orc` |
 | `submission_method`     | `<string>`  | no       | ``        | `serverless`, `bigframes`, `cluster` |
-| `notebook_template_id`  | `<Integer>` | no       | ``        | `<NOTEBOOK RUNTIME TEMPLATE_ID>` |
+| `notebook_template_id`  | `<integer>` | no       | ``        | `<NOTEBOOK RUNTIME TEMPLATE_ID>` |
 | `compute_region`        | `<string>`  | no       | ``        | `<COMPUTE_REGION>` |
 | `gcs_bucket`            | `<string>`  | no       | ``        | `<GCS_BUCKET>` |
 | `packages`              | `<string>`  | no       | ``        | `['numpy<=1.1.1', 'pandas', 'mlflow']` |

--- a/website/docs/reference/resource-configs/bigquery-configs.md
+++ b/website/docs/reference/resource-configs/bigquery-configs.md
@@ -558,6 +558,12 @@ The `incremental_strategy` config can be set to one of the following values:
 - `insert_overwrite`
 - [`microbatch`](/docs/build/incremental-microbatch)
 
+### Change history
+
+The `enable_change_history` parameter enables [BigQuery's change history feature](https://cloud.google.com/bigquery/docs/change-history) which tracks changes made to a BigQuery table. When enabled, you can use the change history to audit and debug the behavior of your incremental models. 
+
+`enable_change_history` is set to `<boolean>` values.
+
 ### Performance and cost
 
 The operations performed by dbt while building a BigQuery incremental model can
@@ -1196,7 +1202,6 @@ The BigQuery Python models also have the following additional configuration para
 | `gcs_bucket`            | `<string>`  | no       | ``        | `<GCS_BUCKET>` |
 | `packages`              | `<string>`  | no       | ``        | `['numpy<=1.1.1', 'pandas', 'mlflow']` |
 | `timeout`               | `<integer>` | no       | ``        | `<timeout_in_seconds>` |
-| `enable_change_history` | `<boolean>` | no       | ``        | `True`, `False`   |
 
 - The `enable_list_inference` parameter
   - The `enable_list_inference` parameter enables a PySpark data frame to read multiple records in the same operation. By default, this is set to `True` to support the default `intermediate_format` of `parquet`.
@@ -1219,8 +1224,6 @@ The BigQuery Python models also have the following additional configuration para
 - The `timeout` parameter
   - The `timeout` parameter specifies the maximum execution time in seconds for the Python model. This is particularly useful for BigFrames models that may require longer execution times for complex data processing or machine learning workloads. If not specified, the model will use the default timeout configured for the execution environment.
 
-- The `enable_change_history` parameter
-  - The `enable_change_history` parameter enables [BigQuery's change history feature](https://cloud.google.com/bigquery/docs/change-history) which tracks changes made to a BigQuery table. When enabled, you can use the change history to audit and debug the behavior of your incremental models.
 
 **Related docs:**
 

--- a/website/docs/reference/resource-configs/bigquery-configs.md
+++ b/website/docs/reference/resource-configs/bigquery-configs.md
@@ -1195,6 +1195,7 @@ The BigQuery Python models also have the following additional configuration para
 | `compute_region`        | `<string>`  | no       | ``        | `<COMPUTE_REGION>` |
 | `gcs_bucket`            | `<string>`  | no       | ``        | `<GCS_BUCKET>` |
 | `packages`              | `<string>`  | no       | ``        | `['numpy<=1.1.1', 'pandas', 'mlflow']` |
+| `timeout`               | `<integer>` | no       | ``        | `<timeout_in_seconds>` |
 | `enable_change_history` | `<boolean>` | no       | ``        | `True`, `False`   |
 
 - The `enable_list_inference` parameter
@@ -1214,6 +1215,9 @@ The BigQuery Python models also have the following additional configuration para
 
 - The `gcs_bucket` parameter
   - The `gcs_bucket` parameter specifies the GCS bucket used for storing artifacts for the job.
+
+- The `timeout` parameter
+  - The `timeout` parameter specifies the maximum execution time in seconds for the Python model. This is particularly useful for BigFrames models that may require longer execution times for complex data processing or machine learning workloads. If not specified, the model will use the default timeout configured for the execution environment.
 
 - The `enable_change_history` parameter
   - The `enable_change_history` parameter enables [BigQuery's change history feature](https://cloud.google.com/bigquery/docs/change-history) which tracks changes made to a BigQuery table. When enabled, you can use the change history to audit and debug the behavior of your incremental models.


### PR DESCRIPTION
## What are you changing in this pull request and why?
This pull request adds the `timeout` configuration parameter for BigFrames Python models to the BigQuery configurations reference page.

This parameter was recently introduced and is used in related content (e.g., blog posts) but was not yet documented on the `dbt-bigquery` reference page. Adding it ensures that users have complete and accurate documentation for configuring their BigFrames Python models.

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).

---
[Slack Thread](https://dbt-labs.slack.com/archives/C08AA468V54/p1769807942572429?thread_ts=1769807942.572429&cid=C08AA468V54)

<a href="https://cursor.com/background-agent?bcId=bc-4d959241-7ec2-434b-a8a7-b39300ee5b77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4d959241-7ec2-434b-a8a7-b39300ee5b77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

