### PR TITLE
Added a troubleshooting step for DNS issues with manifest downloads

### DIFF
--- a/website/snippets/_fusion-troubleshooting.md
+++ b/website/snippets/_fusion-troubleshooting.md
@@ -84,3 +84,16 @@ To resolve the `dbt language server is not running in this workspace` error, you
 
 This should resolve the error and open your dbt project by opening the workspace it belongs to. For more information on workspaces, refer to [What is a VS Code workspace?](https://code.visualstudio.com/docs/editing/workspaces/workspaces).
 </Expandable>
+
+<Expandable alt_header="Manifest cannot be downloaded from the dbt platform">
+
+If the **dbt Extension** cannot download the manifest from the **dbt platform** or you get `warning: dbt1200: Failed to download manifest` using **Fusion CLI**, you are probably having DNS related issues.
+
+To confirm this you can do DNS lookup for the host dbt fusion is trying to download from (e.g. prodeu2.blob.core.windows.net) by using `dig` on Linux or `nslookup` on Windows.
+
+If this won't return an IP address, the probable reason is you company is using the same cloud provider with private endpoints for cloud resources and the DNS requests for these are forwarded to private DNS zones.
+
+This situation can be remedied by setting up an internet fallback which will then return a public ip to any cloud storage that do not have a private ip registered with the private dns zone.
+
+For Azure refer to [Fallback to internet for Azure Private DNS zones](https://learn.microsoft.com/en-us/azure/dns/private-dns-fallback).
+</Expandable>

--- a/website/snippets/_fusion-troubleshooting.md
+++ b/website/snippets/_fusion-troubleshooting.md
@@ -87,13 +87,13 @@ This should resolve the error and open your dbt project by opening the workspace
 
 <Expandable alt_header="Manifest cannot be downloaded from the dbt platform">
 
-If the **dbt Extension** cannot download the manifest from the **dbt platform** or you get `warning: dbt1200: Failed to download manifest` using **Fusion CLI**, you are probably having DNS related issues.
+If the dbt VS Code extension cannot download the manifest from the <Constant name="dbt_platform" /> or you get `warning: dbt1200: Failed to download manifest` using <Constant name="fusion" /> locally, you are probably having DNS-related issues.
 
-To confirm this you can do DNS lookup for the host dbt fusion is trying to download from (e.g. prodeu2.blob.core.windows.net) by using `dig` on Linux or `nslookup` on Windows.
+To confirm this, do a DNS lookup for the host <Constant name="fusion" /> is trying to download from (for example, prodeu2.blob.core.windows.net) by using `dig` on Linux/Mac or `nslookup` on Windows.
 
-If this won't return an IP address, the probable reason is you company is using the same cloud provider with private endpoints for cloud resources and the DNS requests for these are forwarded to private DNS zones.
+If this doesn't return an IP address, the likely reason is that your company uses the same cloud provider with private endpoints for cloud resources, and DNS requests for these are forwarded to private DNS zones.
 
-This situation can be remedied by setting up an internet fallback which will then return a public ip to any cloud storage that do not have a private ip registered with the private dns zone.
+This situation can be remedied by setting up an internet fallback, which will then return a public IP to any cloud storage that does not have a private IP registered with the private DNS zone.
 
 For Azure refer to [Fallback to internet for Azure Private DNS zones](https://learn.microsoft.com/en-us/azure/dns/private-dns-fallback).
 </Expandable>


### PR DESCRIPTION
## What are you changing in this pull request and why?
Added a new troubleshooting category to fusion to address issues with manifest download from the dbt platform in corporate environments with private DNS. 

## Checklist

- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).