### PR TITLE
docs: add interactive setup (elicitation) for dbt-mcp

### DIFF
--- a/website/docs/docs/dbt-ai/integrate-mcp-claude.md
+++ b/website/docs/docs/dbt-ai/integrate-mcp-claude.md
@@ -54,6 +54,10 @@ You can set up Claude Code with both the local and remote `dbt-mcp` server. We r
 
 ### Set up with local dbt MCP server
 
+:::tip Zero-config setup with elicitation
+Claude Code supports [elicitation](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#elicitation), so you can add dbt-mcp with no environment variables. dbt-mcp will prompt you for your <Constant name="dbt_platform" /> host on the first tool call. See [Interactive setup](/docs/dbt-ai/setup-local-mcp#interactive-setup) for details.
+:::
+
 1. Follow [Set up local MCP](/docs/dbt-ai/setup-local-mcp) and choose the configuration that matches your use case: 
    - OAuth with the <Constant name="dbt_platform" />
    - [CLI only](/docs/dbt-ai/setup-local-mcp#cli-only)

--- a/website/docs/docs/dbt-ai/setup-local-mcp.md
+++ b/website/docs/docs/dbt-ai/setup-local-mcp.md
@@ -76,6 +76,35 @@ Once configured, your session connects to the <Constant name="dbt_platform"/> ac
 
 After completing OAuth setup, skip to [Test your configuration](#optional-test-your-configuration).
 
+### Interactive setup (elicitation) {#interactive-setup}
+
+If your MCP client supports [elicitation](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#elicitation), you can skip pre-configuring `DBT_HOST` entirely. dbt-mcp will prompt you to enter your host the first time you call a platform tool.
+
+This is the simplest setup for platform features &mdash; no environment variables needed upfront:
+
+```json
+{
+  "mcpServers": {
+    "dbt": {
+      "command": "uvx",
+      "args": ["dbt-mcp"]
+    }
+  }
+}
+```
+
+When you call a platform tool (like `get_all_models`), dbt-mcp will:
+
+1. Display a form asking for your <Constant name="dbt_platform" /> host (for example, `ab123.us1.dbt.com`).
+2. Start the OAuth authentication flow in your browser.
+3. Persist the host to `~/.dbt/mcp-config.yml` so you won't be prompted again.
+
+:::info Client support
+Elicitation is supported in [Claude Code](https://www.anthropic.com/claude-code). Claude Desktop and other clients that don't support elicitation will continue to require `DBT_HOST` as an environment variable.
+:::
+
+After completing interactive setup, skip to [Test your configuration](#optional-test-your-configuration).
+
 ### CLI only (no dbt platform) {#cli-only}
 
 This option runs the MCP server locally and connects it to your local dbt project using `DBT_PROJECT_DIR` and `DBT_PATH`.


### PR DESCRIPTION
## Summary

- Adds a new **Interactive setup (elicitation)** section to the local MCP setup guide documenting the zero-config path — clients supporting elicitation get prompted for `DBT_HOST` on the first platform tool call
- Adds a tip callout in the Claude Code integration guide pointing to the new section

## What this PR does NOT do

- Does not modify or remove any existing documentation
- Does not change behavior descriptions for clients without elicitation support

## Related

- dbt-mcp PR: https://github.com/dbt-labs/dbt-mcp/pull/728
- MCP elicitation spec: https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#elicitation

## Files changed

| File | Change |
|------|--------|
| `setup-local-mcp.md` | Added "Interactive setup (elicitation)" section between OAuth and CLI-only |
| `integrate-mcp-claude.md` | Added tip callout about zero-config elicitation support |