### PR TITLE
Fix example for unit test with `format: sql`

### DIFF
--- a/website/docs/docs/build/unit-tests.md
+++ b/website/docs/docs/build/unit-tests.md
@@ -315,7 +315,7 @@ unit_tests:
       - input: ref('ephemeral_model')
         format: sql
         rows: |
-          select 1 as id, 'emily' as name
+          select 1 as id, 'emily' as first_name
     expect:
       rows:
         - {id: 1, first_name: emily}


### PR DESCRIPTION
The column name for input fixture `rows` needs to match the `expect` rows (expected output)

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-jerco-fix-unit-test-sql-example-dbt-labs.vercel.app/docs/build/unit-tests

<!-- end-vercel-deployment-preview -->