### PR TITLE
Fix Datadog RUM Monitoring

### DIFF
--- a/website/src/theme/Root.js
+++ b/website/src/theme/Root.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { VersionContextProvider } from '../stores/VersionContext'
 import { useVersionUrlSync } from '../utils/useVersionUrlSync'
 import { OptimizelyInitializer } from '../components/OptimizelyInitializer'
+import { DatadogInitializer } from "../components/DatadogInitializer";
 
 /**
  * Inner component that syncs version to URL on route changes.
@@ -17,6 +18,7 @@ function Root({children}) {
   return (
     <VersionContextProvider>
       <OptimizelyInitializer />
+      <DatadogInitializer />
       <VersionUrlSyncHandler>
         {children}
       </VersionUrlSyncHandler>


### PR DESCRIPTION
## What are you changing in this pull request and why?
[Task](https://www.notion.so/dbtlabs/Investigate-Datadog-RUM-not-running-for-Docs-335bb38ebda780939e53f07e31383e68?source=copy_link)

Kind of strange, but the `<DatadogInitializer>` component added to the `Root.js` file in [pr 8674](https://github.com/dbt-labs/docs.getdbt.com/pull/8674) was removed somehow, even though the [history doesn't show when](https://github.com/dbt-labs/docs.getdbt.com/commits/current/website/src/theme/Root.js). I might have accidentally removed it during a merge conflict when adding the `OptimizelyInitializer` if I had to guess.

This adds Datadog RUM monitoring for web vitals back into Docs.

## Preview

Click around in the preview: https://docs-getdbt-com-git-fix-datadog-rum-dbt-labs.vercel.app/

Then go into Datadog > RUM > Web Team, and verify events occurring under the staging env