### PR TITLE
Fix invalid character in feedback widget

### DIFF
--- a/website/src/utils/validate-text-input.js
+++ b/website/src/utils/validate-text-input.js
@@ -40,7 +40,7 @@ export const validateTextInput = (text, setValidationError) => {
   const sqlPatterns = [
     /(\b(union|select|insert|update|delete|drop|create|alter|exec|execute)\b)/gi,
     /(--|\/\*|\*\/)/g,
-    /('|(\\')|('')|(%27)|(%2527))/gi,
+    /((%27)|(%2527))/gi,
   ];
 
   for (const pattern of sqlPatterns) {
@@ -54,7 +54,7 @@ export const validateTextInput = (text, setValidationError) => {
 
   // Check for excessive special characters (potential obfuscation)
   const specialCharRatio =
-    (text.match(/[^a-zA-Z0-9\s.,!?()-]/g) || []).length / text.length;
+    (text.match(/[^a-zA-Z0-9\s.,!?()'-]/g) || []).length / text.length;
   if (specialCharRatio > 0.3 && text.length > 10) {
     setValidationError("Too many special characters. Please use plain text");
     return false;


### PR DESCRIPTION
## What are you changing in this pull request and why?
Updates regex to allow `'` to be entered within the feedback widget.

## Preview
https://docs-getdbt-com-git-fix-feedback-invalid-characters-dbt-labs.vercel.app/best-practices/how-we-structure/1-guide-overview?version=1.12

## Testing
1. Use the link above and attempt to enter feedback using a `'`
2. Confirm no validation error is thrown