### PR TITLE
fix: correct Fusion release track API values

### DIFF
--- a/website/docs/docs/dbt-versions/cloud-release-tracks.md
+++ b/website/docs/docs/dbt-versions/cloud-release-tracks.md
@@ -23,9 +23,9 @@ _`Fusion Stable` is the default for all new <Constant name="fusion" />-powered p
 | Release track | Cadence | Description | [Plan availability](https://www.getdbt.com/pricing) | API value |
 | ------------- | ------- | ----------- | ----------------- | --------- |
 | **Fusion Nightly** | Nightly | The latest nightly build. Includes early access to new features. | All plans | `latest-fusion` |
-| **Fusion Stable** (default) | Weekly | A weekly release that balances stability and feature access. <br /> | All plans | `stable-fusion` |
-| **Fusion Extended** | Monthly | The previous month's final Fusion Stable release. Designed for those who want maximum stability and additional testing time. | Enterprise, Enterprise+ | `extended-fusion` |
-| **Fusion Fallback** | Monthly | The previous month's Fusion Extended release. Emergency rollback option for account admins. | Enterprise+ | `fallback-fusion` |
+| **Fusion Stable** (default) | Weekly | A weekly release that balances stability and feature access. <br /> | All plans | `fusion-stable` |
+| **Fusion Extended** | Monthly | The previous month's final Fusion Stable release. Designed for those who want maximum stability and additional testing time. | Enterprise, Enterprise+ | `fusion-extended` |
+| **Fusion Fallback** | Monthly | The previous month's Fusion Extended release. Emergency rollback option for account admins. | Enterprise+ | `fusion-fallback` |
 
 
 ### dbt Core release tracks
@@ -39,9 +39,9 @@ _`Fusion Stable` is the default for all new <Constant name="fusion" />-powered p
 
 To configure an environment in the [dbt Admin API](/docs/dbt-apis/admin-cloud-api) or [Terraform](https://registry.terraform.io/providers/dbt-labs/dbtcloud/latest) to use a release track, set `dbt_version` to the release track name:
 - `latest-fusion`
-- `stable-fusion`
-- `extended-fusion`
-- `fallback-fusion`
+- `fusion-stable`
+- `fusion-extended`
+- `fusion-fallback`
 - `latest`
 - `compatible`
 - `extended`

--- a/website/docs/docs/dbt-versions/cloud-release-tracks.md
+++ b/website/docs/docs/dbt-versions/cloud-release-tracks.md
@@ -22,7 +22,7 @@ _`Fusion Stable` is the default for all new <Constant name="fusion" />-powered p
 
 | Release track | Cadence | Description | [Plan availability](https://www.getdbt.com/pricing) | API value |
 | ------------- | ------- | ----------- | ----------------- | --------- |
-| **Fusion Nightly** | Nightly | The latest nightly build. Includes early access to new features. | All plans | `latest-fusion` |
+| **Fusion Nightly** | Nightly | The latest nightly build. Includes early access to new features. | All plans | `fusion-nightly` |
 | **Fusion Stable** (default) | Weekly | A weekly release that balances stability and feature access. <br /> | All plans | `fusion-stable` |
 | **Fusion Extended** | Monthly | The previous month's final Fusion Stable release. Designed for those who want maximum stability and additional testing time. | Enterprise, Enterprise+ | `fusion-extended` |
 | **Fusion Fallback** | Monthly | The previous month's Fusion Extended release. Emergency rollback option for account admins. | Enterprise+ | `fusion-fallback` |
@@ -38,8 +38,8 @@ _`Fusion Stable` is the default for all new <Constant name="fusion" />-powered p
 | **Fallback** | The previous month's **Extended** release. | Enterprise+ | `fallback` |
 
 To configure an environment in the [dbt Admin API](/docs/dbt-apis/admin-cloud-api) or [Terraform](https://registry.terraform.io/providers/dbt-labs/dbtcloud/latest) to use a release track, set `dbt_version` to the release track name:
-- `latest-fusion`
-- `fusion-stable`
+- `fusion-nightly`
+- `fusion-stable` (formerly `latest-fusion`)
 - `fusion-extended`
 - `fusion-fallback`
 - `latest`

--- a/website/docs/docs/dbt-versions/upgrade-dbt-version-in-cloud.md
+++ b/website/docs/docs/dbt-versions/upgrade-dbt-version-in-cloud.md
@@ -23,8 +23,8 @@ The **Latest** track ensures you have up-to-date <Constant name="dbt" /> functio
 As a best practice, dbt Labs recommends that you test the upgrade in development first; use the [Override dbt version](#override-dbt-version) setting to test _your_ project on the latest dbt version before upgrading your deployment environments and the default development environment for all your colleagues.
 
 To upgrade an environment in the [<Constant name="dbt" /> Admin API](/docs/dbt-apis/admin-cloud-api) or [Terraform](https://registry.terraform.io/providers/dbt-labs/dbtcloud/latest), set `dbt_version` to the name of your release track:
-- `latest-fusion`
-- `fusion-stable`
+- `fusion-nightly`
+- `fusion-stable` (formerly `latest-fusion`)
 - `fusion-extended`
 - `fusion-fallback`
 - `latest` (default)

--- a/website/docs/docs/dbt-versions/upgrade-dbt-version-in-cloud.md
+++ b/website/docs/docs/dbt-versions/upgrade-dbt-version-in-cloud.md
@@ -24,6 +24,9 @@ As a best practice, dbt Labs recommends that you test the upgrade in development
 
 To upgrade an environment in the [<Constant name="dbt" /> Admin API](/docs/dbt-apis/admin-cloud-api) or [Terraform](https://registry.terraform.io/providers/dbt-labs/dbtcloud/latest), set `dbt_version` to the name of your release track:
 - `latest-fusion`
+- `fusion-stable`
+- `fusion-extended`
+- `fusion-fallback`
 - `latest` (default)
 - `compatible` (available to Starter, Enterprise, Enterprise+ plans)
 - `extended` (available to all Enterprise plans)


### PR DESCRIPTION
## Summary

Corrects the API values for all four Fusion release tracks. The naming convention was wrong in both pages — values should be `fusion-<track>`, not `<track>-fusion`, and `latest-fusion` has been renamed to `fusion-stable`.

| Track | Was (incorrect) | Now (correct) |
|---|---|---|
| Fusion Nightly | `latest-fusion` | `fusion-nightly` |
| Fusion Stable | `stable-fusion` | `fusion-stable` (formerly `latest-fusion`) |
| Fusion Extended | `extended-fusion` | `fusion-extended` |
| Fusion Fallback | `fallback-fusion` | `fusion-fallback` |

## Files changed

- `website/docs/docs/dbt-versions/cloud-release-tracks.md` — fixes table API values + API values list
- `website/docs/docs/dbt-versions/upgrade-dbt-version-in-cloud.md` — fixes + adds the previously missing Fusion tracks

## Test plan

- [ ] Verify all four API values match what dbt platform accepts
- [ ] Confirm `latest-fusion` deprecated alias handling (if any) is covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)