### PR TITLE
PRODDOCS-648: dbt init VS Code

### DIFF
--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -61,7 +61,6 @@ You can learn more through high-quality [dbt Learn courses and workshops](https:
 
 ## Installation
 
-:::tip
 
 It's easy to think of the <Constant name="fusion_engine" /> and the dbt extension as two different products, but they're a powerful combo that works together to unlock the full potential of dbt. Think of the <Constant name="fusion_engine" /> as exactly that — an engine. The dbt extension and VS Code are the chassis, and together they form a powerful vehicle for transforming your data. 
 

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -61,7 +61,6 @@ You can learn more through high-quality [dbt Learn courses and workshops](https:
 
 ## Installation
 
-
 It's easy to think of the <Constant name="fusion_engine" /> and the dbt extension as two different products, but they're a powerful combo that works together to unlock the full potential of dbt. Think of the <Constant name="fusion_engine" /> as exactly that — an engine. The dbt extension and VS Code are the chassis, and together they form a powerful vehicle for transforming your data. 
 
 :::info

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -70,6 +70,7 @@ It's easy to think of the <Constant name="fusion_engine" /> and the dbt extensio
 :::info
 - You can install the <Constant name="fusion_engine" /> and use it standalone with the CLI.
 - You *cannot* use the dbt extension without <Constant name="fusion" /> installed.
+- Use `dbt` as your default command. If you already have another dbt command-line tool installed (such as the <Constant name="platform_cli" /> or <Constant name="core" />), you can use `dbtf` as an unambiguous alias for <Constant name="fusion" />.
 :::
 
 The following are the essential steps from the [<Constant name="fusion_engine" />](/docs/local/install-dbt?version=2#get-started) and [extension](/docs/install-dbt-extension) installation guides:

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -61,6 +61,10 @@ You can learn more through high-quality [dbt Learn courses and workshops](https:
 
 ## Installation
 
+:::tip
+Use `dbt` as your default command. If you already have another dbt command-line tool installed (such as the <Constant name="platform_cli" /> or <Constant name="core" />), you can use `dbtf` as an unambiguous alias for <Constant name="fusion" />.
+:::
+
 It's easy to think of the <Constant name="fusion_engine" /> and the dbt extension as two different products, but they're a powerful combo that works together to unlock the full potential of dbt. Think of the <Constant name="fusion_engine" /> as exactly that — an engine. The dbt extension and VS Code are the chassis, and together they form a powerful vehicle for transforming your data. 
 
 :::info

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -73,11 +73,11 @@ The following are the essential steps from the [<Constant name="fusion_engine" /
 <Tabs queryString="installation">
 <TabItem value="mac-linux" label="macOS & Linux">
 
-1. Run the following command in the terminal to install the `dbtf` binary — <Constant name="fusion" />’s CLI command.
+1. Run the following command in the terminal to install the <Constant name="fusion_engine" /> CLI.
     ```shell
     curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh -s -- --update
     ```
-2. To use `dbtf` immediately after installation, reload your shell so that the new `$PATH` is recognized:
+2. To use `dbt` immediately after installation, reload your shell so that the new `$PATH` is recognized:
     ```shell
     exec $SHELL
     ```
@@ -85,11 +85,11 @@ The following are the essential steps from the [<Constant name="fusion_engine" /
 </TabItem>
 <TabItem value="windows" label="Windows (PowerShell)">
 
-1. Run the following command in PowerShell to install the `dbtf` binary:
+1. Run the following command in PowerShell to install the <Constant name="fusion_engine" /> CLI:
     ```powershell
     irm https://public.cdn.getdbt.com/fs/install/install.ps1 | iex
     ```
-2. To use `dbtf` immediately after installation, reload your shell so that the new `Path` is recognized:
+2. To use `dbt` immediately after installation, reload your shell so that the new `Path` is recognized:
     ```powershell
     Start-Process powershell
     ```
@@ -99,16 +99,16 @@ The following are the essential steps from the [<Constant name="fusion_engine" /
 
 ### Verify the <Constant name="fusion_engine" /> installation
 
-1. After installation, open a new command-line window to confirm that <Constant name="fusion" /> was installed correctly by checking the version. 
+1. After installation, open a new command-line window to confirm that <Constant name="fusion" /> was installed correctly by checking the version.
     ```bash
-    dbtf --version
+    dbt --version
     ```
 2. You should see output similar to the following:
     ```bash
     dbt-fusion 2.0.0-preview.45
     ```
 :::tip
-You can run these commands using `dbt`, or use `dbtf` as an unambiguous alias for <Constant name="fusion" />, if you have another dbt CLI installed on your machine.
+Use `dbt` by default. If you already have another dbt CLI installed (such as the <Constant name="platform_cli" /> or <Constant name="core" />), you can use `dbtf` as an unambiguous alias for <Constant name="fusion" />.
 :::
 
 ### Install the dbt VS Code extension
@@ -126,15 +126,15 @@ The dbt VS Code extension is available in the [Visual Studio extension marketpla
 ## Initialize the Jaffle Shop project
 Now let's create your first dbt project powered by <Constant name="fusion" />!
 
-1. Run `dbt init` to set up an example project and configure a database connection profile.
+1. Run `dbt init` in your terminal from the directory where you want to create the project. It creates an example project and walks you through setting up a connection profile.
    - If you *do not* have a connection profile that you want to use, start with `dbt init` and use the prompts to configure a profile:
     - If you already have a connection profile that you want to use, use the `--skip-profile-setup` flag then edit the generated `dbt_project.yml` to replace `profile: jaffle_shop` with `profile: <YOUR-PROFILE-NAME>`.
 
         ```bash
-        dbtf init --skip-profile-setup
+        dbt init --skip-profile-setup
         ```
 
-    - If you created new credentials through the interactive prompts, `init` automatically runs `dbtf debug` at the end. This ensures the newly created profile establishes a valid connection with the database.
+    - If you created new credentials through the interactive prompts, `init` automatically runs `dbt debug` at the end. This ensures the newly created profile establishes a valid connection with the database.
 
 2. Change directories into your newly created project:
     ```bash
@@ -143,7 +143,7 @@ Now let's create your first dbt project powered by <Constant name="fusion" />!
 
 3. Build your dbt project (which includes creating example data):
     ```bash
-    dbtf build
+    dbt build
     ```
 
 This will:
@@ -166,7 +166,7 @@ Want to see <Constant name="fusion" /> in action? Check out the following video 
   />
 </div>
 
-Now that your project works, open it in VS Code and see Fusion in action:
+Now that your project works, open it in VS Code and see <Constant name="fusion" /> in action:
 
 1. In VS Code, open the **View** menu and click **Command Palette**. Enter **Workspaces: Add Folder to Workspace**.
 2. Select your `jaffle_shop` folder.

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -99,7 +99,7 @@ The following are the essential steps from the [<Constant name="fusion_engine" /
 
 ### Verify the <Constant name="fusion_engine" /> installation
 
-1. After installation, open a new command-line window to confirm that <Constant name="fusion" /> was installed correctly by checking the version.
+1. After installation, open a new command-line window to confirm that <Constant name="fusion" /> installed correctly by checking the version.
     ```bash
     dbt --version
     ```

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -108,7 +108,7 @@ The following are the essential steps from the [<Constant name="fusion_engine" /
     dbt-fusion 2.0.0-preview.45
     ```
 :::tip
-Use `dbt` by default. If you already have another dbt CLI installed (such as the <Constant name="platform_cli" /> or <Constant name="core" />), you can use `dbtf` as an unambiguous alias for <Constant name="fusion" />.
+Use `dbt` as your default command. If you already have another dbt command-line tool installed (such as the <Constant name="platform_cli" /> or <Constant name="core" />), you can use `dbtf` as an unambiguous alias for <Constant name="fusion" />.
 :::
 
 ### Install the dbt VS Code extension

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -62,7 +62,6 @@ You can learn more through high-quality [dbt Learn courses and workshops](https:
 ## Installation
 
 :::tip
-Use `dbt` as your default command. If you already have another dbt command-line tool installed (such as the <Constant name="platform_cli" /> or <Constant name="core" />), you can use `dbtf` as an unambiguous alias for <Constant name="fusion" />.
 
 It's easy to think of the <Constant name="fusion_engine" /> and the dbt extension as two different products, but they're a powerful combo that works together to unlock the full potential of dbt. Think of the <Constant name="fusion_engine" /> as exactly that — an engine. The dbt extension and VS Code are the chassis, and together they form a powerful vehicle for transforming your data. 
 

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -63,7 +63,6 @@ You can learn more through high-quality [dbt Learn courses and workshops](https:
 
 :::tip
 Use `dbt` as your default command. If you already have another dbt command-line tool installed (such as the <Constant name="platform_cli" /> or <Constant name="core" />), you can use `dbtf` as an unambiguous alias for <Constant name="fusion" />.
-:::
 
 It's easy to think of the <Constant name="fusion_engine" /> and the dbt extension as two different products, but they're a powerful combo that works together to unlock the full potential of dbt. Think of the <Constant name="fusion_engine" /> as exactly that — an engine. The dbt extension and VS Code are the chassis, and together they form a powerful vehicle for transforming your data. 
 

--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -111,9 +111,6 @@ The following are the essential steps from the [<Constant name="fusion_engine" /
     ```bash
     dbt-fusion 2.0.0-preview.45
     ```
-:::tip
-Use `dbt` as your default command. If you already have another dbt command-line tool installed (such as the <Constant name="platform_cli" /> or <Constant name="core" />), you can use `dbtf` as an unambiguous alias for <Constant name="fusion" />.
-:::
 
 ### Install the dbt VS Code extension
 
@@ -130,7 +127,7 @@ The dbt VS Code extension is available in the [Visual Studio extension marketpla
 ## Initialize the Jaffle Shop project
 Now let's create your first dbt project powered by <Constant name="fusion" />!
 
-1. Run `dbt init` in your terminal from the directory where you want to create the project. It creates an example project and walks you through setting up a connection profile.
+1. Run `dbt init` in your terminal from the directory where you want to create the project. The `dbt init` command creates an example project and walks you through setting up a connection profile.
    - If you *do not* have a connection profile that you want to use, start with `dbt init` and use the prompts to configure a profile:
     - If you already have a connection profile that you want to use, use the `--skip-profile-setup` flag then edit the generated `dbt_project.yml` to replace `profile: jaffle_shop` with `profile: <YOUR-PROFILE-NAME>`.
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

Resolves [JIRA:PRODDOCS-648](https://dbtlabs.atlassian.net/browse/PRODDOCS-648)

This PR addresses feedback from the thumbs up / thumbs down widget
- Clarifies where to run `dbt init` in your system terminal.
- Per [guidance](https://dbt-labs.slack.com/archives/C0897L5FJ4U/p1770738902305949), this PR standardises on `dbt` by default and limits `dbtf` guidance to disambiguation scenarios when users already have dbt Cloud CLI or dbt Core installed.
- 
## Checklist
<!-- Ensure your PR meets the following items. Feel free to add additiona checklist items to the list if additional checks need to happen before the PR is merged, such as:
- [ ] Needs technical review
- [ ] Change base branch
- [ ] Merge on xyz date
-->
- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).
<!--
PRE-RELEASE VERSION OF dbt (if so, uncomment):
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
<!-- 
ADDING OR REMOVING PAGES (if so, uncomment):
- [ ] Add/remove page in `website/sidebars.js`
- [ ] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages
-->

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-nfiann-init-dbt-labs.vercel.app/guides/fusion-qs

<!-- end-vercel-deployment-preview -->