### PR TITLE
Update promo banner and blog CTA to The Launch Desk Live

### DIFF
--- a/website/blog/ctas.yml
+++ b/website/blog/ctas.yml
@@ -23,3 +23,9 @@
   subheader: Join us for the 2026 State of Analytics Engineering Virtual Event on April 29 with live Q&A and giveaways!
   button_text: Register here
   url: https://www.getdbt.com/resources/webinars/2026-state-of-analytics-engineering-virtual-event/?utm_medium=internal&utm_source=docs&utm_campaign=q1-2027_state-analytics-engineering_aw&utm_content=themed-webinar____&utm_term=all_all__
+
+- name: the_launch_desk_live
+  header: The Launch Desk Live
+  subheader: What's shipping in dbt? Find out at The Launch Desk Live — May 20. Learn what's possible and what to prioritize in your stack.
+  button_text: Save your seat
+  url: https://www.getdbt.com/resources/webinars/the-launch-desk-live-what-s-shipping-in-dbt/?utm_medium=internal&utm_source=docs&utm_campaign=q2-2027_the-launch-desk-live_aw&utm_content=themed-webinar____&utm_term=all_all__

--- a/website/blog/metadata.yml
+++ b/website/blog/metadata.yml
@@ -2,7 +2,7 @@
 featured_image: ""
 
 # This CTA lives in right sidebar on blog index
-featured_cta: "state_of_analytics_engineering_virtual_event"
+featured_cta: "the_launch_desk_live"
 
 # Show or hide hero title, description, cta from blog index
 show_title: false

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -86,14 +86,14 @@ var siteSettings = {
       //debug: true,
     },
     announcementBar: {
-      id: "state-of-analytics-engineering-virtual-event",
+      id: "the-launch-desk-live",
       content:
-        "Join us for the 2026 State of Analytics Engineering Virtual Event on April 29 with live Q&A and giveaways!",
+        "What&#39;s shipping in dbt? Find out at The Launch Desk Live &mdash; May 20. See the lineup and save your seat &#8594;",
       isCloseable: true,
     },
     announcementBarActive: true,
     announcementBarLink:
-      "https://www.getdbt.com/resources/webinars/2026-state-of-analytics-engineering-virtual-event/?utm_medium=internal&utm_source=docs&utm_campaign=q1-2027_state-analytics-engineering_aw&utm_content=themed-webinar____&utm_term=all_all__",
+      "https://www.getdbt.com/resources/webinars/the-launch-desk-live-what-s-shipping-in-dbt/?utm_medium=internal&utm_source=docs&utm_campaign=q2-2027_the-launch-desk-live_aw&utm_content=themed-webinar____&utm_term=all_all__",
     prism: {
       theme: (() => {
         var theme = themes.nightOwl;

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -88,7 +88,7 @@ var siteSettings = {
     announcementBar: {
       id: "the-launch-desk-live",
       content:
-        "What&#39;s shipping in dbt? Find out at The Launch Desk Live &mdash; May 20. See the lineup and save your seat &#8594;",
+        "What's shipping in dbt? Find out at The Launch Desk Live — May 20. Learn what's possible and what to prioritize in your stack.",
       isCloseable: true,
     },
     announcementBarActive: true,


### PR DESCRIPTION
## Summary

- Updates the docs site announcement bar to promote **The Launch Desk Live** virtual event (May 20)
- Adds a new `the_launch_desk_live` CTA entry to `blog/ctas.yml` for the blog sidebar
- Points `blog/metadata.yml` `featured_cta` at the new CTA

Requested via PRODDOCS-969 / Slack. Banner runs until May 21.

## Test plan

- [ ] Verify announcement bar shows new copy on the docs site
- [ ] Verify blog sidebar CTA shows "The Launch Desk Live" with "Save your seat" button
- [ ] Confirm UTM links match the request

🤖 Generated with [Claude Code](https://claude.com/claude-code)