### PR TITLE
Clarify --resource-type vs test_type selector across dbt Core and Fusion

### DIFF
--- a/website/docs/docs/build/data-tests.md
+++ b/website/docs/docs/build/data-tests.md
@@ -26,6 +26,16 @@ Tests are now called data tests to disambiguate from [unit tests](/docs/build/un
 
 :::
 
+:::tip Running only data tests
+To run data tests while excluding unit tests, use the `test_type` selector — this works across all engines:
+
+```bash
+dbt test --select "test_type:data"
+```
+
+In <Constant name="core" /> (v1.9+), you can also use `dbt test --resource-type test`. For more options, see [test selection examples](/reference/node-selection/test-selection-examples).
+:::
+
 ## Overview
 
 Data tests are assertions you make about your models and other resources in your dbt project (for example, sources, seeds, and snapshots). When you run `dbt test`, dbt will tell you if each test in your project passes or fails.

--- a/website/docs/docs/build/data-tests.md
+++ b/website/docs/docs/build/data-tests.md
@@ -280,7 +280,7 @@ To run data tests while excluding unit tests, use the `test_type` selector &mdas
 dbt test --select "test_type:data"
 ```
 
-In <Constant name="core" /> (v1.9+), you can also use `dbt test --resource-type test`. For more options, see [test selection examples](/reference/node-selection/test-selection-examples).
+In <Constant name="core" /> (v1.9+), you can also use `dbt test --resource-type test`. For more options, refer to [test selection examples](/reference/node-selection/test-selection-examples).
 
 ## Storing data test failures
 

--- a/website/docs/docs/build/data-tests.md
+++ b/website/docs/docs/build/data-tests.md
@@ -26,16 +26,6 @@ Tests are now called data tests to disambiguate from [unit tests](/docs/build/un
 
 :::
 
-:::tip Running only data tests
-To run data tests while excluding unit tests, use the `test_type` selector — this works across all engines:
-
-```bash
-dbt test --select "test_type:data"
-```
-
-In <Constant name="core" /> (v1.9+), you can also use `dbt test --resource-type test`. For more options, see [test selection examples](/reference/node-selection/test-selection-examples).
-:::
-
 ## Overview
 
 Data tests are assertions you make about your models and other resources in your dbt project (for example, sources, seeds, and snapshots). When you run `dbt test`, dbt will tell you if each test in your project passes or fails.
@@ -282,6 +272,16 @@ where {{ column_name }} is null
   </TabItem>
 </Tabs>
 
+
+## Running only data tests
+To run data tests while excluding unit tests, use the `test_type` selector &mdash; this works across all engines (<Constant name="core"/> and <Constant name="fusion"/>):
+
+```bash
+dbt test --select "test_type:data"
+```
+
+In <Constant name="core" /> (v1.9+), you can also use `dbt test --resource-type test`. For more options, see [test selection examples](/reference/node-selection/test-selection-examples).
+
 ## Storing data test failures
 
 Normally, a data test query will calculate failures as part of its execution. If you set the optional `--store-failures` flag, the [`store_failures`](/reference/resource-configs/store_failures), or the [`store_failures_as`](/reference/resource-configs/store_failures_as) configs, dbt will first save the results of a test query to a table in the database, and then query that table to calculate the number of failures.
@@ -293,8 +293,6 @@ This workflow allows you to query and examine failing records much more quickly 
 Note that, if you choose to store data test failures:
 - Test result tables are created in a schema suffixed or named `dbt_test__audit`, by default. It is possible to change this value by setting a `schema` config. (For more details on schema naming, see [using custom schemas](/docs/build/custom-schemas).)
 - A test's results will always **replace** previous failures for the same test.
-
-
 
 ## New `data_tests:` syntax
 

--- a/website/docs/docs/build/unit-tests.md
+++ b/website/docs/docs/build/unit-tests.md
@@ -49,7 +49,13 @@ You should unit test a model:
 
 dbt Labs strongly recommends only running unit tests in development or CI environments. Since the inputs of the unit tests are static, there's no need to use additional compute cycles running them in production. Use them in development for a test-driven approach and CI to ensure changes don't break them. 
 
-Use the [resource type](/reference/global-configs/resource-type) flag `--exclude-resource-type` or the <VersionBlock lastVersion="1.10">`DBT_EXCLUDE_RESOURCE_TYPES`</VersionBlock><VersionBlock firstVersion="1.11">`DBT_ENGINE_EXCLUDE_RESOURCE_TYPES`</VersionBlock> environment variable to exclude unit tests from your production builds and save compute. 
+Use the [resource type](/reference/global-configs/resource-type) flag `--exclude-resource-type` or the <VersionBlock lastVersion="1.10">`DBT_EXCLUDE_RESOURCE_TYPES`</VersionBlock><VersionBlock firstVersion="1.11">`DBT_ENGINE_EXCLUDE_RESOURCE_TYPES`</VersionBlock> environment variable to exclude unit tests from your production builds and save compute.
+
+To run only unit tests on demand, use the `test_type` selector — this works across all engines (<Constant name="core" /> and <Constant name="fusion" />):
+
+```bash
+dbt test --select "test_type:unit"
+```
 
 ## Unit testing a model
 

--- a/website/docs/reference/global-configs/resource-type.md
+++ b/website/docs/reference/global-configs/resource-type.md
@@ -8,7 +8,7 @@ sidebar: "resource type"
 
 The `--resource-type` and `--exclude-resource-type` flags include or exclude resource types from the `dbt build`, `dbt clone`, `dbt test`*, and `dbt list` commands.
 
-*<Expandable alt_header="Filtering test types with dbt test"/>
+*<Expandable alt_header="Filtering test types with dbt test">
 
 Use the `test_type` selector to filter test types with `dbt test` &mdash; it works across all engines:
 

--- a/website/docs/reference/global-configs/resource-type.md
+++ b/website/docs/reference/global-configs/resource-type.md
@@ -144,8 +144,8 @@ To run only data tests (excluding unit tests) when using `dbt test`, use the `te
 <File name='Usage'>
 
 ```text
-dbt test --select test_type:data # dbt Core and dbt Fusion engines
-dbt test --resource-type test # dbt Core only
+dbt test --select test_type:data -- dbt Core and dbt Fusion engines
+dbt test --resource-type test -- dbt Core only
 ```
 
 </File>
@@ -188,8 +188,8 @@ To exclude unit tests when using `dbt test`, use the `test_type` selector to run
 <File name='Usage'>
 
 ```text
-dbt test --select test_type:data # dbt Core and dbt Fusion engines
-dbt test --exclude-resource-type unit_test # dbt Core only
+dbt test --select test_type:data -- dbt Core and dbt Fusion engines
+dbt test --exclude-resource-type unit_test -- dbt Core only
 ```
 
 </File>

--- a/website/docs/reference/global-configs/resource-type.md
+++ b/website/docs/reference/global-configs/resource-type.md
@@ -8,7 +8,7 @@ sidebar: "resource type"
 
 The `--resource-type` and `--exclude-resource-type` flags include or exclude resource types from the `dbt build`, `dbt clone`, `dbt test`*, and `dbt list` commands.
 
-*<Expandable alt_header="Filtering test types with `dbt test`"/>
+*<Expandable alt_header="Filtering test types with dbt test"/>
 
 Use the `test_type` selector to filter test types with `dbt test` &mdash; it works across all engines:
 

--- a/website/docs/reference/global-configs/resource-type.md
+++ b/website/docs/reference/global-configs/resource-type.md
@@ -6,7 +6,23 @@ sidebar: "resource type"
 
 <VersionBlock firstVersion="1.9">
 
-The `--resource-type` and `--exclude-resource-type` flags include or exclude resource types from the `dbt build`, `dbt test`, `dbt clone`, and `dbt list` commands.
+The `--resource-type` and `--exclude-resource-type` flags include or exclude resource types from the `dbt build`, `dbt clone`, and `dbt list` commands.
+
+:::note Filtering test types with `dbt test`
+Use the `test_type` selector with `dbt test` to run only unit tests or data tests — this works across all engines (<Constant name="core" /> and <Constant name="fusion" />):
+
+- `dbt test --select test_type:unit` — runs only unit tests
+- `dbt test --select test_type:data` — runs only data tests
+
+In <Constant name="core" /> (v1.9+), you can also use `--resource-type` with `dbt test`:
+
+- `dbt test --resource-type unit_test` — runs only unit tests
+- `dbt test --resource-type test` — runs only data tests
+
+When using <Constant name="fusion"/>, use the `test_type` selector instead of the `--resource-type` flag. The `--resource-type` flag isn't supported with `dbt test` in <Constant name="fusion"/>.
+
+For more examples, see [test selection examples](/reference/node-selection/test-selection-examples).
+:::
 
 </VersionBlock>
 
@@ -122,14 +138,15 @@ dbt build --resource-type test
 
 <VersionBlock firstVersion="1.9">
 
-### Include all data tests during testing
+### Include only data tests during testing
 
-Use the following command to only include data tests when running tests:
+To run only data tests (excluding unit tests) when using `dbt test`, use the `test_type` selector:
 
 <File name='Usage'>
 
 ```text
-dbt test --resource-type test
+dbt test --select test_type:data # dbt Core and dbt Fusion engines
+dbt test --resource-type test # dbt Core only
 ```
 
 </File>
@@ -165,14 +182,15 @@ dbt build --exclude-resource-type unit_test
 
 <VersionBlock firstVersion="1.9">
 
-### Exclude all unit tests during testing
+### Exclude unit tests during testing
 
-Use the following command to exclude unit tests when running tests:
+To exclude unit tests when using `dbt test`, use the `test_type` selector to run only data tests:
 
 <File name='Usage'>
 
 ```text
-dbt test --exclude-resource-type unit_test
+dbt test --select test_type:data # dbt Core and dbt Fusion engines
+dbt test --exclude-resource-type unit_test # dbt Core only
 ```
 
 </File>

--- a/website/docs/reference/global-configs/resource-type.md
+++ b/website/docs/reference/global-configs/resource-type.md
@@ -8,7 +8,7 @@ sidebar: "resource type"
 
 The `--resource-type` and `--exclude-resource-type` flags include or exclude resource types from the `dbt build`, `dbt clone`, `dbt test`*, and `dbt list` commands.
 
-***Filtering test types with `dbt test`**
+*<Expandable alt_header="Filtering test types with `dbt test`"/>
 
 Use the `test_type` selector to filter test types with `dbt test` &mdash; it works across all engines:
 
@@ -21,7 +21,7 @@ If you're using <Constant name="core" /> v1.9+, you can also use `--resource-typ
 - `dbt test --resource-type test` &mdash; runs only data tests
 
 For more examples, see [test selection examples](/reference/node-selection/test-selection-examples).
-:::
+</Expandable>
 
 </VersionBlock>
 

--- a/website/docs/reference/global-configs/resource-type.md
+++ b/website/docs/reference/global-configs/resource-type.md
@@ -8,7 +8,7 @@ sidebar: "resource type"
 
 The `--resource-type` and `--exclude-resource-type` flags include or exclude resource types from the `dbt build`, `dbt clone`, `dbt test`*, and `dbt list` commands.
 
-*<Expandable alt_header="Filtering test types with dbt test">
+<Expandable alt_header="Filtering test types with dbt test">
 
 Use the `test_type` selector to filter test types with `dbt test` &mdash; it works across all engines:
 

--- a/website/docs/reference/global-configs/resource-type.md
+++ b/website/docs/reference/global-configs/resource-type.md
@@ -6,20 +6,19 @@ sidebar: "resource type"
 
 <VersionBlock firstVersion="1.9">
 
-The `--resource-type` and `--exclude-resource-type` flags include or exclude resource types from the `dbt build`, `dbt clone`, and `dbt list` commands.
+The `--resource-type` and `--exclude-resource-type` flags include or exclude resource types from the `dbt build`, `dbt clone`, `dbt test`*, and `dbt list` commands.
 
-:::note Filtering test types with `dbt test`
-Use the `test_type` selector with `dbt test` to run only unit tests or data tests — this works across all engines (<Constant name="core" /> and <Constant name="fusion" />):
+***Filtering test types with `dbt test`**
 
-- `dbt test --select test_type:unit` — runs only unit tests
-- `dbt test --select test_type:data` — runs only data tests
+Use the `test_type` selector to filter test types with `dbt test` &mdash; it works across all engines:
 
-In <Constant name="core" /> (v1.9+), you can also use `--resource-type` with `dbt test`:
+- `dbt test --select test_type:unit` &mdash; runs only unit tests
+- `dbt test --select test_type:data` &mdash; runs only data tests
 
-- `dbt test --resource-type unit_test` — runs only unit tests
-- `dbt test --resource-type test` — runs only data tests
+If you're using <Constant name="core" /> v1.9+, you can also use `--resource-type`:
 
-When using <Constant name="fusion"/>, use the `test_type` selector instead of the `--resource-type` flag. The `--resource-type` flag isn't supported with `dbt test` in <Constant name="fusion"/>.
+- `dbt test --resource-type unit_test` &mdash; runs only unit tests
+- `dbt test --resource-type test` &mdash; runs only data tests
 
 For more examples, see [test selection examples](/reference/node-selection/test-selection-examples).
 :::

--- a/website/docs/reference/global-configs/resource-type.md
+++ b/website/docs/reference/global-configs/resource-type.md
@@ -6,7 +6,7 @@ sidebar: "resource type"
 
 <VersionBlock firstVersion="1.9">
 
-The `--resource-type` and `--exclude-resource-type` flags include or exclude resource types from the `dbt build`, `dbt clone`, `dbt test`*, and `dbt list` commands.
+The `--resource-type` and `--exclude-resource-type` flags include or exclude resource types from the `dbt build`, `dbt clone`, `dbt test`, and `dbt list` commands.
 
 <Expandable alt_header="Filtering test types with dbt test">
 

--- a/website/docs/reference/node-selection/test-selection-examples.md
+++ b/website/docs/reference/node-selection/test-selection-examples.md
@@ -17,21 +17,31 @@ Test selection is powerful, and we know it can be tricky. To that end, we've inc
 
 ### Direct selection
 
-Run generic tests only:
-
-
-  ```bash
-    dbt test --select "test_type:generic"
-  ```
-
-Run singular tests only:
-
+Run unit tests only:
 
   ```bash
-    dbt test --select "test_type:singular"
+  dbt test --select "test_type:unit"
   ```
 
-In both cases, `test_type` checks a property of the test itself. These are forms of "direct" test selection.
+Run all data tests only (includes both generic and singular):
+
+  ```bash
+  dbt test --select "test_type:data"
+  ```
+
+Run generic data tests only:
+
+  ```bash
+  dbt test --select "test_type:generic"
+  ```
+
+Run singular data tests only:
+
+  ```bash
+  dbt test --select "test_type:singular"
+  ```
+
+In all cases, `test_type` checks a property of the test itself. These are forms of "direct" test selection. The `test_type` selector works across all engines (<Constant name="core" /> and <Constant name="fusion" />).
 
 ### Indirect selection
 

--- a/website/docs/reference/node-selection/test-selection-examples.md
+++ b/website/docs/reference/node-selection/test-selection-examples.md
@@ -17,31 +17,33 @@ Test selection is powerful, and we know it can be tricky. To that end, we've inc
 
 ### Direct selection
 
-Run unit tests only:
+Use the `test_type` selector to run a specific category of tests without relying on model selection. This is useful when you want to isolate unit tests from data tests — for example, running only unit tests during development for fast feedback, or running only data tests in production where unit test compute isn't needed. The `test_type` selector works across all engines (<Constant name="core" /> and <Constant name="fusion" />).
+
+**Run only unit tests** — use this during development or CI to validate SQL logic before materializing models:
 
   ```bash
   dbt test --select "test_type:unit"
   ```
 
-Run all data tests only (includes both generic and singular):
+**Run all data tests** (includes both generic and singular) — use this to skip unit tests entirely, for example in production pipelines:
 
   ```bash
   dbt test --select "test_type:data"
   ```
 
-Run generic data tests only:
+**Run only generic data tests** — use this to run schema-level assertions defined in `.yml` files (such as `not_null` and `unique`), without running custom SQL test files:
 
   ```bash
   dbt test --select "test_type:generic"
   ```
 
-Run singular data tests only:
+**Run only singular data tests** — use this to run only custom SQL test files from your `tests/` directory, without running generic schema tests:
 
   ```bash
   dbt test --select "test_type:singular"
   ```
 
-In all cases, `test_type` checks a property of the test itself. These are forms of "direct" test selection. The `test_type` selector works across all engines (<Constant name="core" /> and <Constant name="fusion" />).
+In all cases, `test_type` checks a property of the test itself — these are forms of "direct" test selection.
 
 ### Indirect selection
 


### PR DESCRIPTION
## Summary

- **`resource-type.md`**: Adds a section block clarifying that `test_type` selector works on all engines, while `--resource-type` with `dbt test` is dbt Core 1.9+ only and not supported in Fusion. Also updates the "Include only data tests" and "Exclude unit tests" expandable examples to show both the cross-engine (`test_type`) and Core-only (`--resource-type`) commands side by side.
- **`test-selection-examples.md`**: Adds `test_type:unit` and `test_type:data` to the Direct selection section — previously only `generic` and `singular` were shown, leaving no examples of how to split unit tests from data tests.
- **`data-tests.md`**: Adds a section showing how to run only data tests using `test_type:data`, with the Core-only `--resource-type test` alternative.
- **`unit-tests.md`**: Adds `test_type:unit` selector as the cross-engine way to run only unit tests, alongside the existing `--exclude-resource-type` production-build guidance.

## Context

Validated by hands-on testing (dbt Core 1.11.8 + dbt Fusion 2.0.0-preview.173):
- `dbt test --resource-type unit_test/test` ✅ works in Core, ❌ errors in Fusion
- `dbt test --select "test_type:unit/data"` ✅ works on both engines
- Filed dbt-labs/dbt-fusion#1628 to track the Fusion gap

## Test plan

- [x] Verify rendered output on staging for all four pages
- [x] Confirm `<Constant name="core" />` and `<Constant name="fusion" />` render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-fix-resource-type-test-dbt-labs.vercel.app/docs/build/data-tests
- https://docs-getdbt-com-git-fix-resource-type-test-dbt-labs.vercel.app/docs/build/unit-tests
- https://docs-getdbt-com-git-fix-resource-type-test-dbt-labs.vercel.app/reference/global-configs/resource-type
- https://docs-getdbt-com-git-fix-resource-type-test-dbt-labs.vercel.app/reference/node-selection/test-selection-examples

<!-- end-vercel-deployment-preview -->