### PR TITLE
Update fusion-qs tag from dbt Cloud to dbt platform

### DIFF
--- a/website/docs/guides/fusion-qs.md
+++ b/website/docs/guides/fusion-qs.md
@@ -5,7 +5,7 @@ id: "fusion"
 level: 'Beginner'
 icon: 'zap'
 hide_table_of_contents: true
-tags: ['dbt Fusion engine', 'dbt Cloud','Quickstart']
+tags: ['dbt Fusion engine', 'dbt platform','Quickstart']
 recently_updated: true
 ---
 


### PR DESCRIPTION
## Summary
- Updates `tags` in `docs/guides/fusion-qs.md` from `'dbt Cloud'` to `'dbt platform'` to align with the active naming transition.
- This was the only guide in `docs/guides/` still using the `dbt Cloud` tag; `airflow-and-dbt-cloud.md` and `how-to-use-databricks-workflows-to-run-dbt-cloud-jobs.md` already use `dbt platform`.

## Test plan
- [x] Verify the Fusion quickstart still renders correctly
- [x] Confirm the `dbt platform` tag filter on the guides page includes this guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-guides-category-dbt-labs.vercel.app/guides?version=1.12&tags=dbt+platform

<!-- end-vercel-deployment-preview -->