### PR TITLE
Clarify warn notification behavior in job notifications docs

### DIFF
--- a/website/docs/docs/deploy/job-notifications.md
+++ b/website/docs/docs/deploy/job-notifications.md
@@ -7,7 +7,8 @@ description: "Set up notifications in dbt to receive email or Slack alerts about
 Set up notifications in <Constant name="dbt_platform" /> to receive alerts about the outcome of a job run. You can choose to be notified by one or more of the following job run outcomes:
 
 - **Succeeds** option &mdash; A job run completed successfully with no warnings or errors.
-- **Warns** option &mdash; A job run encountered warnings from [data tests](/docs/build/data-tests) or [source freshness](/docs/deploy/source-freshness) checks. This notification is triggered by warning-level log lines from those steps, not the job's overall run status. A job that shows "success" in the user interface can still trigger a warn notification if test or freshness steps logged warnings.
+- **Warns** option &mdash; A job run encountered warnings from [data tests](/docs/build/data-tests) or [source freshness](/docs/deploy/source-freshness) checks. 
+  - This notification is triggered by warning-level log lines from those steps, not the job's overall run status. A job that shows "success" in the user interface can still trigger a warn notification if test or freshness steps logged warnings.
 - **Fails** option &mdash; A job run failed to complete. 
 - **Is canceled** option &mdash; A job run is canceled.
 

--- a/website/docs/docs/deploy/job-notifications.md
+++ b/website/docs/docs/deploy/job-notifications.md
@@ -4,10 +4,10 @@ id: "job-notifications"
 description: "Set up notifications in dbt to receive email or Slack alerts about job run status."
 ---
 
-Set up notifications in <Constant name="dbt_platform" /> to receive alerts about the status of a job run. You can choose to be notified by one or more of the following job run statuses: 
+Set up notifications in <Constant name="dbt_platform" /> to receive alerts about the outcome of a job run. You can choose to be notified by one or more of the following job run outcomes:
 
 - **Succeeds** option &mdash; A job run completed successfully with no warnings or errors.
-- **Warns** option &mdash; A job run encountered warnings from [data tests](/docs/build/data-tests) or [source freshness](/docs/deploy/source-freshness) checks (if applicable).
+- **Warns** option &mdash; A job run encountered warnings from [data tests](/docs/build/data-tests) or [source freshness](/docs/deploy/source-freshness) checks. This notification is triggered by warning-level log lines from those steps, not the job's overall run status. A job that shows "success" in the UI can still trigger a warn notification if test or freshness steps logged warnings.
 - **Fails** option &mdash; A job run failed to complete. 
 - **Is canceled** option &mdash; A job run is canceled.
 

--- a/website/docs/docs/deploy/job-notifications.md
+++ b/website/docs/docs/deploy/job-notifications.md
@@ -7,7 +7,7 @@ description: "Set up notifications in dbt to receive email or Slack alerts about
 Set up notifications in <Constant name="dbt_platform" /> to receive alerts about the outcome of a job run. You can choose to be notified by one or more of the following job run outcomes:
 
 - **Succeeds** option &mdash; A job run completed successfully with no warnings or errors.
-- **Warns** option &mdash; A job run encountered warnings from [data tests](/docs/build/data-tests) or [source freshness](/docs/deploy/source-freshness) checks. This notification is triggered by warning-level log lines from those steps, not the job's overall run status. A job that shows "success" in the UI can still trigger a warn notification if test or freshness steps logged warnings.
+- **Warns** option &mdash; A job run encountered warnings from [data tests](/docs/build/data-tests) or [source freshness](/docs/deploy/source-freshness) checks. This notification is triggered by warning-level log lines from those steps, not the job's overall run status. A job that shows "success" in the user interface can still trigger a warn notification if test or freshness steps logged warnings.
 - **Fails** option &mdash; A job run failed to complete. 
 - **Is canceled** option &mdash; A job run is canceled.
 


### PR DESCRIPTION
## Summary

- Changes "status" to "outcome" in the opening description, since the system doesn't check the job's overall run status
- Adds a clarifying note to the **Warns** bullet explaining that warn notifications are triggered by warning-level log lines from test/freshness steps — not the overall run status. A job showing "success" in the UI can still trigger a warn notification.

## Context

Surfaced in a support ticket where a user wasn't receiving warn notifications because they hadn't enabled them, but was confused because their jobs showed "success" overall. The current docs imply notifications track the run's overall status, which is misleading.

See internal Slack thread: https://dbt-labs.slack.com/archives/C08H1T53Y2F/p1776177959119949

## Test plan

- [x] Review rendered doc at https://docs.getdbt.com/docs/deploy/job-notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-job-notification-outcome-dbt-labs.vercel.app/docs/deploy/job-notifications

<!-- end-vercel-deployment-preview -->