### PR TITLE
Add reason for skipping March 2026 compatible release

### DIFF
--- a/website/docs/docs/dbt-versions/compatible-track-changelog.md
+++ b/website/docs/docs/dbt-versions/compatible-track-changelog.md
@@ -12,7 +12,7 @@ For more information, see [release tracks](/docs/dbt-versions/cloud-release-trac
 
 ## March 2026
 
-The compatible release slated for March 2026 will be skipped in order to further stabilize the minor upgrade of `dbt-core==1.11.6` across the dbt platform.
+The compatible release scheduled for March 2026 will be skipped in order to further stabilize the minor upgrade of `dbt-core==1.11.6` across the dbt platform.
 
 Compatible releases will resume in April 2026.
 

--- a/website/docs/docs/dbt-versions/compatible-track-changelog.md
+++ b/website/docs/docs/dbt-versions/compatible-track-changelog.md
@@ -10,6 +10,12 @@ Each monthly **Compatible** release includes functionality matching up-to-date o
 
 For more information, see [release tracks](/docs/dbt-versions/cloud-release-tracks).
 
+## March 2026
+
+The compatible release slated for March 2026 will be skipped in order to further stabilize the minor upgrade of `dbt-core==1.11.6` across the dbt Platform.
+
+Compatible releases will resume in April 2026.
+
 ## February 2026
 
 Release date: February 27, 2026

--- a/website/docs/docs/dbt-versions/compatible-track-changelog.md
+++ b/website/docs/docs/dbt-versions/compatible-track-changelog.md
@@ -12,7 +12,7 @@ For more information, see [release tracks](/docs/dbt-versions/cloud-release-trac
 
 ## March 2026
 
-The compatible release slated for March 2026 will be skipped in order to further stabilize the minor upgrade of `dbt-core==1.11.6` across the dbt Platform.
+The compatible release slated for March 2026 will be skipped in order to further stabilize the minor upgrade of `dbt-core==1.11.6` across the dbt platform.
 
 Compatible releases will resume in April 2026.
 


### PR DESCRIPTION
Update compatible changelogs with March 2026 release info - skipping to further stabilize latest OSS minor version of dbt-core in platform.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-march-compatible-changelog-dbt-labs.vercel.app/docs/dbt-versions/compatible-track-changelog

<!-- end-vercel-deployment-preview -->