### PR TITLE
fix: use MTPL_Admin role for AWS self-hosted PrivateLink principal

### DIFF
--- a/website/docs/docs/platform/secure/private-connectivity/aws/self-hosted.md
+++ b/website/docs/docs/platform/secure/private-connectivity/aws/self-hosted.md
@@ -51,9 +51,9 @@ Before you begin, make sure to review the following requirements:
 
     - Confirm that your service or application is operational and healthy behind the designated load balancer before proceeding.
 
-3. **dbt AWS Account ARN**
+3. **dbt AWS IAM Role ARN**
 
-    - Contact [dbt Support](mailto:support@getdbt.com) to obtain the dbt AWS account ARN. You will need this in order to allow dbt to connect to your Endpoint Service.
+    - Contact [dbt Support](mailto:support@getdbt.com) to obtain the dbt AWS IAM role ARN. You will need this in order to allow dbt to connect to your Endpoint Service.
 
 
 ## Additional NLB configuration
@@ -99,9 +99,9 @@ For more details, see [Update the security groups for your Network Load Balancer
 
 5. After the Endpoint Service is created, select it and go to the **Allow principals** tab
 
-6. Click **Allow principals** and add the dbt AWS account ARN that you obtained from support:
+6. Click **Allow principals** and add the dbt AWS IAM role ARN that you obtained from support:
 
-    - Principal: `arn:aws:iam::<dbt-account-id>:root`
+    - Principal: `arn:aws:iam::<dbt-account-id>:role/MTPL_Admin`
 
 ### Obtain the endpoint service name
 


### PR DESCRIPTION
## Summary

The [AWS self-hosted PrivateLink setup guide](https://docs.getdbt.com/docs/platform/secure/private-connectivity/aws/aws-self-hosted) currently instructs customers to allow `arn:aws:iam::<dbt-account-id>:root` as the principal on their VPC Endpoint Service. This grants access to the entire dbt AWS account.

The correct principal is `arn:aws:iam::<dbt-account-id>:role/MTPL_Admin` — the specific IAM role used for PrivateLink provisioning. This follows least-privilege and matches the guidance customers have historically received from dbt Support.

**Changes:**
- Prerequisites: "dbt AWS Account ARN" → "dbt AWS IAM Role ARN"
- Step 6 principal: `:root` → `:role/MTPL_Admin`

Flagged by @davidhaworth in [#dev-privatelink](https://dbt-labs.slack.com/archives/C03U5QJEWLC/p1778858685059869).

**Preview:** [View changed page](https://docs-getdbt-com-git-fix-aws-self-hosted-principal-dbt-labs.vercel.app/docs/platform/secure/private-connectivity/aws/aws-self-hosted#grant-dbt-access-to-the-endpoint-service)

## Checklist
- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) so my content aligns with these guidelines.
