### PR TITLE
Add pages for run_query_as.

### DIFF
--- a/website/dbt-versions.js
+++ b/website/dbt-versions.js
@@ -297,6 +297,10 @@ exports.versionedPages = [
     page: "reference/global-configs/sqlparse",
     firstVersion: "1.11",
   },
+  {
+    page: "reference/dbt-jinja-functions/run_query_as",
+    firstVersion: "2.0",
+  },
 ];
 
 /**

--- a/website/docs/reference/dbt-jinja-functions/run_query.md
+++ b/website/docs/reference/dbt-jinja-functions/run_query.md
@@ -7,6 +7,10 @@ description: "Use `run_query` macro to run queries and fetch results."
 
 The `run_query` macro provides a convenient way to run queries and fetch their results. It is a wrapper around the [statement block](/reference/dbt-jinja-functions/statement-blocks), which is more flexible, but also more complicated to use.
 
+<VersionBlock firstVersion="2.0">
+If you need to execute SQL without fetching results, such as `alter` statements and other <Term id="ddl" /> or <Term id="dml" /> statements, use [`run_query_as`](/reference/dbt-jinja-functions/run_query_as) with `fetch_result=False`.
+</VersionBlock>
+
 __Args__:
  * `sql`: The SQL query to execute
 
@@ -84,7 +88,11 @@ group by 1
 </File>
 
 
-You can also use `run_query` to perform SQL queries that aren't select statements.
+You can also use `run_query` to perform SQL queries that aren't `select` statements.
+
+<VersionBlock firstVersion="2.0">
+If you need explicit control over whether dbt fetches results for one of these statements, use [`run_query_as`](/reference/dbt-jinja-functions/run_query_as). This is useful for statements such as `alter`, where you may want `fetch_result=False`.
+</VersionBlock>
 
 <File name='macros/run_vacuum.sql'>
 

--- a/website/docs/reference/dbt-jinja-functions/run_query_as.md
+++ b/website/docs/reference/dbt-jinja-functions/run_query_as.md
@@ -1,0 +1,52 @@
+---
+title: "About run_query_as macro"
+sidebar_label: "run_query_as"
+id: "run_query_as"
+description: "Use `run_query_as` to run queries with an explicit `fetch_result` setting."
+---
+
+The `run_query_as` macro provides a user-friendly wrapper around the [statement block](/reference/dbt-jinja-functions/statement-blocks). Use it when you need to name the statement and explicitly control whether dbt fetches results.
+
+__Args__:
+ * `sql`: The SQL query to execute
+ * `name`: The name for the statement result
+ * `fetch_result`: If `True`, load the results of the statement into the Jinja context. Defaults to `True`.
+
+Returns an [Agate table](https://agate.readthedocs.io/page/api/table.html) if `fetch_result=True`. If `fetch_result=False`, it does not return a table.
+
+**Note:** The `run_query_as` macro will not begin a transaction automatically. If you want to run your query inside a transaction, use `begin` and `commit` statements as needed.
+
+:::info Fusion-only
+`run_query_as` is available in dbt Fusion engine and is not available in dbt Core.
+:::
+
+**Example usage:**
+
+<File name='models/my_model.sql'>
+
+```jinja2
+{% set results = run_query_as('select 1 as id', 'example_query') %}
+
+{% if results is not none %}
+  {{ log(results.print_table(), info=True) }}
+{% endif %}
+```
+
+</File>
+
+Use `fetch_result=False` for statements where you do not want dbt to fetch results, such as `alter` statements and other <Term id="ddl" /> or <Term id="dml" /> statements.
+
+<File name='macros/set_query_tag.sql'>
+
+```jinja2
+{% macro set_query_tag(tag) %}
+
+  {% set query %}
+    alter session set query_tag = '{{ tag }}'
+  {% endset %}
+
+  {% do run_query_as(query, 'set_query_tag', fetch_result=False) %}
+{% endmacro %}
+```
+
+</File>


### PR DESCRIPTION
## What are you changing in this pull request and why?


We have users that need to turn off row fetching for certain queries. for that, fusion provides `run_query_as` with the `fetch` as a functional parameter.

Closes https://dbtlabs.atlassian.net/browse/PRODDOCS-878

## Checklist

- [x] Needs technical review
- [ ] Change base branch
- [ ] Merge on xyz date

- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [x] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ]  The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).
<!--
PRE-RELEASE VERSION OF dbt (if so, uncomment):
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
 
ADDING OR REMOVING PAGES (if so, uncomment):
- [x] Add/remove page in `website/sidebars.js`
- [x] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages
