### PR TITLE
Clarify Fusion admin permission section

### DIFF
--- a/website/docs/docs/cloud/manage-access/enterprise-permissions.md
+++ b/website/docs/docs/cloud/manage-access/enterprise-permissions.md
@@ -122,7 +122,7 @@ Notable features:
 </Expandable>
 <Expandable alt_header="Fusion admin">
 
-This permission set enables users to interact with <Constant name="fusion"/> upgrade workflows. We recommend limiting this permission to users who are actively working on migrating a project to <Constant name="fusion"/>.
+This permission set enables users to interact with <Constant name="fusion"/> upgrade workflows. We recommend limiting this permission to users who are actively [working on migrating](/guides/upgrade-to-fusion?step=1) a project to <Constant name="fusion"/>.
 
 By default, all users can access the <Constant name="fusion"/> upgrade experience. When the upgrade permissions setting is enabled, only users with the **Fusion admin** or **Account admin** permission set can perform upgrades. If the setting is disabled (no check mark), upgrades are not restricted.
 

--- a/website/docs/docs/cloud/manage-access/enterprise-permissions.md
+++ b/website/docs/docs/cloud/manage-access/enterprise-permissions.md
@@ -122,16 +122,14 @@ Notable features:
 </Expandable>
 <Expandable alt_header="Fusion admin">
 
-This permission set is used exclusively to enable users to interact with the Fusion upgrade workflows. We recommend limiting this permission to users and projects that are Fusion-ready. 
+This permission set enables users to interact with <Constant name="fusion"/> upgrade workflows. We recommend limiting this permission to users who are actively working on migrating a project to <Constant name="fusion"/>.
 
-By default, all users can access the Fusion upgrade experience and perform upgrades based on their existing permissions. When the Fusion upgrade permissions setting is enabled (when you see a check mark), only users with the fusion admin or account admin permission set can perform upgrades. If the setting is disabled (no check mark), upgrades are not restricted.
+By default, all users can access the <Constant name="fusion"/> upgrade experience. When the upgrade permissions setting is enabled, only users with the **Fusion admin** or **Account admin** permission set can perform upgrades. If the setting is disabled (no check mark), upgrades are not restricted.
 
-When upgrade permissions are enabled:
+- **Fusion admin** &mdash; Assign to user accounts only. Cannot be assigned to service tokens.
+- **Account admin** &mdash; Assign to user accounts or service tokens. Allows both users and service tokens to perform upgrades.
 
-- **Fusion admin** &mdash; Assign to user accounts. This permission cannot be assigned to service tokens.
-- **Account admin** &mdash; Assign to users or service tokens. This permission allows both users and service tokens to perform upgrades.
-
-See the [dbt platform Fusion upgrade](/docs/dbt-versions/upgrade-dbt-version-in-cloud#dbt-fusion-engine) docs for more information.
+For more information, refer to [Upgrade to dbt Fusion](/docs/dbt-versions/upgrade-dbt-version-in-cloud#dbt-fusion-engine).
 
 </Expandable>
 <Expandable alt_header="Git admin">

--- a/website/docs/docs/cloud/manage-access/enterprise-permissions.md
+++ b/website/docs/docs/cloud/manage-access/enterprise-permissions.md
@@ -129,7 +129,7 @@ By default, all users can access the <Constant name="fusion"/> upgrade experienc
 - **Fusion admin** &mdash; Assign to user accounts only. Cannot be assigned to service tokens.
 - **Account admin** &mdash; Assign to user accounts or service tokens. Allows both users and service tokens to perform upgrades.
 
-For more information, refer to [Upgrade to dbt Fusion](/docs/dbt-versions/upgrade-dbt-version-in-cloud#dbt-fusion-engine).
+For more information, refer to [Upgrade to dbt <Constant name="fusion"/>](/docs/dbt-versions/upgrade-dbt-version-in-cloud#dbt-fusion-engine).
 
 </Expandable>
 <Expandable alt_header="Git admin">


### PR DESCRIPTION
## Summary
- Tightens language in the Fusion admin `<Expandable>` section
- Uses `<Constant name="fusion"/>` for consistent terminology
- Simplifies the "By default" sentence while restoring the "If the setting is disabled (no check mark), upgrades are not restricted" clarification
- Simplifies bullet list: Fusion admin can't be assigned to service tokens; Account admin allows both users and service tokens
- Updates link text to "Upgrade to dbt Fusion"

raised internally: https://dbt-labs.slack.com/archives/C02N953LRDF/p1776794497227559

## Test plan
- [x] Verify the Expandable renders correctly in the docs site
- [x] Confirm the link resolves correctly to the Fusion engine section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-fusion-admin-dbt-labs.vercel.app/docs/cloud/manage-access/enterprise-permissions

<!-- end-vercel-deployment-preview -->