### PR TITLE
Create rehype plugin that readds markdown codeblock language to codeblocks

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,6 +1,7 @@
 import path from "path";
 import math from "remark-math";
 import katex from "rehype-katex";
+import rehypeCodeLanguage from "./plugins/rehypeCodeLanguage.js";
 const { themes } = require('prism-react-renderer')
 
 const { versions, versionedPages, versionedCategories } = require("./dbt-versions");
@@ -373,6 +374,9 @@ var siteSettings = {
           enableMarkdownFiles: true,
           enableLlmsFullTxt: true,
           relativePaths: false,
+        },
+        processing: {
+          beforeDefaultRehypePlugins: [rehypeCodeLanguage],
         },
         include: {
           includeBlog: false,

--- a/website/plugins/rehypeCodeLanguage.js
+++ b/website/plugins/rehypeCodeLanguage.js
@@ -1,0 +1,46 @@
+/**
+ * Rehype plugin that copies language-* classes from <pre> to child <code>.
+ *
+ * Docusaurus renders code blocks as:
+ *   <pre class="prism-code language-sql ..."><code class="codeBlockLines_xxx">
+ *
+ * But hast-util-to-mdast only looks for language-* on <code>, not <pre>.
+ * This plugin bridges that gap so the llms-txt plugin preserves
+ * code fence language identifiers (e.g. ```sql instead of ```).
+ */
+import { visit } from "unist-util-visit";
+
+export default function rehypeCodeLanguage() {
+  return (tree) => {
+    visit(tree, "element", (node) => {
+      if (node.tagName !== "pre") return;
+
+      const preClasses = node.properties?.className;
+      if (!Array.isArray(preClasses)) return;
+
+      const langClass = preClasses.find(
+        (c) => typeof c === "string" && c.startsWith("language-")
+      );
+      if (!langClass) return;
+
+      const codeChild = node.children?.find(
+        (child) => child.type === "element" && child.tagName === "code"
+      );
+      if (!codeChild) return;
+
+      if (!codeChild.properties) {
+        codeChild.properties = {};
+      }
+      if (!Array.isArray(codeChild.properties.className)) {
+        codeChild.properties.className = [];
+      }
+
+      const alreadyHasLang = codeChild.properties.className.some(
+        (c) => typeof c === "string" && c.startsWith("language-")
+      );
+      if (!alreadyHasLang) {
+        codeChild.properties.className.push(langClass);
+      }
+    });
+  };
+}


### PR DESCRIPTION
See https://docusaurus.io/docs/markdown-features/plugins

This plugin adds the language from codeblocks into the final built markdown, for pages like
https://docs.getdbt.com/reference/dbt-jinja-functions/source.md.

E.g:

```sql
select 1
```

Compiles to:

```
select 1
```

This plugin re-adds the sql block.

---

Context: I'm building a plugin for JetBrains IDEs (PyCharm, IntelliJ, DataSpelll etc), and have a documentation provider that shows documentation on hover, e.g for ref:

<img width="2189" height="1228" alt="image" src="https://github.com/user-attachments/assets/7fd29082-1cef-4159-b656-ce59ab3974ec" />

But the compiled markdown files don't contain the types, so it loses its syntax highlighting.