### PR TITLE
Wrap PrivateLink email templates in always-open Expandable

### DIFF
--- a/website/docs/docs/cloud/secure/private-connectivity/aws/databricks.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/aws/databricks.md
@@ -27,13 +27,15 @@ The following steps walk you through the setup of a Databricks AWS PrivateLink e
 
    <Expandable alt_header="Support request email template" is_open={true}>
 
-   **Subject:** New AWS Multi-Tenant PrivateLink Request
+   ```text
+   Subject: New AWS Multi-Tenant PrivateLink Request
 
-   - **Type:** Databricks
-   - **dbt platform account URL:**
-   - **Databricks instance name:**
-   - **Databricks cluster AWS Region** (for example, us-east-1, eu-west-2):
-   - **dbt AWS multi-tenant environment** (US, EMEA, AU):
+   - Type: Databricks
+   - dbt platform account URL:
+   - Databricks instance name:
+   - Databricks cluster AWS Region (for example, us-east-1, eu-west-2):
+   - dbt AWS multi-tenant environment (US, EMEA, AU):
+   ```
 
    </Expandable>
     <PrivateLinkSLA />

--- a/website/docs/docs/cloud/secure/private-connectivity/aws/databricks.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/aws/databricks.md
@@ -23,15 +23,19 @@ The following steps walk you through the setup of a Databricks AWS PrivateLink e
 1. Locate your [Databricks instance name](https://docs.databricks.com/en/workspace/workspace-details.html#workspace-instance-names-urls-and-ids).
    - Example: `cust-success.cloud.databricks.com`
 
-2. Add the required information to the following template and submit your AWS PrivateLink request to [dbt Support](/docs/dbt-support#dbt-cloud-support): 
-    ```
-    Subject: New AWS Multi-Tenant PrivateLink Request
-    - Type: Databricks
-    - dbt platform account URL:
-    - Databricks instance name:
-    - Databricks cluster AWS Region (for example, us-east-1, eu-west-2):
-    - dbt AWS multi-tenant environment (US, EMEA, AU):
-    ```
+2. Add the required information to the following template and submit your AWS PrivateLink request to [dbt Support](/docs/dbt-support#dbt-cloud-support):
+
+   <Expandable alt_header="Support request email template" is_open={true}>
+
+   **Subject:** New AWS Multi-Tenant PrivateLink Request
+
+   - **Type:** Databricks
+   - **dbt platform account URL:**
+   - **Databricks instance name:**
+   - **Databricks cluster AWS Region** (for example, us-east-1, eu-west-2):
+   - **dbt AWS multi-tenant environment** (US, EMEA, AU):
+
+   </Expandable>
     <PrivateLinkSLA />
 
 3. Once <Constant name="dbt" /> Support notifies you that setup is complete, [register the VPC endpoint in Databricks](https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html#step-3-register-privatelink-objects-and-attach-them-to-a-workspace) and attach it to the workspace:

--- a/website/docs/docs/cloud/secure/private-connectivity/aws/databricks.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/aws/databricks.md
@@ -23,7 +23,7 @@ The following steps walk you through the setup of a Databricks AWS PrivateLink e
 1. Locate your [Databricks instance name](https://docs.databricks.com/en/workspace/workspace-details.html#workspace-instance-names-urls-and-ids).
    - Example: `cust-success.cloud.databricks.com`
 
-2. Add the required information to the following template and submit your AWS PrivateLink request to [dbt Support](/docs/dbt-support#dbt-cloud-support):
+2. Add the required information to the following template and submit your AWS PrivateLink request to [dbt Support](mailto:support@getdbt.com):
 
    <Expandable alt_header="Support request email template" is_open={true}>
 

--- a/website/docs/docs/cloud/secure/private-connectivity/aws/postgres.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/aws/postgres.md
@@ -77,13 +77,15 @@ Add the required information to the template below and submit your request to [d
 
 <Expandable alt_header="Support request email template" is_open={true}>
 
-**Subject:** New Multi-Tenant PrivateLink Request
+```text
+Subject: New Multi-Tenant PrivateLink Request
 
-- **Type:** Postgres Interface-type
-- **dbt platform account URL:**
-- **VPC Endpoint Service Name:**
-- **Postgres server AWS Region** (for example, us-east-1, eu-west-2):
-- **dbt AWS multi-tenant environment** (US, EMEA, AU):
+- Type: Postgres Interface-type
+- dbt platform account URL:
+- VPC Endpoint Service Name:
+- Postgres server AWS Region (for example, us-east-1, eu-west-2):
+- dbt AWS multi-tenant environment (US, EMEA, AU):
+```
 
 </Expandable>
 

--- a/website/docs/docs/cloud/secure/private-connectivity/aws/postgres.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/aws/postgres.md
@@ -74,14 +74,18 @@ Once the VPC Endpoint Service is provisioned, you can find the service name in t
 
 ### 4. Submit your request to dbt Support
 Add the required information to the template below and submit your request to [dbt Support](/community/resources/getting-help#dbt-cloud-support):
-```
-Subject: New Multi-Tenant PrivateLink Request
-- Type: Postgres Interface-type
-- dbt platform account URL:
-- VPC Endpoint Service Name:
-- Postgres server AWS Region (for example, us-east-1, eu-west-2):
-- dbt AWS multi-tenant environment (US, EMEA, AU):
-```
+
+<Expandable alt_header="Support request email template" is_open={true}>
+
+**Subject:** New Multi-Tenant PrivateLink Request
+
+- **Type:** Postgres Interface-type
+- **dbt platform account URL:**
+- **VPC Endpoint Service Name:**
+- **Postgres server AWS Region** (for example, us-east-1, eu-west-2):
+- **dbt AWS multi-tenant environment** (US, EMEA, AU):
+
+</Expandable>
 
 
 import PrivateLinkSLA from '/snippets/_private-connection-SLA.md';

--- a/website/docs/docs/cloud/secure/private-connectivity/aws/postgres.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/aws/postgres.md
@@ -73,7 +73,7 @@ Once the VPC Endpoint Service is provisioned, you can find the service name in t
 <Lightbox src="/img/docs/dbt-cloud/privatelink-endpoint-service-name.png" width="70%" title="Get service name field value"/>
 
 ### 4. Submit your request to dbt Support
-Add the required information to the template below and submit your request to [dbt Support](/community/resources/getting-help#dbt-cloud-support):
+Add the required information to the template below and submit your request to [dbt Support](mailto:support@getdbt.com):
 
 <Expandable alt_header="Support request email template" is_open={true}>
 

--- a/website/docs/docs/cloud/secure/private-connectivity/aws/redshift.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/aws/redshift.md
@@ -45,26 +45,34 @@ AWS provides two different ways to create a PrivateLink VPC endpoint for a Redsh
 5. Add the required information to the following template, and submit your request to [dbt Support](/community/resources/getting-help#dbt-cloud-support):
 
    - **Standard Redshift**
-       ```
-       Subject: New Multi-Tenant PrivateLink Request
-       - Type: Redshift-managed
-       - dbt platform account URL:
-       - Redshift cluster name:
-       - Redshift cluster AWS account ID:
-       - Redshift cluster AWS Region (for example, us-east-1, eu-west-2):
-       - <Constant name="dbt" /> multi-tenant environment (US, EMEA, AU):
-       ```
+
+     <Expandable alt_header="Support request email template" is_open={true}>
+
+     **Subject:** New Multi-Tenant PrivateLink Request
+
+     - **Type:** Redshift-managed
+     - **dbt platform account URL:**
+     - **Redshift cluster name:**
+     - **Redshift cluster AWS account ID:**
+     - **Redshift cluster AWS Region** (for example, us-east-1, eu-west-2):
+     - **dbt multi-tenant environment** (US, EMEA, AU):
+
+     </Expandable>
 
    - **Redshift Serverless**
-       ```
-       Subject: New Multi-Tenant PrivateLink Request
-       - Type: Redshift-managed - Serverless
-       - dbt platform account URL:
-       - Redshift workgroup name:
-       - Redshift workgroup AWS account ID:
-       - Redshift workgroup AWS Region (for example, us-east-1, eu-west-2):
-       - <Constant name="dbt" /> multi-tenant environment (US, EMEA, AU):
-       ```
+
+     <Expandable alt_header="Support request email template" is_open={true}>
+
+     **Subject:** New Multi-Tenant PrivateLink Request
+
+     - **Type:** Redshift-managed - Serverless
+     - **dbt platform account URL:**
+     - **Redshift workgroup name:**
+     - **Redshift workgroup AWS account ID:**
+     - **Redshift workgroup AWS Region** (for example, us-east-1, eu-west-2):
+     - **dbt multi-tenant environment** (US, EMEA, AU):
+
+     </Expandable>
 
 import PrivateLinkSLA from '/snippets/_private-connection-SLA.md';
 
@@ -124,14 +132,18 @@ Once the VPC Endpoint Service is provisioned, you can find the service name in t
 
 ### 4. Submit your request to dbt Support
 Add the required information to the template below and submit your request to [dbt Support](/community/resources/getting-help#dbt-cloud-support):
-```
-Subject: New Multi-Tenant PrivateLink Request
-- Type: Redshift Interface-type
-- dbt platform account URL:
-- VPC Endpoint Service Name:
-- Redshift cluster AWS Region (for example, us-east-1, eu-west-2):
-- dbt AWS multi-tenant environment (US, EMEA, AU):
-```
+
+<Expandable alt_header="Support request email template" is_open={true}>
+
+**Subject:** New Multi-Tenant PrivateLink Request
+
+- **Type:** Redshift Interface-type
+- **dbt platform account URL:**
+- **VPC Endpoint Service Name:**
+- **Redshift cluster AWS Region** (for example, us-east-1, eu-west-2):
+- **dbt AWS multi-tenant environment** (US, EMEA, AU):
+
+</Expandable>
 
 <PrivateLinkSLA />
 

--- a/website/docs/docs/cloud/secure/private-connectivity/aws/redshift.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/aws/redshift.md
@@ -48,14 +48,16 @@ AWS provides two different ways to create a PrivateLink VPC endpoint for a Redsh
 
      <Expandable alt_header="Support request email template" is_open={true}>
 
-     **Subject:** New Multi-Tenant PrivateLink Request
+     ```text
+     Subject: New Multi-Tenant PrivateLink Request
 
-     - **Type:** Redshift-managed
-     - **dbt platform account URL:**
-     - **Redshift cluster name:**
-     - **Redshift cluster AWS account ID:**
-     - **Redshift cluster AWS Region** (for example, us-east-1, eu-west-2):
-     - **dbt multi-tenant environment** (US, EMEA, AU):
+     - Type: Redshift-managed
+     - dbt platform account URL:
+     - Redshift cluster name:
+     - Redshift cluster AWS account ID:
+     - Redshift cluster AWS Region (for example, us-east-1, eu-west-2):
+     - dbt multi-tenant environment (US, EMEA, AU):
+     ```
 
      </Expandable>
 
@@ -63,14 +65,16 @@ AWS provides two different ways to create a PrivateLink VPC endpoint for a Redsh
 
      <Expandable alt_header="Support request email template" is_open={true}>
 
-     **Subject:** New Multi-Tenant PrivateLink Request
+     ```text
+     Subject: New Multi-Tenant PrivateLink Request
 
-     - **Type:** Redshift-managed - Serverless
-     - **dbt platform account URL:**
-     - **Redshift workgroup name:**
-     - **Redshift workgroup AWS account ID:**
-     - **Redshift workgroup AWS Region** (for example, us-east-1, eu-west-2):
-     - **dbt multi-tenant environment** (US, EMEA, AU):
+     - Type: Redshift-managed - Serverless
+     - dbt platform account URL:
+     - Redshift workgroup name:
+     - Redshift workgroup AWS account ID:
+     - Redshift workgroup AWS Region (for example, us-east-1, eu-west-2):
+     - dbt multi-tenant environment (US, EMEA, AU):
+     ```
 
      </Expandable>
 
@@ -135,13 +139,15 @@ Add the required information to the template below and submit your request to [d
 
 <Expandable alt_header="Support request email template" is_open={true}>
 
-**Subject:** New Multi-Tenant PrivateLink Request
+```text
+Subject: New Multi-Tenant PrivateLink Request
 
-- **Type:** Redshift Interface-type
-- **dbt platform account URL:**
-- **VPC Endpoint Service Name:**
-- **Redshift cluster AWS Region** (for example, us-east-1, eu-west-2):
-- **dbt AWS multi-tenant environment** (US, EMEA, AU):
+- Type: Redshift Interface-type
+- dbt platform account URL:
+- VPC Endpoint Service Name:
+- Redshift cluster AWS Region (for example, us-east-1, eu-west-2):
+- dbt AWS multi-tenant environment (US, EMEA, AU):
+```
 
 </Expandable>
 

--- a/website/docs/docs/cloud/secure/private-connectivity/aws/redshift.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/aws/redshift.md
@@ -36,13 +36,13 @@ AWS provides two different ways to create a PrivateLink VPC endpoint for a Redsh
 
 <Lightbox src="/img/docs/dbt-cloud/redshiftprivatelink2.png" title="Redshift granted accounts"/>
 
-3. Enter the AWS account ID: `346425330055` - _NOTE: This account ID only applies to <Constant name="dbt" /> Multi-Tenant environments. For Virtual Private/Single-Tenant account IDs please contact [Support](/community/resources/getting-help#dbt-cloud-support)._
+3. Enter the AWS account ID: `346425330055` - _NOTE: This account ID only applies to <Constant name="dbt" /> Multi-Tenant environments. For Virtual Private/Single-Tenant account IDs please contact [Support](mailto:support@getdbt.com)._
 
-4. Choose **Grant access to all VPCs** &mdash;or&mdash; (optional) contact [Support](/community/resources/getting-help#dbt-cloud-support) for the appropriate regional VPC ID to designate in the **Grant access to specific VPCs** field.
+4. Choose **Grant access to all VPCs** &mdash;or&mdash; (optional) contact [Support](mailto:support@getdbt.com) for the appropriate regional VPC ID to designate in the **Grant access to specific VPCs** field.
 
 <Lightbox src="/img/docs/dbt-cloud/redshiftprivatelink3.png" title="Redshift grant access"/>
 
-5. Add the required information to the following template, and submit your request to [dbt Support](/community/resources/getting-help#dbt-cloud-support):
+5. Add the required information to the following template, and submit your request to [dbt Support](mailto:support@getdbt.com):
 
    - **Standard Redshift**
 
@@ -135,7 +135,7 @@ Once the VPC Endpoint Service is provisioned, you can find the service name in t
 <Lightbox src="/img/docs/dbt-cloud/privatelink-endpoint-service-name.png" title="Get service name field value"/>
 
 ### 4. Submit your request to dbt Support
-Add the required information to the template below and submit your request to [dbt Support](/community/resources/getting-help#dbt-cloud-support):
+Add the required information to the template below and submit your request to [dbt Support](mailto:support@getdbt.com):
 
 <Expandable alt_header="Support request email template" is_open={true}>
 

--- a/website/docs/docs/cloud/secure/private-connectivity/aws/self-hosted.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/aws/self-hosted.md
@@ -113,17 +113,20 @@ For more details, see [Update the security groups for your Network Load Balancer
 
 8. Add the required information to the template below, and submit your request to [dbt Support](/community/resources/getting-help#dbt-cloud-support):
 
-```
-Subject: New AWS Self-hosted PrivateLink Request
-- Type: Self-hosted PrivateLink
-- Platform/Service: (for example, Postgres, Starburst, Spark, GitLab, etc.)
-- dbt platform account URL:
-- VPC Endpoint Service Name:
-- Custom DNS (if HTTPS/TLS)
-    - DNS record:
-- Service Region: (for example, us-east-1, eu-west-2)
-- dbt AWS environment (US, EMEA, AU):
-```
+<Expandable alt_header="Support request email template" is_open={true}>
+
+**Subject:** New AWS Self-hosted PrivateLink Request
+
+- **Type:** Self-hosted PrivateLink
+- **Platform/Service** (for example, Postgres, Starburst, Spark, GitLab, etc.):
+- **dbt platform account URL:**
+- **VPC Endpoint Service Name:**
+- **Custom DNS (if HTTPS/TLS):**
+  - DNS record:
+- **Service Region** (for example, us-east-1, eu-west-2):
+- **dbt AWS environment** (US, EMEA, AU):
+
+</Expandable>
 
 import PrivateLinkSLA from '/snippets/_private-connection-SLA.md';
 

--- a/website/docs/docs/cloud/secure/private-connectivity/aws/self-hosted.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/aws/self-hosted.md
@@ -53,7 +53,7 @@ Before you begin, make sure to review the following requirements:
 
 3. **dbt AWS Account ARN**
 
-    - Contact [dbt Support](/community/resources/getting-help#dbt-cloud-support) to obtain the dbt AWS account ARN. You will need this in order to allow dbt to connect to your Endpoint Service.
+    - Contact [dbt Support](mailto:support@getdbt.com) to obtain the dbt AWS account ARN. You will need this in order to allow dbt to connect to your Endpoint Service.
 
 
 ## Additional NLB configuration
@@ -73,7 +73,7 @@ You have two options:
 | Option | Description |
 |--------|-------------|
 | **Disable enforcement** (recommended) | Turn off security group enforcement for PrivateLink traffic. This is the simplest approach and doesn't require knowledge of dbt's internal CIDRs. In the AWS Console: NLB → Security → Edit → Clear **Enforce inbound rules on PrivateLink traffic**. |
-| **Add dbt CIDRs to inbound rules** | If your use case requires security group enforcement on PrivateLink traffic, [contact dbt Support](/community/resources/getting-help#dbt-cloud-support) to obtain the internal CIDR ranges to add to your NLB's security group inbound rules. |
+| **Add dbt CIDRs to inbound rules** | If your use case requires security group enforcement on PrivateLink traffic, [contact dbt Support](mailto:support@getdbt.com) to obtain the internal CIDR ranges to add to your NLB's security group inbound rules. |
 
 For more details, see [Update the security groups for your Network Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-security-groups.html).
 
@@ -111,7 +111,7 @@ For more details, see [Update the security groups for your Network Load Balancer
 
 ### Providing dbt Support with connection details
 
-8. Add the required information to the template below, and submit your request to [dbt Support](/community/resources/getting-help#dbt-cloud-support):
+8. Add the required information to the template below, and submit your request to [dbt Support](mailto:support@getdbt.com):
 
 <Expandable alt_header="Support request email template" is_open={true}>
 
@@ -165,7 +165,7 @@ If the PrivateLink endpoint has been provisioned and configured in <Constant nam
 
 ### Monitoring
 
-To help isolate connection issues over a PrivateLink connection from <Constant name="dbt" />, there are a few monitoring sources that can be used to verify request activity. Requests must first be sent to the endpoint to see anything in the monitoring. [Contact dbt Support](/community/resources/getting-help#dbt-cloud-support) to understand when connection testing occurred or request new connection attempts. Use these times to correlate with activity in the following monitoring sources.
+To help isolate connection issues over a PrivateLink connection from <Constant name="dbt" />, there are a few monitoring sources that can be used to verify request activity. Requests must first be sent to the endpoint to see anything in the monitoring. [Contact dbt Support](mailto:support@getdbt.com) to understand when connection testing occurred or request new connection attempts. Use these times to correlate with activity in the following monitoring sources.
 
 #### VPC Endpoint Service monitoring
 

--- a/website/docs/docs/cloud/secure/private-connectivity/aws/self-hosted.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/aws/self-hosted.md
@@ -115,17 +115,18 @@ For more details, see [Update the security groups for your Network Load Balancer
 
 <Expandable alt_header="Support request email template" is_open={true}>
 
-**Subject:** New AWS Self-hosted PrivateLink Request
+```text
+Subject: New AWS Self-hosted PrivateLink Request
 
-- **Type:** Self-hosted PrivateLink
-- **Platform/Service** (for example, Postgres, Starburst, Spark, GitLab, etc.):
+- Type: Self-hosted PrivateLink
+- Platform/Service (for example, Postgres, Starburst, Spark, GitLab, etc.):
 - **dbt platform account URL:**
-- **VPC Endpoint Service Name:**
-- **Custom DNS (if HTTPS/TLS):**
+- VPC Endpoint Service Name:
+- Custom DNS (if HTTPS/TLS):
   - DNS record:
-- **Service Region** (for example, us-east-1, eu-west-2):
-- **dbt AWS environment** (US, EMEA, AU):
-
+- Service Region (for example, us-east-1, eu-west-2):
+- dbt AWS environment (US, EMEA, AU):
+```
 </Expandable>
 
 import PrivateLinkSLA from '/snippets/_private-connection-SLA.md';

--- a/website/docs/docs/cloud/secure/private-connectivity/aws/snowflake.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/aws/snowflake.md
@@ -38,14 +38,16 @@ To configure Snowflake instances hosted on AWS for [PrivateLink](https://aws.ama
 
 <Expandable alt_header="Support request email template" is_open={true}>
 
-**Subject:** New Multi-Tenant (Azure or AWS) PrivateLink Request
+```text
+Subject: New Multi-Tenant (Azure or AWS) PrivateLink Request
 
-- **Type:** Snowflake
-- **dbt platform account URL:**
-- **SYSTEM$GET_PRIVATELINK_CONFIG output:**
-- **\*Use privatelink-account-url or regionless-privatelink-account-url?:**
-- **\*\*Create Internal Stage PrivateLink endpoint? (Y/N):**
-- **dbt AWS multi-tenant environment** (US, EMEA, AU):
+- Type: Snowflake
+- dbt platform account URL:
+- SYSTEM$GET_PRIVATELINK_CONFIG output:
+- *Use privatelink-account-url or regionless-privatelink-account-url?:
+- **Create Internal Stage PrivateLink endpoint? (Y/N):
+- dbt AWS multi-tenant environment (US, EMEA, AU):
+```
 
 </Expandable>
 _*By default, <Constant name="dbt" /> will be configured to use `privatelink-account-url` from the provided [SYSTEM$GET_PRIVATELINK_CONFIG](https://docs.snowflake.com/en/sql-reference/functions/system_get_privatelink_config.html) as the PrivateLink endpoint. Upon request, `regionless-privatelink-account-url` can be used instead._

--- a/website/docs/docs/cloud/secure/private-connectivity/aws/snowflake.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/aws/snowflake.md
@@ -27,14 +27,14 @@ To configure Snowflake instances hosted on AWS for [PrivateLink](https://aws.ama
 1. Open a support case with Snowflake to allow access from the <Constant name="dbt" /> AWS account.
    - Snowflake prefers that the account owner opens the support case directly rather than dbt Labs acting on their behalf. For more information, refer to [Snowflake's knowledge base article](https://community.snowflake.com/s/article/HowtosetupPrivatelinktoSnowflakefromCloudServiceVendors).
    - Provide them with your <Constant name="dbt" /> account ID along with any other information requested in the article.
-     - **AWS account ID**: `346425330055` &mdash; _Note: This account ID only applies to AWS <Constant name="dbt" /> multi-tenant environments. For AWS Virtual Private/Single-Tenant account IDs, contact [dbt Support](/docs/dbt-support#dbt-cloud-support)._
+     - **AWS account ID**: `346425330055` &mdash; _Note: This account ID only applies to AWS <Constant name="dbt" /> multi-tenant environments. For AWS Virtual Private/Single-Tenant account IDs, contact [dbt Support](mailto:support@getdbt.com)._
    - You need `ACCOUNTADMIN` access to the Snowflake instance to submit a support request.
 
 <Lightbox src="/img/docs/dbt-cloud/snowflakeprivatelink1.png" title="Open snowflake case"/>
 
 2. After Snowflake has granted the requested access, run the Snowflake system function [SYSTEM$GET_PRIVATELINK_CONFIG](https://docs.snowflake.com/en/sql-reference/functions/system_get_privatelink_config.html) and copy the output.
 
-3. Add the required information to the following template and submit your request to  [dbt Support](/docs/dbt-support#dbt-cloud-support):
+3. Add the required information to the following template and submit your request to  [dbt Support](mailto:support@getdbt.com):
 
 <Expandable alt_header="Support request email template" is_open={true}>
 

--- a/website/docs/docs/cloud/secure/private-connectivity/aws/snowflake.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/aws/snowflake.md
@@ -36,15 +36,18 @@ To configure Snowflake instances hosted on AWS for [PrivateLink](https://aws.ama
 
 3. Add the required information to the following template and submit your request to  [dbt Support](/docs/dbt-support#dbt-cloud-support):
 
-```
-Subject: New Multi-Tenant (Azure or AWS) PrivateLink Request
-- Type: Snowflake
-- dbt platform account URL:
-- SYSTEM$GET_PRIVATELINK_CONFIG output:
-- *Use privatelink-account-url or regionless-privatelink-account-url?:
-- **Create Internal Stage PrivateLink endpoint? (Y/N): 
-- dbt AWS multi-tenant environment (US, EMEA, AU):
-```
+<Expandable alt_header="Support request email template" is_open={true}>
+
+**Subject:** New Multi-Tenant (Azure or AWS) PrivateLink Request
+
+- **Type:** Snowflake
+- **dbt platform account URL:**
+- **SYSTEM$GET_PRIVATELINK_CONFIG output:**
+- **\*Use privatelink-account-url or regionless-privatelink-account-url?:**
+- **\*\*Create Internal Stage PrivateLink endpoint? (Y/N):**
+- **dbt AWS multi-tenant environment** (US, EMEA, AU):
+
+</Expandable>
 _*By default, <Constant name="dbt" /> will be configured to use `privatelink-account-url` from the provided [SYSTEM$GET_PRIVATELINK_CONFIG](https://docs.snowflake.com/en/sql-reference/functions/system_get_privatelink_config.html) as the PrivateLink endpoint. Upon request, `regionless-privatelink-account-url` can be used instead._
 
 _** Internal Stage PrivateLink must be [enabled on the Snowflake account](https://docs.snowflake.com/en/user-guide/private-internal-stages-aws#prerequisites) to use this feature_

--- a/website/docs/docs/cloud/secure/private-connectivity/azure/databricks.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/azure/databricks.md
@@ -25,16 +25,18 @@ The following steps walk you through the setup of a Databricks Azure Private Lin
 
    <Expandable alt_header="Support request email template" is_open={true}>
 
-   **Subject:** New Azure Multi-Tenant Private Link Request
+   ```text
+   Subject: New Azure Multi-Tenant Private Link Request
 
-   - **Type:** Databricks
-   - **dbt platform account URL:**
-   - **Databricks instance name:**
-   - **Azure Databricks Workspace URL** (for example, `adb-################.##.azuredatabricks.net`)
-   - **Databricks Azure resource ID:** `/subscriptions/SUB_ID/resourceGroups/RG/providers/Microsoft.Databricks/workspaces/WORKSPACE_NAME`
-     - Use the full ARM resource ID, replacing `SUB_ID`, `RG`, and `WORKSPACE_NAME` with your values
-   - **dbt Azure multi-tenant environment (EMEA):**
-   - **Azure Databricks workspace region** (for example, `WestEurope`, `NorthEurope`)
+   - Type: Databricks
+   - dbt platform account URL:
+   - Databricks instance name:
+   - Azure Databricks Workspace URL (for example, adb-################.##.azuredatabricks.net)
+   - Databricks Azure resource ID: /subscriptions/SUB_ID/resourceGroups/RG/providers/Microsoft.Databricks/workspaces/WORKSPACE_NAME
+     - Use the full ARM resource ID, replacing SUB_ID, RG, and WORKSPACE_NAME with your values
+   - dbt Azure multi-tenant environment (EMEA):
+   - Azure Databricks workspace region (for example, WestEurope, NorthEurope)
+   ```
 
    </Expandable>
 

--- a/website/docs/docs/cloud/secure/private-connectivity/azure/databricks.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/azure/databricks.md
@@ -21,7 +21,7 @@ The following steps walk you through the setup of a Databricks Azure Private Lin
     The path format is: `/subscriptions/<subscription_uuid>/resourceGroups/<resource_group_name>/providers/Microsoft.Databricks/workspaces/<workspace_name>`.
 2. From the workspace overview, click **JSON view**. 
 3. Copy the value in the `resource_id` field.  
-4. Add the required information to the following template and submit your Azure Private Link request to [dbt Support](/docs/dbt-support#dbt-cloud-support):
+4. Add the required information to the following template and submit your Azure Private Link request to [dbt Support](mailto:support@getdbt.com):
 
    <Expandable alt_header="Support request email template" is_open={true}>
 

--- a/website/docs/docs/cloud/secure/private-connectivity/azure/postgres.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/azure/postgres.md
@@ -26,14 +26,16 @@ From your Azure portal:
 
    <Expandable alt_header="Support request email template" is_open={true}>
 
-   **Subject:** New Azure Multi-Tenant Private Link Request
+   ```text
+   Subject: New Azure Multi-Tenant Private Link Request
 
-   - **Type:** Azure Database for Postgres Flexible Server
-   - **dbt platform account URL:**
-   - **Postgres Flexible Server name:**
-   - **Azure Database for Postgres Flexible Server resource ID:**
-   - **dbt Azure multi-tenant environment** (EMEA):
-   - **Azure Postgres server region** (for example, WestEurope, NorthEurope):
+   - Type: Azure Database for Postgres Flexible Server
+   - dbt platform account URL:
+   - Postgres Flexible Server name:
+   - Azure Database for Postgres Flexible Server resource ID:
+   - dbt Azure multi-tenant environment (EMEA):
+   - Azure Postgres server region (for example, WestEurope, NorthEurope):
+   ```
 
    </Expandable>
 5. Once our Support team confirms the endpoint has been created, navigate to the Azure Database for Postgres Flexible Server in the Azure Portal and browse to **Settings** > **Networking**. In the **Private Endpoints** section, highlight the `dbt` named option and select **Approve**. Confirm with dbt Support that the connection has been approved so they can validate the connection and make it available for use in <Constant name="dbt" />.

--- a/website/docs/docs/cloud/secure/private-connectivity/azure/postgres.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/azure/postgres.md
@@ -22,7 +22,7 @@ From your Azure portal:
 2. From the server overview, click **JSON view**. 
 3. Copy the value in the **Resource ID** field at the top of the pane.  
     The path format is: `/subscriptions/<subscription_uuid>/resourceGroups/<resource_group_name>/providers/Microsoft.DBforPostgreSQL/flexibleServers/<server_name>`.
-4. Add the required information to the following template and submit your Azure Private Link request to [dbt Support](/docs/dbt-support#dbt-cloud-support):
+4. Add the required information to the following template and submit your Azure Private Link request to [dbt Support](mailto:support@getdbt.com):
 
    <Expandable alt_header="Support request email template" is_open={true}>
 

--- a/website/docs/docs/cloud/secure/private-connectivity/azure/postgres.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/azure/postgres.md
@@ -22,16 +22,20 @@ From your Azure portal:
 2. From the server overview, click **JSON view**. 
 3. Copy the value in the **Resource ID** field at the top of the pane.  
     The path format is: `/subscriptions/<subscription_uuid>/resourceGroups/<resource_group_name>/providers/Microsoft.DBforPostgreSQL/flexibleServers/<server_name>`.
-4. Add the required information to the following template and submit your Azure Private Link request to [dbt Support](/docs/dbt-support#dbt-cloud-support): 
-    ```
-      Subject: New Azure Multi-Tenant Private Link Request
-    - Type: Azure Database for Postgres Flexible Server
-    - dbt platform account URL:
-    - Postgres Flexible Server name:
-    - Azure Database for Postgres Flexible Server resource ID:
-    - dbt Azure multi-tenant environment (EMEA):
-    - Azure Postgres server region (for example, WestEurope, NorthEurope):
-    ```
+4. Add the required information to the following template and submit your Azure Private Link request to [dbt Support](/docs/dbt-support#dbt-cloud-support):
+
+   <Expandable alt_header="Support request email template" is_open={true}>
+
+   **Subject:** New Azure Multi-Tenant Private Link Request
+
+   - **Type:** Azure Database for Postgres Flexible Server
+   - **dbt platform account URL:**
+   - **Postgres Flexible Server name:**
+   - **Azure Database for Postgres Flexible Server resource ID:**
+   - **dbt Azure multi-tenant environment** (EMEA):
+   - **Azure Postgres server region** (for example, WestEurope, NorthEurope):
+
+   </Expandable>
 5. Once our Support team confirms the endpoint has been created, navigate to the Azure Database for Postgres Flexible Server in the Azure Portal and browse to **Settings** > **Networking**. In the **Private Endpoints** section, highlight the `dbt` named option and select **Approve**. Confirm with dbt Support that the connection has been approved so they can validate the connection and make it available for use in <Constant name="dbt" />.
 
 

--- a/website/docs/docs/cloud/secure/private-connectivity/azure/self-hosted.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/azure/self-hosted.md
@@ -53,7 +53,7 @@ Before you begin, make sure to review the following requirements:
 
 3. **dbt Azure Subscription ID**
 
-    - Contact [dbt Support](/community/resources/getting-help#dbt-cloud-support) to obtain the dbt Azure subscription ID. You will need this in order to allow dbt to connect to your Private Link Service.
+    - Contact [dbt Support](mailto:support@getdbt.com) to obtain the dbt Azure subscription ID. You will need this in order to allow dbt to connect to your Private Link Service.
 
 
 ## Instructions
@@ -134,7 +134,7 @@ Before you begin, make sure to review the following requirements:
 
 ### Providing dbt Support with connection details
 
-11. Add the required information to the template below, and submit your request to [dbt Support](/community/resources/getting-help#dbt-cloud-support):
+11. Add the required information to the template below, and submit your request to [dbt Support](mailto:support@getdbt.com):
 
 <Expandable alt_header="Support request email template" is_open={true}>
 

--- a/website/docs/docs/cloud/secure/private-connectivity/azure/self-hosted.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/azure/self-hosted.md
@@ -136,17 +136,20 @@ Before you begin, make sure to review the following requirements:
 
 11. Add the required information to the template below, and submit your request to [dbt Support](/community/resources/getting-help#dbt-cloud-support):
 
-```
-Subject: New Azure Self-hosted Private Link Request
-- Type: Self-hosted Private Link
-- Platform/Service: (for example, Postgres, Starburst, Spark, GitLab, etc.)
-- dbt platform account URL:
-- Private Link Service Alias:
-- Custom DNS (if HTTPS/TLS)
-    - DNS record:
-- Service Region: (for example, East US, West Europe)
-- dbt Azure environment (EMEA):
-```
+<Expandable alt_header="Support request email template" is_open={true}>
+
+**Subject:** New Azure Self-hosted Private Link Request
+
+- **Type:** Self-hosted Private Link
+- **Platform/Service** (for example, Postgres, Starburst, Spark, GitLab, etc.):
+- **dbt platform account URL:**
+- **Private Link Service Alias:**
+- **Custom DNS (if HTTPS/TLS):**
+  - DNS record:
+- **Service Region** (for example, East US, West Europe):
+- **dbt Azure environment** (EMEA):
+
+</Expandable>
 
 import PrivateLinkSLA from '/snippets/_private-connection-SLA.md';
 

--- a/website/docs/docs/cloud/secure/private-connectivity/azure/self-hosted.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/azure/self-hosted.md
@@ -138,16 +138,18 @@ Before you begin, make sure to review the following requirements:
 
 <Expandable alt_header="Support request email template" is_open={true}>
 
-**Subject:** New Azure Self-hosted Private Link Request
+```text
+Subject: New Azure Self-hosted Private Link Request
 
-- **Type:** Self-hosted Private Link
-- **Platform/Service** (for example, Postgres, Starburst, Spark, GitLab, etc.):
-- **dbt platform account URL:**
-- **Private Link Service Alias:**
-- **Custom DNS (if HTTPS/TLS):**
+- Type: Self-hosted Private Link
+- Platform/Service (for example, Postgres, Starburst, Spark, GitLab, etc.):
+- dbt platform account URL:
+- Private Link Service Alias:
+- Custom DNS (if HTTPS/TLS):
   - DNS record:
-- **Service Region** (for example, East US, West Europe):
-- **dbt Azure environment** (EMEA):
+- Service Region (for example, East US, West Europe):
+- dbt Azure environment (EMEA):
+```
 
 </Expandable>
 

--- a/website/docs/docs/cloud/secure/private-connectivity/azure/snowflake.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/azure/snowflake.md
@@ -40,14 +40,16 @@ SELECT SYSTEM$GET_PRIVATELINK_CONFIG();
 
 <Expandable alt_header="Support request email template" is_open={true}>
 
-**Subject:** New Multi-Tenant Azure PrivateLink Request
+```text
+Subject: New Multi-Tenant Azure PrivateLink Request
 
-- **Type:** Snowflake
-- **dbt platform account URL:**
-- **The output from SYSTEM$GET_PRIVATELINK_CONFIG:**
+- Type: Snowflake
+- dbt platform account URL:
+- The output from SYSTEM$GET_PRIVATELINK_CONFIG:
   - Include the privatelink-pls-id
-  - Enable Internal Stage Private Link? Y/N (If Y, output must include `privatelink-internal-stage`)
-- **dbt Azure multi-tenant environment** (EMEA):
+  - Enable Internal Stage Private Link? Y/N (If Y, output must include privatelink-internal-stage)
+- dbt Azure multi-tenant environment (EMEA):
+```
 
 </Expandable>
 

--- a/website/docs/docs/cloud/secure/private-connectivity/azure/snowflake.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/azure/snowflake.md
@@ -36,7 +36,7 @@ SELECT SYSTEM$GET_PRIVATELINK_CONFIG();
 
 ```
 
-2. Add the required information to the following template and submit your request to  [dbt Support](/docs/dbt-support#dbt-cloud-support):
+2. Add the required information to the following template and submit your request to  [dbt Support](mailto:support@getdbt.com):
 
 <Expandable alt_header="Support request email template" is_open={true}>
 

--- a/website/docs/docs/cloud/secure/private-connectivity/azure/snowflake.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/azure/snowflake.md
@@ -36,17 +36,20 @@ SELECT SYSTEM$GET_PRIVATELINK_CONFIG();
 
 ```
 
-2. Add the required information to the following template and submit your request to  [dbt Support](/docs/dbt-support#dbt-cloud-support): 
+2. Add the required information to the following template and submit your request to  [dbt Support](/docs/dbt-support#dbt-cloud-support):
 
-```
-Subject: New Multi-Tenant Azure PrivateLink Request
-- Type: Snowflake
-- dbt platform account URL:
-- The output from SYSTEM$GET_PRIVATELINK_CONFIG:
+<Expandable alt_header="Support request email template" is_open={true}>
+
+**Subject:** New Multi-Tenant Azure PrivateLink Request
+
+- **Type:** Snowflake
+- **dbt platform account URL:**
+- **The output from SYSTEM$GET_PRIVATELINK_CONFIG:**
   - Include the privatelink-pls-id
   - Enable Internal Stage Private Link? Y/N (If Y, output must include `privatelink-internal-stage`)
-- dbt Azure multi-tenant environment (EMEA):
-```
+- **dbt Azure multi-tenant environment** (EMEA):
+
+</Expandable>
 
 3. dbt Support will provide the `private endpoint resource_id` of our `private_endpoint` and the `CIDR` range for you to complete the [PrivateLink configuration](https://community.snowflake.com/s/article/HowtosetupPrivatelinktoSnowflakefromCloudServiceVendors) by contacting the Snowflake Support team. 
 

--- a/website/docs/docs/cloud/secure/private-connectivity/azure/synapse.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/azure/synapse.md
@@ -22,7 +22,7 @@ From your Azure portal:
 2. From the workspace overview, click **JSON view**. 
 3. Copy the value in the **Resource ID** field at the top of the pane.  
     The path format is: `/subscriptions/<subscription_uuid>/resourceGroups/<resource_group_name>/providers/Microsoft.Synapse/workspaces/<workspace_name>`.
-4. Add the required information to the following template and submit your Azure Private Link request to [dbt Support](/docs/dbt-support#dbt-cloud-support):
+4. Add the required information to the following template and submit your Azure Private Link request to [dbt Support](mailto:support@getdbt.com):
 
    <Expandable alt_header="Support request email template" is_open={true}>
 

--- a/website/docs/docs/cloud/secure/private-connectivity/azure/synapse.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/azure/synapse.md
@@ -26,14 +26,16 @@ From your Azure portal:
 
    <Expandable alt_header="Support request email template" is_open={true}>
 
-   **Subject:** New Azure Multi-Tenant Private Link Request
+   ```text
+   Subject: New Azure Multi-Tenant Private Link Request
 
-   - **Type:** Azure Synapse
-   - **dbt platform account URL:**
-   - **Server name:**
-   - **Azure Synapse workspace resource ID:**
-   - **dbt Azure multi-tenant environment** (EMEA):
-   - **Azure Synapse workspace region** (for example, WestEurope, NorthEurope):
+   - Type: Azure Synapse
+   - dbt platform account URL:
+   - Server name:
+   - Azure Synapse workspace resource ID:
+   - dbt Azure multi-tenant environment (EMEA):
+   - Azure Synapse workspace region (for example, WestEurope, NorthEurope):
+   ```
 
    </Expandable>
 5. Once our Support team confirms the endpoint has been created, navigate to the Azure Synapse workspace in the Azure Portal and browse to **Security** > **Private endpoint connections**. In the **Private endpoint connections** table, highlight the `dbt` named option and select **Approve**. Confirm with dbt Support that the connection has been approved so they can validate the connection and make it available for use in <Constant name="dbt" />.

--- a/website/docs/docs/cloud/secure/private-connectivity/azure/synapse.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/azure/synapse.md
@@ -22,16 +22,20 @@ From your Azure portal:
 2. From the workspace overview, click **JSON view**. 
 3. Copy the value in the **Resource ID** field at the top of the pane.  
     The path format is: `/subscriptions/<subscription_uuid>/resourceGroups/<resource_group_name>/providers/Microsoft.Synapse/workspaces/<workspace_name>`.
-4. Add the required information to the following template and submit your Azure Private Link request to [dbt Support](/docs/dbt-support#dbt-cloud-support): 
-    ```
-      Subject: New Azure Multi-Tenant Private Link Request
-    - Type: Azure Synapse
-    - dbt platform account URL:
-    - Server name:
-    - Azure Synapse workspace resource ID:
-    - dbt Azure multi-tenant environment (EMEA):
-    - Azure Synapse workspace region (for example, WestEurope, NorthEurope):
-    ```
+4. Add the required information to the following template and submit your Azure Private Link request to [dbt Support](/docs/dbt-support#dbt-cloud-support):
+
+   <Expandable alt_header="Support request email template" is_open={true}>
+
+   **Subject:** New Azure Multi-Tenant Private Link Request
+
+   - **Type:** Azure Synapse
+   - **dbt platform account URL:**
+   - **Server name:**
+   - **Azure Synapse workspace resource ID:**
+   - **dbt Azure multi-tenant environment** (EMEA):
+   - **Azure Synapse workspace region** (for example, WestEurope, NorthEurope):
+
+   </Expandable>
 5. Once our Support team confirms the endpoint has been created, navigate to the Azure Synapse workspace in the Azure Portal and browse to **Security** > **Private endpoint connections**. In the **Private endpoint connections** table, highlight the `dbt` named option and select **Approve**. Confirm with dbt Support that the connection has been approved so they can validate the connection and make it available for use in <Constant name="dbt" />.
 
 

--- a/website/docs/docs/cloud/secure/private-connectivity/gcp/bigquery.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/gcp/bigquery.md
@@ -20,13 +20,16 @@ The following steps walk you through the setup of a GCP BigQuery [Private Servic
 
 To enable dbt to privately connect to your BigQuery project via PSC, the regional PSC endpoint needs be enabled for your dbt account. Using the following template, submit a request to [dbt Support](/docs/dbt-support#dbt-cloud-support):
 
-```
-Subject: New Multi-Tenant GCP PSC Request
-- Type: BigQuery
-- dbt platform account URL:
-- BigQuery project region: 
-- dbt GCP multi-tenant environment:
-```
+<Expandable alt_header="Support request email template" is_open={true}>
+
+**Subject:** New Multi-Tenant GCP PSC Request
+
+- **Type:** BigQuery
+- **dbt platform account URL:**
+- **BigQuery project region:**
+- **dbt GCP multi-tenant environment:**
+
+</Expandable>
 
 import PrivateLinkSLA from '/snippets/_private-connection-SLA.md';
 

--- a/website/docs/docs/cloud/secure/private-connectivity/gcp/bigquery.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/gcp/bigquery.md
@@ -18,7 +18,7 @@ The following steps walk you through the setup of a GCP BigQuery [Private Servic
 
 ## Enabling dbt for GCP Private Service Connect
 
-To enable dbt to privately connect to your BigQuery project via PSC, the regional PSC endpoint needs be enabled for your dbt account. Using the following template, submit a request to [dbt Support](/docs/dbt-support#dbt-cloud-support):
+To enable dbt to privately connect to your BigQuery project via PSC, the regional PSC endpoint needs be enabled for your dbt account. Using the following template, submit a request to [dbt Support](mailto:support@getdbt.com):
 
 <Expandable alt_header="Support request email template" is_open={true}>
 

--- a/website/docs/docs/cloud/secure/private-connectivity/gcp/bigquery.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/gcp/bigquery.md
@@ -22,12 +22,14 @@ To enable dbt to privately connect to your BigQuery project via PSC, the regiona
 
 <Expandable alt_header="Support request email template" is_open={true}>
 
-**Subject:** New Multi-Tenant GCP PSC Request
+```text
+Subject: New Multi-Tenant GCP PSC Request
 
-- **Type:** BigQuery
-- **dbt platform account URL:**
-- **BigQuery project region:**
-- **dbt GCP multi-tenant environment:**
+- Type: BigQuery
+- dbt platform account URL:
+- BigQuery project region:
+- dbt GCP multi-tenant environment:
+```
 
 </Expandable>
 

--- a/website/docs/docs/cloud/secure/private-connectivity/gcp/self-hosted.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/gcp/self-hosted.md
@@ -120,17 +120,20 @@ Before you begin, make sure to review the following requirements:
 
 12. Add the required information to the template below, and submit your request to [dbt Support](/community/resources/getting-help#dbt-cloud-support):
 
-```
-Subject: New GCP Self-hosted Private Service Connect Request
-- Type: Self-hosted PSC
-- dbt platform account URL:
-- Platform/Service: (for example, Postgres, Starburst, Spark, GitLab, etc.)
-- Service Attachment URI:
-- Custom DNS (if HTTPS/TLS)
-    - DNS record:
-- Service Region: (for example, us-east1, us-central1)
-- dbt GCP environment (US):
-```
+<Expandable alt_header="Support request email template" is_open={true}>
+
+**Subject:** New GCP Self-hosted Private Service Connect Request
+
+- **Type:** Self-hosted PSC
+- **dbt platform account URL:**
+- **Platform/Service** (for example, Postgres, Starburst, Spark, GitLab, etc.):
+- **Service Attachment URI:**
+- **Custom DNS (if HTTPS/TLS):**
+  - DNS record:
+- **Service Region** (for example, us-east1, us-central1):
+- **dbt GCP environment** (US):
+
+</Expandable>
 
 import PrivateLinkSLA from '/snippets/_private-connection-SLA.md';
 

--- a/website/docs/docs/cloud/secure/private-connectivity/gcp/self-hosted.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/gcp/self-hosted.md
@@ -122,16 +122,18 @@ Before you begin, make sure to review the following requirements:
 
 <Expandable alt_header="Support request email template" is_open={true}>
 
-**Subject:** New GCP Self-hosted Private Service Connect Request
+```text
+Subject: New GCP Self-hosted Private Service Connect Request
 
-- **Type:** Self-hosted PSC
-- **dbt platform account URL:**
-- **Platform/Service** (for example, Postgres, Starburst, Spark, GitLab, etc.):
-- **Service Attachment URI:**
-- **Custom DNS (if HTTPS/TLS):**
+- Type: Self-hosted PSC
+- dbt platform account URL:
+- Platform/Service (for example, Postgres, Starburst, Spark, GitLab, etc.):
+- Service Attachment URI:
+- Custom DNS (if HTTPS/TLS):
   - DNS record:
-- **Service Region** (for example, us-east1, us-central1):
-- **dbt GCP environment** (US):
+- Service Region (for example, us-east1, us-central1):
+- dbt GCP environment (US):
+```
 
 </Expandable>
 

--- a/website/docs/docs/cloud/secure/private-connectivity/gcp/self-hosted.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/gcp/self-hosted.md
@@ -53,7 +53,7 @@ Before you begin, make sure to review the following requirements:
 
 3. **dbt GCP Project ID**
 
-    - Contact [dbt Support](/community/resources/getting-help#dbt-cloud-support) to obtain the dbt GCP project ID. You will need this in order to share your service attachment with the dbt platform.
+    - Contact [dbt Support](mailto:support@getdbt.com) to obtain the dbt GCP project ID. You will need this in order to share your service attachment with the dbt platform.
 
 
 ## Instructions
@@ -118,7 +118,7 @@ Before you begin, make sure to review the following requirements:
 
 ### Providing dbt Support with connection details
 
-12. Add the required information to the template below, and submit your request to [dbt Support](/community/resources/getting-help#dbt-cloud-support):
+12. Add the required information to the template below, and submit your request to [dbt Support](mailto:support@getdbt.com):
 
 <Expandable alt_header="Support request email template" is_open={true}>
 

--- a/website/docs/docs/cloud/secure/private-connectivity/gcp/snowflake.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/gcp/snowflake.md
@@ -32,14 +32,17 @@ To configure Snowflake instances hosted on GCP for [Private Service Connect](htt
 
 2. Add the required information to the following template and submit your request to  [dbt Support](/docs/dbt-support#dbt-cloud-support):
 
-```
-Subject: New Multi-Tenant GCP PSC Request
-- Type: Snowflake
-- dbt platform account URL:
-- SYSTEM$GET_PRIVATELINK_CONFIG output:
-- *Use privatelink-account-url or regionless-privatelink-account-url?: 
-- dbt GCP multi-tenant environment:
-```
+<Expandable alt_header="Support request email template" is_open={true}>
+
+**Subject:** New Multi-Tenant GCP PSC Request
+
+- **Type:** Snowflake
+- **dbt platform account URL:**
+- **SYSTEM$GET_PRIVATELINK_CONFIG output:**
+- **\*Use privatelink-account-url or regionless-privatelink-account-url?:**
+- **dbt GCP multi-tenant environment:**
+
+</Expandable>
 _*By default, <Constant name="dbt" /> will be configured to use `privatelink-account-url` from the provided [SYSTEM$GET_PRIVATELINK_CONFIG](https://docs.snowflake.com/en/sql-reference/functions/system_get_privatelink_config.html) as the PrivateLink endpoint. Upon request, `regionless-privatelink-account-url` can be used instead._
 
 

--- a/website/docs/docs/cloud/secure/private-connectivity/gcp/snowflake.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/gcp/snowflake.md
@@ -34,13 +34,15 @@ To configure Snowflake instances hosted on GCP for [Private Service Connect](htt
 
 <Expandable alt_header="Support request email template" is_open={true}>
 
-**Subject:** New Multi-Tenant GCP PSC Request
+```text
+Subject: New Multi-Tenant GCP PSC Request
 
-- **Type:** Snowflake
-- **dbt platform account URL:**
-- **SYSTEM$GET_PRIVATELINK_CONFIG output:**
-- **\*Use privatelink-account-url or regionless-privatelink-account-url?:**
-- **dbt GCP multi-tenant environment:**
+- Type: Snowflake
+- dbt platform account URL:
+- SYSTEM$GET_PRIVATELINK_CONFIG output:
+- *Use privatelink-account-url or regionless-privatelink-account-url?:
+- dbt GCP multi-tenant environment:
+```
 
 </Expandable>
 _*By default, <Constant name="dbt" /> will be configured to use `privatelink-account-url` from the provided [SYSTEM$GET_PRIVATELINK_CONFIG](https://docs.snowflake.com/en/sql-reference/functions/system_get_privatelink_config.html) as the PrivateLink endpoint. Upon request, `regionless-privatelink-account-url` can be used instead._

--- a/website/docs/docs/cloud/secure/private-connectivity/gcp/snowflake.md
+++ b/website/docs/docs/cloud/secure/private-connectivity/gcp/snowflake.md
@@ -30,7 +30,7 @@ To configure Snowflake instances hosted on GCP for [Private Service Connect](htt
 
 1. Run the Snowflake system function [SYSTEM$GET_PRIVATELINK_CONFIG](https://docs.snowflake.com/en/sql-reference/functions/system_get_privatelink_config.html) and copy the output.
 
-2. Add the required information to the following template and submit your request to  [dbt Support](/docs/dbt-support#dbt-cloud-support):
+2. Add the required information to the following template and submit your request to  [dbt Support](mailto:support@getdbt.com):
 
 <Expandable alt_header="Support request email template" is_open={true}>
 


### PR DESCRIPTION
## Summary

- All support request email templates across PrivateLink docs (AWS, Azure, GCP) are now wrapped in `<Expandable alt_header="Support request email template" is_open={true}>` so users can link to the exact specific section.
- Content is formatted with text backtickts to match the existing layout

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-fix-privatelink-expandable-open-dbt-labs.vercel.app/docs/cloud/secure/private-connectivity/aws/databricks
- https://docs-getdbt-com-git-fix-privatelink-expandable-open-dbt-labs.vercel.app/docs/cloud/secure/private-connectivity/aws/postgres
- https://docs-getdbt-com-git-fix-privatelink-expandable-open-dbt-labs.vercel.app/docs/cloud/secure/private-connectivity/aws/redshift
- https://docs-getdbt-com-git-fix-privatelink-expandable-open-dbt-labs.vercel.app/docs/cloud/secure/private-connectivity/aws/self-hosted
- https://docs-getdbt-com-git-fix-privatelink-expandable-open-dbt-labs.vercel.app/docs/cloud/secure/private-connectivity/aws/snowflake
- https://docs-getdbt-com-git-fix-privatelink-expandable-open-dbt-labs.vercel.app/docs/cloud/secure/private-connectivity/azure/databricks
- https://docs-getdbt-com-git-fix-privatelink-expandable-open-dbt-labs.vercel.app/docs/cloud/secure/private-connectivity/azure/postgres
- https://docs-getdbt-com-git-fix-privatelink-expandable-open-dbt-labs.vercel.app/docs/cloud/secure/private-connectivity/azure/self-hosted
- https://docs-getdbt-com-git-fix-privatelink-expandable-open-dbt-labs.vercel.app/docs/cloud/secure/private-connectivity/azure/snowflake
- https://docs-getdbt-com-git-fix-privatelink-expandable-open-dbt-labs.vercel.app/docs/cloud/secure/private-connectivity/azure/synapse
- https://docs-getdbt-com-git-fix-privatelink-expandable-open-dbt-labs.vercel.app/docs/cloud/secure/private-connectivity/gcp/bigquery
- https://docs-getdbt-com-git-fix-privatelink-expandable-open-dbt-labs.vercel.app/docs/cloud/secure/private-connectivity/gcp/self-hosted
- https://docs-getdbt-com-git-fix-privatelink-expandable-open-dbt-labs.vercel.app/docs/cloud/secure/private-connectivity/gcp/snowflake

<!-- end-vercel-deployment-preview -->