### PR TITLE
Consolidate Enterprise+ tier snippets for IP restrictions and private connectivity

### DIFF
--- a/website/docs/docs/platform/secure/ip-restrictions.md
+++ b/website/docs/docs/platform/secure/ip-restrictions.md
@@ -9,9 +9,9 @@ pagination_prev: null
 
 # Configuring public IP restrictions <Lifecycle status="managed_plus" />
 
-import SetUpPages from '/snippets/_available-tiers-iprestrictions.md';
+import SetUpPages from '/snippets/_available-tiers-enterprise-plus.md';
 
-<SetUpPages features={'/snippets/_available-tiers-iprestrictions.md'}/>
+<SetUpPages features={'/snippets/_available-tiers-enterprise-plus.md'}/>
 
 IP restrictions help control which IP addresses can connect to <Constant name="dbt" />. They allow <Constant name="dbt" /> customers to meet security and compliance controls by only allowing approved IPs to connect to their <Constant name="dbt" /> environment. This feature is supported in all regions across NA, Europe, and Asia-Pacific, but contact us if you have questions about availability.
 

--- a/website/docs/docs/platform/secure/private-connectivity/aws/databricks.md
+++ b/website/docs/docs/platform/secure/private-connectivity/aws/databricks.md
@@ -8,11 +8,11 @@ pagination_next: null
 
 # Configuring Databricks PrivateLink <Lifecycle status="managed_plus" />
 
-import SetUpPages from '/snippets/_available-tiers-private-connection.md';
+import SetUpPages from '/snippets/_available-tiers-enterprise-plus.md';
 import PrivateLinkSLA from '/snippets/_private-connection-SLA.md';
 import CloudProviders from '/snippets/_private-connection-across-providers.md';
 
-<SetUpPages features={'/snippets/_available-tiers-private-connection.md'}/>
+<SetUpPages features={'/snippets/_available-tiers-enterprise-plus.md'}/>
 
 The following steps walk you through the setup of a Databricks AWS PrivateLink endpoint in the <Constant name="dbt" /> multi-tenant environment.
 

--- a/website/docs/docs/platform/secure/private-connectivity/aws/overview.md
+++ b/website/docs/docs/platform/secure/private-connectivity/aws/overview.md
@@ -5,7 +5,7 @@ description: "Configure private connections for AWS deployments of the dbt platf
 sidebar_label: "About AWS PrivateLink"
 ---
 
-import SetUpPages from '/snippets/_available-tiers-private-connection.md';
+import SetUpPages from '/snippets/_available-tiers-enterprise-plus.md';
 import AWSMatrix from '/snippets/_aws-private-connectivity-matrix.md';
 
 <SetUpPages />

--- a/website/docs/docs/platform/secure/private-connectivity/aws/postgres.md
+++ b/website/docs/docs/platform/secure/private-connectivity/aws/postgres.md
@@ -7,12 +7,12 @@ sidebar_label: "Postgres"
 
 # Configure AWS PrivateLink for Postgres <Lifecycle status="managed_plus" />
 
-import SetUpPages from '/snippets/_available-tiers-private-connection.md';
+import SetUpPages from '/snippets/_available-tiers-enterprise-plus.md';
 import PrivateLinkTroubleshooting from '/snippets/_privatelink-troubleshooting.md';
 import PrivateLinkCrossZone from '/snippets/_privatelink-cross-zone-load-balancing.md';
 import CloudProviders from '/snippets/_private-connection-across-providers.md';
 
-<SetUpPages features={'/snippets/_available-tiers-private-connection.md'}/>
+<SetUpPages features={'/snippets/_available-tiers-enterprise-plus.md'}/>
 
 A Postgres database, hosted either in AWS or in a properly connected on-prem data center, can be accessed through a private network connection using AWS Interface-type PrivateLink. The type of Target Group connected to the Network Load Balancer (NLB) may vary based on the location and type of Postgres instance being connected, as explained in the following steps.
 

--- a/website/docs/docs/platform/secure/private-connectivity/aws/redshift.md
+++ b/website/docs/docs/platform/secure/private-connectivity/aws/redshift.md
@@ -7,12 +7,12 @@ sidebar_label: "Redshift"
 
 # Configure AWS PrivateLink for Redshift <Lifecycle status="managed_plus" />
 
-import SetUpPages from '/snippets/_available-tiers-private-connection.md';
+import SetUpPages from '/snippets/_available-tiers-enterprise-plus.md';
 import PrivateLinkTroubleshooting from '/snippets/_privatelink-troubleshooting.md';
 import PrivateLinkCrossZone from '/snippets/_privatelink-cross-zone-load-balancing.md';
 import CloudProviders from '/snippets/_private-connection-across-providers.md';
 
-<SetUpPages features={'/snippets/_available-tiers-private-connection.md'}/>
+<SetUpPages features={'/snippets/_available-tiers-enterprise-plus.md'}/>
 
 AWS provides two different ways to create a PrivateLink VPC endpoint for a Redshift cluster that is running in another VPC: 
 - [Redshift-managed PrivateLink Endpoints](https://docs.aws.amazon.com/redshift/latest/mgmt/managing-cluster-cross-vpc.html)

--- a/website/docs/docs/platform/secure/private-connectivity/aws/self-hosted.md
+++ b/website/docs/docs/platform/secure/private-connectivity/aws/self-hosted.md
@@ -7,9 +7,9 @@ sidebar_label: "Self-hosted services"
 
 # Configuring AWS PrivateLink for a self-hosted service <Lifecycle status="managed_plus" />
 
-import SetUpPages from '/snippets/_available-tiers-private-connection.md';
+import SetUpPages from '/snippets/_available-tiers-enterprise-plus.md';
 
-<SetUpPages features={'/snippets/_available-tiers-private-connection.md'}/>
+<SetUpPages features={'/snippets/_available-tiers-enterprise-plus.md'}/>
 
 AWS PrivateLink enables secure, private connectivity between <Constant name="dbt" /> and your self-hosted services. These services may include version control systems (VCS), data warehouses, or any other applications you manage. With PrivateLink, you do not need to expose your service to the public internet. All communication occurs over a private network, significantly enhancing security. For more details, refer to the [AWS PrivateLink documentation](https://docs.aws.amazon.com/vpc/latest/privatelink/).
 

--- a/website/docs/docs/platform/secure/private-connectivity/aws/snowflake.md
+++ b/website/docs/docs/platform/secure/private-connectivity/aws/snowflake.md
@@ -7,10 +7,10 @@ sidebar_label: "Snowflake"
 
 # Configuring Snowflake PrivateLink <Lifecycle status="managed_plus" />
 
-import SetUpPages from '/snippets/_available-tiers-private-connection.md';
+import SetUpPages from '/snippets/_available-tiers-enterprise-plus.md';
 import CloudProviders from '/snippets/_private-connection-across-providers.md';
 
-<SetUpPages features={'/snippets/_available-tiers-private-connection.md'}/>
+<SetUpPages features={'/snippets/_available-tiers-enterprise-plus.md'}/>
 
 The following steps walk you through the setup of an AWS-hosted Snowflake PrivateLink endpoint in a <Constant name="dbt" /> multi-tenant environment.
 

--- a/website/docs/docs/platform/secure/private-connectivity/azure/databricks.md
+++ b/website/docs/docs/platform/secure/private-connectivity/azure/databricks.md
@@ -6,10 +6,10 @@ sidebar_label: "Databricks"
 pagination_next: null
 ---
 
-import SetUpPages from '/snippets/_available-tiers-private-connection.md';
+import SetUpPages from '/snippets/_available-tiers-enterprise-plus.md';
 import CloudProviders from '/snippets/_private-connection-across-providers.md';
 
-<SetUpPages features={'/snippets/_available-tiers-private-connection.md'}/>
+<SetUpPages features={'/snippets/_available-tiers-enterprise-plus.md'}/>
 
 The following steps walk you through the setup of a Databricks Azure Private Link endpoint in the <Constant name="dbt" /> multi-tenant environment.
 

--- a/website/docs/docs/platform/secure/private-connectivity/azure/overview.md
+++ b/website/docs/docs/platform/secure/private-connectivity/azure/overview.md
@@ -5,10 +5,10 @@ description: "Configure private connections for Azure deployments of the dbt pla
 sidebar_label: "About Azure Private Link"
 ---
 
-import SetUpPages from '/snippets/_available-tiers-private-connection.md';
+import SetUpPages from '/snippets/_available-tiers-enterprise-plus.md';
 import AzureMatrix from '/snippets/_azure-private-connectivity-matrix.md';
 
-<SetUpPages features={'/snippets/_available-tiers-private-connection.md'}/>
+<SetUpPages features={'/snippets/_available-tiers-enterprise-plus.md'}/>
 
 Azure Private Link enables secure, private connectivity between <Constant name="dbt" /> and your Azure-hosted services. With Private Link, traffic between dbt and your data platforms or self-hosted services stays within the Azure network and does not traverse the public internet.
 

--- a/website/docs/docs/platform/secure/private-connectivity/azure/postgres.md
+++ b/website/docs/docs/platform/secure/private-connectivity/azure/postgres.md
@@ -5,10 +5,10 @@ description: "Configuring Private Link for Azure Database for Postgres Flexible 
 sidebar_label: "Azure Database for PostgreSQL Flexible Server"
 ---
 
-import SetUpPages from '/snippets/_available-tiers-private-connection.md';
+import SetUpPages from '/snippets/_available-tiers-enterprise-plus.md';
 import CloudProviders from '/snippets/_private-connection-across-providers.md';
 
-<SetUpPages features={'/snippets/_available-tiers-private-connection.md'}/>
+<SetUpPages features={'/snippets/_available-tiers-enterprise-plus.md'}/>
 
 The following steps walk you through the setup of a Private Link endpoint for Azure Database for Postgres Flexible Server in a <Constant name="dbt" /> multi-tenant environment.
 

--- a/website/docs/docs/platform/secure/private-connectivity/azure/self-hosted.md
+++ b/website/docs/docs/platform/secure/private-connectivity/azure/self-hosted.md
@@ -7,9 +7,9 @@ sidebar_label: "Self-hosted services"
 
 # Configuring Azure Private Link for a self-hosted service <Lifecycle status="managed_plus" />
 
-import SetUpPages from '/snippets/_available-tiers-private-connection.md';
+import SetUpPages from '/snippets/_available-tiers-enterprise-plus.md';
 
-<SetUpPages features={'/snippets/_available-tiers-private-connection.md'}/>
+<SetUpPages features={'/snippets/_available-tiers-enterprise-plus.md'}/>
 
 Azure Private Link enables secure, private connectivity between <Constant name="dbt" /> and your self-hosted services. These services may include version control systems (VCS), data warehouses, or any other applications you manage. With Private Link, you do not need to expose your service to the public internet. All communication occurs over a private network, significantly enhancing security. For more details, refer to the Azure [Private Link documentation](https://learn.microsoft.com/en-us/azure/private-link/private-link-overview).
 

--- a/website/docs/docs/platform/secure/private-connectivity/azure/snowflake.md
+++ b/website/docs/docs/platform/secure/private-connectivity/azure/snowflake.md
@@ -5,10 +5,10 @@ description: "Configuring Azure Private Link for Snowflake."
 sidebar_label: "Snowflake"
 ---
 
-import SetUpPages from '/snippets/_available-tiers-private-connection.md';
+import SetUpPages from '/snippets/_available-tiers-enterprise-plus.md';
 import CloudProviders from '/snippets/_private-connection-across-providers.md';
 
-<SetUpPages features={'/snippets/_available-tiers-private-connection.md'}/>
+<SetUpPages features={'/snippets/_available-tiers-enterprise-plus.md'}/>
 
 The following steps walk you through the setup of an Azure-hosted Snowflake Private Link endpoint in a <Constant name="dbt" /> multi-tenant environment.
 

--- a/website/docs/docs/platform/secure/private-connectivity/azure/synapse.md
+++ b/website/docs/docs/platform/secure/private-connectivity/azure/synapse.md
@@ -5,10 +5,10 @@ description: "Configuring Private Link for Azure Synapse."
 sidebar_label: "Azure Synapse"
 ---
 
-import SetUpPages from '/snippets/_available-tiers-private-connection.md';
+import SetUpPages from '/snippets/_available-tiers-enterprise-plus.md';
 import CloudProviders from '/snippets/_private-connection-across-providers.md';
 
-<SetUpPages features={'/snippets/_available-tiers-private-connection.md'}/>
+<SetUpPages features={'/snippets/_available-tiers-enterprise-plus.md'}/>
 
 The following steps walk you through the setup of a Private Link endpoint for Azure Synapse in a <Constant name="dbt" /> multi-tenant environment.
 

--- a/website/docs/docs/platform/secure/private-connectivity/gcp/bigquery.md
+++ b/website/docs/docs/platform/secure/private-connectivity/gcp/bigquery.md
@@ -7,7 +7,7 @@ sidebar_label: "BigQuery"
 
 # Configuring BigQuery Private Service Connect <Lifecycle status="managed_plus" />
 
-import SetUpPages from '/snippets/_available-tiers-private-connection.md';
+import SetUpPages from '/snippets/_available-tiers-enterprise-plus.md';
 import CloudProviders from '/snippets/_private-connection-across-providers.md';
 
 <SetUpPages />

--- a/website/docs/docs/platform/secure/private-connectivity/gcp/overview.md
+++ b/website/docs/docs/platform/secure/private-connectivity/gcp/overview.md
@@ -5,10 +5,10 @@ description: "Configure private connections for GCP deployments of the dbt platf
 sidebar_label: "About GCP Private Service Connect"
 ---
 
-import SetUpPages from '/snippets/_available-tiers-private-connection.md';
+import SetUpPages from '/snippets/_available-tiers-enterprise-plus.md';
 import GCPMatrix from '/snippets/_gcp-private-connectivity-matrix.md';
 
-<SetUpPages features={'/snippets/_available-tiers-private-connection.md'}/>
+<SetUpPages features={'/snippets/_available-tiers-enterprise-plus.md'}/>
 
 GCP Private Service Connect enables secure, private connectivity between <Constant name="dbt" /> and your GCP-hosted services. With Private Service Connect, traffic between dbt and your data platforms or self-hosted services stays within the Google Cloud network and does not traverse the public internet.
 

--- a/website/docs/docs/platform/secure/private-connectivity/gcp/self-hosted.md
+++ b/website/docs/docs/platform/secure/private-connectivity/gcp/self-hosted.md
@@ -9,9 +9,9 @@ sidebar_label: "Self-hosted services"
 
 
 
-import SetUpPages from '/snippets/_available-tiers-private-connection.md';
+import SetUpPages from '/snippets/_available-tiers-enterprise-plus.md';
 
-<SetUpPages features={'/snippets/_available-tiers-private-connection.md'}/>
+<SetUpPages features={'/snippets/_available-tiers-enterprise-plus.md'}/>
 
 GCP Private Service Connect (PSC) enables secure, private connectivity between <Constant name="dbt" /> and your self-hosted services. These services may include version control systems (VCS), data warehouses, or any other applications you manage. With PSC, you do not need to expose your service to the public internet. All communication occurs over a private network, significantly enhancing security. For more details, refer to the GCP [Private Service Connect documentation](https://cloud.google.com/private-service-connect).
 

--- a/website/docs/docs/platform/secure/private-connectivity/gcp/snowflake.md
+++ b/website/docs/docs/platform/secure/private-connectivity/gcp/snowflake.md
@@ -7,10 +7,10 @@ sidebar_label: "Snowflake"
 
 # Configuring Snowflake Private Service Connect <Lifecycle status="managed_plus" />
 
-import SetUpPages from '/snippets/_available-tiers-private-connection.md';
+import SetUpPages from '/snippets/_available-tiers-enterprise-plus.md';
 import CloudProviders from '/snippets/_private-connection-across-providers.md';
 
-<SetUpPages features={'/snippets/_available-tiers-private-connection.md'}/>
+<SetUpPages features={'/snippets/_available-tiers-enterprise-plus.md'}/>
 
 The following steps walk you through the setup of a GCP Snowflake Private Service Connect (PSC) endpoint in a <Constant name="dbt" /> multi-tenant environment.
 

--- a/website/docs/docs/platform/secure/private-connectivity/overview.md
+++ b/website/docs/docs/platform/secure/private-connectivity/overview.md
@@ -5,7 +5,7 @@ description: "Configuring private connections."
 sidebar_label: "About private connectivity"
 ---
 
-import SetUpPages from '/snippets/_available-tiers-private-connection.md';
+import SetUpPages from '/snippets/_available-tiers-enterprise-plus.md';
 import CloudProviders from '/snippets/_private-connection-across-providers.md';
 import PrivateLinkHostnameWarning from '/snippets/_private-connection-hostname-restriction.md';
 

--- a/website/snippets/_available-tiers-enterprise-plus.md
+++ b/website/snippets/_available-tiers-enterprise-plus.md
@@ -1,7 +1,6 @@
-
 :::info Available to certain Enterprise tiers
 
-The private connection feature is available on the following <Constant name="dbt" /> Enterprise tiers:
+This feature is available on the following <Constant name="dbt" /> Enterprise tiers:
  * Enterprise+
  * Virtual Private
 

--- a/website/snippets/_available-tiers-iprestrictions.md
+++ b/website/snippets/_available-tiers-iprestrictions.md
@@ -1,9 +1,0 @@
-:::info Available to certain Enterprise tiers
-
-Organizations can configure IP restrictions using the following <Constant name="dbt" /> Enterprise tiers:
- * Enterprise+ 
- * Virtual Private
-
-To learn more about these tiers, contact us at [sales@getdbt.com](mailto:sales@getdbt.com).
-
-:::


### PR DESCRIPTION
## Summary
- Replaces the two near-duplicate snippets (`_available-tiers-iprestrictions.md` and `_available-tiers-private-connection.md`) with a single `_available-tiers-enterprise-plus.md` that uses feature-agnostic language.
- Repoints all 18 importing pages (IP restrictions + private connectivity overviews and per-cloud setup pages) to the consolidated snippet.

Closes #9108

## Test plan
- [ ] Build the docs locally and confirm the callout renders correctly on `/docs/platform/secure/ip-restrictions` and `/docs/platform/secure/private-connectivity/private-connectivity`
- [ ] Spot-check one private-connectivity per-cloud setup page (for example, `aws/snowflake`) to confirm the snippet still renders
- [ ] Confirm no remaining references to the deleted snippet filenames

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-enterprise-snippets-dbt-labs.vercel.app/docs/platform/secure/ip-restrictions
- https://docs-getdbt-com-git-update-enterprise-snippets-dbt-labs.vercel.app/docs/platform/secure/private-connectivity/aws/databricks
- https://docs-getdbt-com-git-update-enterprise-snippets-dbt-labs.vercel.app/docs/platform/secure/private-connectivity/aws/overview
- https://docs-getdbt-com-git-update-enterprise-snippets-dbt-labs.vercel.app/docs/platform/secure/private-connectivity/aws/postgres
- https://docs-getdbt-com-git-update-enterprise-snippets-dbt-labs.vercel.app/docs/platform/secure/private-connectivity/aws/redshift
- https://docs-getdbt-com-git-update-enterprise-snippets-dbt-labs.vercel.app/docs/platform/secure/private-connectivity/aws/self-hosted
- https://docs-getdbt-com-git-update-enterprise-snippets-dbt-labs.vercel.app/docs/platform/secure/private-connectivity/aws/snowflake
- https://docs-getdbt-com-git-update-enterprise-snippets-dbt-labs.vercel.app/docs/platform/secure/private-connectivity/azure/databricks
- https://docs-getdbt-com-git-update-enterprise-snippets-dbt-labs.vercel.app/docs/platform/secure/private-connectivity/azure/overview
- https://docs-getdbt-com-git-update-enterprise-snippets-dbt-labs.vercel.app/docs/platform/secure/private-connectivity/azure/postgres
- https://docs-getdbt-com-git-update-enterprise-snippets-dbt-labs.vercel.app/docs/platform/secure/private-connectivity/azure/self-hosted
- https://docs-getdbt-com-git-update-enterprise-snippets-dbt-labs.vercel.app/docs/platform/secure/private-connectivity/azure/snowflake
- https://docs-getdbt-com-git-update-enterprise-snippets-dbt-labs.vercel.app/docs/platform/secure/private-connectivity/azure/synapse
- https://docs-getdbt-com-git-update-enterprise-snippets-dbt-labs.vercel.app/docs/platform/secure/private-connectivity/gcp/bigquery
- https://docs-getdbt-com-git-update-enterprise-snippets-dbt-labs.vercel.app/docs/platform/secure/private-connectivity/gcp/overview
- https://docs-getdbt-com-git-update-enterprise-snippets-dbt-labs.vercel.app/docs/platform/secure/private-connectivity/gcp/self-hosted
- https://docs-getdbt-com-git-update-enterprise-snippets-dbt-labs.vercel.app/docs/platform/secure/private-connectivity/gcp/snowflake
- https://docs-getdbt-com-git-update-enterprise-snippets-dbt-labs.vercel.app/docs/platform/secure/private-connectivity/overview

<!-- end-vercel-deployment-preview -->