### PR TITLE
Add the "size" feature to lifecycle

### DIFF
--- a/website/snippets/_fusion-lifecycle-callout.md
+++ b/website/snippets/_fusion-lifecycle-callout.md
@@ -1,9 +1,9 @@
 :::info important
 
 The <Constant name="fusion_engine" /> is currently available for installation in: 
-- [Local command line interface (CLI) tools](/docs/local/install-dbt?version=2#get-started) <Lifecycle status="preview" />
-- [VS Code and Cursor with the dbt extension](/docs/install-dbt-extension) <Lifecycle status="preview" />
-- [dbt platform environments](/docs/dbt-versions/upgrade-dbt-version-in-cloud#dbt-fusion-engine) <Lifecycle status="private_preview" />
+- [Local command line interface (CLI) tools](/docs/local/install-dbt?version=2#get-started) <Lifecycle status="preview" size="80%" />
+- [VS Code and Cursor with the dbt extension](/docs/install-dbt-extension) <Lifecycle status="preview" size="80%" />
+- [dbt platform environments](/docs/dbt-versions/upgrade-dbt-version-in-cloud#dbt-fusion-engine) <Lifecycle status="private_preview" size="80%" />
 
 Join the conversation in our Community Slack channel [`#dbt-fusion-engine`](https://getdbt.slack.com/archives/C088YCAB6GH).
 

--- a/website/snippets/_fusion-lifecycle-callout.md
+++ b/website/snippets/_fusion-lifecycle-callout.md
@@ -3,7 +3,7 @@
 The <Constant name="fusion_engine" /> is currently available for installation in: 
 - [Local command line interface (CLI) tools](/docs/local/install-dbt?version=2#get-started) <Lifecycle status="preview" size="80%" />
 - [VS Code and Cursor with the dbt extension](/docs/install-dbt-extension) <Lifecycle status="preview" size="80%" />
-- [dbt platform environments](/docs/dbt-versions/upgrade-dbt-version-in-cloud#dbt-fusion-engine) <Lifecycle status="private_preview" size="80%" />
+- [<Constant name="dbt_platform" /> environments](/docs/dbt-versions/upgrade-dbt-version-in-cloud#dbt-fusion-engine) <Lifecycle status="private_preview" size="80%" />
 
 Join the conversation in our Community Slack channel [`#dbt-fusion-engine`](https://getdbt.slack.com/archives/C088YCAB6GH).
 

--- a/website/src/components/lifeCycle/index.js
+++ b/website/src/components/lifeCycle/index.js
@@ -68,6 +68,8 @@ export default function Lifecycle(props) {
     return null;
   }
 
+  const sizePercent = props.size !== undefined ? parseFloat(props.size) / 100 : 1;
+
   const statuses = props.status.split(',').map(s => {
     const trimmedStatus = s.trim();
     return PLAN_VARIABLES[trimmedStatus] || trimmedStatus;
@@ -85,6 +87,7 @@ export default function Lifecycle(props) {
           cursor: url ? 'pointer' : 'default', // Non-clickable for unknown status
           transition: 'background-color 0.2s ease, transform 0.2s ease, text-decoration 0.2s ease',
           textDecoration: 'none', // No underline
+          fontSize: `${sizePercent}rem`,
         };
 
         // Get display name or fallback to status


### PR DESCRIPTION
## What are you changing in this pull request and why?

When defining the Lifecycle status this will allow you to reduce the size. If no size is defined, the lifecycle will display at 100% (1 rem)

To reduce the size add the `size="num%"` field

So `<Lifecycle status="Preview" size="85%" />` will reduce the size of the pill on screen by 15%


## Checklist
<!-- Ensure your PR meets the following items. Feel free to add additiona checklist items to the list if additional checks need to happen before the PR is merged, such as:
- [ ] Needs technical review
- [ ] Change base branch
- [ ] Merge on xyz date
-->
- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).
<!--
PRE-RELEASE VERSION OF dbt (if so, uncomment):
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
<!-- 
ADDING OR REMOVING PAGES (if so, uncomment):
- [ ] Add/remove page in `website/sidebars.js`
- [ ] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages
-->
