### PR TITLE
Fix: update broken link & remove extra "1"

### DIFF
--- a/website/docs/docs/deploy/advanced-ci.md
+++ b/website/docs/docs/deploy/advanced-ci.md
@@ -27,9 +27,9 @@ You can opt into Advanced CI in <Constant name="dbt" />. Please refer to [Accoun
 
 ## Compare changes feature {#compare-changes}
 
-For [CI jobs](/docs/deploy/ci-jobs) that have the [**dbt compare** option enabled](/docs/deploy/ci-jobs#set-up-ci-jobs), <Constant name="dbt" /> compares the changes between the last applied state of the production environment (defaulting to deferral for lower compute costs) and the latest changes from the pull request, whenever a pull request is opened or new commits are pushed.  1
+For [CI jobs](/docs/deploy/ci-jobs) that have the [**dbt compare** option enabled](/docs/deploy/ci-jobs#set-up-ci-jobs), <Constant name="dbt" /> compares the changes between the last applied state of the production environment (defaulting to deferral for lower compute costs) and the latest changes from the pull request, whenever a pull request is opened or new commits are pushed.
 
-You can also compare changes in development. For more details, see [Compare changes in local development]
+You can also compare changes in development. For more details, see [Compare changes in development](/docs/deploy/advanced-ci#compare-changes-in-development).
 
 dbt reports the comparison differences in:
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
This PR attempts to fix a missing/broken link & an errant "1" on the `https://docs.getdbt.com/docs/deploy/advanced-ci` page.

One note, I made a judgment call in this PR, choosing to update wording slightly & link to [this subheader](https://docs.getdbt.com/docs/deploy/advanced-ci?version=1.10#compare-changes-in-development), as I believe [this chart](https://docs.getdbt.com/docs/deploy/advanced-ci?version=1.10#differences-between-compare-changes-in-development-and-advanced-ci-compare-changes) is quite useful and flows nicely in sequence.

It could also link directly to [this page](https://docs.getdbt.com/docs/fusion/vs-compare-changes?version=1.10) if desired.

**Before:**
<img width="897" height="248" alt="Screenshot 2026-04-29 at 4 21 23 PM" src="https://github.com/user-attachments/assets/ca100ff9-9895-4d43-aa77-552894a84d1f" />

## Checklist
<!-- Ensure your PR meets the following items. Feel free to add additiona checklist items to the list if additional checks need to happen before the PR is merged, such as:
- [ ] Needs technical review
- [ ] Change base branch
- [ ] Merge on xyz date
-->
- [X] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).
<!--
PRE-RELEASE VERSION OF dbt (if so, uncomment):
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
<!-- 
ADDING OR REMOVING PAGES (if so, uncomment):
- [ ] Add/remove page in `website/sidebars.js`
- [ ] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages
-->
