### PR TITLE
Update Joel Labes title to Staff DX Advocate

### DIFF
--- a/website/blog/authors.yml
+++ b/website/blog/authors.yml
@@ -319,7 +319,7 @@ joel_labes:
     bluesky: https://bsky.app/profile/joellab.es
   name: Joel Labes
   page: true
-  title: Senior Developer Experience Advocate at dbt Labs
+  title: Staff Developer Experience Advocate at dbt Labs
 jonathan_natkins:
   description: Natty also writes about startups, equity, data, and more in his Substack called [Semi-Structured](http://semistructured.substack.com/).
   image_url: /img/blog/authors/jonathan-natkins.jpeg


### PR DESCRIPTION
## Summary
- Updates Joel Labes' title from "Senior Developer Experience Advocate" to "Staff Developer Experience Advocate"

## Test plan
- [ ] Verify author card displays correctly on blog posts

🤖 Generated with [Claude Code](https://claude.ai/code)