### PR TITLE
Setup dev environments

### DIFF
--- a/website/docs/docs/environments-in-dbt.md
+++ b/website/docs/docs/environments-in-dbt.md
@@ -7,11 +7,21 @@ pagination_next: null
 
 In software engineering, environments are used to enable engineers to develop and test code without impacting the users of their software. Typically, there are two types of environments in dbt:
 
-- **Deployment or Production** (or _prod_) &mdash; Refers to the environment that end users interact with. 
+- **Deployment or Production** (or _prod_) &mdash; Refers to the environment that end users interact with.
 
 - **Development** (or _dev_) &mdash; Refers to the environment that engineers work in. This means that engineers can work iteratively when writing and testing new code in _development_. Once they are confident in these changes, they can deploy their code to _production_.
 
 In traditional software engineering, different environments often use completely separate architecture. For example, the dev and prod versions of a website may use different servers and databases. <Term id="data-warehouse">Data warehouses</Term> can also be designed to have separate environments &mdash; the _production_ environment refers to the relations (for example, schemas, tables, and <Term id="view">views</Term>) that your end users query (often through a BI tool).
+
+### Environment separation
+
+There are several common approaches to isolating environments in a data warehouse:
+
+import EnvironmentSeparation from '/snippets/_environment-separation.md';
+
+<EnvironmentSeparation />
+
+We recommend using separate schemas per developer as the default approach. The pattern `dbt_<username>` for dev schemas ensures each developer has an isolated space without overwriting each other's work.
 
 Configure environments to tell <Constant name="dbt" /> or <Constant name="core" /> how to build and execute your project in development and production:
 

--- a/website/docs/docs/local/dbt-core-environments.md
+++ b/website/docs/docs/local/dbt-core-environments.md
@@ -1,17 +1,252 @@
 ---
 title: "dbt environments"
 id: "dbt-core-environments"
+description: "Learn how to set up and maintain separate development, CI, and production environments in your local dbt installation using targets and environment variables."
 pagination_next: "docs/running-a-dbt-project/run-your-dbt-projects"
 ---
 
-dbt makes it easy to maintain separate production and development environments through the use of [targets](/reference/dbt-jinja-functions/target.md) within a [profile](/docs/local/profiles.yml). A typical profile, when using dbt locally (for example, running from your command line), will have a target named `dev` and have this set as the default. This means that while making changes, your objects will be built in your _development_ target without affecting production queries made by your end users. Once you are confident in your changes, you can deploy the code to _production_, by running your dbt project with a _prod_ target.
+dbt makes it easy to maintain separate development, CI, and production environments through the use of [targets](/reference/dbt-jinja-functions/target) within a [profile](/docs/local/profiles.yml). A typical profile will have a `dev` target set as the default so that, while making changes, your objects are built in your development environment without affecting production queries made by end users. Once you are confident in your changes, you can deploy the code to production by running your dbt project with a `prod` target.
 
 :::info Running dbt in production
 
-You can learn more about different ways to run dbt in production in [this article](/docs/deploy/deployments).
+Learn more about different approaches to running dbt in production in [this guide](/docs/deploy/deployments).
 
 :::
 
-Targets offer the flexibility to decide how to implement your separate environments – whether you want to use separate schemas, databases, or entirely different clusters altogether! We recommend using _different schemas within one database_ to separate your environments. This is the easiest to set up and is the most cost-effective solution in a modern cloud-based data stack.
+## Separation strategies
 
-In practice, this means that most of the details in a target will be consistent across all targets, except for the `schema` and user credentials. If you have multiple dbt users writing code, it often makes sense for _each user_ to have their own _development_ environment. A pattern we've found useful is to set your dev target schema to be `dbt_<username>`. User credentials should also differ across targets so that each dbt user is using their own data warehouse user.
+Targets give you flexibility in _how_ to separate your environments. The three main approaches are:
+
+import EnvironmentSeparation from '/snippets/_environment-separation.md';
+
+<EnvironmentSeparation />
+
+We recommend _separate schemas within one database_ for most teams. It is the easiest to set up and the most cost-effective solution on modern cloud data warehouses.
+
+## Setting up schemas per developer
+
+When multiple developers use dbt, each person should write to their own development schema so they don't overwrite each other's work. A pattern that works well is naming your dev target schema `dbt_<username>`:
+
+<File name='~/.dbt/profiles.yml'>
+
+```yaml
+my_project:
+  target: dev
+  outputs:
+    dev:
+      type: postgres  # replace with your adapter
+      host: localhost
+      user: "{{ env_var('DBT_DEV_USER') }}"
+      password: "{{ env_var('DBT_DEV_PASSWORD') }}"
+      port: 5432
+      dbname: analytics
+      schema: "dbt_{{ env_var('DBT_USERNAME') }}"  # e.g. dbt_alice, dbt_bob
+      threads: 4
+
+    prod:
+      type: postgres
+      host: prod-warehouse.example.com
+      user: "{{ env_var('DBT_PROD_USER') }}"
+      password: "{{ env_var('DBT_PROD_PASSWORD') }}"
+      port: 5432
+      dbname: analytics
+      schema: analytics
+      threads: 8
+```
+
+</File>
+
+:::tip Credentials in profiles.yml
+
+Use [env_var()](/reference/dbt-jinja-functions/env_var) for sensitive values like passwords and usernames — keep them out of version control. See [using environment variables in profiles.yml](#using-environment-variables-in-profilesyml) below.
+
+:::
+
+There is no need to create your target schema ahead of time — dbt checks whether it exists at run time and creates it if it doesn't.
+
+### Setting your local environment variables
+
+Each developer needs to export the variables that their `profiles.yml` references. Add these to your shell profile (for example, `~/.zshrc`, `~/.bashrc`, or `~/.bash_profile`) so they are set automatically:
+
+<Tabs>
+<TabItem value="mac-linux" label="macOS / Linux">
+
+```bash
+# ~/.zshrc or ~/.bashrc
+export DBT_USERNAME="alice"
+export DBT_DEV_USER="alice"
+export DBT_DEV_PASSWORD="my_dev_password"
+```
+
+After editing, reload your shell:
+
+```bash
+source ~/.zshrc
+```
+
+</TabItem>
+<TabItem value="windows" label="Windows">
+
+```powershell
+# In PowerShell, set for current user permanently:
+[System.Environment]::SetEnvironmentVariable("DBT_USERNAME", "alice", "User")
+[System.Environment]::SetEnvironmentVariable("DBT_DEV_USER", "alice", "User")
+[System.Environment]::SetEnvironmentVariable("DBT_DEV_PASSWORD", "my_dev_password", "User")
+```
+
+Or use **System Properties → Environment Variables** in the Windows UI.
+
+</TabItem>
+</Tabs>
+
+Verify the variables are set:
+
+```bash
+echo $DBT_USERNAME
+# alice
+```
+
+## Using environment variables in profiles.yml
+
+Any field in `profiles.yml` can reference an environment variable using the `{{ env_var('VAR_NAME') }}` Jinja function. You can also supply a default value as the second argument to avoid compilation errors in environments where a variable isn't set:
+
+```yaml
+schema: "dbt_{{ env_var('DBT_USERNAME', 'default') }}"
+```
+
+This approach follows the [twelve-factor app methodology](https://12factor.net/config) — credentials and environment-specific values live in the environment, not in code.
+
+For more, see the [env_var reference](/reference/dbt-jinja-functions/env_var).
+
+## Setting up a CI environment
+
+In a CI pipeline (such as GitHub Actions, GitLab CI, or CircleCI), set environment variables at the pipeline level so that dbt can connect to your warehouse and build into an isolated schema.
+
+A recommended CI schema naming pattern is `dbt_cloud_pr_<PR_NUMBER>` or simply `ci` — this prevents CI runs from writing over production or development schemas.
+
+<Tabs>
+<TabItem value="github-actions" label="GitHub Actions">
+
+```yaml
+# .github/workflows/dbt-ci.yml
+name: dbt CI
+
+on:
+  pull_request:
+
+jobs:
+  dbt-check:
+    runs-on: ubuntu-latest
+    env:
+      DBT_USERNAME: ci
+      DBT_DEV_USER: ${{ secrets.DBT_PROD_USER }}
+      DBT_DEV_PASSWORD: ${{ secrets.DBT_PROD_PASSWORD }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install dbt
+        run: pip install dbt-postgres  # replace with your adapter
+
+      - name: Run dbt
+        run: dbt build --target dev --profiles-dir .
+```
+
+</TabItem>
+<TabItem value="gitlab-ci" label="GitLab CI">
+
+```yaml
+# .gitlab-ci.yml
+dbt-check:
+  stage: test
+  image: python:3.11
+  variables:
+    DBT_USERNAME: "ci"
+    DBT_DEV_USER: $DBT_PROD_USER   # set as CI/CD variable in GitLab UI
+    DBT_DEV_PASSWORD: $DBT_PROD_PASSWORD
+  script:
+    - pip install dbt-postgres  # replace with your adapter
+    - dbt build --target dev --profiles-dir .
+  only:
+    - merge_requests
+```
+
+</TabItem>
+</Tabs>
+
+Store secrets (passwords, tokens) in your CI platform's secret store — GitHub Actions Secrets, GitLab CI/CD Variables, etc. — rather than in your repository.
+
+## Separating environments at the database or account level
+
+Sometimes schema-level separation is insufficient. For example:
+
+- Your warehouse enforces different network policies per account.
+- Compliance requirements prevent dev and prod data from sharing an account.
+- You want to use a lower-spec warehouse tier for development.
+
+To target a different **database**, update the `dbname` (Postgres/Redshift) or `database` (Snowflake/BigQuery) field per target in your profile:
+
+```yaml
+my_project:
+  target: dev
+  outputs:
+    dev:
+      type: snowflake
+      account: "{{ env_var('SNOWFLAKE_ACCOUNT') }}"
+      database: analytics_dev       # separate database for dev
+      schema: "dbt_{{ env_var('DBT_USERNAME') }}"
+      warehouse: dev_warehouse
+      ...
+
+    prod:
+      type: snowflake
+      account: "{{ env_var('SNOWFLAKE_ACCOUNT') }}"
+      database: analytics           # production database
+      schema: analytics
+      warehouse: prod_warehouse
+      ...
+```
+
+To target a different **account or cluster entirely**, change the `account` (Snowflake), `host` (Postgres/Redshift), or project (BigQuery) value per target:
+
+```yaml
+my_project:
+  target: dev
+  outputs:
+    dev:
+      type: snowflake
+      account: "{{ env_var('SNOWFLAKE_DEV_ACCOUNT') }}"   # separate dev account
+      ...
+
+    prod:
+      type: snowflake
+      account: "{{ env_var('SNOWFLAKE_PROD_ACCOUNT') }}"  # production account
+      ...
+```
+
+## How dbt names schemas across environments
+
+By default, dbt builds all models into the schema defined in `target.schema`. When you use [custom schemas](/docs/build/custom-schemas) (for example, `+schema: marketing`), dbt appends the custom schema to the target schema: `<target_schema>_<custom_schema>`.
+
+This means:
+
+| Environment | target.schema | Custom schema config | Resulting schema |
+|---|---|---|---|
+| Dev (alice) | `dbt_alice` | none | `dbt_alice` |
+| Dev (alice) | `dbt_alice` | `marketing` | `dbt_alice_marketing` |
+| Prod | `analytics` | none | `analytics` |
+| Prod | `analytics` | `marketing` | `analytics_marketing` |
+
+The target schema prefix ensures that no two environments write to the same location, even when custom schemas are in use.
+
+For advanced patterns — such as using the raw custom schema in production while using only the target schema in dev and CI — refer to [Custom schemas](/docs/build/custom-schemas#a-built-in-alternative-pattern-for-generating-schema-names).
+
+## Related docs
+
+- [About profiles.yml](/docs/local/profiles.yml)
+- [Custom schemas](/docs/build/custom-schemas)
+- [Custom databases](/docs/build/custom-databases)
+- [env_var Jinja function](/reference/dbt-jinja-functions/env_var)
+- [dbt environment best practices](/guides/set-up-ci)
+- [Running dbt in production](/docs/deploy/deployments)
+- [Deployment environments](/docs/deploy/deploy-environments)

--- a/website/docs/docs/local/dbt-core-environments.md
+++ b/website/docs/docs/local/dbt-core-environments.md
@@ -184,7 +184,7 @@ Sometimes schema-level separation is insufficient. For example:
 - Compliance requirements prevent dev and prod data from sharing an account.
 - You want to use a lower-spec warehouse tier for development.
 
-To target a different **database**, update the `dbname` (Postgres/Redshift) or `database` (Snowflake/BigQuery) field per target in your profile:
+To target a different database, update the `dbname` (Postgres/Redshift) or `database` (Snowflake/BigQuery) field per target in your profile:
 
 ```yaml
 my_project:
@@ -207,7 +207,7 @@ my_project:
       ...
 ```
 
-To target a different **account or cluster entirely**, change the `account` (Snowflake), `host` (Postgres/Redshift), or project (BigQuery) value per target:
+To target a different account or cluster entirely, change the `account` (Snowflake), `host` (Postgres/Redshift), or `project` (BigQuery) value per target:
 
 ```yaml
 my_project:

--- a/website/docs/faqs/Environments/profile-env-vars.md
+++ b/website/docs/faqs/Environments/profile-env-vars.md
@@ -1,7 +1,38 @@
 ---
 title: Can I use environment variables in my profile?
-description: "Use env_var in your profile"
+description: "Use env_var in your profile to avoid storing credentials in version control."
 sidebar_label: 'Use env_var in your profile'
 id: profile-env-vars
 ---
-Yes! Check out the docs on [environment variables](/reference/dbt-jinja-functions/env_var) for more information.
+
+Yes! Any field in `profiles.yml` can reference an environment variable using the [`env_var()` Jinja function](/reference/dbt-jinja-functions/env_var):
+
+```yaml
+my_project:
+  target: dev
+  outputs:
+    dev:
+      type: postgres
+      host: localhost
+      user: "{{ env_var('DBT_DEV_USER') }}"
+      password: "{{ env_var('DBT_DEV_PASSWORD') }}"
+      schema: "dbt_{{ env_var('DBT_USERNAME') }}"
+      port: 5432
+      threads: 4
+```
+
+This keeps sensitive credentials out of version control. Set the variables in your shell before running dbt:
+
+```bash
+export DBT_DEV_USER=alice
+export DBT_DEV_PASSWORD=my_password
+export DBT_USERNAME=alice
+```
+
+You can supply a default value as the second argument to avoid compilation errors when a variable isn't set:
+
+```yaml
+schema: "dbt_{{ env_var('DBT_USERNAME', 'default') }}"
+```
+
+For a full walkthrough of how to configure separate dev, CI, and prod environments using env vars, see [dbt Core environments](/docs/local/dbt-core-environments).

--- a/website/snippets/_environment-separation.md
+++ b/website/snippets/_environment-separation.md
@@ -1,0 +1,5 @@
+| Approach | How | When to use |
+|---|---|---|
+| **Separate schemas** (recommended) | Each environment writes to a different schema in the same database | Works for most teams; lowest cost and easiest to set up |
+| **Separate databases** | Each environment targets a different database. | Useful when schema-level access controls are insufficient. |
+| **Separate accounts or clusters** | Each environment connects to a completely different warehouse account or cluster. | Needed for strict network or compliance isolation between environments. |


### PR DESCRIPTION
## What are you changing in this pull request and why?

This PR significantly expands the dbt Core environment setup documentation to give users a practical, end-to-end guide for configuring development, CI, and production environments.

### Changes

- **`environments-in-dbt.md`** — Added a new "Environment separation" section that imports a shared snippet and recommends the `dbt_<username>` schema pattern for developer isolation.

- **`dbt-core-environments.md`** — Major rewrite and expansion of the page:
  - Rewrote the intro for clarity and to include CI as a first-class environment.
  - Added a "Separation strategies" section using the new shared snippet table.
  - Added a "Setting up schemas per developer" section with a full `profiles.yml` example using `env_var()`.
  - Added a "Setting your local environment variables" section with OS-specific instructions (macOS/Linux and Windows tabs).
  - Added a "Using environment variables in profiles.yml" section explaining the pattern and linking to twelve-factor methodology.
  - Added a "Setting up a CI environment" section with working GitHub Actions and GitLab CI examples.
  - Added a "Separating environments at the database or account level" section for teams with stricter isolation needs.
  - Added a "How dbt names schemas across environments" section with a reference table showing how target schema and custom schema combine.
  - Added a "Related docs" section.

- **`faqs/Environments/profile-env-vars.md`** — Expanded from a single-sentence stub to a full FAQ page with a `profiles.yml` example, shell export instructions, default value usage, and a cross-link to the Core environments guide.

- **`snippets/_environment-separation.md`** — New shared snippet containing a comparison table of the three environment separation approaches (separate schemas, databases, or accounts/clusters), reused across multiple pages.

## Checklist

- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).

---
🚀 Deployment available! Here are the direct links to the updated files:

- https://docs-getdbt-com-git-setup-dev-environments-dbt-labs.vercel.app/docs/environments-in-dbt
- https://docs-getdbt-com-git-setup-dev-environments-dbt-labs.vercel.app/docs/local/dbt-core-environments
- https://docs-getdbt-com-git-setup-dev-environments-dbt-labs.vercel.app/faqs/Environments/profile-env-vars

Closes https://github.com/dbt-labs/docs.getdbt.com/issues/3081