### PR TITLE
Setup Datadog RUM Monitoring for Core Web Vitals

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -18,6 +18,17 @@ const GIT_BRANCH = process?.env?.VERCEL_GIT_COMMIT_REF;
 
 let { ALGOLIA_APP_ID, ALGOLIA_API_KEY, ALGOLIA_INDEX_NAME } = process.env;
 
+// Datadog RUM (Core Web Vitals) - env vars at build time
+const datadogConfig = {
+  applicationId: process.env.DD_APP_ID || '',
+  clientToken: process.env.DD_CLIENT_TOKEN || '',
+  service: process.env.DD_SERVICE || 'docs-getdbt-com',
+  env: process.env.DD_ENV || process.env.VERCEL_ENV || 'production',
+  version: process.env.VERCEL_GIT_COMMIT_SHA || process.env.VERCEL_GIT_SHA || 'unknown',
+  sessionSampleRate: parseInt(process.env.DD_SAMPLE_RATE || '25', 10),
+  sessionReplaySampleRate: parseInt(process.env.DD_SESSION_REPLAY_SAMPLE_RATE || '10', 10),
+};
+
 let metatags = [];
 // If not `current` and not `main` branch, do not index site
 if (GIT_BRANCH && (GIT_BRANCH !== "current" && GIT_BRANCH !== "main")) {
@@ -45,6 +56,7 @@ var siteSettings = {
   tagline: "End user documentation, guides and technical reference for dbt",
   title: "dbt Developer Hub",
   url: SITE_URL,
+  datadog: datadogConfig,
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "throw",
   trailingSlash: false,

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -18,17 +18,6 @@ const GIT_BRANCH = process?.env?.VERCEL_GIT_COMMIT_REF;
 
 let { ALGOLIA_APP_ID, ALGOLIA_API_KEY, ALGOLIA_INDEX_NAME } = process.env;
 
-// Datadog RUM (Core Web Vitals) - env vars at build time
-const datadogConfig = {
-  applicationId: process.env.DD_APP_ID || '',
-  clientToken: process.env.DD_CLIENT_TOKEN || '',
-  service: process.env.DD_SERVICE || 'docs-getdbt-com',
-  env: process.env.DD_ENV || process.env.VERCEL_ENV || 'production',
-  version: process.env.VERCEL_GIT_COMMIT_SHA || process.env.VERCEL_GIT_SHA || 'unknown',
-  sessionSampleRate: parseInt(process.env.DD_SAMPLE_RATE || '25', 10),
-  sessionReplaySampleRate: parseInt(process.env.DD_SESSION_REPLAY_SAMPLE_RATE || '10', 10),
-};
-
 let metatags = [];
 // If not `current` and not `main` branch, do not index site
 if (GIT_BRANCH && (GIT_BRANCH !== "current" && GIT_BRANCH !== "main")) {
@@ -56,7 +45,6 @@ var siteSettings = {
   tagline: "End user documentation, guides and technical reference for dbt",
   title: "dbt Developer Hub",
   url: SITE_URL,
-  datadog: datadogConfig,
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "throw",
   trailingSlash: false,

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "version": "0.0.0",
       "dependencies": {
+        "@datadog/browser-rum": "^6.27.1",
         "@docusaurus/core": "^3.7.0",
         "@docusaurus/faster": "^3.7.0",
         "@docusaurus/plugin-ideal-image": "^3.7.0",
@@ -3357,6 +3358,39 @@
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/@datadog/browser-core": {
+      "version": "6.28.1",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-6.28.1.tgz",
+      "integrity": "sha512-h5y6aEyMTBZ091Y1mVLe2ta2YHiBa1qEEHliIp7+lb7rMZ1uWzYUzAu83bmTfvgI/yEZdHcVeTjxMucAncwK3g==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@datadog/browser-rum": {
+      "version": "6.28.1",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-6.28.1.tgz",
+      "integrity": "sha512-7KwMvhVsvTdt6OtB3dnSW8KZDycne3hAI96+CcWUII6Wg9Xv+UH1dbIW1skDHp9ANmLl1DZrSs9XdWCYR7rqSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@datadog/browser-core": "6.28.1",
+        "@datadog/browser-rum-core": "6.28.1"
+      },
+      "peerDependencies": {
+        "@datadog/browser-logs": "6.28.1"
+      },
+      "peerDependenciesMeta": {
+        "@datadog/browser-logs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@datadog/browser-rum-core": {
+      "version": "6.28.1",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-6.28.1.tgz",
+      "integrity": "sha512-/Eu2YuQkpdZk4GvQi4AV1/dt60qrEt0HTQC53PXoWav7SGx2UNWlTCxO6wio6kzgmlkyqa/gCscWqnUsQPWWXg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@datadog/browser-core": "6.28.1"
       }
     },
     "node_modules/@dbt-labs/react-dbt-dag": {

--- a/website/package.json
+++ b/website/package.json
@@ -11,6 +11,7 @@
     "cleanup-duplicates": "node scripts/cleanup_duplicate_constants.js"
   },
   "dependencies": {
+    "@datadog/browser-rum": "^6.27.1",
     "@docusaurus/core": "^3.7.0",
     "@docusaurus/faster": "^3.7.0",
     "@docusaurus/plugin-ideal-image": "^3.7.0",

--- a/website/plugins/customWebpackConfig/index.js
+++ b/website/plugins/customWebpackConfig/index.js
@@ -19,6 +19,14 @@ module.exports = function customWebpackConfigPlugin() {
             "process.versions.node": JSON.stringify(
               process.versions.node || "0.0.0"
             ),
+            // Datadog RUM - injected at build time for client bundle
+            "process.env.DD_APP_ID": JSON.stringify(process.env.DD_APP_ID || ""),
+            "process.env.DD_CLIENT_TOKEN": JSON.stringify(process.env.DD_CLIENT_TOKEN || ""),
+            "process.env.DD_SERVICE": JSON.stringify(process.env.DD_SERVICE || "docs-getdbt-com"),
+            "process.env.DD_ENV": JSON.stringify(process.env.DD_ENV || process.env.VERCEL_ENV || "production"),
+            "process.env.DD_VERSION": JSON.stringify(process.env.VERCEL_GIT_COMMIT_SHA || process.env.VERCEL_GIT_SHA || "unknown"),
+            "process.env.DD_SAMPLE_RATE": JSON.stringify(process.env.DD_SAMPLE_RATE || "25"),
+            "process.env.DD_SESSION_REPLAY_SAMPLE_RATE": JSON.stringify(process.env.DD_SESSION_REPLAY_SAMPLE_RATE || "10"),
           }),
           new NodePolyfillPlugin({}),
         ],

--- a/website/src/components/DatadogInitializer.js
+++ b/website/src/components/DatadogInitializer.js
@@ -1,23 +1,41 @@
 /**
  * Initializes Datadog RUM when consent is given (OneTrust performance group).
- * Renders nothing; runs once on mount and reacts to consent changes.
+ * Config is injected at build time via webpack DefinePlugin (see plugins/customWebpackConfig).
  */
 
 import { useEffect } from 'react';
 import { datadogRum } from '@datadog/browser-rum';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import { initDatadogRum } from '../utils/datadog';
 import { hasPerformanceConsent, onConsentChanged } from '../utils/consent';
 
 let isRumInitialized = false;
 
-export function DatadogInitializer() {
-  const { siteConfig } = useDocusaurusContext();
-  const datadogConfig = siteConfig?.datadog;
+// Build config from env (injected at build time by customWebpackConfig)
+function getDatadogConfig() {
+  return {
+    applicationId: process.env.DD_APP_ID || '',
+    clientToken: process.env.DD_CLIENT_TOKEN || '',
+    service: process.env.DD_SERVICE || 'docs-getdbt-com',
+    env: process.env.DD_ENV || 'production',
+    version: process.env.DD_VERSION || 'unknown',
+    sessionSampleRate: parseInt(process.env.DD_SAMPLE_RATE || '25', 10),
+    sessionReplaySampleRate: parseInt(process.env.DD_SESSION_REPLAY_SAMPLE_RATE || '10', 10),
+  };
+}
 
+export function DatadogInitializer() {
   useEffect(() => {
+    const datadogConfig = getDatadogConfig();
+    console.log("DEBUG: datadogConfig =", {
+      service: datadogConfig.service,
+      env: datadogConfig.env,
+      version: datadogConfig.version,
+      sessionSampleRate: datadogConfig.sessionSampleRate,
+      sessionReplaySampleRate: datadogConfig.sessionReplaySampleRate,
+    });
+
     const initRUM = () => {
-      if (isRumInitialized || !datadogConfig) return;
+      if (isRumInitialized || !datadogConfig.applicationId || !datadogConfig.clientToken) return;
 
       initDatadogRum(datadogConfig);
       isRumInitialized = true;
@@ -25,6 +43,8 @@ export function DatadogInitializer() {
 
     const disableRUM = () => {
       if (!isRumInitialized) return;
+
+      console.log("DEBUG: disabling RUM");
 
       // Clear any user-identifying context
       datadogRum.setGlobalContext({
@@ -43,6 +63,8 @@ export function DatadogInitializer() {
       const hasConsent =
         process.env.NODE_ENV === 'development' || hasPerformanceConsent();
 
+      console.log("DEBUG: hasConsent =", hasConsent);
+
       if (hasConsent) {
         initRUM();
       } else {
@@ -55,13 +77,14 @@ export function DatadogInitializer() {
 
     // 2. Listen for OneTrust updates (handles timing issue)
     const removeListener = onConsentChanged(() => {
+      console.log("DEBUG: consent changed");
       evaluateConsent();
     });
 
     return () => {
       removeListener?.();
     };
-  }, [datadogConfig]);
+  }, []);
 
   return null;
 }

--- a/website/src/components/DatadogInitializer.js
+++ b/website/src/components/DatadogInitializer.js
@@ -26,14 +26,7 @@ function getDatadogConfig() {
 export function DatadogInitializer() {
   useEffect(() => {
     const datadogConfig = getDatadogConfig();
-    console.log("DEBUG: datadogConfig =", {
-      service: datadogConfig.service,
-      env: datadogConfig.env,
-      version: datadogConfig.version,
-      sessionSampleRate: datadogConfig.sessionSampleRate,
-      sessionReplaySampleRate: datadogConfig.sessionReplaySampleRate,
-    });
-
+  
     const initRUM = () => {
       if (isRumInitialized || !datadogConfig.applicationId || !datadogConfig.clientToken) return;
 
@@ -43,8 +36,6 @@ export function DatadogInitializer() {
 
     const disableRUM = () => {
       if (!isRumInitialized) return;
-
-      console.log("DEBUG: disabling RUM");
 
       // Clear any user-identifying context
       datadogRum.setGlobalContext({
@@ -63,8 +54,6 @@ export function DatadogInitializer() {
       const hasConsent =
         process.env.NODE_ENV === 'development' || hasPerformanceConsent();
 
-      console.log("DEBUG: hasConsent =", hasConsent);
-
       if (hasConsent) {
         initRUM();
       } else {
@@ -77,7 +66,6 @@ export function DatadogInitializer() {
 
     // 2. Listen for OneTrust updates (handles timing issue)
     const removeListener = onConsentChanged(() => {
-      console.log("DEBUG: consent changed");
       evaluateConsent();
     });
 

--- a/website/src/components/DatadogInitializer.js
+++ b/website/src/components/DatadogInitializer.js
@@ -1,0 +1,67 @@
+/**
+ * Initializes Datadog RUM when consent is given (OneTrust performance group).
+ * Renders nothing; runs once on mount and reacts to consent changes.
+ */
+
+import { useEffect } from 'react';
+import { datadogRum } from '@datadog/browser-rum';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import { initDatadogRum } from '../utils/datadog';
+import { hasPerformanceConsent, onConsentChanged } from '../utils/consent';
+
+let isRumInitialized = false;
+
+export function DatadogInitializer() {
+  const { siteConfig } = useDocusaurusContext();
+  const datadogConfig = siteConfig?.datadog;
+
+  useEffect(() => {
+    const initRUM = () => {
+      if (isRumInitialized || !datadogConfig) return;
+
+      initDatadogRum(datadogConfig);
+      isRumInitialized = true;
+    };
+
+    const disableRUM = () => {
+      if (!isRumInitialized) return;
+
+      // Clear any user-identifying context
+      datadogRum.setGlobalContext({
+        user: {
+          id: undefined,
+          name: undefined,
+          email: undefined,
+        },
+      });
+
+      // NOTE: Datadog RUM cannot be fully "stopped" once initialized.
+      // This ensures no PII continues being sent.
+    };
+
+    const evaluateConsent = () => {
+      const hasConsent =
+        process.env.NODE_ENV === 'development' || hasPerformanceConsent();
+
+      if (hasConsent) {
+        initRUM();
+      } else {
+        disableRUM();
+      }
+    };
+
+    // 1. Attempt immediately (handles non-GDPR + already-loaded OneTrust)
+    evaluateConsent();
+
+    // 2. Listen for OneTrust updates (handles timing issue)
+    const removeListener = onConsentChanged(() => {
+      evaluateConsent();
+    });
+
+    return () => {
+      removeListener?.();
+    };
+  }, [datadogConfig]);
+
+  return null;
+}

--- a/website/src/theme/Root.js
+++ b/website/src/theme/Root.js
@@ -1,10 +1,12 @@
 import React from 'react'
 import { VersionContextProvider } from '../stores/VersionContext'
+import { DatadogInitializer } from '../components/DatadogInitializer'
 
 // Default implementation, that you can customize
 function Root({children}) {
   return (
     <VersionContextProvider>
+      <DatadogInitializer />
       {children}
     </VersionContextProvider>
   )

--- a/website/src/utils/consent.js
+++ b/website/src/utils/consent.js
@@ -1,0 +1,29 @@
+/**
+ * OneTrust consent helpers for performance/cookie consent.
+ * Used to gate Datadog RUM (Core Web Vitals) on user consent.
+ */
+
+const PERFORMANCE_GROUP_ID = 'C0002';
+
+export function hasPerformanceConsent() {
+  if (typeof window === 'undefined') return false;
+
+  const groups = window.OnetrustActiveGroups || '';
+  return groups.split(',').includes(PERFORMANCE_GROUP_ID);
+}
+
+/**
+ * Listen for OneTrust consent updates.
+ * Returns a function to remove the listener, or undefined when not in browser.
+ */
+export function onConsentChanged(callback) {
+  if (typeof window === 'undefined') return undefined;
+
+  const handler = () => {
+    callback();
+  };
+  window.addEventListener('OneTrustGroupsUpdated', handler);
+  return () => {
+    window.removeEventListener('OneTrustGroupsUpdated', handler);
+  };
+}

--- a/website/src/utils/datadog.js
+++ b/website/src/utils/datadog.js
@@ -1,0 +1,43 @@
+/**
+ * Datadog RUM initialization for Core Web Vitals and session replay.
+ * Config is passed from docusaurus.config.js (build-time env vars).
+ */
+
+import { datadogRum } from '@datadog/browser-rum';
+
+let initialized = false;
+
+/**
+ * @param {Object} config - From siteConfig.datadog (DD_APP_ID, DD_CLIENT_TOKEN, etc.)
+ */
+export function initDatadogRum(config) {
+  if (
+    initialized ||
+    !config?.applicationId ||
+    !config?.clientToken ||
+    typeof window === 'undefined'
+  ) {
+    return;
+  }
+
+  datadogRum.init({
+    applicationId: config.applicationId,
+    clientToken: config.clientToken,
+    site: 'datadoghq.com',
+
+    service: config.service || 'docs-getdbt-com',
+    env: config.env || 'production',
+    version: config.version || 'unknown',
+
+    sessionSampleRate: config.sessionSampleRate ?? 25,
+    sessionReplaySampleRate: config.sessionReplaySampleRate ?? 10,
+
+    trackResources: true,
+    trackLongTasks: true,
+    trackUserInteractions: true,
+
+    defaultPrivacyLevel: 'mask-user-input',
+  });
+
+  initialized = true;
+}


### PR DESCRIPTION
## What are you changing in this pull request and why?
[Task](https://www.notion.so/dbtlabs/Core-Web-Vitals-reporting-Engineering-2aebb38ebda780e4ab13d30c9e077b14?source=copy_link)

Adds Datadog RUM Monitoring for tracking Core Web Vitals.

Created a Notion template to report on the metrics on a monthly cadence: https://www.notion.so/dbtlabs/Demo-for-review-Core-Web-Vitals-Monthly-Report-313bb38ebda78092be7acc0914c90c36?source=copy_link

## Preview

https://docs-getdbt-com-git-datadog-web-vitals-dbt-labs.vercel.app/

1. Click around on the site and visit multiple pages
2. Verify `browser-intake` appears in network tab
3. Verify Datadog picking up site in RUM Monitoring (link to Datadog in www pr [here](https://github.com/dbt-labs/www.getdbt.com-replatforming/pull/642))