### PR TITLE
Clarify dbt plans for remote MCP docs

### DIFF
--- a/website/docs/docs/dbt-ai/mcp-quickstart-remote.md
+++ b/website/docs/docs/dbt-ai/mcp-quickstart-remote.md
@@ -7,6 +7,8 @@ id: "mcp-quickstart-remote"
 
 import MCPCreditUsage from '/snippets/_mcp-credit-usage.md';
 
+# Use dbt MCP with zero local install <Lifecycle status="self_service,managed,managed_plus"/>
+
 The remote MCP server connects to <Constant name="dbt_platform"/> using HTTP. No local installation is required &mdash; you configure your MCP client with a URL and headers instead of running `uvx dbt-mcp`.
 
 ## When to use remote MCP

--- a/website/docs/docs/dbt-ai/mcp-quickstart-remote.md
+++ b/website/docs/docs/dbt-ai/mcp-quickstart-remote.md
@@ -7,7 +7,7 @@ id: "mcp-quickstart-remote"
 
 import MCPCreditUsage from '/snippets/_mcp-credit-usage.md';
 
-# Use dbt MCP with zero local install <Lifecycle status="self_service,managed,managed_plus"/>
+# Use dbt MCP with no local install <Lifecycle status="self_service,managed,managed_plus"/>
 
 The remote MCP server connects to <Constant name="dbt_platform"/> using HTTP. No local installation is required &mdash; you configure your MCP client with a URL and headers instead of running `uvx dbt-mcp`.
 

--- a/website/docs/docs/dbt-ai/setup-remote-mcp.md
+++ b/website/docs/docs/dbt-ai/setup-remote-mcp.md
@@ -5,6 +5,8 @@ description: "Learn how to set up the remote dbt-mcp server"
 id: "setup-remote-mcp"
 ---
 
+# Set up remote MCP <Lifecycle status="self_service,managed,managed_plus"/>
+
 The remote MCP server uses an HTTP connection and makes calls to dbt-mcp hosted on the cloud-based <Constant name="dbt_platform" />. This setup requires no local installation and is ideal for data consumption use cases.
 
 ## When to use remote MCP

--- a/website/docs/docs/dbt-ai/setup-remote-mcp.md
+++ b/website/docs/docs/dbt-ai/setup-remote-mcp.md
@@ -5,7 +5,7 @@ description: "Learn how to set up the remote dbt-mcp server"
 id: "setup-remote-mcp"
 ---
 
-# Set up remote MCP <Lifecycle status="self_service,managed,managed_plus"/>
+# Set up the remote MCP server <Lifecycle status="self_service,managed,managed_plus"/>
 
 The remote MCP server uses an HTTP connection and makes calls to dbt-mcp hosted on the cloud-based <Constant name="dbt_platform" />. This setup requires no local installation and is ideal for data consumption use cases.
 


### PR DESCRIPTION
## Summary
- Add `self_service, managed, managed_plus` lifecycle pills to the H1 of the two remote MCP docs (`setup-remote-mcp` and `mcp-quickstart-remote`) so readers can immediately see which dbt platform plans support remote MCP.
- Matches the existing pill convention used on `dbt-agents.md` and `developer-agent.md`.

## Test plan
- [ ] Build the docs locally and confirm the pills render on both pages
- [ ] Verify pill links route to the product lifecycle page

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-clarify-mcp-plan-dbt-labs.vercel.app/docs/build/documentation
- https://docs-getdbt-com-git-update-clarify-mcp-plan-dbt-labs.vercel.app/docs/build/sql-models
- https://docs-getdbt-com-git-update-clarify-mcp-plan-dbt-labs.vercel.app/docs/dbt-ai/mcp-quickstart-remote
- https://docs-getdbt-com-git-update-clarify-mcp-plan-dbt-labs.vercel.app/docs/dbt-ai/setup-remote-mcp
- https://docs-getdbt-com-git-update-clarify-mcp-plan-dbt-labs.vercel.app/docs/dbt-versions/cloud-release-tracks
- https://docs-getdbt-com-git-update-clarify-mcp-plan-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/02-upgrading-to-fusion
- https://docs-getdbt-com-git-update-clarify-mcp-plan-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/03-upgrading-to-v1.12
- https://docs-getdbt-com-git-update-clarify-mcp-plan-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/04-upgrading-to-v1.11
- https://docs-getdbt-com-git-update-clarify-mcp-plan-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/05-upgrading-to-v1.10
- https://docs-getdbt-com-git-update-clarify-mcp-plan-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/06-upgrading-to-v1.9
- https://docs-getdbt-com-git-update-clarify-mcp-plan-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/07-upgrading-to-v1.8
- https://docs-getdbt-com-git-update-clarify-mcp-plan-dbt-labs.vercel.app/docs/dbt-versions/release-notes
- https://docs-getdbt-com-git-update-clarify-mcp-plan-dbt-labs.vercel.app/docs/dbt-versions/upgrade-dbt-version-in-cloud
- https://docs-getdbt-com-git-update-clarify-mcp-plan-dbt-labs.vercel.app/docs/fusion/fusion-releases
- https://docs-getdbt-com-git-update-clarify-mcp-plan-dbt-labs.vercel.app/docs/local/connect-data-platform/snowflake-setup
- https://docs-getdbt-com-git-update-clarify-mcp-plan-dbt-labs.vercel.app/docs/local/install-dbt
- https://docs-getdbt-com-git-update-clarify-mcp-plan-dbt-labs.vercel.app/docs/platform-integrations/downstream-exposures-tableau
- https://docs-getdbt-com-git-update-clarify-mcp-plan-dbt-labs.vercel.app/docs/platform-integrations/orchestrate-exposures
- https://docs-getdbt-com-git-update-clarify-mcp-plan-dbt-labs.vercel.app/faqs/Core/install-pip-best-practices
- https://docs-getdbt-com-git-update-clarify-mcp-plan-dbt-labs.vercel.app/reference/commands/list
- https://docs-getdbt-com-git-update-clarify-mcp-plan-dbt-labs.vercel.app/reference/global-configs/behavior-changes

<!-- end-vercel-deployment-preview -->