### PR TITLE
Add cross-database grants limitation to Redshift datasharing

### DIFF
--- a/website/docs/docs/local/connect-data-platform/redshift-setup.md
+++ b/website/docs/docs/local/connect-data-platform/redshift-setup.md
@@ -385,6 +385,7 @@ The following macros switch to `SHOW` commands when `datasharing: true`:
 Take note of the following limitations when using `datasharing`:
 
 - Creating views (including materialized views) in another database is not supported.
+- Grants on objects in another database are not supported.
 - Source freshness checks can have a lag of up to 5 minutes.
 - Metadata queries are limited to 10,000 rows. If a database has more than 10,000 schemas, or a schema has more than 10,000 tables, dbt runs can result in unexpected scenarios.
 - Cross-database writes require the `SNAPSHOT` transaction isolation level.

--- a/website/docs/docs/local/connect-data-platform/redshift-setup.md
+++ b/website/docs/docs/local/connect-data-platform/redshift-setup.md
@@ -385,7 +385,7 @@ The following macros switch to `SHOW` commands when `datasharing: true`:
 Take note of the following limitations when using `datasharing`:
 
 - Creating views (including materialized views) in another database is not supported.
-- Grants on objects in another database are not supported.
+- Cross-database grants on objects are not supported.
 - Source freshness checks can have a lag of up to 5 minutes.
 - Metadata queries are limited to 10,000 rows. If a database has more than 10,000 schemas, or a schema has more than 10,000 tables, dbt runs can result in unexpected scenarios.
 - Cross-database writes require the `SNAPSHOT` transaction isolation level.


### PR DESCRIPTION
## What are you changing in this pull request and why?

Adds a new bullet to the `datasharing` limitations list in the Redshift setup page noting that grants on objects in another database are not supported. This surfaces a known limitation users may otherwise hit unexpectedly when configuring cross-database access via `datasharing: true`.

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [x] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)) — change is inside the existing `<VersionBlock lastVersion="1.99">` block.
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes) — N/A, this is a documentation-only clarification of an existing limitation.