### PR TITLE
Add datasharing to redshift configs page

### DIFF
--- a/website/docs/docs/local/connect-data-platform/redshift-setup.md
+++ b/website/docs/docs/local/connect-data-platform/redshift-setup.md
@@ -127,6 +127,7 @@ Find Redshift-specific configuration information in the [Redshift adapter refere
 <ProductCard text="Fusion compatible" url="/docs/local/connect-data-platform/redshift-setup?version=2" /> connection also available.
 
 import SetUpPages from '/snippets/_setup-pages-intro.md';
+import RedshiftDatasharing from '/snippets/_redshift-datasharing.md';
 
 <SetUpPages meta={frontMatter.meta} />
 
@@ -340,56 +341,7 @@ To run certain macros with autocommit, load the profile with autocommit using th
 
 ### `datasharing` <Lifecycle status="beta" />
 
-Previously, the Redshift adapter used PostgreSQL-compatible catalog tables (for example, `pg_*`, `information_schema`) for metadata operations such as listing relations, schemas, and columns. These tables only surface objects within the currently connected database, which prevents cross-database operations needed for [Redshift Datasharing](https://docs.aws.amazon.com/redshift/latest/dg/datashare-overview.html).
-
-Starting `dbt-redshift v1.11.0rc1`, you can set `datasharing: true` in your `profiles.yml` to enable cross-database and cross-cluster access. When enabled, `dbt-redshift` switches metadata queries to Redshift's native `SHOW` system commands. You can then materialize models into a database or cluster other than the one specified in your profile using `{{ config(database='other_db') }}`.
-
-Example configuration:
-
-<File name='profiles.yml'>
-
-```yml
-company-name:
-  target: dev
-  outputs:
-    dev:
-      type: redshift
-      host: hostname.region.redshift.amazonaws.com
-      ...
-      datasharing: true  # default: false
-```
-
-</File>
-
-Once enabled, you can materialize a model into a different database by setting `database` in the model config. For example:
-
-```sql
-{{ config(database='other_db') }}
-
-select * from {{ ref('my_model') }}
-```
-
-The following macros switch to `SHOW` commands when `datasharing: true`:
-
-| Macro | Without `datasharing` | With `datasharing` |
-|-------|-----------------------|-------------------|
-| `list_relations_without_caching` | `information_schema.tables` | `SHOW TABLES FROM SCHEMA` |
-| `list_schemas`, `check_schema_exists` | `pg_namespace` | `SHOW SCHEMAS FROM DATABASE` |
-| `get_columns_in_relation` | `information_schema.columns` | `SHOW COLUMNS FROM TABLE` |
-| Catalog queries | `pg_class`, `pg_tables`, `pg_views` | `SHOW TABLES FROM SCHEMA` + `SVV_REDSHIFT_COLUMNS` |
-| `get_relation_last_modified` | `information_schema.tables` | `SHOW TABLES FROM SCHEMA` |
-| Grants | `pg_user`, `has_table_privilege()` | `SHOW GRANTS ON TABLE` |
-<br /><br />
-`ra3_node: true` also enables this behavior and is supported for backward compatibility. For new projects, use `datasharing: true` instead.
-
-Take note of the following limitations when using `datasharing`:
-
-- Creating views (including materialized views) in another database is not supported.
-- Cross-database grants on objects are not supported.
-- Source freshness checks can have a lag of up to 5 minutes.
-- Metadata queries are limited to 10,000 rows. If a database has more than 10,000 schemas, or a schema has more than 10,000 tables, dbt runs can result in unexpected scenarios.
-- Cross-database writes require the `SNAPSHOT` transaction isolation level.
-- For views that reference tables in another database, define them as [late-binding views](/reference/resource-configs/redshift-configs#late-binding-views).
+<RedshiftDatasharing />
 
 ### Deprecated `profile` parameters in 1.5
 

--- a/website/docs/reference/resource-configs/redshift-configs.md
+++ b/website/docs/reference/resource-configs/redshift-configs.md
@@ -11,6 +11,8 @@ To-do:
 - think about whether some of these should be outside of models
 --->
 
+import RedshiftDatasharing from '/snippets/_redshift-datasharing.md';
+
 ## Incremental materialization strategies
 
 In dbt-redshift, the following incremental materialization strategies are supported:
@@ -115,6 +117,10 @@ The Redshift adapter supports the `query_group` session parameter, enabling dbt 
   ```
 
 </VersionBlock>
+
+## Datasharing <Lifecycle status="beta" />
+
+<RedshiftDatasharing />
 
 ## Late binding views
 

--- a/website/docs/reference/resource-configs/redshift-configs.md
+++ b/website/docs/reference/resource-configs/redshift-configs.md
@@ -122,6 +122,8 @@ The Redshift adapter supports the `query_group` session parameter, enabling dbt 
 
 <RedshiftDatasharing />
 
+For setup instructions, see [Redshift setup](/docs/local/connect-data-platform/redshift-setup).
+
 ## Late binding views
 
 Redshift supports <Term id="view">views</Term> unbound from their dependencies, or [late binding views](https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_VIEW.html#late-binding-views). This DDL option "unbinds" a view from the data it selects from. In practice, this means that if upstream views or tables are dropped with a cascade qualifier, the late-binding view does not get dropped as well.

--- a/website/snippets/_redshift-datasharing.md
+++ b/website/snippets/_redshift-datasharing.md
@@ -41,7 +41,7 @@ The following macros switch to `SHOW` commands when `datasharing: true`:
 `ra3_node: true` also enables this behavior and is supported for backward compatibility. For new projects, use `datasharing: true` instead.
 
 :::note
-If you see `pg_*` queries running with `datasharing: true`, this is not automatically a bug. Only the macros listed above are migrated &mdash; some queries remain on `pg_*` by design (for example, dependency tracking and UDF/function discovery. In addition any custom macro overrides in your project are not affected by this setting. To confirm whether a `pg_*` query is expected, check which macro is being overridden and which metadata operation is running.
+If you see `pg_*` queries running with `datasharing` enabled, this is not automatically a bug. Only the macros listed above are migrated &mdash; some macros remain on `pg_*` by design (for example, `get_relations` for dependency tracking and `list_function_relations_without_caching` for function discovery). Custom macro overrides in your project are not affected. To confirm whether a `pg_*` query is expected, check which macro is being overridden and which metadata operation is running.
 :::
 
 Take note of the following limitations when using `datasharing`:

--- a/website/snippets/_redshift-datasharing.md
+++ b/website/snippets/_redshift-datasharing.md
@@ -41,7 +41,7 @@ The following macros switch to `SHOW` commands when `datasharing: true`:
 `ra3_node: true` also enables this behavior and is supported for backward compatibility. For new projects, use `datasharing: true` instead.
 
 :::note
-If you see `pg_*` queries running with `datasharing: true` enabled, this is not automatically a bug. Only the macros listed above are migrated &mdash; some queries remain on `pg_*` by design (for example, late-binding view columns, external columns, and dependency tracking), and custom macro overrides in your project are not affected by this setting. To confirm whether a `pg_*` query is expected, check which macro is being overridden and which metadata operation is running.
+If you see `pg_*` queries running with `datasharing: true`, this is not automatically a bug. Only the macros listed above are migrated &mdash; some queries remain on `pg_*` by design (for example, late-binding view columns, external columns, and dependency tracking), and custom macro overrides in your project are not affected by this setting. To confirm whether a `pg_*` query is expected, check which macro is being overridden and which metadata operation is running.
 :::
 
 Take note of the following limitations when using `datasharing`:

--- a/website/snippets/_redshift-datasharing.md
+++ b/website/snippets/_redshift-datasharing.md
@@ -41,7 +41,7 @@ The following macros switch to `SHOW` commands when `datasharing: true`:
 `ra3_node: true` also enables this behavior and is supported for backward compatibility. For new projects, use `datasharing: true` instead.
 
 :::note
-If you see `pg_*` queries running with `datasharing` enabled, this is not automatically a bug. Only the macros listed above are migrated &mdash; some macros remain on `pg_*` by design (for example, `get_relations` for dependency tracking and `list_function_relations_without_caching` for function discovery). Custom macro overrides in your project are not affected. To confirm whether a `pg_*` query is expected, check which macro is being overridden and which metadata operation is running.
+If you see `pg_*` queries running with `datasharing` enabled, this is not necessarily a bug. Only the macros listed above are migrated &mdash; some macros remain on `pg_*` by design (for example, `get_relations` for dependency tracking and `list_function_relations_without_caching` for function discovery). Custom macro overrides in your project are not affected. To confirm whether a `pg_*` query is expected, check which macro is being overridden and which metadata operation is running.
 :::
 
 The following limitations apply when using `datasharing`:

--- a/website/snippets/_redshift-datasharing.md
+++ b/website/snippets/_redshift-datasharing.md
@@ -41,7 +41,7 @@ The following macros switch to `SHOW` commands when `datasharing: true`:
 `ra3_node: true` also enables this behavior and is supported for backward compatibility. For new projects, use `datasharing: true` instead.
 
 :::note
-If you see `pg_*` queries running with `datasharing: true`, this is not automatically a bug. Only the macros listed above are migrated &mdash; some queries remain on `pg_*` by design (for example, late-binding view columns, external columns, and dependency tracking), and custom macro overrides in your project are not affected by this setting. To confirm whether a `pg_*` query is expected, check which macro is being overridden and which metadata operation is running.
+If you see `pg_*` queries running with `datasharing: true`, this is not automatically a bug. Only the macros listed above are migrated &mdash; some queries remain on `pg_*` by design (for example, dependency tracking and UDF/function discovery. In addition any custom macro overrides in your project are not affected by this setting. To confirm whether a `pg_*` query is expected, check which macro is being overridden and which metadata operation is running.
 :::
 
 Take note of the following limitations when using `datasharing`:

--- a/website/snippets/_redshift-datasharing.md
+++ b/website/snippets/_redshift-datasharing.md
@@ -44,7 +44,7 @@ The following macros switch to `SHOW` commands when `datasharing: true`:
 If you see `pg_*` queries running with `datasharing` enabled, this is not automatically a bug. Only the macros listed above are migrated &mdash; some macros remain on `pg_*` by design (for example, `get_relations` for dependency tracking and `list_function_relations_without_caching` for function discovery). Custom macro overrides in your project are not affected. To confirm whether a `pg_*` query is expected, check which macro is being overridden and which metadata operation is running.
 :::
 
-Take note of the following limitations when using `datasharing`:
+The following limitations apply when using `datasharing`:
 
 - Creating views (including materialized views) in another database is not supported.
 - Cross-database grants on objects are not supported.

--- a/website/snippets/_redshift-datasharing.md
+++ b/website/snippets/_redshift-datasharing.md
@@ -1,0 +1,54 @@
+Previously, the Redshift adapter used PostgreSQL-compatible catalog tables (for example, `pg_*`, `information_schema`) for metadata operations such as listing relations, schemas, and columns. These tables only surface objects within the currently connected database, which prevents cross-database operations needed for [Redshift Datasharing](https://docs.aws.amazon.com/redshift/latest/dg/datashare-overview.html).
+
+Starting `dbt-redshift` v1.11.0rc1, you can set `datasharing: true` in your `profiles.yml` to enable cross-database and cross-cluster access. When enabled, `dbt-redshift` switches metadata queries to Redshift's native `SHOW` system commands. You can then materialize models into a database or cluster other than the one specified in your profile using `{{ config(database='other_db') }}`.
+
+Example configuration:
+
+<File name='profiles.yml'>
+
+```yml
+company-name:
+  target: dev
+  outputs:
+    dev:
+      type: redshift
+      host: hostname.region.redshift.amazonaws.com
+      ...
+      datasharing: true  # default: false
+```
+
+</File>
+
+Once enabled, you can materialize a model into a different database by setting `database` in the model config. For example:
+
+```sql
+{{ config(database='other_db') }}
+
+select * from {{ ref('my_model') }}
+```
+
+The following macros switch to `SHOW` commands when `datasharing: true`:
+
+| Macro | Without `datasharing` | With `datasharing` |
+|---|---|---|
+| `list_relations_without_caching` | `information_schema.tables` | `SHOW TABLES FROM SCHEMA` |
+| `list_schemas`, `check_schema_exists` | `pg_namespace` | `SHOW SCHEMAS FROM DATABASE` |
+| `get_columns_in_relation` | `information_schema.columns` | `SHOW COLUMNS FROM TABLE` |
+| Catalog queries | `pg_class`, `pg_tables`, `pg_views` | `SHOW TABLES FROM SCHEMA` + `SVV_REDSHIFT_COLUMNS` |
+| `get_relation_last_modified` | `information_schema.tables` | `SHOW TABLES FROM SCHEMA` |
+| Grants | `pg_user`, `has_table_privilege()` | `SHOW GRANTS ON TABLE` |
+
+`ra3_node: true` also enables this behavior and is supported for backward compatibility. For new projects, use `datasharing: true` instead.
+
+:::note
+If you see `pg_*` queries running with `datasharing: true` enabled, this is not automatically a bug. Only the macros listed above are migrated &mdash; some queries remain on `pg_*` by design (for example, late-binding view columns, external columns, and dependency tracking), and custom macro overrides in your project are not affected by this setting. To confirm whether a `pg_*` query is expected, check which macro is being overridden and which metadata operation is running.
+:::
+
+Take note of the following limitations when using `datasharing`:
+
+- Creating views (including materialized views) in another database is not supported.
+- Cross-database grants on objects are not supported.
+- Source freshness checks can have a lag of up to 5 minutes.
+- Metadata queries are limited to 10,000 rows. If a database has more than 10,000 schemas, or a schema has more than 10,000 tables, dbt runs can result in unexpected scenarios.
+- Cross-database writes require the `SNAPSHOT` transaction isolation level.
+- For views that reference tables in another database, define them as [late-binding views](/reference/resource-configs/redshift-configs#late-binding-views).


### PR DESCRIPTION
## What are you changing in this pull request and why?
Closes https://dbtlabs.atlassian.net/browse/PRODDOCS-999

Adds a `Datasharing` section to the Redshift configurations reference page (`reference/resource-configs/redshift-configs`) so that customers debugging metadata behavior can self-serve without having to find the connection setup docs.

The `datasharing` credential was documented in the connection setup page (dbt-labs/docs.getdbt.com#8920) but customers tend to land on the configs page first when troubleshooting. This PR surfaces the same content there via a shared snippet.

**Changes:**
- `reference/resource-configs/redshift-configs.md` — added a `## Datasharing` section with a note clarifying which metadata paths migrate and which stay on `pg_*` by design
- `docs/local/connect-data-platform/redshift-setup.md` — refactored the existing datasharing content into a shared snippet
- `snippets/_redshift-datasharing.md` — new shared snippet containing the intro, example config, macro migration table, `ra3_node` backward-compatibility note, troubleshooting note, and limitations; used by both the configs page and the setup page

Previews:
- [Connect Redshift to dbt Core](https://docs-getdbt-com-git-redshift-datasharing-dbt-labs.vercel.app/docs/local/connect-data-platform/redshift-setup?version=1.13#datasharing)
- [Redshift configurations](https://docs-getdbt-com-git-redshift-datasharing-dbt-labs.vercel.app/reference/resource-configs/redshift-configs?version=1.13#datasharing)

## Checklist
<!-- Ensure your PR meets the following items. Feel free to add additional checklist items to the list if additional checks need to happen before the PR is merged, such as:
- [ ] Needs technical review
- [ ] Change base branch
- [ ] Merge on xyz date
-->
- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-redshift-datasharing-dbt-labs.vercel.app/docs/local/connect-data-platform/redshift-setup
- https://docs-getdbt-com-git-redshift-datasharing-dbt-labs.vercel.app/reference/resource-configs/redshift-configs

<!-- end-vercel-deployment-preview -->