### PR TITLE
fix: update broken Dot documentation link

### DIFF
--- a/website/snippets/_sl-partner-links.md
+++ b/website/snippets/_sl-partner-links.md
@@ -45,10 +45,10 @@ The following tools integrate with the dbt Semantic Layer:
   <div className="card-container">
     <Card
       title="Dot"
-      link="https://docs.getdot.ai/dot/integrations/dbt-semantic-layer"
+      link="https://docs.getdot.ai/integrations/semantic-layers/dbt-semantic-layer"
       body="Enable everyone to analyze data with AI in Slack or Teams."
       icon="dot-ai"/>
-      <a href="https://docs.getdot.ai/dot/integrations/dbt-semantic-layer"
+      <a href="https://docs.getdot.ai/integrations/semantic-layers/dbt-semantic-layer"
       className="external-link"
       target="_blank"
       rel="noopener noreferrer">


### PR DESCRIPTION
## Summary

- Fix broken link to Dot's dbt Semantic Layer integration documentation
- The Dot documentation site was reorganized, moving integration pages from `/dot/integrations/` to `/integrations/semantic-layers/`
- The old URL (`https://docs.getdot.ai/dot/integrations/dbt-semantic-layer`) returns a 404; the new URL (`https://docs.getdot.ai/integrations/semantic-layers/dbt-semantic-layer`) is the correct destination

## What changed

Updated both the `link` attribute and the `<a href>` for the Dot card in `website/snippets/_sl-partner-links.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)