### PR TITLE
Fix broken GitLab link in example-projects FAQ

### DIFF
--- a/website/docs/faqs/Project/example-projects.md
+++ b/website/docs/faqs/Project/example-projects.md
@@ -10,7 +10,7 @@ Yes!
 
 * **Quickstart Tutorial:** You can build your own example dbt project in the [quickstart guide](/docs/get-started-dbt)
 * **Jaffle Shop:** A demonstration project (closely related to the tutorial) for a fictional e-commerce store ([main source code](https://github.com/dbt-labs/jaffle-shop) and [source code using duckdb](https://github.com/dbt-labs/jaffle_shop_duckdb))
-* **GitLab:** Gitlab's internal dbt project is open source and is a great example of how to use dbt at scale ([source code](https://gitlab.com/gitlab-data/analytics/-/tree/master/transform/snowflake-dbt))
+* **GitLab:** Gitlab's internal dbt project is open source and is a great example of how to use dbt at scale ([source code](https://gitlab.com/gitlab-com/content-sites/handbook/blob/main/content/handbook/enterprise-data/platform/dbt-guide.md))
 * **dummy-dbt:** A containerized dbt project that populates the Sakila database in Postgres and populates dbt seeds, models, snapshots, and tests. The project can be used for testing and experimentation purposes ([source code](https://github.com/gmyrianthous/dbt-dummy))
 * **Google Analytics 4:** A demonstration project that transforms the Google Analytics 4 BigQuery exports to various models ([source code](https://github.com/stacktonic-com/stacktonic-dbt-example-project), [docs](https://stacktonic.com/article/google-analytics-big-query-and-dbt-a-dbt-example-project))
 * **Make Open Data:**  A production-grade ELT with tests, documentation, and CI/CD (GHA) about French open data (housing, demography, geography, etc). It can be used to learn with voluminous and ambiguous data. Contributions are welcome ([source code](https://github.com/make-open-data/make-open-data), [docs](https://make-open-data.fr/))


### PR DESCRIPTION
## Summary

- Updates the broken GitLab source code link in the [example-projects FAQ](https://docs.getdbt.com/faqs/Project/example-projects)
- Old URL (404): `https://gitlab.com/gitlab-data/analytics/-/tree/master/transform/snowflake-dbt`
- New URL: `https://gitlab.com/gitlab-com/content-sites/handbook/blob/main/content/handbook/enterprise-data/platform/dbt-guide.md`

Fixes #8916

## Test plan

- [x] Verify the new GitLab link resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-fix-gitlab-link-dbt-labs.vercel.app/faqs/Project/example-projects

<!-- end-vercel-deployment-preview -->