### PR TITLE
Document DBT_MCP_SL_MAX_RESPONSE_CHARS env var

### DIFF
--- a/website/docs/docs/dbt-ai/mcp-environment-variables.md
+++ b/website/docs/docs/dbt-ai/mcp-environment-variables.md
@@ -114,6 +114,7 @@ These variables control the behavior of Semantic Layer tools.
 | Variable | Default | Description |
 | --- | --- | --- |
 | `DBT_MCP_SL_METRICS_RELATED_MAX` | `10` | Maximum number of metrics for which `list_metrics` also returns dimension and entity names inline, reducing the number of tool calls needed to answer data questions. When the metric count is at or below this value, dimensions and entities are embedded directly in the `list_metrics` response. When above this value, only metric names are returned and the LLM calls `get_dimensions`/`get_entities` separately. Set to `0` to always return metrics only and never inline dimension or entity data. |
+| `DBT_MCP_SL_MAX_RESPONSE_CHARS` | `16000` | Maximum character length of the CSV returned by `list_metrics`. Must be an integer `>= 0`. When the response would exceed this length _and_ the metric count is above `DBT_MCP_SL_METRICS_RELATED_MAX`, the `description` and `metadata` columns are dropped from the response to save tokens. Set to `0` to disable trimming and always return the full response. |
 </SimpleTable>
 
 ## Logging and debugging


### PR DESCRIPTION
## Summary
- Documents the new `DBT_MCP_SL_MAX_RESPONSE_CHARS` env var in the MCP environment variables reference, alongside the existing `DBT_MCP_SL_METRICS_RELATED_MAX` row since the two interact.
- Covers the default (`16000`), the `>= 0` integer constraint, the response-trimming behavior (drops `description` and `metadata` columns), and the `0` opt-out.

Refs:
- dbt-labs/dbt-mcp#767
- dbt-labs/dbt-mcp#768

## Test plan
- [ ] Spot-check rendered table in preview

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-docs-mcp-sl-max-response-chars-dbt-labs.vercel.app/docs/dbt-ai/mcp-environment-variables

<!-- end-vercel-deployment-preview -->