### PR TITLE
Re-add adapter property table

### DIFF
--- a/website/docs/reference/global-configs/behavior-changes.md
+++ b/website/docs/reference/global-configs/behavior-changes.md
@@ -116,6 +116,7 @@ This table outlines which version of the dbt adapter contains the behavior chang
 | [use_info_schema_for_columns](/reference/global-configs/databricks-changes#use-information-schema-for-columns) | Databricks 1.9.0                   | TBD | ✅ |
 | [use_user_folder_for_python](/reference/global-configs/databricks-changes#use-users-folder-for-python-model-notebooks)  | Databricks 1.9.0                   | TBD  | ✅ |
 | [use_materialization_v2](/reference/global-configs/databricks-changes#use-restructured-materializations)      | Databricks 1.10.0                  | TBD| - |
+| [use_replace_on_for_insert_overwrite](/reference/global-configs/databricks-changes#use-replace-on-for-insert_overwrite-strategy)   | Databricks 1.11.0  | 1.11.0  | - |
 | [enable_truthy_nulls_equals_macro](/reference/global-configs/snowflake-changes#the-enable_truthy_nulls_equals_macro-flag) | Snowflake 1.9.0 | TBD | - |
 | [restrict_direct_pg_catalog_access](/reference/global-configs/redshift-changes#the-restrict_direct_pg_catalog_access-flag) | Redshift 1.9.0 | TBD | - |
 | [redshift_skip_autocommit_transaction_statements](/reference/global-configs/redshift-changes#redshift_skip_autocommit_transaction_statements-flag) | Redshift 1.12.0 | TBD | - |

--- a/website/docs/reference/global-configs/databricks-changes.md
+++ b/website/docs/reference/global-configs/databricks-changes.md
@@ -11,8 +11,7 @@ The following are the current [behavior change flags](/docs/reference/global-con
 | [`use_info_schema_for_columns`](#use-information-schema-for-columns) | 1.9.0                   | N/A                        | **Removed in 1.11.0** |
 | [`use_user_folder_for_python`](#use-users-folder-for-python-model-notebooks)  | 1.9.0                   | 1.11.0                     | Default changed to `True` |
 | [`use_materialization_v2`](#use-restructured-materializations)      | 1.10.0                  | TBD                        | Active |
-| [`use_managed_iceberg`](#use-managed-iceberg)  | 1.11.0  |  1.12.0                                                     | Active |
-| [`use_replace_on_for_insert_overwrite`](#use-replace-on-for-insert_overwrite-strategy)   | 1.11.0   | 1.12.0                    | Active, defaults to `True` |
+| [`use_replace_on_for_insert_overwrite`](#use-replace-on-for-insert_overwrite-strategy)   | 1.11.0   | 1.11.0                    | Active, defaults to `True` |
 
 ## Use information schema for columns
 
@@ -203,13 +202,24 @@ models:
 
 </File>
 
-## Use managed Iceberg
-
-When you set `table_format` to `iceberg`, the `use_managed_iceberg` flag controls how the table is created. By default, this flag is set to `False` and dbt creates a [UniForm](https://www.databricks.com/blog/delta-uniform-universal-format-lakehouse-interoperability) table. When set to `True`, dbt creates a [managed Iceberg](https://docs.databricks.com/aws/en/tables/managed) table.
 
 ## Use `replace on` for `insert_overwrite` strategy
 
-The `use_replace_on_for_insert_overwrite` flag is only relevant when using incremental models with the `insert_overwrite` strategy on SQL warehouses. The flag is `True` by default and results in using the [`insert into ... replace on`](https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-syntax-dml-insert-into#replace-on) syntax to perform dynamic partition/cluster overwrites, which is the same behavior as in cluster computes. When the flag is set to `False`, `insert_overwrite` will truncate the entire table when used with SQL warehouses. The flag is not relevant for cluster computes because the `insert_overwrite`'s behavior has always been dynamic partition/cluster overwrites in cluster computes.
+The `use_replace_on_for_insert_overwrite` flag controls which SQL syntax dbt generates for incremental models using the `insert_overwrite` strategy. This flag defaults to `True`.
 
-If you previously relied on this behavior to get full table replacement without dropping existing metadata, that behavior continues to exist with the flag set to `True`, provided you do not use any partitions or liquid clustering clusters.
-These data layout optimizations only tend to have a significant effect for tables that are approximately 1 TB large or greater, at which point regular replacement of all of the data is probably not the best approach.
+<SimpleTable>
+
+| Flag value | SQL generated | Description |
+|---|---|---|
+| `True` (default) | [`INSERT INTO ... REPLACE ON`](https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-syntax-dml-insert-into#replace-on) | Uses the latest, recommended Databricks syntax to replace matching partitions.  |
+| `False` | `INSERT OVERWRITE` | Uses the older Spark syntax to overwrite partitions. Depends on Spark session settings.|  <br />
+</SimpleTable>
+
+When disabled on SQL warehouses, `insert_overwrite` truncates and replaces the entire table (equivalent to the `table` materialization) instead of performing partition-level overwrites. On all-purpose or job clusters, both syntaxes produce the same functional outcome &mdash; the difference is only syntactical.
+
+To disable, set the flag to `False` in your `dbt_project.yml`:
+
+```yaml
+flags:
+  use_replace_on_for_insert_overwrite: false
+```


### PR DESCRIPTION
this pr adds `use_managed_iceberg` change that i erroneously removed in https://github.com/dbt-labs/docs.getdbt.com/commit/a5378a6286512186c6aabcfb45ae16fd66d55165#diff-1cf86e82c385dd5fa31e85ba75cc93d6170a661d06b082bbcb05c7a5a00a8451

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-fix-add-use-managed-icbg-dbt-labs.vercel.app/reference/global-configs/behavior-changes
- https://docs-getdbt-com-git-fix-add-use-managed-icbg-dbt-labs.vercel.app/reference/global-configs/databricks-changes

<!-- end-vercel-deployment-preview -->