### PR TITLE
PRODDOCS-608: clarify mcp usage

### DIFF
--- a/website/docs/docs/dbt-ai/setup-local-mcp.md
+++ b/website/docs/docs/dbt-ai/setup-local-mcp.md
@@ -37,6 +37,8 @@ After completing OAuth setup, skip to [Test your configuration](#optional-test-y
 
 ### CLI only (no dbt platform)
 
+This option runs the MCP server locally and connects it to your local dbt project using `DBT_PROJECT_DIR` and `DBT_PATH`.
+
 If you're using the <Constant name="core" /> or <Constant name="fusion" /> CLI and don't need access to <Constant name="dbt_platform" /> features (Discovery API, Semantic Layer, Administrative API), you can set up local MCP with just your dbt project information.
 
 Add this configuration to your MCP client (refer to the specific [integration guides](#set-up-your-mcp-client) for exact file locations):


### PR DESCRIPTION
this pr addresses user feedback from the thumbs up/down feedback widget

Closes https://dbtlabs.atlassian.net/browse/PRODDOCS-608?atlOrigin=eyJpIjoiNmMzYTkzMTc5Y2UzNDAzZGI4NTRjMDc5YzgxMTE5ZjMiLCJwIjoiaiJ9

feedback:
> Running the MCP server locally on a local project should be included in this documentation. Its unclear what youre supposed to do here.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-clarify-mcp-dbt-labs.vercel.app/docs/dbt-ai/setup-local-mcp

<!-- end-vercel-deployment-preview -->