### PR TITLE
Fix typo in version check documentation

### DIFF
--- a/website/docs/reference/project-configs/require-dbt-version.md
+++ b/website/docs/reference/project-configs/require-dbt-version.md
@@ -145,7 +145,7 @@ Runtime Error
 
 ## Disabling version checks
 
-To suppress failures to to incompatible dbt versions, supply the `--no-version-check` flag to `dbt run`.
+To suppress failures to incompatible dbt versions, supply the `--no-version-check` flag to `dbt run`.
 ```
 $ dbt run --no-version-check
 Running with dbt=1.5.0


### PR DESCRIPTION
i found a typo while reading through the documentatio:

To suppress failures to to incompatible dbt versions, supply the --no-version-check flag to dbt run.
