### PR TITLE
Hiding the cache page for fusion where it is deprecated

### DIFF
--- a/website/dbt-versions.js
+++ b/website/dbt-versions.js
@@ -297,6 +297,10 @@ exports.versionedPages = [
     page: "docs/local/connect-data-platform/yellowbrick-setup",
     lastVersion: "1.99",
   },
+  {
+    page: "reference/global-configs/cache",
+    lastVersion: "1.99",
+  },
 ];
 
 /**


### PR DESCRIPTION
## What are you changing in this pull request and why?
 
The function described on the cache page is deprecated in Fusion according to:
https://docs.getdbt.com/docs/dbt-versions/core-upgrade/upgrading-to-fusion?version=1.12#deprecated-flags

In addition fusion gives a warning if this is used: 
"warning: dbt1700: --cache-selected is no longer supported"