### PR TITLE
Update date filters to use session_start instead of page_view_start

### DIFF
--- a/website/docs/docs/build/incremental-microbatch.md
+++ b/website/docs/docs/build/incremental-microbatch.md
@@ -133,8 +133,8 @@ with page_views as (
     select * from (
         -- filtered on configured event_time
         select * from "analytics"."page_views"
-        where page_view_start >= '2024-10-01 00:00:00'  -- Oct 1
-        and page_view_start < '2024-10-02 00:00:00'
+        where session_start >= '2024-10-01 00:00:00'  -- Oct 1
+        and session_start < '2024-10-02 00:00:00'
     )
 
 ),
@@ -163,8 +163,8 @@ with page_views as (
     select * from (
         -- filtered on configured event_time
         select * from "analytics"."page_views"
-        where page_view_start >= '2024-10-02 00:00:00'  -- Oct 2
-        and page_view_start < '2024-10-03 00:00:00'
+        where session_start >= '2024-10-02 00:00:00'  -- Oct 2
+        and session_start < '2024-10-03 00:00:00'
     )
 
 ),


### PR DESCRIPTION
## What are you changing in this pull request and why?
In the config section of sql model is configured like event_time --> session_start right? It must be the real filter, isnt it?
