### PR TITLE
Temp: Remove Discourse dev blog comments

### DIFF
--- a/website/src/components/discourseBlogComments/index.js
+++ b/website/src/components/discourseBlogComments/index.js
@@ -13,6 +13,8 @@ export const DiscourseBlogComments = ({title,slug}) => {
     const [isError, setIsError] = useState(false)
     const [next, setNext] = useState(commentsToLoad)
 
+    // Generate preview
+
     // Handle loading more comments
     const loadMoreComments = () => {
       setNext(next + commentsToLoad)

--- a/website/src/components/discourseBlogComments/index.js
+++ b/website/src/components/discourseBlogComments/index.js
@@ -13,8 +13,6 @@ export const DiscourseBlogComments = ({title,slug}) => {
     const [isError, setIsError] = useState(false)
     const [next, setNext] = useState(commentsToLoad)
 
-    // Generate preview
-
     // Handle loading more comments
     const loadMoreComments = () => {
       setNext(next + commentsToLoad)

--- a/website/src/theme/BlogPostPage/index.js
+++ b/website/src/theme/BlogPostPage/index.js
@@ -122,10 +122,10 @@ function BlogPostPageContent({sidebar, children}) {
 
       <BlogPostItem>{children}</BlogPostItem>
 
-      <DiscourseBlogComments
+      {/* <DiscourseBlogComments
         title={frontMatter.title}
         slug={frontMatter.slug}
-      />
+      /> */}
 
       {(nextItem || prevItem) && (
         <BlogPostPaginator nextItem={nextItem} prevItem={prevItem} />


### PR DESCRIPTION
## What are you changing in this pull request and why?
[Notion Task](https://www.notion.so/Fix-discourse-module-duplicating-footer-sections-on-docs-blog-204d77afb21e4a3e8e71049254bfba67?source=copy_link)

Removing discourse blog comments for now to prevent duplicate sections issue. Will open a separate PR to bring the comments back and implement a fix.

## Preview
https://docs-getdbt-com-git-fix-discourse-comments-dbt-labs.vercel.app/blog/modernizing-the-semantic-layer-spec