### PR TITLE
redshift_skip_autocommit_transaction_statements defaults to false

### DIFF
--- a/website/docs/docs/dbt-versions/core-upgrade/03-upgrading-to-v1.12.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/03-upgrading-to-v1.12.md
@@ -109,6 +109,7 @@ You can read more about each of these behavior changes in the following links:
 
 ### Redshift
 
+- The [`redshift_skip_autocommit_transaction_statements`](/reference/global-configs/redshift-changes#redshift_skip_autocommit_transaction_statements-flag) flag defaults to `False`, preserving legacy behavior of sending `BEGIN`/`COMMIT`/`ROLLBACK` statements even when autocommit is enabled. To skip unnecessary transaction statements and improve performance, set the flag to `True`.
 - Added support for the `query_group` session parameter, allowing dbt to tag queries for Redshift Workload Manager routing and query logging. When configured in a profile, dbt sets `query_group` when opening a connection and the value applies for the duration of that session. You can also configure `query_group` at the model level to temporarily override the default value for a specific model, and dbt reverts the value at the end of model materialization. For more information, see [Redshift configurations](/reference/resource-configs/redshift-configs#session-configuration).
 
 ## Quick hits

--- a/website/docs/docs/dbt-versions/core-upgrade/04-upgrading-to-v1.11.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/04-upgrading-to-v1.11.md
@@ -125,7 +125,6 @@ dbt parse --warn-error-options '{"silence": ["Deprecations"]}'
 ### Redshift
 
 - The new `datasharing` profile credential enables `dbt-redshift` to use Redshift-native metadata commands (`SHOW` commands such as `SHOW TABLES` and `SHOW COLUMNS`) instead of PostgreSQL catalog tables such as `pg_*` and `information_schema`. This supports cross-database and cross-cluster access with [Redshift Datasharing](https://docs.aws.amazon.com/redshift/latest/dg/datashare-overview.html). For configuration details, refer to [Redshift setup](/docs/local/connect-data-platform/redshift-setup#datasharing).<Lifecycle status="beta" />
-- The [`redshift_skip_autocommit_transaction_statements`](/reference/global-configs/redshift-changes#the-redshift_skip_autocommit_transaction_statements-flag) flag is now `True` by default. When `autocommit=True` (the default since dbt-redshift 1.5), dbt now skips sending unnecessary `BEGIN`/`COMMIT`/`ROLLBACK` statements, improving performance by reducing round trips to Redshift. To preserve the legacy behavior, set the flag to `False`.
 
 ### Spark
 

--- a/website/docs/reference/global-configs/redshift-changes.md
+++ b/website/docs/reference/global-configs/redshift-changes.md
@@ -28,7 +28,7 @@ The `redshift_skip_autocommit_transaction_statements` flag is `False` by default
 
 When `autocommit=True` (the default since `dbt-redshift 1.5`), each statement is automatically committed by the driver. By default, dbt still sends explicit `BEGIN` / `COMMIT` / `ROLLBACK` statements, which are unnecessary and add extra round trips to Redshift.
 
-When you set the `redshift_skip_autocommit_transaction_statements` flag set to `True`, dbt skips sending transaction management statements when autocommit is enabled, reducing unnecessary round trips and improving performance.
+When you set the `redshift_skip_autocommit_transaction_statements` to `True`, dbt skips sending transaction management statements when autocommit is enabled, reducing unnecessary round trips and improving performance.
 
 #### Key behaviors
 

--- a/website/docs/reference/global-configs/redshift-changes.md
+++ b/website/docs/reference/global-configs/redshift-changes.md
@@ -22,25 +22,20 @@ Note that this flag does not apply to all metadata queries emitted by the adapte
 While you shouldn't notice any behavior changes due to this change, however, to be cautious dbt Labs is gating it behind a behavior-change flag and encouraging you to test it before it becoming the default.
 -->
 
-## `redshift_skip_autocommit_transaction_statements` flag
+## The `redshift_skip_autocommit_transaction_statements` flag {#redshift_skip_autocommit_transaction_statements-flag}
 
-The `redshift_skip_autocommit_transaction_statements` flag is `False` by default, preserving legacy transaction behavior.
+Available starting `dbt-redshift` 1.12.0.
 
-When `autocommit=True` (the default since `dbt-redshift 1.5`), each statement is automatically committed by the driver. By default, dbt still sends explicit `BEGIN` / `COMMIT` / `ROLLBACK` statements, which are unnecessary and add extra round trips to Redshift.
+The `redshift_skip_autocommit_transaction_statements` flag controls whether dbt sends explicit `BEGIN`, `COMMIT`, and `ROLLBACK` statements to Amazon Redshift when the connection runs with autocommit enabled. Since `dbt-redshift` 1.5, the default Redshift connection uses `autocommit=True`, so the driver already commits each statement. In that setup, the statements are redundant with autocommit and add extra round trips to Redshift.
 
-When you set the `redshift_skip_autocommit_transaction_statements` to `True`, dbt skips sending transaction management statements when autocommit is enabled, reducing unnecessary round trips and improving performance.
+- When set to `False` (default), dbt sends `BEGIN`, `COMMIT`, and `ROLLBACK` statements (legacy behavior).
+- When set to `True`, dbt skips the following transaction statements, which can reduce round trips and improve performance:
 
-#### Key behaviors
+  - `begin()` does not send `BEGIN`.
+  - `commit()` does not send `COMMIT`.
+  - `rollback_if_open()` does not send `ROLLBACK`.
 
-When the flag is `True` and autocommit is `True`:
-
-- `begin()` skips sending `BEGIN`
-- `commit()` skips sending `COMMIT`
-- `rollback_if_open()` skips sending `ROLLBACK`
-
-dbt still maintains its internal `transaction_open` state to preserve compatibility with dbt’s transaction tracking, even when actual statements are skipped.
-
-### Enabling the optimization
+dbt still maintains its internal `transaction_open` state so that transaction tracking in dbt stays consistent, even when those statements are skipped.
 
 To skip unnecessary transaction statements when autocommit is enabled, set the flag to `True` in your `dbt_project.yml`:
 
@@ -53,8 +48,8 @@ flags:
 
 </File>
 
-### Backward compatibility
+### How this flag interacts with `autocommit`
 
-- **`autocommit=False`**: Unchanged. Explicit transactions still work as before regardless of this flag.
-- **`autocommit=True` with flag set to `True`**: Skips unnecessary transaction statements for better performance.
-- **`autocommit=True` with flag set to `False` (default)**: Sends `BEGIN`/`COMMIT`/`ROLLBACK` statements (legacy behavior).
+- If the connection uses `autocommit=False`, dbt’s explicit transaction behavior is unchanged.
+- If the connection uses `autocommit=True` (default) and the flag is `False` (default), dbt still sends `BEGIN`, `COMMIT`, and `ROLLBACK`.
+- If the connection uses `autocommit=True` and the flag is `True`, dbt skips those statements.

--- a/website/docs/reference/global-configs/redshift-changes.md
+++ b/website/docs/reference/global-configs/redshift-changes.md
@@ -37,7 +37,7 @@ The `redshift_skip_autocommit_transaction_statements` flag controls whether dbt 
 
 dbt still maintains its internal `transaction_open` state so transaction tracking remains consistent even when those SQL statements are skipped.
 
-To skip unnecessary transaction statements when autocommit is enabled, set the flag to `True` in your `dbt_project.yml`:
+To skip unnecessary transaction statements when `autocommit` is enabled, set the flag to `True` in your `dbt_project.yml`:
 
 <File name='dbt_project.yml'>
 

--- a/website/docs/reference/global-configs/redshift-changes.md
+++ b/website/docs/reference/global-configs/redshift-changes.md
@@ -26,14 +26,14 @@ While you shouldn't notice any behavior changes due to this change, however, to 
 
 Available starting `dbt-redshift` 1.12.0.
 
-The `redshift_skip_autocommit_transaction_statements` flag controls whether dbt sends explicit `BEGIN`, `COMMIT`, and `ROLLBACK` statements to Amazon Redshift when the connection runs with autocommit enabled. Since `dbt-redshift` 1.5, the default Redshift connection uses `autocommit=True`, so the driver already commits each statement. In that setup, the statements are redundant with autocommit and add extra round trips to Redshift.
+The `redshift_skip_autocommit_transaction_statements` flag controls whether dbt sends explicit [`BEGIN`](https://docs.aws.amazon.com/redshift/latest/dg/r_BEGIN.html), [`COMMIT`](https://docs.aws.amazon.com/redshift/latest/dg/r_COMMIT.html), and [`ROLLBACK`](https://docs.aws.amazon.com/redshift/latest/dg/r_ROLLBACK.html) statements to Amazon Redshift when the connection runs with autocommit enabled. Since `dbt-redshift` 1.5, the default Redshift connection uses `autocommit=True`, so the driver already commits each statement. In that setup, the statements are redundant with autocommit and add extra round trips to Redshift.
 
 - When set to `False` (default), dbt sends `BEGIN`, `COMMIT`, and `ROLLBACK` statements (legacy behavior).
-- When set to `True`, dbt skips the following transaction statements, which can reduce round trips and improve performance:
+- When set to `True`, dbt does not send `BEGIN`, `COMMIT`, or `ROLLBACK` statements to Redshift, which can reduce round trips and improve performance. dbt still calls `begin()`, `commit()`, and `rollback_if_open()` on the connection, but no longer issues the matching SQL:
 
-  - `begin()` does not send `BEGIN`.
-  - `commit()` does not send `COMMIT`.
-  - `rollback_if_open()` does not send `ROLLBACK`.
+  - `begin()` is invoked, but dbt does not execute `BEGIN` on Redshift.
+  - `commit()` is invoked, but dbt does not execute `COMMIT` on Redshift.
+  - `rollback_if_open()` is invoked, but dbt does not execute `ROLLBACK` on Redshift.
 
 dbt still maintains its internal `transaction_open` state so transaction tracking remains consistent even when those SQL statements are skipped.
 

--- a/website/docs/reference/global-configs/redshift-changes.md
+++ b/website/docs/reference/global-configs/redshift-changes.md
@@ -35,7 +35,7 @@ The `redshift_skip_autocommit_transaction_statements` flag controls whether dbt 
   - `commit()` does not send `COMMIT`.
   - `rollback_if_open()` does not send `ROLLBACK`.
 
-dbt still maintains its internal `transaction_open` state so that transaction tracking in dbt stays consistent, even when those statements are skipped.
+dbt still maintains its internal `transaction_open` state so transaction tracking remains consistent even when those SQL statements are skipped.
 
 To skip unnecessary transaction statements when autocommit is enabled, set the flag to `True` in your `dbt_project.yml`:
 

--- a/website/docs/reference/global-configs/redshift-changes.md
+++ b/website/docs/reference/global-configs/redshift-changes.md
@@ -26,7 +26,7 @@ While you shouldn't notice any behavior changes due to this change, however, to 
 
 Available starting `dbt-redshift` 1.12.0.
 
-The `redshift_skip_autocommit_transaction_statements` flag controls whether dbt sends explicit [`BEGIN`](https://docs.aws.amazon.com/redshift/latest/dg/r_BEGIN.html), [`COMMIT`](https://docs.aws.amazon.com/redshift/latest/dg/r_COMMIT.html), and [`ROLLBACK`](https://docs.aws.amazon.com/redshift/latest/dg/r_ROLLBACK.html) statements to Amazon Redshift when the connection runs with autocommit enabled. Since `dbt-redshift` 1.5, the default Redshift connection uses `autocommit=True`, so the driver already commits each statement. In that setup, the statements are redundant with autocommit and add extra round trips to Redshift.
+The `redshift_skip_autocommit_transaction_statements` flag controls whether dbt sends explicit [`BEGIN`](https://docs.aws.amazon.com/redshift/latest/dg/r_BEGIN.html), [`COMMIT`](https://docs.aws.amazon.com/redshift/latest/dg/r_COMMIT.html), and [`ROLLBACK`](https://docs.aws.amazon.com/redshift/latest/dg/r_ROLLBACK.html) statements to Amazon Redshift when autocommit is enabled. Since `dbt-redshift` 1.5, the default Redshift connection uses `autocommit=True`, so the driver already commits each statement. In that setup, the statements are redundant when autocommit is enabled and add extra round trips to Redshift.
 
 - When set to `False` (default), dbt sends `BEGIN`, `COMMIT`, and `ROLLBACK` statements (legacy behavior).
 - When set to `True`, dbt does not send `BEGIN`, `COMMIT`, or `ROLLBACK` statements to Redshift, which can reduce round trips and improve performance. dbt still calls `begin()`, `commit()`, and `rollback_if_open()` on the connection, but no longer issues the matching SQL:

--- a/website/docs/reference/global-configs/redshift-changes.md
+++ b/website/docs/reference/global-configs/redshift-changes.md
@@ -24,15 +24,15 @@ While you shouldn't notice any behavior changes due to this change, however, to 
 
 ## `redshift_skip_autocommit_transaction_statements` flag
 
-The `redshift_skip_autocommit_transaction_statements` flag is `True` by default.
+The `redshift_skip_autocommit_transaction_statements` flag is `False` by default, preserving legacy transaction behavior.
 
-When `autocommit=True` (the default since `dbt-redshift 1.5`), each statement is automatically committed by the driver. Previously, dbt still sent explicit `BEGIN` / `COMMIT` / `ROLLBACK` statements, which were unnecessary and added extra round trips to Redshift.
+When `autocommit=True` (the default since `dbt-redshift 1.5`), each statement is automatically committed by the driver. By default, dbt still sends explicit `BEGIN` / `COMMIT` / `ROLLBACK` statements, which are unnecessary and add extra round trips to Redshift.
 
-With the `redshift_skip_autocommit_transaction_statements` flag enabled, dbt skips sending transaction management statements when you enable autocommit, reducing unnecessary round trips and improving performance.
+When you set the `redshift_skip_autocommit_transaction_statements` flag set to `True`, dbt skips sending transaction management statements when autocommit is enabled, reducing unnecessary round trips and improving performance.
 
 #### Key behaviors
 
-When both the flag and autocommit are `True`:
+When the flag is `True` and autocommit is `True`:
 
 - `begin()` skips sending `BEGIN`
 - `commit()` skips sending `COMMIT`
@@ -40,15 +40,15 @@ When both the flag and autocommit are `True`:
 
 dbt still maintains its internal `transaction_open` state to preserve compatibility with dbt’s transaction tracking, even when actual statements are skipped.
 
-### Preserving legacy behavior
+### Enabling the optimization
 
-To preserve the legacy behavior of sending `BEGIN`/`COMMIT`/`ROLLBACK` statements even when autocommit is enabled, set the flag to `False` in your `dbt_project.yml`:
+To skip unnecessary transaction statements when autocommit is enabled, set the flag to `True` in your `dbt_project.yml`:
 
 <File name='dbt_project.yml'>
 
 ```yaml
 flags:
-  redshift_skip_autocommit_transaction_statements: false
+  redshift_skip_autocommit_transaction_statements: true
 ```
 
 </File>
@@ -56,5 +56,5 @@ flags:
 ### Backward compatibility
 
 - **`autocommit=False`**: Unchanged. Explicit transactions still work as before regardless of this flag.
-- **`autocommit=True` with flag (default)**: Skips unnecessary transaction statements for better performance.
-- **`autocommit=True` without flag**: Sends `BEGIN`/`COMMIT`/`ROLLBACK` (legacy behavior).
+- **`autocommit=True` with flag set to `True`**: Skips unnecessary transaction statements for better performance.
+- **`autocommit=True` with flag set to `False` (default)**: Sends `BEGIN`/`COMMIT`/`ROLLBACK` statements (legacy behavior).


### PR DESCRIPTION
## What are you changing in this pull request and why?
Doc for https://github.com/dbt-labs/dbt-adapters/pull/1697 + some editorial improvements
Closes https://dbtlabs.atlassian.net/browse/PRODDOCS-831

Preview: https://docs-getdbt-com-git-switch-default-to-false-dbt-labs.vercel.app/reference/global-configs/redshift-changes?version=1.12

## Checklist
<!-- Ensure your PR meets the following items. Feel free to add additiona checklist items to the list if additional checks need to happen before the PR is merged, such as:
- [ ] Needs technical review
- [ ] Change base branch
- [ ] Merge on xyz date
-->
- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).
<!--
PRE-RELEASE VERSION OF dbt (if so, uncomment):
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
<!-- 
ADDING OR REMOVING PAGES (if so, uncomment):
- [ ] Add/remove page in `website/sidebars.js`
- [ ] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages
-->

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-switch-default-to-false-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/03-upgrading-to-v1.12
- https://docs-getdbt-com-git-switch-default-to-false-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/04-upgrading-to-v1.11
- https://docs-getdbt-com-git-switch-default-to-false-dbt-labs.vercel.app/reference/global-configs/redshift-changes

<!-- end-vercel-deployment-preview -->