### PR TITLE
update sha

### DIFF
--- a/.github/workflows/preview-link.yml
+++ b/.github/workflows/preview-link.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # actions/checkout@v4.3.1
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
preview link workflow was failing due to node version deprecation warning for june 2026 node deprecation. 

this pr updates actions/checkout from the 
old SHA (08eba0b) to                       
34e114876b0b11c390a56381ad16ebd13914f8d5 (v4.3.1),