### PR TITLE
copy_grants for Snowflake dynamic tables

### DIFF
--- a/website/docs/docs/dbt-versions/core-upgrade/03-upgrading-to-v1.12.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/03-upgrading-to-v1.12.md
@@ -106,7 +106,6 @@ You can read more about each of these behavior changes in the following links:
 
 ### Snowflake
 
-- You can set [`copy_grants: true`](/reference/resource-configs/snowflake-configs#copy-grants-dynamic-tables) on a dynamic table to preserve existing object-level privileges when the table is recreated during a full refresh. When set to `false` (default), all previously granted permissions are dropped on recreation, requiring manual re-grants.
 - You can set the [`iceberg_version`](/docs/mesh/iceberg/snowflake-iceberg-support#adapter-properties) config on Snowflake Iceberg tables to control which Iceberg format version Snowflake uses. Set it to `3` to use Iceberg V3, which improves `VARIANT` type support and makes row-level changes more efficient by tracking deletions separately instead of rewriting data. The default value is `2`. Note that you cannot change the value of `iceberg_version` after table creation.
 - You can configure the [`scheduler`](/reference/resource-configs/snowflake-configs#scheduler) parameter on Snowflake dynamic tables to control how refreshes are managed. Setting it to `ENABLE` lets Snowflake automatically refresh the dynamic table, while `DISABLE` means dbt manages refreshes during model execution. When `scheduler` is set to `ENABLE`, you must also specify [`target_lag`](/reference/resource-configs/snowflake-configs#target-lag). 
 

--- a/website/docs/docs/dbt-versions/core-upgrade/03-upgrading-to-v1.12.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/03-upgrading-to-v1.12.md
@@ -106,6 +106,7 @@ You can read more about each of these behavior changes in the following links:
 
 ### Snowflake
 
+- You can set [`copy_grants: true`](/reference/resource-configs/snowflake-configs#copy-grants-dynamic-tables) on a dynamic table to preserve existing object-level privileges when the table is recreated during a full refresh. When set to `false` (default), all previously granted permissions are dropped on recreation, requiring manual re-grants.
 - You can set the [`iceberg_version`](/docs/mesh/iceberg/snowflake-iceberg-support#adapter-properties) config on Snowflake Iceberg tables to control which Iceberg format version Snowflake uses. Set it to `3` to use Iceberg V3, which improves `VARIANT` type support and makes row-level changes more efficient by tracking deletions separately instead of rewriting data. The default value is `2`. Note that you cannot change the value of `iceberg_version` after table creation.
 - You can configure the [`scheduler`](/reference/resource-configs/snowflake-configs#scheduler) parameter on Snowflake dynamic tables to control how refreshes are managed. Setting it to `ENABLE` lets Snowflake automatically refresh the dynamic table, while `DISABLE` means dbt manages refreshes during model execution. When `scheduler` is set to `ENABLE`, you must also specify [`target_lag`](/reference/resource-configs/snowflake-configs#target-lag). 
 

--- a/website/docs/docs/dbt-versions/core-upgrade/04-upgrading-to-v1.11.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/04-upgrading-to-v1.11.md
@@ -117,7 +117,7 @@ dbt parse --warn-error-options '{"silence": ["Deprecations"]}'
 - The Snowflake adapter supports basic table materialization on Iceberg tables registered in a Glue catalog through a [catalog-linked database](https://docs.snowflake.com/en/user-guide/tables-iceberg-catalog-linked-database#label-catalog-linked-db-create). For more information, see [Glue Data Catalog](/docs/mesh/iceberg/snowflake-iceberg-support#external-catalogs).
 - The `cluster_by` configuration is supported in dynamic tables. For more information, see [Dynamic table clustering](/reference/resource-configs/snowflake-configs#dynamic-table-clustering).
 - The `immutable_where` configuration is supported in dynamic tables. For more information, see [Snowflake configurations](/reference/resource-configs/snowflake-configs#immutable-where).
-- You can set [`copy_grants: true`](/reference/resource-configs/snowflake-configs#copy-grants-dynamic-tables) on a dynamic table to preserve existing object-level privileges when the table is recreated during a full refresh. When set to `false` (default), all previously granted permissions are dropped on recreation, requiring manual re-grants.
+- You can set [`copy_grants: true`](/reference/resource-configs/snowflake-configs#copy-grants-dynamic-tables) on a dynamic table to preserve existing object-level privileges when the table is recreated during a `--full-refresh`. When set to `false` (default), all previously granted permissions are dropped on recreation, requiring manual re-grants.
 
 ### BigQuery
 

--- a/website/docs/docs/dbt-versions/core-upgrade/04-upgrading-to-v1.11.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/04-upgrading-to-v1.11.md
@@ -117,6 +117,7 @@ dbt parse --warn-error-options '{"silence": ["Deprecations"]}'
 - The Snowflake adapter supports basic table materialization on Iceberg tables registered in a Glue catalog through a [catalog-linked database](https://docs.snowflake.com/en/user-guide/tables-iceberg-catalog-linked-database#label-catalog-linked-db-create). For more information, see [Glue Data Catalog](/docs/mesh/iceberg/snowflake-iceberg-support#external-catalogs).
 - The `cluster_by` configuration is supported in dynamic tables. For more information, see [Dynamic table clustering](/reference/resource-configs/snowflake-configs#dynamic-table-clustering).
 - The `immutable_where` configuration is supported in dynamic tables. For more information, see [Snowflake configurations](/reference/resource-configs/snowflake-configs#immutable-where).
+- You can set [`copy_grants: true`](/reference/resource-configs/snowflake-configs#copy-grants-dynamic-tables) on a dynamic table to preserve existing object-level privileges when the table is recreated during a full refresh. When set to `false` (default), all previously granted permissions are dropped on recreation, requiring manual re-grants.
 
 ### BigQuery
 

--- a/website/docs/reference/resource-configs/snowflake-configs.md
+++ b/website/docs/reference/resource-configs/snowflake-configs.md
@@ -514,7 +514,7 @@ Learn more about `INITIALIZATION_WAREHOUSE` in [Snowflake's docs](https://docs.s
 
 ### Copy grants (dynamic tables)
 
-Starting `dbt-snowflake` v1.12, you can use `copy_grants` to preserve existing object-level privileges when Snowflake recreates a dynamic table with `CREATE OR REPLACE`. Without it, all previously granted permissions are dropped when the table is recreated, and downstream users or roles lose access until grants are manually re-applied.
+Starting `dbt-snowflake` v1.12, you can use `copy_grants` to preserve existing object-level privileges when Snowflake recreates a dynamic table with `CREATE OR REPLACE`. When disabled, all previously granted permissions are dropped when the table is recreated, and downstream users or roles lose access until grants are manually re-applied.
 
 When you set `copy_grants: true` on a dynamic table, dbt adds the `COPY GRANTS` clause to the `CREATE OR REPLACE DYNAMIC TABLE` statement. This preserves existing object-level privileges on the table during full refreshes, so you don't need to re-grant access after the table is recreated.
 

--- a/website/docs/reference/resource-configs/snowflake-configs.md
+++ b/website/docs/reference/resource-configs/snowflake-configs.md
@@ -226,7 +226,8 @@ models:
 | [`initialize`](#initialize)     | `<string>` | no       | `ON_CREATE` | n/a   |
 | [`cluster_by`](#dynamic-table-clustering)     | `<string>` or `<list>` | no       | `None` | alter   |
 | [`immutable_where`](#immutable-where)     | `<string>` | no       | `None` | alter   |
-| [`transient`](#transient-dynamic-tables)     | `<boolean>` | no       | `False` | full refresh   |
+| [`transient`](#transient-dynamic-tables)     | `<boolean>` | no       | `false` | full refresh   |
+| [`copy_grants`](#copying-grants)     | `<boolean>` | no       | `false` | full refresh   |
 
 
 <Tabs
@@ -257,6 +258,7 @@ models:
     [+](/reference/resource-configs/plus-prefix)[cluster_by](#dynamic-table-clustering): <column-name> | [<column-name>, <column-name>, ...]
     [+](/reference/resource-configs/plus-prefix)[immutable_where](#immutable-where): <condition>
     [+](/reference/resource-configs/plus-prefix)[transient](#transient-dynamic-tables): true | false
+    [+](/reference/resource-configs/plus-prefix)[copy_grants](#copy-grants-dynamic-tables): true | false
 
 ```
 
@@ -285,6 +287,7 @@ models:
       [cluster_by](#dynamic-table-clustering): <column-name> | [<column-name>, <column-name>, ...]
       [immutable_where](#immutable-where): <condition>
       [transient](#transient-dynamic-tables): true | false
+      [copy_grants](#copy-grants-dynamic-tables): true | false
 
 ```
 
@@ -311,6 +314,7 @@ models:
     [cluster_by](#dynamic-table-clustering)="<column-name>" | ["<column-name>", "<column-name>", ...],
     [immutable_where](#immutable-where)="<condition>",
     [transient](#transient-dynamic-tables)=true | false,
+    [copy_grants](#copy-grants-dynamic-tables)=true | false,
 
 ) }}
 
@@ -508,6 +512,29 @@ select * from {{ source('raw', 'events') }}
 
 Learn more about `INITIALIZATION_WAREHOUSE` in [Snowflake's docs](https://docs.snowflake.com/en/user-guide/dynamic-tables-warehouses).
 
+### Copy grants (dynamic tables)
+
+Starting `dbt-snowflake` v1.12, you can use `copy_grants` to preserve existing object-level privileges when Snowflake recreates a dynamic table with `CREATE OR REPLACE`. Without it, all previously granted permissions are dropped when the table is recreated, and downstream users or roles lose access until grants are manually re-applied.
+
+When you set `copy_grants: true` on a dynamic table, dbt adds the `COPY GRANTS` clause to the `CREATE OR REPLACE DYNAMIC TABLE` statement. This preserves existing object-level privileges on the table during full refreshes, so you don't need to re-grant access after the table is recreated.
+
+`copy_grants` only takes effect during a full refresh. It has no effect during incremental refreshes.
+
+To configure the `copy_grants` parameter, refer to the following example:
+
+```sql
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='MY_WH',
+    target_lag='1 hour',
+    copy_grants=true
+) }}
+
+select * from {{ source('raw', 'events') }}
+```
+
+Learn more about `COPY GRANTS` in [Snowflake's docs](https://docs.snowflake.com/en/sql-reference/sql/create-dynamic-table).
+
 </VersionBlock>
 
 ### Limitations
@@ -521,9 +548,7 @@ As with materialized views on most data platforms, there are limitations associa
 
 Find more information about dynamic table limitations in Snowflake's [docs](https://docs.snowflake.com/en/user-guide/dynamic-tables-tasks-create#dynamic-table-limitations-and-supported-functions).
 
-For dbt limitations, these dbt features are not supported:
-- [Model contracts](/docs/mesh/govern/model-contracts)
-- [Copy grants configuration](/reference/resource-configs/snowflake-configs#copying-grants)
+For dbt limitations, [Model contracts](/docs/mesh/govern/model-contracts) are not supported.
 
 ### Troubleshooting dynamic tables
 
@@ -1150,7 +1175,7 @@ select * from index_sessions
 
 ## Copying grants
 
-When the `copy_grants` config is set to `true`, dbt will add the `copy grants` <Term id="ddl" /> qualifier when rebuilding tables and <Term id="view">views</Term>. The default value is `false`.
+When the `copy_grants` config is set to `true`, dbt will add the `copy grants` <Term id="ddl" /> qualifier when rebuilding tables, <Term id="view">views</Term>, and [dynamic tables](#copy-grants-dynamic-tables) (`dbt-snowflake` v1.12 and later). The default value is `false`.
 
 <File name='dbt_project.yml'>
 

--- a/website/docs/reference/resource-configs/snowflake-configs.md
+++ b/website/docs/reference/resource-configs/snowflake-configs.md
@@ -227,7 +227,7 @@ models:
 | [`cluster_by`](#dynamic-table-clustering)     | `<string>` or `<list>` | no       | `None` | alter   |
 | [`immutable_where`](#immutable-where)     | `<string>` | no       | `None` | alter   |
 | [`transient`](#transient-dynamic-tables)     | `<boolean>` | no       | `false` | full refresh   |
-| [`copy_grants`](#copying-grants)     | `<boolean>` | no       | `false` | full refresh   |
+| [`copy_grants`](#copy-grants-dynamic-tables)     | `<boolean>` | no       | `false` | full refresh   |
 
 
 <Tabs

--- a/website/docs/reference/resource-configs/snowflake-configs.md
+++ b/website/docs/reference/resource-configs/snowflake-configs.md
@@ -230,8 +230,8 @@ models:
 | [`initialize`](#initialize)     | `<string>` | no       | `ON_CREATE` | n/a   |
 | [`cluster_by`](#dynamic-table-clustering)     | `<string>` or `<list>` | no       | `None` | alter   |
 | [`immutable_where`](#immutable-where)     | `<string>` | no       | `None` | alter   |
-| [`transient`](#transient-dynamic-tables)     | `<boolean>` | no       | `false` | full refresh   |
 | [`copy_grants`](#copy-grants-dynamic-tables)     | `<boolean>` | no       | `false` | full refresh   |
+| [`transient`](#transient-dynamic-tables)     | `<boolean>` | no       | `false` | full refresh   |
 
 
 <Tabs
@@ -261,8 +261,8 @@ models:
     [+](/reference/resource-configs/plus-prefix)[initialize](#initialize): ON_CREATE | ON_SCHEDULE 
     [+](/reference/resource-configs/plus-prefix)[cluster_by](#dynamic-table-clustering): <column-name> | [<column-name>, <column-name>, ...]
     [+](/reference/resource-configs/plus-prefix)[immutable_where](#immutable-where): <condition>
-    [+](/reference/resource-configs/plus-prefix)[transient](#transient-dynamic-tables): true | false
     [+](/reference/resource-configs/plus-prefix)[copy_grants](#copy-grants-dynamic-tables): true | false
+    [+](/reference/resource-configs/plus-prefix)[transient](#transient-dynamic-tables): true | false
 
 ```
 
@@ -290,8 +290,8 @@ models:
       [initialize](#initialize): ON_CREATE | ON_SCHEDULE
       [cluster_by](#dynamic-table-clustering): <column-name> | [<column-name>, <column-name>, ...]
       [immutable_where](#immutable-where): <condition>
-      [transient](#transient-dynamic-tables): true | false
       [copy_grants](#copy-grants-dynamic-tables): true | false
+      [transient](#transient-dynamic-tables): true | false
 
 ```
 
@@ -317,8 +317,8 @@ models:
     [initialize](#initialize)="ON_CREATE" | "ON_SCHEDULE", 
     [cluster_by](#dynamic-table-clustering)="<column-name>" | ["<column-name>", "<column-name>", ...],
     [immutable_where](#immutable-where)="<condition>",
-    [transient](#transient-dynamic-tables)=true | false,
     [copy_grants](#copy-grants-dynamic-tables)=true | false,
+    [transient](#transient-dynamic-tables)=true | false,
 
 ) }}
 

--- a/website/docs/reference/resource-configs/snowflake-configs.md
+++ b/website/docs/reference/resource-configs/snowflake-configs.md
@@ -464,11 +464,9 @@ Learn more about `IMMUTABLE WHERE` in [Snowflake's docs](https://docs.snowflake.
 
 ### Copy grants (dynamic tables)
 
-Starting `dbt-snowflake` v1.11, you can use `copy_grants` to preserve existing object-level privileges when Snowflake recreates a dynamic table with `CREATE OR REPLACE`. When disabled, all previously granted permissions are dropped when the table is recreated, and downstream users or roles lose access until grants are manually re-applied.
+Starting `dbt-snowflake` v1.11, you can use `copy_grants` to preserve existing object-level privileges when dbt generates a `CREATE OR REPLACE DYNAMIC TABLE` statement. When disabled, all previously granted permissions are dropped when the table is recreated, and downstream users or roles lose access until grants are manually re-applied.
 
-When you set `copy_grants: true` on a dynamic table, dbt adds the `COPY GRANTS` clause to the `CREATE OR REPLACE DYNAMIC TABLE` statement. This preserves existing object-level privileges on the table during full refreshes, so you don't need to re-grant access after the table is recreated.
-
-`copy_grants` only takes effect during a full refresh. It has no effect during incremental refreshes.
+When you set `copy_grants: true` on a dynamic table, dbt adds the `COPY GRANTS` clause to the `CREATE OR REPLACE DYNAMIC TABLE` statement. This preserves existing object-level privileges on the table during `--full-refresh` runs, so you don't need to re-grant access after the table is recreated.
 
 To configure the `copy_grants` parameter, refer to the following example:
 

--- a/website/docs/reference/resource-configs/snowflake-configs.md
+++ b/website/docs/reference/resource-configs/snowflake-configs.md
@@ -125,6 +125,7 @@ models:
 | [`initialize`](#initialize)     | `<string>` | no       | `ON_CREATE` | n/a   |
 | [`cluster_by`](#dynamic-table-clustering)     | `<string>` or `<list>` | no       | `None` | alter   |
 | [`immutable_where`](#immutable-where)     | `<string>` | no       | `None` | alter   |
+| [`copy_grants`](#copy-grants-dynamic-tables)     | `<boolean>` | no       | `false` | full refresh   |
 
 
 <Tabs
@@ -152,6 +153,7 @@ models:
     [+](/reference/resource-configs/plus-prefix)[initialize](#initialize): ON_CREATE | ON_SCHEDULE 
     [+](/reference/resource-configs/plus-prefix)[cluster_by](#dynamic-table-clustering): <column-name> | [<column-name>, <column-name>, ...]
     [+](/reference/resource-configs/plus-prefix)[immutable_where](#immutable-where): <condition>
+    [+](/reference/resource-configs/plus-prefix)[copy_grants](#copy-grants-dynamic-tables): true | false
 
 ```
 
@@ -177,6 +179,7 @@ models:
       [initialize](#initialize): ON_CREATE | ON_SCHEDULE 
       [cluster_by](#dynamic-table-clustering): <column-name> | [<column-name>, <column-name>, ...]
       [immutable_where](#immutable-where): <condition>
+      [copy_grants](#copy-grants-dynamic-tables): true | false
 
 ```
 
@@ -200,6 +203,7 @@ models:
     [initialize](#initialize)="ON_CREATE" | "ON_SCHEDULE", 
     [cluster_by](#dynamic-table-clustering)="<column-name>" | ["<column-name>", "<column-name>", ...],
     [immutable_where](#immutable-where)="<condition>",
+    [copy_grants](#copy-grants-dynamic-tables)=true | false,
 
 ) }}
 
@@ -458,6 +462,29 @@ from {{ source('raw', 'events') }}
 
 Learn more about `IMMUTABLE WHERE` in [Snowflake's docs](https://docs.snowflake.com/en/user-guide/dynamic-tables-immutability-constraints).
 
+### Copy grants (dynamic tables)
+
+Starting `dbt-snowflake` v1.11, you can use `copy_grants` to preserve existing object-level privileges when Snowflake recreates a dynamic table with `CREATE OR REPLACE`. When disabled, all previously granted permissions are dropped when the table is recreated, and downstream users or roles lose access until grants are manually re-applied.
+
+When you set `copy_grants: true` on a dynamic table, dbt adds the `COPY GRANTS` clause to the `CREATE OR REPLACE DYNAMIC TABLE` statement. This preserves existing object-level privileges on the table during full refreshes, so you don't need to re-grant access after the table is recreated.
+
+`copy_grants` only takes effect during a full refresh. It has no effect during incremental refreshes.
+
+To configure the `copy_grants` parameter, refer to the following example:
+
+```sql
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='MY_WH',
+    target_lag='1 hour',
+    copy_grants=true
+) }}
+
+select * from {{ source('raw', 'events') }}
+```
+
+Learn more about `COPY GRANTS` in [Snowflake's docs](https://docs.snowflake.com/en/sql-reference/sql/create-dynamic-table).
+
 </VersionBlock>
 
 <VersionBlock firstVersion="1.12">
@@ -511,29 +538,6 @@ select * from {{ source('raw', 'events') }}
 - To revert to the default behavior after setting an initialization warehouse, either remove the `snowflake_initialization_warehouse` parameter from your model configuration or explicitly set it to `None`.
 
 Learn more about `INITIALIZATION_WAREHOUSE` in [Snowflake's docs](https://docs.snowflake.com/en/user-guide/dynamic-tables-warehouses).
-
-### Copy grants (dynamic tables)
-
-Starting `dbt-snowflake` v1.12, you can use `copy_grants` to preserve existing object-level privileges when Snowflake recreates a dynamic table with `CREATE OR REPLACE`. When disabled, all previously granted permissions are dropped when the table is recreated, and downstream users or roles lose access until grants are manually re-applied.
-
-When you set `copy_grants: true` on a dynamic table, dbt adds the `COPY GRANTS` clause to the `CREATE OR REPLACE DYNAMIC TABLE` statement. This preserves existing object-level privileges on the table during full refreshes, so you don't need to re-grant access after the table is recreated.
-
-`copy_grants` only takes effect during a full refresh. It has no effect during incremental refreshes.
-
-To configure the `copy_grants` parameter, refer to the following example:
-
-```sql
-{{ config(
-    materialized='dynamic_table',
-    snowflake_warehouse='MY_WH',
-    target_lag='1 hour',
-    copy_grants=true
-) }}
-
-select * from {{ source('raw', 'events') }}
-```
-
-Learn more about `COPY GRANTS` in [Snowflake's docs](https://docs.snowflake.com/en/sql-reference/sql/create-dynamic-table).
 
 </VersionBlock>
 
@@ -1175,7 +1179,7 @@ select * from index_sessions
 
 ## Copying grants
 
-When the `copy_grants` config is set to `true`, dbt will add the `copy grants` <Term id="ddl" /> qualifier when rebuilding tables, <Term id="view">views</Term>, and [dynamic tables](#copy-grants-dynamic-tables) (`dbt-snowflake` v1.12 and later). The default value is `false`.
+When the `copy_grants` config is set to `true`, dbt will add the `copy grants` <Term id="ddl" /> qualifier when rebuilding tables, <Term id="view">views</Term>, and [dynamic tables](#copy-grants-dynamic-tables) (`dbt-snowflake` v1.11 and later). The default value is `false`.
 
 <File name='dbt_project.yml'>
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
Closes https://github.com/dbt-labs/docs.getdbt.com/issues/9111

Documents `copy_grants` support for Snowflake dynamic tables, added in `dbt-snowflake` v1.11 via [dbt-labs/dbt-adapters#1498](https://github.com/dbt-labs/dbt-adapters/pull/1498).

### Changes
- **`snowflake-configs.md`**:
  - Added `copy_grants` to the v1.11 dynamic tables config table and all three config tab examples (project YAML, properties YAML, SQL config)
  - Added new `### Copy grants (dynamic tables)` subsection under the v1.11 `VersionBlock`, explaining the behavior, default value, and an example
  - Updated the `## Copying grants` section to mention dynamic table support (v1.11+) and link to the new subsection
  - Removed the stale limitation bullet that listed copy grants as unsupported for dynamic tables
- **`04-upgrading-to-v1.11.md`**: Added a bullet to the Snowflake adapter section describing the new `copy_grants` config for dynamic tables

Previews:
- [Upgrade guide for 1.12](https://docs-getdbt-com-git-copygrant-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/upgrading-to-v1.12?version=1.12#snowflake)
- [Snowflake configurations](https://docs-getdbt-com-git-copygrant-dbt-labs.vercel.app/reference/resource-configs/snowflake-configs)

## Checklist
- [x] I have reviewed the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md)
- [x] The changes in this PR are limited to the issue description above