### PR TITLE
Update pointers to artifact architecture doc

### DIFF
--- a/website/docs/reference/global-configs/behavior-changes.md
+++ b/website/docs/reference/global-configs/behavior-changes.md
@@ -40,14 +40,14 @@ Examples of behavior changes:
 - dbt begins raising a validation _error_ that it didn't previously.
 - dbt changes the signature of a built-in macro. Your project has a custom reimplementation of that macro. This could lead to errors, because your custom reimplementation will be passed arguments it cannot accept.
 - A dbt adapter renames or removes a method that was previously available on the `{{ adapter }}` object in the dbt-Jinja context.
-- dbt makes a breaking change to contracted metadata artifacts by deleting a required field, changing the name or type of an existing field, or removing the default value of an existing field ([README](https://github.com/dbt-labs/dbt-core/blob/37d382c8e768d1e72acd767e0afdcb1f0dc5e9c5/core/dbt/artifacts/README.md#breaking-changes)).
+- dbt makes a breaking change to contracted metadata artifacts by deleting a required field, changing the name or type of an existing field, or removing the default value of an existing field ([README](https://github.com/dbt-labs/dbt-core/blob/main/docs/arch/7_Artifacts.md#breaking-changes)).
 - dbt removes one of the fields from [structured logs](/reference/events-logging#structured-logging).
 
 The following are **not** behavior changes:
 - Fixing a bug where the previous behavior was defective, undesirable, or undocumented.
 - dbt begins raising a _warning_ that it didn't previously.
 - dbt updates the language of human-friendly messages in log events.
-- dbt makes a non-breaking change to contracted metadata artifacts by adding a new field with a default, or deleting a field with a default ([README](https://github.com/dbt-labs/dbt-core/blob/37d382c8e768d1e72acd767e0afdcb1f0dc5e9c5/core/dbt/artifacts/README.md#non-breaking-changes)).
+- dbt makes a non-breaking change to contracted metadata artifacts by adding a new field with a default, or deleting a field with a default ([README](https://github.com/dbt-labs/dbt-core/blob/main/docs/arch/7_Artifacts.md#non-breaking-changes)).
 
 The vast majority of changes are not behavior changes. Because introducing these changes does not require any action on the part of users, they are included in continuous releases of <Constant name="dbt" /> and patch releases of <Constant name="core" />.
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
The docs point to a file at a point in time, which has since been moved to the architecture directory. 

The link didn't 404 since it was pointing to a specific commit, but it was stale. This updates it. 

Potentially open to pinning to a specific commit if this is a docs team standard practice, but it diverging over time feels bad 🤷

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-joellabes-patch-4-dbt-labs.vercel.app/reference/global-configs/behavior-changes

<!-- end-vercel-deployment-preview -->