### PR TITLE
extended attributes env var clarification

### DIFF
--- a/website/docs/docs/cloud/about-profiles.md
+++ b/website/docs/docs/cloud/about-profiles.md
@@ -75,7 +75,9 @@ The following steps are the same regardless of which approach you take:
     - Has no consecutive dashes or underscores
 2. From **Connection details**, select a connection from the list of available [global connections](/docs/cloud/connect-data-platform/about-connections#connection-management) or add a new connection. 
 3. Configure the **Deployment credentials** for your warehouse connection.
-4. Add any [**Extended attributes**](/docs/dbt-cloud-environments#extended-attributes) you need.
+4. Add any [**Extended attributes**](/docs/dbt-cloud-environments#extended-attributes) you need. If you use [`env_var()`](/reference/dbt-jinja-functions/env_var) in Extended Attributes, the referenced environment variables must be _project-scoped_ in order to work with connection tests. Since profiles are environment-agnostic, environment-scoped variables are not available during connection tests.
+
+   To set a project-scoped variable: go to **Orchestration** > **Environments** > **Environment variables**, and enter a value in the **Project default** column. Learn more in [environment variables](/docs/build/environment-variables?version=2.0#setting-environment-variables).
 5. Click **Save** at the top of the screen. 
 
 <Lightbox src="/img/docs/dbt-cloud/profile-sample.png" width="60%" title="Sample of a configured profile." />

--- a/website/docs/docs/cloud/about-profiles.md
+++ b/website/docs/docs/cloud/about-profiles.md
@@ -77,7 +77,7 @@ The following steps are the same regardless of which approach you take:
 3. Configure the **Deployment credentials** for your warehouse connection.
 4. Add any [**Extended attributes**](/docs/dbt-cloud-environments#extended-attributes) you need. If you use [`env_var()`](/reference/dbt-jinja-functions/env_var) in Extended Attributes, the referenced environment variables must be _project-scoped_ in order to work with connection tests. Since profiles are environment-agnostic, environment-scoped variables are not available during connection tests.
 
-   To set a project-scoped variable: go to **Orchestration** > **Environments** > **Environment variables**, and enter a value in the **Project default** column. Learn more in [environment variables](/docs/build/environment-variables?version=2.0#setting-environment-variables).
+   To set a project-scoped variable, go to **Orchestration** > **Environments** > **Environment variables**, and enter a value in the **Project default** column. Learn more in [environment variables](/docs/build/environment-variables?version=2.0#setting-environment-variables).
 5. Click **Save** at the top of the screen. 
 
 <Lightbox src="/img/docs/dbt-cloud/profile-sample.png" width="60%" title="Sample of a configured profile." />

--- a/website/snippets/_cloud-environments-info.md
+++ b/website/snippets/_cloud-environments-info.md
@@ -71,6 +71,12 @@ password: '{{ env_var(''DBT_ENV_SECRET_PASSWORD'') }}'
 #### Extended Attributes don't mask secret values
 We recommend avoiding setting secret values to prevent visibility in the text box and logs. A common workaround is to wrap extended attributes in [environment variables](/docs/build/environment-variables). In the earlier example, `password: '{{ env_var(''DBT_ENV_SECRET_PASSWORD'') }}'` will get a value from the `DBT_ENV_SECRET_PASSWORD` environment variable at runtime.
 
+:::note Profile connection tests and environment variables
+If you're using [profiles](/docs/cloud/about-profiles) for deployment environments, any `env_var` references in Extended Attributes must use _project-scoped_ environment variables. Since profiles are environment-agnostic, environment-scoped variables aren't available during connection tests. Jobs run normally since they have a real environment, but connection tests will fail if the referenced variable is only set at the environment level.
+
+To set a project-scoped variable: go to **Orchestration** > **Environments** > **Environment variables**, and set a value in the **Project default** column. This value applies across all environments in the project, making it available to profiles during connection tests. See [environment variables](/docs/build/environment-variables?version=2.0#setting-environment-variables) for more information.
+:::
+
 #### How extended attributes work
 If you're developing in the [<Constant name="studio_ide" />](/docs/cloud/studio-ide/develop-in-studio), [<Constant name="platform_cli" />](/docs/cloud/cloud-cli-installation), or [orchestrating job runs](/docs/deploy/deployments), extended attributes parses through the provided YAML and extracts the `profiles.yml` attributes. For each individual attribute:
 

--- a/website/snippets/_cloud-environments-info.md
+++ b/website/snippets/_cloud-environments-info.md
@@ -70,10 +70,10 @@ password: '{{ env_var(''DBT_ENV_SECRET_PASSWORD'') }}'
 
 #### Extended Attributes don't mask secret values
 
-- We recommend avoiding setting secret values to prevent visibility in the text box and logs. A common workaround is to wrap extended attributes in [environment variables](/docs/build/environment-variables). In the earlier example, `password: '{{ env_var(''DBT_ENV_SECRET_PASSWORD'') }}'` will get a value from the `DBT_ENV_SECRET_PASSWORD` environment variable at runtime.
+- We recommend you avoid setting secret values to prevent visibility in the text box and logs. A common workaround is to wrap extended attributes in [environment variables](/docs/build/environment-variables). In the earlier example, `password: '{{ env_var(''DBT_ENV_SECRET_PASSWORD'') }}'` will get a value from the `DBT_ENV_SECRET_PASSWORD` environment variable at runtime.
 - If you're using [profiles](/docs/cloud/about-profiles) for deployment environments, any `env_var` references in Extended Attributes must use _project-scoped_ environment variables. Since profiles are environment-agnostic, environment-scoped variables aren't available during connection tests. Jobs run normally since they have a real environment, but connection tests will fail if the referenced variable is only set at the environment level.
   
-  To set a project-scoped variable: go to **Orchestration** > **Environments** > **Environment variables**, and set a value in the **Project default** column. This value applies across all environments in the project, making it available to profiles during connection tests. See [environment variables](/docs/build/environment-variables?version=2.0#setting-environment-variables) for more information.
+  To set a project-scoped variable, go to **Orchestration** > **Environments** > **Environment variables**, and set a value in the **Project default** column. This value applies across all environments in the project, making it available to profiles during connection tests. See [environment variables](/docs/build/environment-variables?version=2.0#setting-environment-variables) for more information.
 
 #### How extended attributes work
 If you're developing in the [<Constant name="studio_ide" />](/docs/cloud/studio-ide/develop-in-studio), [<Constant name="platform_cli" />](/docs/cloud/cloud-cli-installation), or [orchestrating job runs](/docs/deploy/deployments), extended attributes parses through the provided YAML and extracts the `profiles.yml` attributes. For each individual attribute:

--- a/website/snippets/_cloud-environments-info.md
+++ b/website/snippets/_cloud-environments-info.md
@@ -69,13 +69,11 @@ password: '{{ env_var(''DBT_ENV_SECRET_PASSWORD'') }}'
 ```
 
 #### Extended Attributes don't mask secret values
-We recommend avoiding setting secret values to prevent visibility in the text box and logs. A common workaround is to wrap extended attributes in [environment variables](/docs/build/environment-variables). In the earlier example, `password: '{{ env_var(''DBT_ENV_SECRET_PASSWORD'') }}'` will get a value from the `DBT_ENV_SECRET_PASSWORD` environment variable at runtime.
 
-:::note Profile connection tests and environment variables
-If you're using [profiles](/docs/cloud/about-profiles) for deployment environments, any `env_var` references in Extended Attributes must use _project-scoped_ environment variables. Since profiles are environment-agnostic, environment-scoped variables aren't available during connection tests. Jobs run normally since they have a real environment, but connection tests will fail if the referenced variable is only set at the environment level.
-
-To set a project-scoped variable: go to **Orchestration** > **Environments** > **Environment variables**, and set a value in the **Project default** column. This value applies across all environments in the project, making it available to profiles during connection tests. See [environment variables](/docs/build/environment-variables?version=2.0#setting-environment-variables) for more information.
-:::
+- We recommend avoiding setting secret values to prevent visibility in the text box and logs. A common workaround is to wrap extended attributes in [environment variables](/docs/build/environment-variables). In the earlier example, `password: '{{ env_var(''DBT_ENV_SECRET_PASSWORD'') }}'` will get a value from the `DBT_ENV_SECRET_PASSWORD` environment variable at runtime.
+- If you're using [profiles](/docs/cloud/about-profiles) for deployment environments, any `env_var` references in Extended Attributes must use _project-scoped_ environment variables. Since profiles are environment-agnostic, environment-scoped variables aren't available during connection tests. Jobs run normally since they have a real environment, but connection tests will fail if the referenced variable is only set at the environment level.
+  
+  To set a project-scoped variable: go to **Orchestration** > **Environments** > **Environment variables**, and set a value in the **Project default** column. This value applies across all environments in the project, making it available to profiles during connection tests. See [environment variables](/docs/build/environment-variables?version=2.0#setting-environment-variables) for more information.
 
 #### How extended attributes work
 If you're developing in the [<Constant name="studio_ide" />](/docs/cloud/studio-ide/develop-in-studio), [<Constant name="platform_cli" />](/docs/cloud/cloud-cli-installation), or [orchestrating job runs](/docs/deploy/deployments), extended attributes parses through the provided YAML and extracts the `profiles.yml` attributes. For each individual attribute:
@@ -83,9 +81,7 @@ If you're developing in the [<Constant name="studio_ide" />](/docs/cloud/studio-
 - If the attribute exists in another source (such as your project settings), it will replace its value (like environment-level values) in the profile. It also overrides any custom environment variables (if not itself wired using the syntax described for secrets above)
 
 - If the attribute doesn't exist, it will add the attribute or value pair to the profile.
+- 
 
 #### Only the **top-level keys** are accepted in extended attributes
 This means that if you want to change a specific sub-key value, you must provide the entire top-level key as a JSON block in your resulting YAML. For example, if you want to customize a particular field within a [service account JSON](/docs/local/connect-data-platform/bigquery-setup#service-account-json) for your BigQuery connection (like 'project_id' or 'client_email'), you need to provide an override for the entire top-level `keyfile_json` main key/attribute using extended attributes. Include the sub-fields as a nested JSON block.
-
-
-


### PR DESCRIPTION
this pr clarifies that env vars used in extended attributes must be project scoped in order for connection tests to pass. adds it in a couple of different places

raised in internal thread: https://dbt-labs.slack.com/archives/C08LENMDNSK/p1775048196230299

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-profile-env-var-dbt-labs.vercel.app/docs/cloud/about-profiles

<!-- end-vercel-deployment-preview -->