### PR TITLE
Update validation command from 'validate-configs' to 'validate'

### DIFF
--- a/website/docs/docs/build/validation.md
+++ b/website/docs/docs/build/validation.md
@@ -14,7 +14,7 @@ The code that handles validation [can be found here](https://github.com/dbt-labs
 
 ## Validations command
 
-You can run validations from the <Constant name="dbt_platform" /> or the command line with the following [MetricFlow commands](/docs/build/metricflow-commands). In <Constant name="cloud" />, you need developer credentials to run `dbt sl validate-configs` in the IDE or CLI, and deployment credentials to run it in CI.
+You can run validations from the <Constant name="dbt_platform" /> or the command line with the following [MetricFlow commands](/docs/build/metricflow-commands). In <Constant name="cloud" />, you need developer credentials to run `dbt sl validate` in the IDE or CLI, and deployment credentials to run it in CI.
 
 ```bash
 # dbt platform and Fusion users in IDE / Cloud CLI


### PR DESCRIPTION
Fix typo

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-b-per-patch-1-dbt-labs.vercel.app/docs/build/validation

<!-- end-vercel-deployment-preview -->