### PR TITLE
FR-2076 docs(permissions): add Job Creator enterprise permission set

### DIFF
--- a/website/docs/docs/cloud/manage-access/enterprise-permissions.md
+++ b/website/docs/docs/cloud/manage-access/enterprise-permissions.md
@@ -159,17 +159,33 @@ Notable features:
 - Can access <Constant name="catalog" />.
 
 </Expandable>
+<Expandable alt_header="Environment admin">
+
+Environment admin is a project-level permission set for users who need to manage environment settings (such as dbt version, connections, and extended attributes) scoped to specific environment tiers, in addition to creating and running jobs within those environments. It extends Job creator with environment editing capabilities.
+
+Notable features:
+- Environment admin is a project-level set with **environment-level scoping**.
+- Can **edit existing environments** within the assigned environment categories or specific environments — including dbt version, connection, extended attributes, and environment-level environment variables.
+- Cannot **create** new environments — environment creation requires full Admin or Account admin permissions.
+- Cannot **delete** environments — environment deletion requires full Admin or Account admin permissions.
+- Cannot **change deployment types** on environments — this prevents promoting a staging environment to production, which would escalate the user's own access scope.
+- Can create and edit jobs within assigned environments (same as Job creator).
+- Can trigger runs within assigned environments (same as Job creator).
+- Supports scoping by environment category (for example, `staging`, `production`) and/or by specific environment ID.
+
+</Expandable>
 <Expandable alt_header="Job creator">
 
 Job creator is a project-level permission set for users who need to create and manage dbt jobs scoped to specific environment tiers (for example, staging) without the ability to modify environment infrastructure. It fills the gap between Job runner (can only trigger runs) and Job admin (can create jobs but also controls environments).
 
 Notable features:
-- Job creator is a project-level set.
-- Can create and edit jobs — but only within the environment categories assigned at the group or service token level (for example, `staging`). This is set via **Environment write access** at assignment time.
-- Can trigger runs in any environment, unconditionally — regardless of environment category assignment.
+- Job creator is a project-level set with **environment-level scoping**.
+- Can create and edit jobs — but only within the environment categories or specific environments assigned at the group or service token level (for example, `staging`). This is set via **Environment write access** at assignment time.
+- Can trigger runs — but only within the assigned environment scope. A Job creator scoped to staging cannot trigger runs on production jobs.
 - Can set environment variable overrides at the job level. Project-level and environment-level environment variable writes require `environments_write`, which this permission set does not include.
 - Cannot create, delete, or reconfigure environments (`environments_write` is intentionally absent).
 - Read-only access to connections, credentials, environments, integrations, metadata, profiles, and projects.
+- Supports scoping by environment category (for example, `staging`, `production`) and/or by specific environment ID.
 
 </Expandable>
 <Expandable alt_header="Job runner">
@@ -177,21 +193,21 @@ Notable features:
 Job runner is a specialized permission set for users who need access to run jobs and view the outcomes.
 
 Notable features:
-- Job runner is a project-level set.
-- Can run jobs.
-- Has read-only access to jobs, including status and results.
-- No other access to <Constant name="dbt" /> features. 
+- Job runner is a project-level set with **environment-level scoping**.
+- Can trigger runs — scoped to the environment categories or specific environments assigned at the group or service token level. Existing Job runner grants are automatically set to "All environments" for backward compatibility.
+- Has read-only access to jobs, environments, and run results.
+- Supports scoping by environment category (for example, `staging`, `production`) and/or by specific environment ID.
 
 </Expandable>
 <Expandable alt_header="Job viewer">
 
-Job viewer enables users to monitor and review job executions within <Constant name="dbt" />. Users with this role can see jobs’ status, logs, and outcomes but cannot initiate or modify them. 
+Job viewer enables users to monitor and review job executions within <Constant name="dbt" />. Users with this role can see jobs’ status, logs, and outcomes but cannot initiate or modify them.
 
 Notable features:
-- Job viewer is a project-level set.
-- Read-only access to job results, status, and logs.
-- No other access to <Constant name="dbt" /> features. 
+- Job viewer is a project-level set with **environment-level scoping**.
+- Read-only access to job results, status, and logs — scoped to the environment categories or specific environments assigned at the group or service token level. Existing Job viewer grants are automatically set to "All environments" for backward compatibility.
 - Can access <Constant name="catalog" />.
+- Supports scoping by environment category (for example, `staging`, `production`) and/or by specific environment ID.
 
 </Expandable>
 

--- a/website/docs/docs/cloud/manage-access/enterprise-permissions.md
+++ b/website/docs/docs/cloud/manage-access/enterprise-permissions.md
@@ -159,9 +159,22 @@ Notable features:
 - Can access <Constant name="catalog" />.
 
 </Expandable>
+<Expandable alt_header="Job creator">
+
+Job creator is a project-level permission set for users who need to create and manage dbt jobs scoped to specific environment tiers (for example, staging) without the ability to modify environment infrastructure. It fills the gap between Job runner (can only trigger runs) and Job admin (can create jobs but also controls environments).
+
+Notable features:
+- Job creator is a project-level set.
+- Can create and edit jobs — but only within the environment categories assigned at the group or service token level (for example, `staging`). This is set via **Environment write access** at assignment time.
+- Can trigger runs in any environment, unconditionally — regardless of environment category assignment.
+- Can set environment variable overrides at the job level. Project-level and environment-level environment variable writes require `environments_write`, which this permission set does not include.
+- Cannot create, delete, or reconfigure environments (`environments_write` is intentionally absent).
+- Read-only access to connections, credentials, environments, integrations, metadata, profiles, and projects.
+
+</Expandable>
 <Expandable alt_header="Job runner">
 
-Job runner is a specialized permission set for users who need access to run jobs and view the outcomes. 
+Job runner is a specialized permission set for users who need access to run jobs and view the outcomes.
 
 Notable features:
 - Job runner is a project-level set.

--- a/website/docs/docs/dbt-versions/dbt-cloud-release-notes-gen.md
+++ b/website/docs/docs/dbt-versions/dbt-cloud-release-notes-gen.md
@@ -18,6 +18,14 @@ unlisted: true
 Release notes are grouped by date for single-tenant environments.
 
 
+## March 25, 2026
+
+## New
+
+### APIs, Identity, and Administration
+
+- **Job Creator enterprise permission set:** Enterprise accounts can now assign the `Job Creator` permission set to groups and service tokens. Job Creator fills the gap between Job runner (can only trigger runs) and Job admin (full environment control): users can create and edit jobs scoped to specific environment categories (for example, `staging`) and trigger runs in any environment unconditionally, without `environments_write` access. See [Enterprise permissions](/docs/cloud/manage-access/enterprise-permissions) for details.
+
 ## March 18, 2026
 
 ## Enhancements

--- a/website/snippets/_enterprise-permissions-table.md
+++ b/website/snippets/_enterprise-permissions-table.md
@@ -76,43 +76,45 @@ Key:
 #### Account access for project permissions
 
 <FilterableTable>
-| Account-level permission | Admin | Analyst | Database admin | Developer | Git Admin | Job admin | Job runner  | Job viewer  | Metadata (Discovery API only) | Semantic Layer | Stakeholder/Read-Only | Team admin |
-|--------------------------|:-----:|:-------:|:--------------:|:---------:|:---------:|:---------:|:-----------:|:-----------:|:--------:|:--------------:|:-----------:|:----------:|
-| Account settings         |   R   |    -    |      R         |     -     |     R     |     -     |     -       |      -      |    -     |        -       |      -      |     R      |
-| Auth provider            |   -   |    -    |      -         |     -     |     -     |     -     |     -       |      -      |    -     |        -       |      -      |     -      |
-| Billing                  |   -   |    -    |      -         |     -     |     -     |     -     |     -       |      -      |    -     |        -       |      -      |     -      |
-| Connections              |   R   |    R    |      R         |     R     |     R     |     R     |     -       |      -      |    -     |        -       |      R      |     R      |
-| Groups                   |   R   |    -    |      R         |     R     |     R     |     -     |     -       |      -      |    -     |        -       |      R      |     R      |
-| Invitations              |   W   |    R    |      R         |     R     |     R     |     R     |     -       |      R      |    -     |        -       |      R      |     R      |
-| Licenses                 |   W   |    R    |      R         |     R     |     R     |     R     |     -       |      R      |    -     |        -       |      -      |     R      |
-| Members                  |   W   |    -    |      R         |     R     |     R     |     -     |     -       |      -      |    -     |        -       |      R      |     R      |
-| Project (create)         |   -   |    -    |      -         |     -     |     -     |     -     |     -       |      -      |    -     |        -       |      -      |     -      |
-| Public models            |   R   |    R    |      R         |     R     |     R     |     R     |     -       |      R      |     R    |        R       |      R      |     R      |
-| Service tokens           |   -   |    -    |      -         |     -     |     -     |     -     |     -       |      -      |    -     |        -       |      -      |     -      |
-| Webhooks                 |   W   |    -    |      -         |     W     |     -     |     -     |     -       |      -      |    -     |        -       |      -      |     -      |
+| Account-level permission | Admin | Analyst | Database admin | Developer | Git Admin | Job admin | Job creator | Job runner  | Job viewer  | Metadata (Discovery API only) | Semantic Layer | Stakeholder/Read-Only | Team admin |
+|--------------------------|:-----:|:-------:|:--------------:|:---------:|:---------:|:---------:|:-----------:|:-----------:|:-----------:|:--------:|:--------------:|:-----------:|:----------:|
+| Account settings         |   R   |    -    |      R         |     -     |     R     |     -     |     -       |      -      |      -      |    -     |        -       |      -      |     R      |
+| Auth provider            |   -   |    -    |      -         |     -     |     -     |     -     |     -       |      -      |      -      |    -     |        -       |      -      |     -      |
+| Billing                  |   -   |    -    |      -         |     -     |     -     |     -     |     -       |      -      |      -      |    -     |        -       |      -      |     -      |
+| Connections              |   R   |    R    |      R         |     R     |     R     |     R     |     R       |      -      |      -      |    -     |        -       |      R      |     R      |
+| Groups                   |   R   |    -    |      R         |     R     |     R     |     -     |     -       |      -      |      -      |    -     |        -       |      R      |     R      |
+| Invitations              |   W   |    R    |      R         |     R     |     R     |     R     |     R       |      -      |      R      |    -     |        -       |      R      |     R      |
+| Licenses                 |   W   |    R    |      R         |     R     |     R     |     R     |     R       |      -      |      R      |    -     |        -       |      -      |     R      |
+| Members                  |   W   |    -    |      R         |     R     |     R     |     -     |     -       |      -      |      -      |    -     |        -       |      R      |     R      |
+| Project (create)         |   -   |    -    |      -         |     -     |     -     |     -     |     -       |      -      |      -      |    -     |        -       |      -      |     -      |
+| Public models            |   R   |    R    |      R         |     R     |     R     |     R     |     R       |      -      |      R      |     R    |        R       |      R      |     R      |
+| Service tokens           |   -   |    -    |      -         |     -     |     -     |     -     |     -       |      -      |      -      |    -     |        -       |      -      |     -      |
+| Webhooks                 |   W   |    -    |      -         |     W     |     -     |     -     |     -       |      -      |      -      |    -     |        -       |      -      |     -      |
 </FilterableTable>
 
 #### Project access for project permissions
 
 <FilterableTable>
-|Project-level permission  | Admin | Analyst | Database admin | Developer | Fusion admin | Git Admin | Job admin | Job runner  | Job viewer  | Metadata (Discovery API only) | Semantic Layer | Stakeholder/Read-Only | Team admin |
-|--------------------------|:-----:|:-------:|:--------------:|:---------:|:------------:|:---------:|:---------:|:-----------:|:-----------:|:---------------------------------------:|:--------------:|:-----------:|:----------:|
-| Environment credentials  |   W   |    R    |       W        |     R     |      -       |     R     |     W     |    -        |      -      |                  -                      |        -       |     R       |     R      |
-| Custom env. variables    |   W   |    W#  |       W         |     W#    |      -       |     W     |     W     |     -       |      R      |                  -                      |        -       |     R       |     W      |
-| Data platform configs    |   W   |    W    |       W        |     W     |      -       |     R     |     W     |     -       |      -      |                  -                      |       -        |     R       |     R      |
-| Develop (IDE or CLI)     |   W   |    W    |       -        |     W     |      -       |     -     |     -     |     -       |      -      |                  -                      |       -        |     -       |      -     |
-| Environments             |   W   |    R    |       R        |     R     |      -       |     R     |     W     |      -      |      R      |                  -                      |       -        |     R       |     R      |
-| Fusion upgrade           |   -   |    -    |      -         |     -     |      W       |     -     |     -     |     -       |      -      |    -     |        -       |      -      |     -      |
-| Jobs                     |   W   |    R*   |       R*       |     R*    |      -       |     R*    |     W     |      R      |      R      |                  -                      |       -        |     R       |     R*     |
-| Metadata GraphQL API access| R   |    R    |       R        |     R     |      -       |     R     |     R     |      -      |      R      |                  R                      |       -        |     R       |     R      |
-| Permissions              |   W   |    -    |       R        |     R     |      -       |     R     |     -     |      -      |      -      |                  -                      |       -        |     -       |     R      |
-| Projects                 |   W   |    R    |       W        |     R     |      -       |     W     |     R     |      -      |      R      |                  -                      |       -        |     R       |     W      |
-| Repositories             |   W   |    R    |       R        |     R     |      -       |     W     |     -     |      -      |      -      |                  -                      |       -        |     R       |     R      |
-| Runs                     |   W   |    R*   |       R*       |     R*    |      -       |     R*    |     W     |      W      |      R      |                  -                      |       -        |     R       |     R*     |
-| Semantic Layer config    |   W   |    R    |       W        |     R     |      -       |     R     |     R     |      -      |      -      |                  -                      |        W       |     R       |     R      |
+|Project-level permission  | Admin | Analyst | Database admin | Developer | Fusion admin | Git Admin | Job admin | Job creator | Job runner  | Job viewer  | Metadata (Discovery API only) | Semantic Layer | Stakeholder/Read-Only | Team admin |
+|--------------------------|:-----:|:-------:|:--------------:|:---------:|:------------:|:---------:|:---------:|:-----------:|:-----------:|:-----------:|:---------------------------------------:|:--------------:|:-----------:|:----------:|
+| Environment credentials  |   W   |    R    |       W        |     R     |      -       |     R     |     W     |     R       |    -        |      -      |                  -                      |        -       |     R       |     R      |
+| Custom env. variables    |   W   |    W#  |       W         |     W#    |      -       |     W     |     W     |     W†      |     -       |      R      |                  -                      |        -       |     R       |     W      |
+| Data platform configs    |   W   |    W    |       W        |     W     |      -       |     R     |     W     |     -       |     -       |      -      |                  -                      |       -        |     R       |     R      |
+| Develop (IDE or CLI)     |   W   |    W    |       -        |     W     |      -       |     -     |     -     |     -       |     -       |      -      |                  -                      |       -        |     -       |      -     |
+| Environments             |   W   |    R    |       R        |     R     |      -       |     R     |     W     |     R       |      -      |      R      |                  -                      |       -        |     R       |     R      |
+| Fusion upgrade           |   -   |    -    |      -         |     -     |      W       |     -     |     -     |     -       |     -       |      -      |    -     |        -       |      -      |     -      |
+| Jobs                     |   W   |    R*   |       R*       |     R*    |      -       |     R*    |     W     |     W*      |      R      |      R      |                  -                      |       -        |     R       |     R*     |
+| Metadata GraphQL API access| R   |    R    |       R        |     R     |      -       |     R     |     R     |     R       |      -      |      R      |                  R                      |       -        |     R       |     R      |
+| Permissions              |   W   |    -    |       R        |     R     |      -       |     R     |     -     |     -       |      -      |      -      |                  -                      |       -        |     -       |     R      |
+| Projects                 |   W   |    R    |       W        |     R     |      -       |     W     |     R     |     R       |      -      |      R      |                  -                      |       -        |     R       |     W      |
+| Repositories             |   W   |    R    |       R        |     R     |      -       |     W     |     -     |     -       |      -      |      -      |                  -                      |       -        |     R       |     R      |
+| Runs                     |   W   |    R*   |       R*       |     R*    |      -       |     R*    |     W     |     W       |      W      |      R      |                  -                      |       -        |     R       |     R*     |
+| Semantic Layer config    |   W   |    R    |       W        |     R     |      -       |     R     |     R     |     -       |      -      |      -      |                  -                      |        W       |     R       |     R      |
 
 </FilterableTable>
 
 \* These permissions are `R`ead-only by default, but may be changed to `W`rite with [environment permissions](/docs/cloud/manage-access/environment-permissions#environments-and-roles).
 
 \# Custom env. variables for the `Developer` and `Analyst` roles are set in the **Credentials** section of **Account settings**.
+
+\† Custom env. variables for the `Job creator` role allow job-scope overrides only. Project-level and environment-level environment variable writes require `environments_write`, which is not included in this permission set.


### PR DESCRIPTION
## What are you changing in this pull request and why?

Adds the new `Job Creator` enterprise permission set to the enterprise permissions reference documentation.

**Why:** The `job_creator` permission set fills the gap between Job runner (can only trigger runs) and Job admin (full environment control + `environments_write`). Enterprise customers (Nordstrom, T-Mobile, Mass General) need to grant developers the ability to create jobs scoped to specific environment tiers (for example, `staging`) without exposing production infrastructure controls. This docs PR documents the new permission set so customers can understand and configure it correctly.

**Changes:**
- `website/docs/docs/cloud/manage-access/enterprise-permissions.md` — new `<Expandable alt_header="Job creator">` block between Job admin and Job runner
- `website/snippets/_enterprise-permissions-table.md` — new `Job creator` column in both the account-access and project-access tables; new `†` footnote clarifying env var write scope
- `website/docs/docs/dbt-versions/dbt-cloud-release-notes-gen.md` — release note entry for March 25, 2026

**Dependencies:** Depends on `dbt-cloud` PR 1a (enum + permission set class) being merged and deployed. Docs should go live with or just before feature flag rollout.

## Checklist

- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [x] Applied the proper versioning rules if the content is for specific dbt version(s): not applicable — this is an Enterprise plan feature with no dbt version dependency.
- [x] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).

**Preview checklist:**
- [ ] Expandable block renders correctly between Job admin and Job runner
- [ ] Job creator column appears in both permission tables with correct values
- [ ] `†` footnote renders and links to correct text
- [ ] Release note entry appears under March 25, 2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)