### PR TITLE
Update login URLs from cloud.getdbt.com to login.dbt.com

### DIFF
--- a/website/docs/docs/platform/migration.md
+++ b/website/docs/docs/platform/migration.md
@@ -54,7 +54,7 @@ Complete all of these items to ensure your <Constant name="dbt" /> resources and
 Use one of these URL login options:
 
 - [https://login.dbt.com](https://login.dbt.com): Universal login shows the accounts you can access across instances. Account administrators can enable or disable this path with **Enable global account discovery** in [Account settings](/docs/platform/account-settings#enable-global-account-discovery).
-- `us1.dbt.com`: If you previously signed in with a username and password at `cloud.getdbt.com`, plan to sign in at `us1.dbt.com` instead. The original URL still works, but you need to click through to continue after sign-in. If SSO is configured, use the unique URL listed in your SSO account settings, for example, `ACCOUNT_PREFIX.us1.dbt.com`.
+- `us1.dbt.com`: If you previously signed in with a username and password at `login.dbt.com`, plan to sign in at `us1.dbt.com` instead. The original URL still works, but you need to click through to continue after sign-in. If SSO is configured, use the unique URL listed in your SSO account settings, for example, `ACCOUNT_PREFIX.us1.dbt.com`.
 - `ACCOUNT_PREFIX.us1.dbt.com`: A unique URL specifically for your account. If you belong to multiple accounts, each will have a unique URL available as long as they have been migrated to multi-cell. 
 Check out [access, regions, and IP addresses](/docs/platform/about-platform/access-regions-ip-addresses) for more information.
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -216,7 +216,7 @@ var siteSettings = {
           items: [
             {
               label: "Log in to dbt",
-              to: "https://cloud.getdbt.com/",
+              to: "https://login.dbt.com/",
               target: "_blank",
             },
             {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What are you changing in this pull request and why?

Updated login URL references from `cloud.getdbt.com` to `login.dbt.com` in two locations:

1. **Migration documentation** (`website/docs/docs/platform/migration.md`): Updated the post-migration login options section to reference `login.dbt.com` instead of `cloud.getdbt.com` as the URL users previously signed in with.

2. **Navbar configuration** (`website/docusaurus.config.js`): Updated the "Log in to dbt" link in the navbar from `https://cloud.getdbt.com/` to `https://login.dbt.com/`.

These changes align with the current branding and login flow where `login.dbt.com` is the universal entry point for dbt platform accounts.

## Checklist

- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content adheres to these guidelines.
- [x] For new resources, I read through the [contribution guidelines](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/README.md) and the [content types](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-types.md).
- [x] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://dbt-labs.slack.com/archives/C0A16RWFC4E/p1777909268765939?thread_ts=1777909268.765939&cid=C0A16RWFC4E)

<div><a href="https://cursor.com/agents/bc-5cc5739b-3549-529c-8a46-2e95c7b1cdfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5cc5739b-3549-529c-8a46-2e95c7b1cdfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

