### PR TITLE
remove fusion callout

### DIFF
--- a/website/snippets/_fusion-migration-workflow.md
+++ b/website/snippets/_fusion-migration-workflow.md
@@ -1,9 +1,5 @@
 If you have access to [<Constant name="dev_agent"/>](/docs/dbt-ai/developer-agent) and [<Constant name="copilot"/>](/docs/platform/studio-ide/develop-copilot) with [AI features](/docs/platform/enable-dbt-copilot?version=2.0#enable-dbt-copilot) enabled, you can use the [<Constant name="fusion"/> migration workflow](/docs/dbt-ai/developer-agent#fusion-migration-workflow) skill. This skill can help you fix compatibility errors directly from the <Constant name="studio_ide" /> using <Constant name="copilot" /> &mdash; no manual log investigation needed. It classifies every error, applies validated fixes automatically, and surfaces what's blocked.
 
-:::info
-The <Constant name="fusion" /> migration workflow is accessible through the <Constant name="dev_agent" /> in the <Constant name="studio_ide" />. If you're using VS Code or the <Constant name="platform_cli" />, use the [autofix tool](https://docs.getdbt.com/guides/fusion-package-compat?step=4) instead.
-:::
-
 1. From the job list, click the **Review job** button for a job with a successful run.
    - If you don't see the **Review job** button, enable the **Show Fusion eligibility** toggle in the job list.
 2. In the **<Constant name="fusion"/> eligibility unknown for this job** pop-up, click **Debug in Studio with Copilot**.


### PR DESCRIPTION
Fixes Slack feedback   that the Fusion migration skill is available in VS Code and the platform CLI through a one-click install in the Studio IDE, not just in the Studio IDE itself.

What changed:

Removed the restrictive info box that stated the migration workflow is only accessible through the Developer agent in the Studio IDE
Updated copy to accurately reflect that the skill is available across Studio IDE, VS Code, and the platform CLI
Maintained all other workflow documentation unchanged
Files changed:

website/snippets/_fusion-migration-workflow.md — Updated callout and introductory text