### PR TITLE
docs: clarify BigQuery WIF is not supported in dbt Fusion

### DIFF
--- a/website/docs/docs/cloud/manage-access/set-up-bigquery-oauth.md
+++ b/website/docs/docs/cloud/manage-access/set-up-bigquery-oauth.md
@@ -104,6 +104,10 @@ Select **Allow**. This redirects you back to the <Constant name="dbt_platform" /
 
 ## Set up BigQuery Workload Identity Federation <Lifecycle status= "managed" /> 
 
+:::note dbt Fusion
+Workload Identity Federation (WIF) is not currently supported in dbt Fusion. If you're using dbt Fusion, use a Service Account or Native OAuth connection instead. Support is coming soon.
+:::
+
 Workload Identity Federation (WIF) allows application workloads, running outside the <Constant name="dbt_platform" />, to act as a service account without the need to manage service accounts or other keys for deployment environments. The following instructions will enable you to authenticate your BigQuery connection in the <Constant name="dbt_platform" /> using WIF. 
 Currently, Microsoft Entra ID is the only supported identity provider (IdP). If you need additional IdP support, please contact your account team.
 

--- a/website/docs/docs/cloud/manage-access/set-up-bigquery-oauth.md
+++ b/website/docs/docs/cloud/manage-access/set-up-bigquery-oauth.md
@@ -104,12 +104,12 @@ Select **Allow**. This redirects you back to the <Constant name="dbt_platform" /
 
 ## Set up BigQuery Workload Identity Federation <Lifecycle status= "managed" /> 
 
-:::info WIF not supported in <Constant name="fusion"/>
-Workload Identity Federation (WIF) is not currently supported in <Constant name="fusion"/>. If you're using <Constant name="fusion"/>, use a Service Account or Native OAuth connection instead. Support is coming soon.
-:::
-
 Workload Identity Federation (WIF) allows application workloads, running outside the <Constant name="dbt_platform" />, to act as a service account without the need to manage service accounts or other keys for deployment environments. The following instructions will enable you to authenticate your BigQuery connection in the <Constant name="dbt_platform" /> using WIF. 
 Currently, Microsoft Entra ID is the only supported identity provider (IdP). If you need additional IdP support, please contact your account team.
+
+:::info WIF not supported in <Constant name="fusion_engine"/>
+WIF is not currently supported in <Constant name="fusion"/>. If you're using the <Constant name="fusion_engine"/>, use a Service Account or Native OAuth connection instead. Support is coming soon.
+:::
 
 ### 1. Set up Entra ID
 

--- a/website/docs/docs/cloud/manage-access/set-up-bigquery-oauth.md
+++ b/website/docs/docs/cloud/manage-access/set-up-bigquery-oauth.md
@@ -104,7 +104,7 @@ Select **Allow**. This redirects you back to the <Constant name="dbt_platform" /
 
 ## Set up BigQuery Workload Identity Federation <Lifecycle status= "managed" /> 
 
-:::note dbt Fusion
+:::info WIF not supported in <Constant name="fusion"/>
 Workload Identity Federation (WIF) is not currently supported in <Constant name="fusion"/>. If you're using <Constant name="fusion"/>, use a Service Account or Native OAuth connection instead. Support is coming soon.
 :::
 

--- a/website/docs/docs/cloud/manage-access/set-up-bigquery-oauth.md
+++ b/website/docs/docs/cloud/manage-access/set-up-bigquery-oauth.md
@@ -108,7 +108,7 @@ Workload Identity Federation (WIF) allows application workloads, running outside
 Currently, Microsoft Entra ID is the only supported identity provider (IdP). If you need additional IdP support, please contact your account team.
 
 :::info WIF not supported in <Constant name="fusion_engine"/>
-WIF is not currently supported in [<Constant name="fusion"/](/docs/fusion/supported-features?version=2.0#bigquery)>. If you're using the <Constant name="fusion_engine"/>, use Native OAuth connection instead. Support for WIF is coming soon.
+WIF is not currently supported in [<Constant name="fusion"/>](/docs/fusion/supported-features?version=2.0#bigquery). Use a [Native OAuth connection](#set-up-bigquery-native-oauth) or service account instead. Support for WIF is coming soon.
 :::
 
 ### 1. Set up Entra ID

--- a/website/docs/docs/cloud/manage-access/set-up-bigquery-oauth.md
+++ b/website/docs/docs/cloud/manage-access/set-up-bigquery-oauth.md
@@ -108,7 +108,7 @@ Workload Identity Federation (WIF) allows application workloads, running outside
 Currently, Microsoft Entra ID is the only supported identity provider (IdP). If you need additional IdP support, please contact your account team.
 
 :::info WIF not supported in <Constant name="fusion_engine"/>
-WIF is not currently supported in <Constant name="fusion"/>. If you're using the <Constant name="fusion_engine"/>, use Native OAuth connection instead. Support for WIF is coming soon.
+WIF is not currently supported in [<Constant name="fusion"/](/docs/fusion/supported-features?version=2.0#bigquery)>. If you're using the <Constant name="fusion_engine"/>, use Native OAuth connection instead. Support for WIF is coming soon.
 :::
 
 ### 1. Set up Entra ID

--- a/website/docs/docs/cloud/manage-access/set-up-bigquery-oauth.md
+++ b/website/docs/docs/cloud/manage-access/set-up-bigquery-oauth.md
@@ -108,7 +108,7 @@ Workload Identity Federation (WIF) allows application workloads, running outside
 Currently, Microsoft Entra ID is the only supported identity provider (IdP). If you need additional IdP support, please contact your account team.
 
 :::info WIF not supported in <Constant name="fusion_engine"/>
-WIF is not currently supported in [<Constant name="fusion"/>](/docs/fusion/supported-features?version=2.0#bigquery). Use a [Native OAuth connection](#set-up-bigquery-native-oauth) or service account instead. Support for WIF is coming soon.
+WIF is not currently supported in [<Constant name="fusion"/>](/docs/fusion/supported-features?version=2.0#bigquery). Use a [Native OAuth connection](#set-up-bigquery-native-oauth) or service account instead. [Support for WIF](https://github.com/dbt-labs/dbt-fusion/issues/1629) is coming soon.
 :::
 
 ### 1. Set up Entra ID

--- a/website/docs/docs/cloud/manage-access/set-up-bigquery-oauth.md
+++ b/website/docs/docs/cloud/manage-access/set-up-bigquery-oauth.md
@@ -108,7 +108,7 @@ Workload Identity Federation (WIF) allows application workloads, running outside
 Currently, Microsoft Entra ID is the only supported identity provider (IdP). If you need additional IdP support, please contact your account team.
 
 :::info WIF not supported in <Constant name="fusion_engine"/>
-WIF is not currently supported in <Constant name="fusion"/>. If you're using the <Constant name="fusion_engine"/>, use a Service Account or Native OAuth connection instead. Support is coming soon.
+WIF is not currently supported in <Constant name="fusion"/>. If you're using the <Constant name="fusion_engine"/>, use Native OAuth connection instead. Support for WIF is coming soon.
 :::
 
 ### 1. Set up Entra ID

--- a/website/docs/docs/cloud/manage-access/set-up-bigquery-oauth.md
+++ b/website/docs/docs/cloud/manage-access/set-up-bigquery-oauth.md
@@ -105,7 +105,7 @@ Select **Allow**. This redirects you back to the <Constant name="dbt_platform" /
 ## Set up BigQuery Workload Identity Federation <Lifecycle status= "managed" /> 
 
 :::note dbt Fusion
-Workload Identity Federation (WIF) is not currently supported in dbt Fusion. If you're using dbt Fusion, use a Service Account or Native OAuth connection instead. Support is coming soon.
+Workload Identity Federation (WIF) is not currently supported in <Constant name="fusion"/>. If you're using <Constant name="fusion"/>, use a Service Account or Native OAuth connection instead. Support is coming soon.
 :::
 
 Workload Identity Federation (WIF) allows application workloads, running outside the <Constant name="dbt_platform" />, to act as a service account without the need to manage service accounts or other keys for deployment environments. The following instructions will enable you to authenticate your BigQuery connection in the <Constant name="dbt_platform" /> using WIF. 

--- a/website/snippets/_fusion-dwh.md
+++ b/website/snippets/_fusion-dwh.md
@@ -1,7 +1,7 @@
    <Expandable alt_header="BigQuery">  
     - Service Account / User Token
     - Native OAuth
-    - External OAuth (Workload Identity Federation is not currently supported in dbt Fusion — coming soon)
+    - External OAuth (Workload Identity Federation is not currently supported in <Constant name="fusion"/>. Support coming soon)
     - [Required permissions](/docs/local/connect-data-platform/bigquery-setup#required-permissions)
   </Expandable>
 

--- a/website/snippets/_fusion-dwh.md
+++ b/website/snippets/_fusion-dwh.md
@@ -1,7 +1,7 @@
    <Expandable alt_header="BigQuery">  
     - Service Account / User Token
     - Native OAuth
-    - External OAuth
+    - External OAuth (Workload Identity Federation is not currently supported in dbt Fusion — coming soon)
     - [Required permissions](/docs/local/connect-data-platform/bigquery-setup#required-permissions)
   </Expandable>
 

--- a/website/snippets/_fusion-dwh.md
+++ b/website/snippets/_fusion-dwh.md
@@ -2,7 +2,7 @@
     - Service Account / User Token
     - Native OAuth
     - External OAuth 
-      - [Workload Identity Federation](/docs/cloud/manage-access/set-up-bigquery-oauth?version=1.12#set-up-bigquery-workload-identity-federation) isn't currently supported in <Constant name="fusion"/>. Support coming soon.
+      - [Workload Identity Federation](/docs/cloud/manage-access/set-up-bigquery-oauth?version=1.12#set-up-bigquery-workload-identity-federation) isn't currently supported in <Constant name="fusion"/>. Use a [Native OAuth connection](/docs/cloud/manage-access/set-up-bigquery-oauth#set-up-bigquery-native-oauth) or service account instead. Support coming soon.
     - [Required permissions](/docs/local/connect-data-platform/bigquery-setup#required-permissions)
   </Expandable>
 

--- a/website/snippets/_fusion-dwh.md
+++ b/website/snippets/_fusion-dwh.md
@@ -1,7 +1,8 @@
    <Expandable alt_header="BigQuery">  
     - Service Account / User Token
     - Native OAuth
-    - External OAuth (Workload Identity Federation is not currently supported in <Constant name="fusion"/>. Support coming soon)
+    - External OAuth 
+      - [Workload Identity Federation](/docs/cloud/manage-access/set-up-bigquery-oauth?version=1.12#set-up-bigquery-workload-identity-federation) isn't currently supported in <Constant name="fusion"/>. Support coming soon.
     - [Required permissions](/docs/local/connect-data-platform/bigquery-setup#required-permissions)
   </Expandable>
 


### PR DESCRIPTION
## Summary

- Adds a callout to the BigQuery OAuth setup page (`set-up-bigquery-oauth.md`) at the top of the Workload Identity Federation section, noting WIF is not currently supported in dbt Fusion (coming soon)
- Updates the `_fusion-dwh.md` snippet to note WIF is not currently supported under the BigQuery External OAuth entry on the supported-features page

Linked to https://github.com/dbt-labs/dbt-fusion/issues/1629

## Test plan

- [x] Confirm callout renders on `/docs/cloud/manage-access/set-up-bigquery-oauth` under the WIF section
- [x] Confirm note visible in BigQuery expandable on `/docs/fusion/supported-features`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-fix-fusion-wif-new-dbt-labs.vercel.app/docs/cloud/manage-access/set-up-bigquery-oauth

<!-- end-vercel-deployment-preview -->