### PR TITLE
Change pip install command to async version

### DIFF
--- a/website/docs/docs/dbt-apis/sl-python-sdk.md
+++ b/website/docs/docs/dbt-apis/sl-python-sdk.md
@@ -38,7 +38,7 @@ Async installation means your program can start a task and then move on to other
 For more details, refer to [asyncio](https://docs.python.org/3/library/asyncio.html).
 
 ```bash
-pip install "dbt-sl-sdk[sync]"
+pip install "dbt-sl-sdk[async]"
 ```
 
 Since the [Python ADBC driver](https://github.com/apache/arrow-adbc/tree/main/python/adbc_driver_manager) doesn't yet support asyncio natively, `dbt-sl-sdk` uses a [`ThreadPoolExecutor`](https://github.com/dbt-labs/semantic-layer-sdk-python/blob/5e52e1ca840d20a143b226ae33d194a4a9bc008f/dbtsl/api/adbc/client/asyncio.py#L62) to run `query` and `list dimension-values` (all operations that are done with ADBC).  This is why you might see multiple Python threads spawning.


### PR DESCRIPTION
Incredibly small fix - but we had a typo for the async `dbt-sl-sdk` install code block.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-fix-sl-sdk-async-dbt-labs.vercel.app/docs/dbt-apis/sl-python-sdk

<!-- end-vercel-deployment-preview -->