### PR TITLE
Add redirect from dbt-cloud-release-notes-gen to dbt-platform-release-notes-gen

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1486,6 +1486,11 @@
       "permanent": true
     },
     {
+      "source": "/docs/dbt-versions/dbt-cloud-release-notes-gen",
+      "destination": "/docs/dbt-versions/dbt-platform-release-notes-gen",
+      "permanent": true
+    },
+    {
       "source": "/docs/verified-adapters",
       "destination": "/docs/supported-data-platforms",
       "permanent": true


### PR DESCRIPTION
## Summary
- Adds a permanent redirect from `/docs/dbt-versions/dbt-cloud-release-notes-gen` to `/docs/dbt-versions/dbt-platform-release-notes-gen` in `vercel.json`

## Test plan
- [ ] Verify that `https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes-gen` redirects to `https://docs.getdbt.com/docs/dbt-versions/dbt-platform-release-notes-gen`

🤖 Generated with [Claude Code](https://claude.com/claude-code)