### PR TITLE
Enhance meta configuration documentation for tests

### DIFF
--- a/website/docs/reference/resource-configs/meta.md
+++ b/website/docs/reference/resource-configs/meta.md
@@ -176,7 +176,7 @@ Use the `meta` field to add metadata to [generic](/docs/build/data-tests#generic
 
 **Generic data tests**
 
-Add meta under the config block in your YAML properties file:
+Add `meta` under the `config` block in your `properties.yml` file:
 
 <File name="models/properties.yml">
   

--- a/website/docs/reference/resource-configs/meta.md
+++ b/website/docs/reference/resource-configs/meta.md
@@ -860,7 +860,7 @@ semantic-models:
 
 ### Add meta to generic and singular data tests
 
-This example uses property files for [generic data tests](/docs/build/data-tests#generic-data-tests), and `config()` in SQL for [singular data tests](/docs/build/data-tests#singular-data-tests). You can also set defaults in `dbt_project.yml` or `tests/properties.yml`.
+The following examples show how to add `meta` to [generic data tests](/docs/build/data-tests#generic-data-tests) in a `properties.yml` file, and to [singular data tests](/docs/build/data-tests#singular-data-tests) using `config()`. You can also set defaults in `dbt_project.yml` or `tests/properties.yml`.
 
 <Tabs>
 <TabItem value="generic" label="Generic data test">

--- a/website/docs/reference/resource-configs/meta.md
+++ b/website/docs/reference/resource-configs/meta.md
@@ -860,7 +860,7 @@ semantic-models:
 
 ### Add meta to generic and singular data tests
 
-This example uses property files for [generic data tests](/docs/build/data-tests#generic-data-tests), and `config()` in SQL for [singular data tests](/docs/build/data-tests#singular-data-tests). You can also set `config.meta` in [`tests/properties.yml`](/reference/data-test-configs) as well.
+This example uses property files for [generic data tests](/docs/build/data-tests#generic-data-tests), and `config()` in SQL for [singular data tests](/docs/build/data-tests#singular-data-tests). You can also set defaults in `dbt_project.yml` or `tests/properties.yml`.
 
 <Tabs>
 <TabItem value="generic" label="Generic data test">

--- a/website/docs/reference/resource-configs/meta.md
+++ b/website/docs/reference/resource-configs/meta.md
@@ -561,6 +561,7 @@ To demonstrate how to use the `meta` config, here are some examples:
   - [Assign owner and favorite\_color in the dbt\_project.yml as a config property](#assign-owner-and-favorite_color-in-the-dbt_projectyml-as-a-config-property)
   - [Assign meta to semantic model](#assign-meta-to-semantic-model)
   - [Assign meta to dimensions, measures, entities](#assign-meta-to-dimensions-measures-entities)
+  - [Add meta to generic and singular data tests](#add-meta-to-generic-and-singular-data-tests)
   - [Access meta values in Python models](#access-meta-values-in-python-models)
 
 
@@ -856,6 +857,48 @@ semantic-models:
 </TabItem>
 </Tabs>
 </VersionBlock>
+
+### Add meta to generic and singular data tests
+
+This example uses property files for [generic data tests](/docs/build/data-tests#generic-data-tests), and `config()` in SQL for [singular data tests](/docs/build/data-tests#singular-data-tests). You can also set `config.meta` in [`tests/properties.yml`](/reference/data-test-configs) as well.
+
+<Tabs>
+<TabItem value="generic" label="Generic data test">
+
+<File name='models/properties.yml'>
+
+```yaml
+models:
+  - name: orders
+    columns:
+      - name: order_id
+        data_tests:
+          - not_null:
+              config:
+                meta:
+                  owner: "@data_team"
+```
+
+</File>
+
+</TabItem>
+
+<TabItem value="singular" label="Singular data test">
+
+<File name='tests/assert_order_ids.sql'>
+
+```sql
+{{ config(meta={'owner': '@data_team'}) }}
+
+select *
+from {{ ref('orders') }}
+where order_id is null
+```
+
+</File>
+
+</TabItem>
+</Tabs>
 
 ### Access meta values in Python models
 

--- a/website/docs/reference/resource-configs/meta.md
+++ b/website/docs/reference/resource-configs/meta.md
@@ -207,7 +207,7 @@ data_tests:
 
 **Singular data tests**
 
-Add meta in the SQL test file using `config()`:
+Add `meta` in the SQL test file using `config()`:
 
 <File name="tests/my_singular_test.sql">
 

--- a/website/docs/reference/resource-configs/meta.md
+++ b/website/docs/reference/resource-configs/meta.md
@@ -173,7 +173,60 @@ See [configs and properties](/reference/configs-and-properties) for details.
 
 <TabItem value="tests">
 
-You can't add YAML `meta` configs for [generic tests](/docs/build/data-tests#generic-data-tests). However, you can add `meta` properties to [singular tests](/docs/build/data-tests#singular-data-tests) using `config()` at the top of the test file. 
+Use the `meta` field to add metadata to [generic](/docs/build/data-tests#generic-data-tests) or [singular tests](/docs/build/data-tests#singular-data-tests). `meta` accepts key-value pairs, is compiled into `manifest.json`, and appears in auto-generated documentation.
+
+**Generic data tests**
+Add meta under the config block in your YAML properties file:
+
+<File name="models/properties.yml"/>
+```yaml
+models:
+  - name: my_model
+    columns:
+      - name: my_column
+        data_tests:
+          - unique:
+              config:
+                meta:
+                  owner: "docs team"
+ ```
+</File>
+
+Or set defaults in `dbt_project.yml`:
+<File name="dbt_project.yml"/>
+```yaml
+data_tests:
+  my_project:
+    +meta:
+      owner: "docs team"
+ ```
+</File>
+
+**Singular data tests**
+
+Add meta in the SQL test file using `config()`:
+
+<File name="tests/my_singular_test.sql"/>
+```sql
+{{ config(meta={'owner': 'docs team'}) }}
+
+select * from {{ ref('my_model') }}
+where my_column is null
+```
+</File>
+
+Or document in `tests/schema.yml`:
+
+<File name="tests/properties.yml"/>
+
+```yaml
+data_tests:
+  - name: my_singular_test
+    config:
+      meta:
+        owner: "analytics_team"
+```
+</File>
 
 </TabItem>
 

--- a/website/docs/reference/resource-configs/meta.md
+++ b/website/docs/reference/resource-configs/meta.md
@@ -2,7 +2,6 @@
 resource_types: all
 datatype: "{<dictionary>}"
 default_value: {}
-hide_table_of_contents: true
 ---
 
 <Tabs

--- a/website/docs/reference/resource-configs/meta.md
+++ b/website/docs/reference/resource-configs/meta.md
@@ -178,7 +178,8 @@ Use the `meta` field to add metadata to [generic](/docs/build/data-tests#generic
 **Generic data tests**
 Add meta under the config block in your YAML properties file:
 
-<File name="models/properties.yml"/>
+<File name="models/properties.yml">
+  
 ```yaml
 models:
   - name: my_model
@@ -193,7 +194,9 @@ models:
 </File>
 
 Or set defaults in `dbt_project.yml`:
-<File name="dbt_project.yml"/>
+
+<File name="dbt_project.yml">
+
 ```yaml
 data_tests:
   my_project:
@@ -206,7 +209,8 @@ data_tests:
 
 Add meta in the SQL test file using `config()`:
 
-<File name="tests/my_singular_test.sql"/>
+<File name="tests/my_singular_test.sql">
+
 ```sql
 {{ config(meta={'owner': 'docs team'}) }}
 
@@ -217,7 +221,7 @@ where my_column is null
 
 Or document in `tests/schema.yml`:
 
-<File name="tests/properties.yml"/>
+<File name="tests/properties.yml">
 
 ```yaml
 data_tests:

--- a/website/docs/reference/resource-configs/meta.md
+++ b/website/docs/reference/resource-configs/meta.md
@@ -176,6 +176,7 @@ See [configs and properties](/reference/configs-and-properties) for details.
 Use the `meta` field to add metadata to [generic](/docs/build/data-tests#generic-data-tests) or [singular tests](/docs/build/data-tests#singular-data-tests). `meta` accepts key-value pairs, is compiled into `manifest.json`, and appears in auto-generated documentation.
 
 **Generic data tests**
+
 Add meta under the config block in your YAML properties file:
 
 <File name="models/properties.yml">
@@ -219,7 +220,7 @@ where my_column is null
 ```
 </File>
 
-Or document in `tests/schema.yml`:
+Or document in `tests/properties.yml`:
 
 <File name="tests/properties.yml">
 


### PR DESCRIPTION
Expanded documentation on adding metadata to generic and singular data tests, including YAML and SQL examples.

raised internally and to address user confusion: https://dbt-labs.slack.com/archives/C09UY9B0GAE/p1774297713457759

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-generic-tests-dbt-labs.vercel.app/reference/resource-configs/meta

<!-- end-vercel-deployment-preview -->