### PR TITLE
clarify default for updates_on

### DIFF
--- a/website/docs/reference/resource-configs/freshness.md
+++ b/website/docs/reference/resource-configs/freshness.md
@@ -25,7 +25,7 @@ models:
       build_after:  # build this model no more often than every X amount of time, as long as it has new data. Available only on dbt platform Enterprise tiers. 
         count: <positive_integer>
         period: minute | hour | day
-        updates_on: any | all # optional config
+        updates_on: any | all # optional config, default is `any`
 ```
   
 </File>
@@ -43,7 +43,7 @@ models:
         build_after:  # build this model no more often than every X amount of time, as long as it has new data. Available only on dbt platform Enterprise tiers. 
           count: <positive_integer>
           period: minute | hour | day
-          updates_on: any | all # optional config
+          updates_on: any | all # optional config, default is `any`
 ```
   
 </File>
@@ -59,7 +59,7 @@ models:
         "build_after": {     # build this model no more often than every X amount of time, as long as as it has new data
         "count": <positive_integer>,
         "period": "minute" | "hour" | "day",
-        "updates_on": "any" | "all" # optional config
+        "updates_on": "any" | "all" # optional config, default is `any`
         } 
       }
     )
@@ -87,7 +87,7 @@ The configuration consists of the following parts:
 |--------------|-------------|
 | `build_after` | Available on dbt platform Enterprise tiers only. Config nested under `freshness`. Used to determine whether a model should be rebuilt when new data is present, based on whether the specified count and period have passed since the model was last built. Although dbt checks for new data every time the job runs, `build_after` ensures the model is only rebuilt if enough time has passed and new data is available. |
 | `count` and `period` | Specify how often dbt should check for new data. For example, `count: 4, period: hour` means dbt will check every 4 hours.<br /><br /> Note that for every `freshness` config, you're required to either set values for both `count` and `period`, or set `freshness: null`.|
-| `updates_on` | Optional. Default is `any`. Determines when upstream data changes should trigger a job build. Use the following values:<br /> - `any`: The model will build once _any_ direct upstream node has new data since the last build. Faster and may increase spend.<br /> - `all`: The model will only build when _all_ direct upstream nodes have new data since the last build. Less spend and more requirements. |
+| `updates_on` | Optional. Default is `any`. Determines when upstream data changes should trigger a job build. Use the following values:<br /> - `any` (default): The model will build once _any_ direct upstream node has new data since the last build. Faster and may increase spend.<br /> - `all`: The model will only build when _all_ direct upstream nodes have new data since the last build. Less spend and more requirements. |
 
 ## Default
 

--- a/website/docs/reference/resource-configs/freshness.md
+++ b/website/docs/reference/resource-configs/freshness.md
@@ -87,7 +87,7 @@ The configuration consists of the following parts:
 |--------------|-------------|
 | `build_after` | Available on dbt platform Enterprise tiers only. Config nested under `freshness`. Used to determine whether a model should be rebuilt when new data is present, based on whether the specified count and period have passed since the model was last built. Although dbt checks for new data every time the job runs, `build_after` ensures the model is only rebuilt if enough time has passed and new data is available. |
 | `count` and `period` | Specify how often dbt should check for new data. For example, `count: 4, period: hour` means dbt will check every 4 hours.<br /><br /> Note that for every `freshness` config, you're required to either set values for both `count` and `period`, or set `freshness: null`.|
-| `updates_on` | Optional. Determines when upstream data changes should trigger a job build. Use the following values:<br /> - `any`: The model will build once _any_ direct upstream node has new data since the last build. Faster and may increase spend.<br /> - `all`: The model will only build when _all_ direct upstream nodes have new data since the last build. Less spend and more requirements. |
+| `updates_on` | Optional. Default is `any`. Determines when upstream data changes should trigger a job build. Use the following values:<br /> - `any`: The model will build once _any_ direct upstream node has new data since the last build. Faster and may increase spend.<br /> - `all`: The model will only build when _all_ direct upstream nodes have new data since the last build. Less spend and more requirements. |
 
 ## Default
 
@@ -100,7 +100,7 @@ build_after:
   updates_on: any
 ```
 
-This means that by default, the model will be built every time a scheduled job runs for any amount of new data.
+The default for `updates_on` is `any`. This means that by default, the model will be built every time a scheduled job runs for any amount of new data.
 
 ## Examples
 


### PR DESCRIPTION
clarifies that `updates_on` default is `any` per internal slack request https://dbt-labs.slack.com/archives/C02NCQ9483C/p1771589217995329

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-updates-on-dbt-labs.vercel.app/reference/resource-configs/freshness

<!-- end-vercel-deployment-preview -->