### PR TITLE
Fix duplicate sections on blog post pages

### DIFF
--- a/website/src/components/discourseBlogComments/index.js
+++ b/website/src/components/discourseBlogComments/index.js
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react'
 import styles from './styles.module.css'
-import axios from 'axios'
 import sanitizeHtml from 'sanitize-html';
 
 export const DiscourseBlogComments = ({title,slug}) => {
@@ -8,7 +7,6 @@ export const DiscourseBlogComments = ({title,slug}) => {
     const DISCOURSE_TOPIC_ENDPOINT = `https://discourse.getdbt.com/t/`
     const commentsToLoad = 6
 
-    const [postSlug, setPostSlug] = useState(slug)
     const [comments, setComments] = useState([])
     const [topicId, setTopicId] = useState(null)
     const [loading, setLoading] = useState(true)
@@ -19,30 +17,30 @@ export const DiscourseBlogComments = ({title,slug}) => {
     const loadMoreComments = () => {
       setNext(next + commentsToLoad)
     }
-  
+
     useEffect(() => {
       let isMounted = true
-      
-      setPostSlug(slug)
-  
+
       const fetchData = async () => {
         try {
 
           const endpoint = `/api/get-discourse-comments?title=${title}&slug=${slug}`
-        
-          const { data } = await axios.get(endpoint)
-  
+
+          const response = await fetch(endpoint)
+
           // Set error state if data not available
-          if(!data) throw new Error('Unable to get latest topics.')
-  
+          if (!response.ok) throw new Error('Unable to get latest topics.')
+
+          const data = await response.json()
+
           // Set topics count
           if(isMounted && data) {
             setComments(data.comments)
             setTopicId(data.topicId)
             setLoading(false)
-            
+
           }
-          
+
         } catch(err) {
           setIsError(true)
           setLoading(false)
@@ -53,8 +51,8 @@ export const DiscourseBlogComments = ({title,slug}) => {
       return () => {
         isMounted = false
       }
-      
-    }, [postSlug])
+
+    }, [slug])
 
     const resultData = () => {
       if (loading) {


### PR DESCRIPTION
## What are you changing in this pull request and why?
[Task](https://www.notion.so/dbtlabs/Fix-discourse-module-duplicating-footer-sections-on-docs-blog-204d77afb21e4a3e8e71049254bfba67?source=copy_link)

- Fixes circular dependency causing blog post sections to duplicate
- Removes axios within this component and replaces with js fetch

## Preview

Verify no sections are duplicated at the bottom of the page, including the blog tags, pagination, discourse comments, footer, sidebar.

https://docs-getdbt-com-git-fix-discourse-comments-dbt-labs.vercel.app/blog/catalog-linked-databases

## Additional Notes

You can see the issue on the live site by scrolling to the bottom of the blog post. Confirming the issue also occurs in preview environments: 
- https://docs.getdbt.com/blog/semantic-layer-vs-text-to-sql-2026
- https://docs-getdbt-com-git-nfiann-platformcredentials-dbt-labs.vercel.app/blog/semantic-layer-vs-text-to-sql-2026
