### PR TITLE
Power BI time granularity docs

### DIFF
--- a/website/docs/docs/cloud-integrations/semantic-layer/power-bi.md
+++ b/website/docs/docs/cloud-integrations/semantic-layer/power-bi.md
@@ -125,13 +125,11 @@ These tables do not actually map to an underlying table in your data warehouse. 
 
 This allows for very flexible analytics workflows, like drag and drop metrics and slice by dimensions and entities &mdash; the <Constant name="semantic_layer" /> will generate the appropriate SQL to actually query your data source for you.
 
-### Modifying time granularity
+#### Modifying time granularity
 
-When you select time dimensions to group by, you'll see a list of available time granularities. The lowest granularity is selected by default. Metric time is the default time dimension for grouping your metrics.
+import SlCustomGranularity from '/snippets/_sl-custom-granularity.md';
 
-:::info 
-Note: [Custom time granularities](/docs/build/metricflow-time-spine#add-custom-granularities) (like fiscal year) aren't currently supported or accessible in this integration. Only [standard granularities](/docs/build/dimensions?dimension=time_gran#time) (like day, week, month, and so on) are available. If you'd like to access custom granularities, consider using the [Semantic Layer APIs](/docs/dbt-cloud-apis/sl-api-overview).
-:::
+<SlCustomGranularity />
 
 ## Considerations
 

--- a/website/docs/docs/cloud-integrations/semantic-layer/power-bi.md
+++ b/website/docs/docs/cloud-integrations/semantic-layer/power-bi.md
@@ -125,6 +125,14 @@ These tables do not actually map to an underlying table in your data warehouse. 
 
 This allows for very flexible analytics workflows, like drag and drop metrics and slice by dimensions and entities &mdash; the <Constant name="semantic_layer" /> will generate the appropriate SQL to actually query your data source for you.
 
+### Modifying time granularity
+
+When you select time dimensions to group by, you'll see a list of available time granularities. The lowest granularity is selected by default. Metric time is the default time dimension for grouping your metrics.
+
+:::info 
+Note: [Custom time granularities](/docs/build/metricflow-time-spine#add-custom-granularities) (like fiscal year) aren't currently supported or accessible in this integration. Only [standard granularities](/docs/build/dimensions?dimension=time_gran#time) (like day, week, month, and so on) are available. If you'd like to access custom granularities, consider using the [Semantic Layer APIs](/docs/dbt-cloud-apis/sl-api-overview).
+:::
+
 ## Considerations
 
 <Expandable alt_header="Not every “column” of METRICS.ALL are compatible with every other column">

--- a/website/docs/docs/cloud-integrations/semantic-layer/tableau.md
+++ b/website/docs/docs/cloud-integrations/semantic-layer/tableau.md
@@ -53,9 +53,17 @@ Alternatively, you can follow these steps to install the connector. Note that th
 
 Visit the [Tableau documentation](https://help.tableau.com/current/pro/desktop/en-us/gettingstarted_overview.htm) to learn more about how to use Tableau worksheets and dashboards.
 
+
 ### Publish from Tableau Desktop to Tableau Server
 
 - **From Desktop to Server** &mdash; Like any Tableau workflow, you can publish your workbook from Tableau Desktop to Tableau Server. For step-by-step instructions, visit Tableau's [publishing guide](https://help.tableau.com/current/pro/desktop/en-us/publish_workbooks_share.htm).
+
+
+#### Modifying time granularity
+
+import SlCustomGranularity from '/snippets/_sl-custom-granularity.md';
+
+<SlCustomGranularity />
 
 ## Things to note
 

--- a/website/snippets/_sl-custom-granularity.md
+++ b/website/snippets/_sl-custom-granularity.md
@@ -1,0 +1,5 @@
+<p>When you select time dimensions in the <strong>Group By</strong> menu, you'll see a list of available time granularities. The lowest granularity is selected by default. Metric time is the default time dimension for grouping your metrics.</p>
+
+:::info 
+Note: [Custom time granularities](/docs/build/metricflow-time-spine#add-custom-granularities) (like fiscal year) aren't currently supported or accessible in this integration. Only [standard granularities](/docs/build/dimensions?dimension=time_gran#time) (like day, week, month, and so on) are available. If you'd like to access custom granularities, consider using the [Semantic Layer APIs](/docs/dbt-cloud-apis/sl-api-overview).
+:::

--- a/website/snippets/_sl-excel-gsheets.md
+++ b/website/snippets/_sl-excel-gsheets.md
@@ -53,11 +53,9 @@
 
 #### Modifying time granularity
 
-<p>When you select time dimensions in the <strong>Group By</strong> menu, you'll see a list of available time granularities. The lowest granularity is selected by default. Metric time is the default time dimension for grouping your metrics.</p>
+import SlCustomGranularity from '/snippets/_sl-custom-granularity.md';
 
-:::info 
-Note: [Custom time granularities](/docs/build/metricflow-time-spine#add-custom-granularities) (like fiscal year) aren't currently supported or accessible in this integration. Only [standard granularities](/docs/build/dimensions?dimension=time_gran#time) (like day, week, month, and so on) are available. If you'd like to access custom granularities, consider using the [Semantic Layer APIs](/docs/dbt-cloud-apis/sl-api-overview).
-:::
+<SlCustomGranularity />
 
 #### Filtering data
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What are you changing in this pull request and why?
This PR adds a new "Modifying time granularity" snippet subsection to the all the SL integration docs. This content, previously available in the Excel docs, explains how to select time dimensions and granularity options within the connectors.

This change ensures consistency and completeness across the documentation for different semantic layer connectors.

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).

---
[Slack Thread](https://dbt-labs.slack.com/archives/C0A16RWFC4E/p1772791243875109?thread_ts=1772791243.875109&cid=C0A16RWFC4E)

<p><a href="https://cursor.com/agents/bc-aec61fcd-879f-4753-a753-7d193c16fe55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aec61fcd-879f-4753-a753-7d193c16fe55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->