### PR TITLE
Fix casing of 'engine' in fusion_engine constant

### DIFF
--- a/website/constants.js
+++ b/website/constants.js
@@ -12,7 +12,7 @@ export const CONSTANTS = {
   dbt_platform: 'dbt platform',
   core: 'dbt Core',
   fusion: 'Fusion',
-  fusion_engine: 'dbt Fusion Engine',
+  fusion_engine: 'dbt Fusion engine',
   dbt: 'dbt',
   cloud_cli: 'dbt CLI',
   explorer: 'Catalog',


### PR DESCRIPTION
Corrected the casing of 'engine' in the fusion_engine constant per PMM