### PR TITLE
dbt metadata documentation

### DIFF
--- a/website/snippets/_generate-metadata.md
+++ b/website/snippets/_generate-metadata.md
@@ -18,13 +18,15 @@ Note that <Constant name="explorer" /> automatically deletes stale metadata afte
 
 | To view in <Constant name="explorer" /> | You must successfully run |
 |---------------------|---------------------------|
-| All metadata        |  [dbt build](/reference/commands/build), [dbt docs generate](/reference/commands/cmd-docs), and [dbt source freshness](/reference/commands/source#dbt-source-freshness) together as part of the same job in the environment
+| All metadata        | [dbt build](/reference/commands/build), [dbt docs generate](/reference/commands/cmd-docs), and [dbt source freshness](/reference/commands/source#dbt-source-freshness) together as part of the same job in the environment |
 | Model lineage, details, or results | [dbt run](/reference/commands/run) or [dbt build](/reference/commands/build) on a given model within a job in the environment |
-| Columns and statistics for models, sources, and snapshots| [dbt docs generate](/reference/commands/cmd-docs) within [a job](/docs/explore/build-and-view-your-docs) in the environment |
-| Test results | [dbt test](/reference/commands/test) or [dbt build](/reference/commands/build) within a job in the environment |
-| Source freshness results | [dbt source freshness](/reference/commands/source#dbt-source-freshness) within a job in the environment |
-| Snapshot details | [dbt snapshot](/reference/commands/snapshot) or [dbt build](/reference/commands/build) within a job in the environment |
+| Columns and statistics for models, sources, and snapshots | [dbt docs generate](/reference/commands/cmd-docs) within [a job](/docs/explore/build-and-view-your-docs) in the environment |
+| Data test results | [dbt test](/reference/commands/test) or [dbt build](/reference/commands/build) within a job in the environment |
+| Unit test results | [dbt test](/reference/commands/test) or [dbt build](/reference/commands/build) within a job in the environment. Unit tests are typically run in development or CI environments only. |
+| Source freshness results | [dbt source freshness](/reference/commands/source#dbt-source-freshness) within a job in the environment |
+| Snapshot details | [dbt snapshot](/reference/commands/snapshot) or [dbt build](/reference/commands/build) within a job in the environment |
 | Seed details | [dbt seed](/reference/commands/seed) or [dbt build](/reference/commands/build) within a job in the environment |
+| Exposure details | [dbt docs generate](/reference/commands/cmd-docs) within a job in the environment. Exposures are defined in YAML files. |
+| Metrics, semantic models, and saved queries | [dbt docs generate](/reference/commands/cmd-docs) within a job in the environment. These [<Constant name="semantic_layer" />](/docs/use-dbt-semantic-layer/dbt-sl) resources are defined in YAML files. |
 
 Richer and more timely metadata will become available as <Constant name="cloud" /> evolves.
-


### PR DESCRIPTION
## What are you changing in this pull request and why?
The existing dbt metadata table on the `explore-projects` page was incomplete, missing several resource types that are now part of dbt. This update ensures the documentation accurately reflects all metadata available for exploration in dbt Cloud.

Specifically, this PR:
*   Renames "Test results" to "Data test results" for better distinction.
*   Adds new entries for "Unit test results", "Exposure details", and "Metrics, semantic models, and saved queries" (for Semantic Layer resources), including the commands required to generate their metadata.
*   Corrects minor table formatting for consistency.

_Note: The original request referenced a Slack thread which was inaccessible. This update is based on an assessment of missing resource types in the current documentation._

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).

---
[Slack Thread](https://dbt-labs.slack.com/archives/C0A16RWFC4E/p1770841413340899?thread_ts=1770841413.340899&cid=C0A16RWFC4E)

<p><a href="https://cursor.com/background-agent?bcId=bc-0bdb357a-1d12-52bd-a09e-7bdc157e8bcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0bdb357a-1d12-52bd-a09e-7bdc157e8bcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

