### PR TITLE
update stict mode language

### DIFF
--- a/website/docs/docs/fusion/new-concepts.md
+++ b/website/docs/docs/fusion/new-concepts.md
@@ -210,7 +210,7 @@ models:
 
 #### strict mode inheritance
 
-Unlike `baseline` or `off`, `strict` mode doesn't propagate to downstream models. This means that if you set a model to `strict`, its downstream models will not inherit `strict` mode unless you set them explicitly. To make all models `strict`, you must set `+static_analysis: strict` on root models first, or use the project-wide config in the next section at the project level.
+Unlike `baseline` or `off`, `strict` mode doesn't propagate to downstream models. If you configure a model as `strict`, its downstream models won't inherit `strict` mode unless you set them explicitly. To make all models `strict`, you must set `+static_analysis: strict` on root models first, or use the project-wide config in the next section at the project level.
 
 For example, in A → B → C with a default of `baseline`, configuring A (a root node) as `strict` makes only A `strict` &mdash; B and C remain baseline unless configured. To make the full chain `strict`, set `+static_analysis: strict` on each relevant model or group, or use a project-wide setting.
 

--- a/website/docs/docs/fusion/new-concepts.md
+++ b/website/docs/docs/fusion/new-concepts.md
@@ -169,7 +169,7 @@ The <Constant name="fusion_engine" /> (strict mode):
 
 You can modify the way static analysis is applied for specific models in your project. The static analysis configuration cascades from most strict to least strict. Going downstream in your lineage, a model can keep the same mode or relax it &mdash; it can't be stricter than its parent. 
 
-Setting a model to `strict` does not automatically make its downstreams strict; they keep the project default unless you set them explicitly. For the full rules and examples, see [How static analysis modes cascade](/reference/resource-configs/static-analysis#how-static-analysis-modes-cascade).
+Setting `static_analysis: strict` on a model does not automatically set `strict` for downstream models; they keep the project default unless you set them explicitly. For rules and examples, refer to [strict mode inheritance](#strict-mode-inheritance) and [How static analysis modes cascade](/reference/resource-configs/static-analysis#how-static-analysis-modes-cascade).
 
 The [`static_analysis`](/reference/resource-configs/static-analysis) config options are:
 
@@ -212,7 +212,7 @@ models:
 
 Unlike `baseline` or `off`, `strict` mode doesn't propagate to downstream models. This means that if you set a model to `strict`, its downstream models will not inherit `strict` mode unless you set them explicitly. To make all models `strict`, you must set `+static_analysis: strict` on root models first, or use the project-wide config in the next section at the project level.
 
-For example, in A → B → C with a default of `baseline`, setting `strict` on A (a root node) makes only A `strict` &mdash; B and C remain `baseline` unless configured. To make the full chain strict, set `+static_analysis: strict` on each relevant model or group, or use a project-wide setting.
+For example, in A → B → C with a default of `baseline`, configuring A (a root node) as `strict` makes only A `strict` &mdash; B and C remain baseline unless configured. To make the full chain `strict`, set `+static_analysis: strict` on each relevant model or group, or use a project-wide setting.
 
 This approach lets you gain the benefits of strict validation where possible while keeping the flexibility of baseline analysis for models that aren't yet compatible.
 
@@ -222,7 +222,7 @@ Refer to [CLI options](/reference/global-configs/command-line-options) and [Conf
 
 ##### Configure strict for the entire project
 
-Many teams want to enable strict mode for the whole project and all packages. You can do this by setting `+static_analysis: strict` under each resource type in `dbt_project.yml` for your project name (and for any package names if you want those to be strict too):
+Many teams want to enable `strict` mode for the whole project and all packages. You can do this by setting `+static_analysis: strict` under each resource type in `dbt_project.yml` for your project name (and for any package names if you want those to be strict too):
 
 <File name='dbt_project.yml'>
 
@@ -258,7 +258,7 @@ analyses:
 
 </File>
 
-Use your project name in place of `my_project` — that's the same value as the `name:` key at the top of `dbt_project.yml` (for example, `jaffle_shop`). To apply strict to a package as well, add another entry under each resource type using the package name as the key; for example, under `models:` add `your_package_name:` with `+static_analysis: strict` beneath it.
+Use your project name in place of `my_project` — that's the same value as the `name:` key at the top of `dbt_project.yml` (for example, `jaffle_shop`). To apply `strict` to a package as well, add another entry under each resource type using the package name as the key; for example, under `models:` add `your_package_name:` with `+static_analysis: strict` beneath it.
 
 ##### Disable static analysis for all models in a package:
 

--- a/website/docs/docs/fusion/new-concepts.md
+++ b/website/docs/docs/fusion/new-concepts.md
@@ -167,7 +167,9 @@ The <Constant name="fusion_engine" /> (strict mode):
 
 ## Configuring `static_analysis`
 
-You can modify the way static analysis is applied for specific models in your project. The static analysis configuration cascades from most strict to least strict. Going downstream in your lineage, a model can keep the same mode or relax it &mdash; it can't be stricter than its parent. For the full rules and examples, see [How static analysis modes cascade](/reference/resource-configs/static-analysis#how-static-analysis-modes-cascade).
+You can modify the way static analysis is applied for specific models in your project. The static analysis configuration cascades from most strict to least strict. Going downstream in your lineage, a model can keep the same mode or relax it &mdash; it can't be stricter than its parent. 
+
+Setting a model to `strict` does not automatically make its downstreams strict; they keep the project default unless you set them explicitly. For the full rules and examples, see [How static analysis modes cascade](/reference/resource-configs/static-analysis#how-static-analysis-modes-cascade).
 
 The [`static_analysis`](/reference/resource-configs/static-analysis) config options are:
 
@@ -206,13 +208,59 @@ models:
 
 </File>
 
+#### strict mode inheritance
+
+Unlike `baseline` or `off`, `strict` mode doesn't propagate to downstream models. This means that if you set a model to `strict`, its downstream models will not inherit `strict` mode unless you set them explicitly. To make all models `strict`, you must set `+static_analysis: strict` on root models first, or use the project-wide config in the next section at the project level.
+
+For example, in A → B → C with a default of `baseline`, setting `strict` on A (a root node) makes only A `strict` &mdash; B and C remain `baseline` unless configured. To make the full chain strict, set `+static_analysis: strict` on each relevant model or group, or use a project-wide setting.
+
 This approach lets you gain the benefits of strict validation where possible while keeping the flexibility of baseline analysis for models that aren't yet compatible.
 
 Refer to [CLI options](/reference/global-configs/command-line-options) and [Configurations and properties](/reference/configs-and-properties) to learn more about configs.
 
 ### Example configurations
 
-Disable static analysis for all models in a package:
+##### Configure strict for the entire project
+
+Many teams want to enable strict mode for the whole project and all packages. You can do this by setting `+static_analysis: strict` under each resource type in `dbt_project.yml` for your project name (and for any package names if you want those to be strict too):
+
+<File name='dbt_project.yml'>
+
+```yaml
+models:
+  my_project:
+    +static_analysis: strict
+
+seeds:
+  my_project:
+    +static_analysis: strict
+
+snapshots:
+  my_project:
+    +static_analysis: strict
+
+tests:
+  my_project:
+    +static_analysis: strict
+
+unit_tests:
+  my_project:
+    +static_analysis: strict
+
+sources:
+  my_project:
+    +static_analysis: strict
+
+analyses:
+  my_project:
+    +static_analysis: strict
+```
+
+</File>
+
+Use your project name in place of `my_project` — that's the same value as the `name:` key at the top of `dbt_project.yml` (for example, `jaffle_shop`). To apply strict to a package as well, add another entry under each resource type using the package name as the key; for example, under `models:` add `your_package_name:` with `+static_analysis: strict` beneath it.
+
+##### Disable static analysis for all models in a package:
 
 <File name='dbt_project.yml'>
 
@@ -230,7 +278,7 @@ models:
 
 </File>
 
-Disable static analysis in YAML:
+##### Disable static analysis in YAML:
 
 <File name='models/my_udf_using_model.yml'>
 
@@ -243,8 +291,7 @@ models:
 
 </File>
 
-
-Disable static analysis for a model using a custom UDF:
+##### Disable static analysis for a model using a custom UDF:
 
 <File name='models/my_udf_using_model.sql'>
 

--- a/website/docs/reference/resource-configs/static-analysis.md
+++ b/website/docs/reference/resource-configs/static-analysis.md
@@ -67,7 +67,7 @@ from {{ ref('my_model') }}
 
 You can configure if and when the <Constant name="fusion_engine" /> performs static SQL analysis for a model. Configure the `static_analysis` config in your project YAML file (`dbt_project.yml`), model properties YAML file, or in a SQL config block in your model file. Refer to [Priciples of static analysis](/docs/fusion/new-concepts?version=1.12#principles-of-static-analysis) for more information on the different modes of static analysis.
 
-Setting a model to `strict` does not automatically make its downstreams strict; they keep the project default unless you set them explicitly. For more info and examples, see [strict mode inheritance](/docs/fusion/new-concepts#strict-mode-inheritance).
+Setting a model to `strict` does not automatically set `strict` for downstream models; they keep the project default unless you configure them explicitly. For more information and examples, refer to [strict mode inheritance](/docs/fusion/new-concepts#strict-mode-inheritance).
 
 The following values are available for `static_analysis`:
 

--- a/website/docs/reference/resource-configs/static-analysis.md
+++ b/website/docs/reference/resource-configs/static-analysis.md
@@ -67,6 +67,8 @@ from {{ ref('my_model') }}
 
 You can configure if and when the <Constant name="fusion_engine" /> performs static SQL analysis for a model. Configure the `static_analysis` config in your project YAML file (`dbt_project.yml`), model properties YAML file, or in a SQL config block in your model file. Refer to [Priciples of static analysis](/docs/fusion/new-concepts?version=1.12#principles-of-static-analysis) for more information on the different modes of static analysis.
 
+Setting a model to `strict` does not automatically make its downstreams strict; they keep the project default unless you set them explicitly. For more info and examples, see [strict mode inheritance](/docs/fusion/new-concepts#strict-mode-inheritance).
+
 The following values are available for `static_analysis`:
 
 - `baseline` (default): Statically analyze SQL. This is the recommended starting point for users transitioning from <Constant name="core" />, providing a smooth migration experience while still catching most SQL errors. You can incrementally opt-in to stricter analysis over time.


### PR DESCRIPTION
this pr updates static_analysis language on strict and how it doesn't propogate to downstream nodes.

raised internally: https://dbt-labs.slack.com/archives/C02NCQ9483C/p1773750732851729

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-baseline-strict-dbt-labs.vercel.app/docs/fusion/new-concepts
- https://docs-getdbt-com-git-update-baseline-strict-dbt-labs.vercel.app/reference/resource-configs/static-analysis

<!-- end-vercel-deployment-preview -->