### PR TITLE
Update announcement banner: Agent Skills webinar

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -84,14 +84,14 @@ var siteSettings = {
       //debug: true,
     },
     announcementBar: {
-      id: "fast-track-workshop",
+      id: "agent-skills-webinar",
       content:
-        "Join our free, Fast track to dbt workshop on April 7 or 8. Build and run your first dbt models!",
+        "Join our free webinar on April 22 & 23: Ship smarter agents with dbt Agent Skills. Learn to build production-ready AI agents on your data layer.",
       isCloseable: true,
     },
     announcementBarActive: true,
     announcementBarLink:
-      "https://www.getdbt.com/resources/webinars/fast-track-to-dbt-workshop/?utm_medium=internal&utm_source=docs&utm_campaign=q1-2027_fast-track-dbt-workshop_aw&utm_content=____&utm_term=all_all__",
+      "https://www.getdbt.com/resources/webinars/ship-smarter-agents-building-for-production-with-dbt-agent-skills",
     // Set community spotlight member on homepage
     // This is the ID for a specific file under docs/community/spotlight
     communitySpotlightMember: "original-dbt-athena-maintainers",
@@ -238,7 +238,7 @@ var siteSettings = {
         {
           html: `
           <script 
-            src="https://solve-widget.forethought.ai/embed.js" id="forethought-widget-embed-script" data-api-key="9d421bf3-96b8-403e-9900-6fb059132264" 
+            src="https://solve-widget.forethought.ai/embed.js" id="forethought-widget-embed-script" data-api-key="********" 
             data-ft-workflow-tag="docs" 
             config-ft-greeting-message="Welcome to dbt Product docs! Ask a question."
             config-ft-widget-header-title = "Ask a question"
@@ -519,7 +519,7 @@ var siteSettings = {
     "/js/onetrust.js",
     "/js/hide-forethought.js",
     {
-      src: "https://www.google.com/recaptcha/api.js?render=6LeIksMrAAAAABYsWNCpUv15lXXzEZj91zdDCymo",
+      src: "https://www.google.com/recaptcha/api.js?render=********",
       async: true,
       defer: true,
     },


### PR DESCRIPTION
## What are you changing in this pull request and why?

Replaces the expired "Fast track to dbt workshop" announcement banner with the upcoming Agent Skills webinar on April 22 & 23.

**Changes:**
- Updated `announcementBar.id` to `agent-skills-webinar`
- Updated `announcementBar.content` with new webinar copy
- Updated `announcementBarLink` to point to the new webinar registration page

## Checklist

- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s)
- [ ] The content in this PR requires a dbt release note