### PR TITLE
Add delete+insert incremental strategy support for dbt-databricks

### DIFF
--- a/website/docs/docs/build/incremental-strategy.md
+++ b/website/docs/docs/build/incremental-strategy.md
@@ -34,7 +34,7 @@ Click the name of the adapter in the following table for more information about 
 | [dbt-redshift](/reference/resource-configs/redshift-configs#incremental-materialization-strategies) |     ✅    |    ✅   |  ✅ |   |   ✅   |
 | [dbt-bigquery](/reference/resource-configs/bigquery-configs#merge-behavior-incremental-models)      |           |    ✅   |    | ✅ |  ✅    |
 | [dbt-spark](/reference/resource-configs/spark-configs#incremental-models)                           |     ✅    |    ✅   |    |    ✅   | ✅ |
-| [dbt-databricks](/reference/resource-configs/databricks-configs#incremental-models)                 |     ✅    |    ✅   |    |          ✅         |          ✅         |
+| [dbt-databricks](/reference/resource-configs/databricks-configs#incremental-models)                 |     ✅    |    ✅   | ✅ |          ✅         |          ✅         |
 | [dbt-snowflake](/reference/resource-configs/snowflake-configs#merge-behavior-incremental-models)    |     ✅    |    ✅   | ✅  | ✅ | ✅  |
 | [dbt-trino](/reference/resource-configs/trino-configs#incremental)                                  |     ✅    |    ✅   | ✅  |    |  ✅  |
 | [dbt-fabric](/reference/resource-configs/fabric-configs#incremental)                                |     ✅    |    ✅   | ✅  |    |    |


### PR DESCRIPTION
## Summary
- Added `✅` for `delete+insert` in the dbt-databricks row of the incremental strategy support table
- Detailed docs for this strategy already exist in [databricks-configs](/https://docs.getdbt.com/reference/resource-configs/databricks-configs#incremental-models)

## References
- dbt-databricks PR: https://github.com/databricks/dbt-databricks/pull/1237

## Test plan
- [x] Verify the incremental strategy table renders correctly with the new checkmark
- [x] Confirm the dbt-databricks row now shows support for `append`, `merge`, `delete+insert`, `insert_overwrite`, and `microbatch`