### PR TITLE
DO NOT MERGE: Fix LinkedIn social share image for blog posts

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -541,7 +541,9 @@ var siteSettings = {
     experimental_faster: {
       swcJsLoader: true,
       swcJsMinimizer: true,
-      swcHtmlMinimizer: true,
+      // Disabled: SWC HTML minifier strips <head> tags (optional in HTML5),
+      // which breaks LinkedIn's OG scraper — it can't find og:image without them
+      swcHtmlMinimizer: false,
       lightningCssMinimizer: true,
       mdxCrossCompilerCache: true,
       rspackBundler: true,

--- a/website/src/theme/BlogLayout/index.js
+++ b/website/src/theme/BlogLayout/index.js
@@ -26,7 +26,6 @@ export default function BlogLayout(props) {
     children,
     title,
     description,
-    image,
     isBlogList,
     isBlogPost,
     ...layoutProps
@@ -71,11 +70,10 @@ export default function BlogLayout(props) {
     <Layout {...layoutProps}>
 
       {/* Set Custom Metadata */}
-       {(image || (featured_image && featured_image !== "")) &&
+       {featured_image && featured_image !== "" &&
          <Head>
-           <meta property="og:image" content={image || featured_image} />
-           <meta name="twitter:image" content={image || featured_image} />
-           {image && <meta property="og:image:alt" content={title || ''} />}
+           <meta property="og:image" content={featured_image} />
+           <meta property="twitter:image" content={featured_image} />
          </Head>
        }
  

--- a/website/src/theme/BlogLayout/index.js
+++ b/website/src/theme/BlogLayout/index.js
@@ -21,13 +21,14 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
 export default function BlogLayout(props) {
   const {
-    sidebar, 
-    toc, 
-    children, 
-    title, 
-    description, 
-    isBlogList, 
-    isBlogPost, 
+    sidebar,
+    toc,
+    children,
+    title,
+    description,
+    image,
+    isBlogList,
+    isBlogPost,
     ...layoutProps
   } = props;
   const hasSidebar = sidebar && sidebar.items.length > 0;
@@ -70,10 +71,11 @@ export default function BlogLayout(props) {
     <Layout {...layoutProps}>
 
       {/* Set Custom Metadata */}
-       {featured_image && featured_image !== "" &&
-         <Head> 
-           <meta property="og:image" content={featured_image} />
-           <meta property="twitter:image" content={featured_image} />
+       {(image || (featured_image && featured_image !== "")) &&
+         <Head>
+           <meta property="og:image" content={image || featured_image} />
+           <meta name="twitter:image" content={image || featured_image} />
+           {image && <meta property="og:image:alt" content={title || ''} />}
          </Head>
        }
  

--- a/website/src/theme/BlogPostPage/index.js
+++ b/website/src/theme/BlogPostPage/index.js
@@ -16,7 +16,6 @@ import { DiscourseBlogComments } from '@site/src/components/discourseBlogComment
 import { useDateTimeFormat } from "@docusaurus/theme-common/internal";
 import StructuredData from '@site/src/components/StructuredData';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import Head from '@docusaurus/Head';
 
 /* dbt Customizations:
  * Import global data from plugin
@@ -106,7 +105,6 @@ function BlogPostPageContent({sidebar, children}) {
         ) : undefined
       }
       isBlogPost={true}
-      image={postImageUrl}
     >
       <StructuredData
         type="BlogPosting"

--- a/website/src/theme/BlogPostPage/index.js
+++ b/website/src/theme/BlogPostPage/index.js
@@ -16,6 +16,7 @@ import { DiscourseBlogComments } from '@site/src/components/discourseBlogComment
 import { useDateTimeFormat } from "@docusaurus/theme-common/internal";
 import StructuredData from '@site/src/components/StructuredData';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import Head from '@docusaurus/Head';
 
 /* dbt Customizations:
  * Import global data from plugin
@@ -84,6 +85,11 @@ function BlogPostPageContent({sidebar, children}) {
   // Get the full URL for the blog post
   const postUrl = `${siteConfig.url}/blog/${frontMatter.slug}`;
 
+  // Construct absolute image URL for social sharing and structured data
+  const postImageUrl = frontMatter.image
+    ? (frontMatter.image.startsWith('http') ? frontMatter.image : `${siteConfig.url}${frontMatter.image}`)
+    : undefined;
+
   return (
     <BlogLayout
       sidebar={sidebar}
@@ -100,6 +106,7 @@ function BlogPostPageContent({sidebar, children}) {
         ) : undefined
       }
       isBlogPost={true}
+      image={postImageUrl}
     >
       <StructuredData
         type="BlogPosting"
@@ -109,6 +116,7 @@ function BlogPostPageContent({sidebar, children}) {
         date={date}
         url={postUrl}
         tags={tags}
+        imageUrl={postImageUrl}
       />
 
       {!hideTableOfContents && toc.length > 0 && (


### PR DESCRIPTION
## DO NOT MERGE — Testing Only

This PR is for testing LinkedIn social share behavior on the Vercel preview deployment.

## Summary
- Pass per-post `image` (from frontmatter) to `BlogLayout` and `StructuredData` so that:
  - `og:image` is explicitly set from BlogLayout (later in the render tree = higher priority with react-helmet)
  - JSON-LD `BlogPosting` schema includes the `image` field (previously missing — LinkedIn uses structured data as a signal)
  - `og:image:alt` is added for accessibility
- Addresses LinkedIn showing author headshots instead of the intended social share image

## How to test
1. Wait for Vercel preview to deploy
2. Go to [LinkedIn Post Inspector](https://www.linkedin.com/post-inspector/inspect/)
3. Paste the preview URL for a blog post with an `image` frontmatter field (e.g. `/blog/dbt-agent-skills`)
4. Verify LinkedIn shows the social share image, not the author headshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)