### PR TITLE
docs: add interactive setup via MCP elicitation

### DIFF
--- a/website/docs/docs/dbt-ai/integrate-mcp-claude.md
+++ b/website/docs/docs/dbt-ai/integrate-mcp-claude.md
@@ -54,12 +54,16 @@ You can set up Claude Code with both the local and remote `dbt-mcp` server. We r
 
 ### Set up with local dbt MCP server
 
-1. Follow [Set up local MCP](/docs/dbt-ai/setup-local-mcp) and choose the configuration that matches your use case: 
+Claude Code supports [elicitation](https://modelcontextprotocol.io/specification/2025-03-26/server/elicitation), so you can use the simplest possible config &mdash; no environment variables needed. dbt-mcp will prompt you for your <Constant name="dbt_platform" /> host and start OAuth on the first tool call. See [Interactive setup](/docs/dbt-ai/setup-local-mcp#interactive-setup) for details.
+
+If you prefer to pre-configure environment variables, follow [Set up local MCP](/docs/dbt-ai/setup-local-mcp) and choose the configuration that matches your use case: 
    - OAuth with the <Constant name="dbt_platform" />
    - [CLI only](/docs/dbt-ai/setup-local-mcp#cli-only)
    - [environment variables](/docs/dbt-ai/setup-local-mcp#environment-variable-configuration) (including an `.env` file with `--env-file` for `dbt-mcp`, if you use that pattern).
-2. Add the same `dbt` server definition to `.mcp.json` at your project root (the repository root for your workspace). Claude Code loads MCP servers from this file. 
-3. Use the same `mcpServers` JSON shape as in [Set up local MCP](/docs/dbt-ai/setup-local-mcp) (`command`, `args`, and `env`, or `args` with `--env-file`), matching the patterns in next [Example config in `.mcp.json`](#example-config-in-mcpjson) section.
+
+Then:
+1. Add the same `dbt` server definition to `.mcp.json` at your project root (the repository root for your workspace). Claude Code loads MCP servers from this file. 
+2. Use the same `mcpServers` JSON shape as in [Set up local MCP](/docs/dbt-ai/setup-local-mcp) (`command`, `args`, and `env`, or `args` with `--env-file`), matching the patterns in next [Example config in `.mcp.json`](#example-config-in-mcpjson) section.
 
 If you already completed local MCP setup for another client, reuse that `dbt` entry in `.mcp.json` &mdash; you don't need a second, separate registration step for Claude Code.
 

--- a/website/docs/docs/dbt-ai/integrate-mcp-claude.md
+++ b/website/docs/docs/dbt-ai/integrate-mcp-claude.md
@@ -54,7 +54,7 @@ You can set up Claude Code with both the local and remote `dbt-mcp` server. We r
 
 ### Set up with local dbt MCP server
 
-Claude Code supports [elicitation](https://modelcontextprotocol.io/specification/2025-03-26/server/elicitation), so you can use the simplest possible config &mdash; no environment variables needed. dbt-mcp will prompt you for your <Constant name="dbt_platform" /> host and start OAuth on the first tool call. See [Interactive setup](/docs/dbt-ai/setup-local-mcp#interactive-setup) for details.
+Claude Code supports [elicitation](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#elicitation), so you can use the simplest possible config &mdash; no environment variables needed. dbt-mcp will prompt you for your <Constant name="dbt_platform" /> host and start OAuth on the first tool call. See [Interactive setup](/docs/dbt-ai/setup-local-mcp#interactive-setup) for details.
 
 If you prefer to pre-configure environment variables, follow [Set up local MCP](/docs/dbt-ai/setup-local-mcp) and choose the configuration that matches your use case: 
    - OAuth with the <Constant name="dbt_platform" />

--- a/website/docs/docs/dbt-ai/integrate-mcp-claude.md
+++ b/website/docs/docs/dbt-ai/integrate-mcp-claude.md
@@ -54,16 +54,22 @@ You can set up Claude Code with both the local and remote `dbt-mcp` server. We r
 
 ### Set up with local dbt MCP server
 
-Claude Code supports [elicitation](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#elicitation), so you can use the simplest possible config &mdash; no environment variables needed. dbt-mcp will prompt you for your <Constant name="dbt_platform" /> host and start OAuth on the first tool call. See [Interactive setup](/docs/dbt-ai/setup-local-mcp#interactive-setup) for details.
+Claude Code supports [elicitation](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#elicitation), so you can use the simplest possible config &mdash; no environment variables needed. Add this to `.mcp.json` at your project root and dbt-mcp will prompt you for your <Constant name="dbt_platform" /> host on the first tool call:
 
-If you prefer to pre-configure environment variables, follow [Set up local MCP](/docs/dbt-ai/setup-local-mcp) and choose the configuration that matches your use case: 
-   - OAuth with the <Constant name="dbt_platform" />
-   - [CLI only](/docs/dbt-ai/setup-local-mcp#cli-only)
-   - [environment variables](/docs/dbt-ai/setup-local-mcp#environment-variable-configuration) (including an `.env` file with `--env-file` for `dbt-mcp`, if you use that pattern).
+```json
+{
+  "mcpServers": {
+    "dbt": {
+      "command": "uvx",
+      "args": ["dbt-mcp"]
+    }
+  }
+}
+```
 
-Then:
-1. Add the same `dbt` server definition to `.mcp.json` at your project root (the repository root for your workspace). Claude Code loads MCP servers from this file. 
-2. Use the same `mcpServers` JSON shape as in [Set up local MCP](/docs/dbt-ai/setup-local-mcp) (`command`, `args`, and `env`, or `args` with `--env-file`), matching the patterns in next [Example config in `.mcp.json`](#example-config-in-mcpjson) section.
+See [Interactive setup](/docs/dbt-ai/setup-local-mcp#interactive-setup) for details on how the flow works.
+
+If you prefer to pre-configure environment variables, follow [Set up local MCP](/docs/dbt-ai/setup-local-mcp) and add the matching config to `.mcp.json`. See [Example config in `.mcp.json`](#example-config-in-mcpjson) below for the full patterns.
 
 If you already completed local MCP setup for another client, reuse that `dbt` entry in `.mcp.json` &mdash; you don't need a second, separate registration step for Claude Code.
 

--- a/website/docs/docs/dbt-ai/setup-local-mcp.md
+++ b/website/docs/docs/dbt-ai/setup-local-mcp.md
@@ -33,7 +33,9 @@ Use this table to understand what each toolset needs and whether it works with o
 | LSP / Fusion | `DBT_PROJECT_DIR`, `DBT_PATH`, and the dbt VS Code extension | Yes | Yes |
 
 :::note Toolsets auto-disable when required variables are missing
-If a required variable is not set, dbt-mcp will automatically disable that toolset rather than error. For example, if `DBT_HOST` is not configured, the Semantic Layer, Discovery, and Admin API toolsets won't be available. To confirm which toolsets are active, set `DBT_MCP_LOG_LEVEL=DEBUG` in your environment and check the [server logs](#debug-configurations).
+If a required variable is not set, dbt-mcp will automatically disable that toolset rather than error. For example, if `DBT_PROJECT_DIR` or `DBT_PATH` is not configured, the dbt CLI toolset won't be available. To confirm which toolsets are active, set `DBT_MCP_LOG_LEVEL=DEBUG` in your environment and check the [server logs](#debug-configurations).
+
+For platform toolsets (Semantic Layer, Discovery API, Admin API), if `DBT_HOST` is not configured and your MCP client supports [elicitation](https://modelcontextprotocol.io/specification/2025-03-26/server/elicitation), dbt-mcp will prompt you to enter your host interactively on the first tool call. See [Interactive setup (elicitation)](#interactive-setup) for details.
 :::
 
 ## Prerequisites
@@ -75,6 +77,35 @@ Once configured, your session connects to the <Constant name="dbt_platform"/> ac
 <Lightbox src="/img/mcp/select-project.png" width="60%" title="Select your dbt platform project"/>
 
 After completing OAuth setup, skip to [Test your configuration](#optional-test-your-configuration).
+
+### Interactive setup (elicitation) {#interactive-setup}
+
+If your MCP client supports [elicitation](https://modelcontextprotocol.io/specification/2025-03-26/server/elicitation), you can skip pre-configuring `DBT_HOST` entirely. dbt-mcp will prompt you to enter your host the first time you call a platform tool.
+
+This is the simplest setup for platform features &mdash; no environment variables needed upfront:
+
+```json
+{
+  "mcpServers": {
+    "dbt": {
+      "command": "uvx",
+      "args": ["dbt-mcp"]
+    }
+  }
+}
+```
+
+When you call a platform tool (like `get_all_models`), dbt-mcp will:
+
+1. Display a form asking for your <Constant name="dbt_platform" /> host (for example, `ab123.us1.dbt.com`).
+2. Start the OAuth authentication flow in your browser.
+3. Persist the host to `~/.dbt/mcp-config.yml` so you won't be prompted again.
+
+:::info Client support
+Elicitation is supported in [Claude Code](https://www.anthropic.com/claude-code). Claude Desktop and other clients that don't support elicitation will fall back to requiring `DBT_HOST` as an environment variable.
+:::
+
+After completing interactive setup, skip to [Test your configuration](#optional-test-your-configuration).
 
 ### CLI only (no dbt platform) {#cli-only}
 
@@ -271,7 +302,7 @@ uvx dbt-mcp
 
 | Environment variable | Required | Description |
 | --- | --- | --- |
-| `DBT_HOST` | Required | Your <Constant name="dbt_platform" /> [instance hostname](/docs/cloud/about-cloud/access-regions-ip-addresses). **Important:** For Multi-cell accounts, exclude the account prefix from the hostname. The default is `cloud.getdbt.com`. |
+| `DBT_HOST` | Required | Your <Constant name="dbt_platform" /> [instance hostname](/docs/cloud/about-cloud/access-regions-ip-addresses). **Important:** For Multi-cell accounts, exclude the account prefix from the hostname. The default is `cloud.getdbt.com`. If your MCP client supports [elicitation](#interactive-setup), this is prompted interactively when not set. |
 | `MULTICELL_ACCOUNT_PREFIX` | Only required for Multi-cell instances | Set your Multi-cell account prefix here (not in DBT_HOST). If you are not using Multi-cell, don't set this value. You can learn more about regions and hosting [here](/docs/cloud/about-cloud/access-regions-ip-addresses). |
 | `DBT_TOKEN` | Required | Your personal access token or service token from the <Constant name="dbt_platform" />. <br/>**Note**: The `execute_sql` tool requires a [Personal Access Token (PAT)](/docs/dbt-cloud-apis/user-tokens) — service tokens do not work for this tool. For Semantic Layer use, a PAT is also recommended. If you're using a service token for other toolsets, make sure it has at least `Semantic Layer Only`, `Metadata Only`, and `Developer` permissions. |
 | `DBT_ACCOUNT_ID` | Required for Administrative API tools | Your [dbt account ID](/faqs/Accounts/find-user-id) |

--- a/website/docs/docs/dbt-ai/setup-local-mcp.md
+++ b/website/docs/docs/dbt-ai/setup-local-mcp.md
@@ -35,7 +35,7 @@ Use this table to understand what each toolset needs and whether it works with o
 :::note Toolsets auto-disable when required variables are missing
 If a required variable is not set, dbt-mcp will automatically disable that toolset rather than error. For example, if `DBT_PROJECT_DIR` or `DBT_PATH` is not configured, the dbt CLI toolset won't be available. To confirm which toolsets are active, set `DBT_MCP_LOG_LEVEL=DEBUG` in your environment and check the [server logs](#debug-configurations).
 
-For platform toolsets (Semantic Layer, Discovery API, Admin API), if `DBT_HOST` is not configured and your MCP client supports [elicitation](https://modelcontextprotocol.io/specification/2025-03-26/server/elicitation), dbt-mcp will prompt you to enter your host interactively on the first tool call. See [Interactive setup (elicitation)](#interactive-setup) for details.
+For platform toolsets (Semantic Layer, Discovery API, Admin API), if `DBT_HOST` is not configured and your MCP client supports [elicitation](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#elicitation), dbt-mcp will prompt you to enter your host interactively on the first tool call. See [Interactive setup (elicitation)](#interactive-setup) for details.
 :::
 
 ## Prerequisites

--- a/website/snippets/_mcp-config-files.md
+++ b/website/snippets/_mcp-config-files.md
@@ -6,6 +6,8 @@ This option is for users who only want dbt platform features (Discovery API, Sem
 
 When you use only the dbt platform, the CLI tools are automatically disabled. You can find the `DBT_HOST` field value in your dbt platform account information under **Access URLs**.
 
+**Tip:** If your MCP client supports [elicitation](/docs/dbt-ai/setup-local-mcp#interactive-setup) (like Claude Code), you can omit `DBT_HOST` and dbt-mcp will prompt you interactively on the first tool call.
+
 
 ```json
 {


### PR DESCRIPTION
## Summary

- Adds a new **Interactive setup (elicitation)** section to the local MCP setup guide documenting the zero-config path — users can skip `DBT_HOST` entirely and dbt-mcp will prompt interactively on the first platform tool call
- Updates the auto-disable note, `DBT_HOST` env var table row, and config snippets to reference the new elicitation path
- Updates the Claude integration guide to recommend elicitation as the simplest setup for Claude Code

## Related

- dbt-mcp PR: https://github.com/dbt-labs/dbt-mcp/pull/728
- MCP elicitation spec: https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#elicitation

## Files changed

| File | Change |
|------|--------|
| `setup-local-mcp.md` | New "Interactive setup" section, updated auto-disable note, updated `DBT_HOST` table row |
| `integrate-mcp-claude.md` | Added elicitation as recommended path for Claude Code |
| `_mcp-config-files.md` | Added tip about omitting `DBT_HOST` with elicitation-capable clients |