### PR TITLE
Add May 2026 compatible release skip announcement

### DIFF
--- a/website/docs/docs/dbt-versions/compatible-track-changelog.md
+++ b/website/docs/docs/dbt-versions/compatible-track-changelog.md
@@ -12,7 +12,7 @@ For more information, see [release tracks](/docs/dbt-versions/dbt-release-tracks
 
 ## May 2026
 
-The compatible release scheduled for May 2026 will be skipped in order to stabilize`dbt-core 1.12.0` release across the <Constant name="dbt_platform"/>.
+The compatible release scheduled for May 2026 will be skipped in order to stabilize `dbt-core 1.12.0` release across the <Constant name="dbt_platform" />.
 
 Compatible releases will resume in June 2026.
 

--- a/website/docs/docs/dbt-versions/compatible-track-changelog.md
+++ b/website/docs/docs/dbt-versions/compatible-track-changelog.md
@@ -12,7 +12,7 @@ For more information, see [release tracks](/docs/dbt-versions/dbt-release-tracks
 
 ## May 2026
 
-The compatible release scheduled for May 2026 will be skipped in order to stabilize dbt-core 1.12.0 release across the dbt platform.
+The compatible release scheduled for May 2026 will be skipped in order to stabilize`dbt-core 1.12.0` release across the <Constant name="dbt_platform"/>.
 
 Compatible releases will resume in June 2026.
 

--- a/website/docs/docs/dbt-versions/compatible-track-changelog.md
+++ b/website/docs/docs/dbt-versions/compatible-track-changelog.md
@@ -10,6 +10,12 @@ Each monthly **Compatible** release includes functionality matching up-to-date o
 
 For more information, see [release tracks](/docs/dbt-versions/dbt-release-tracks).
 
+## May 2026
+
+The compatible release scheduled for May 2026 will be skipped in order to stabilize dbt-core 1.12.0 release across the dbt platform.
+
+Compatible releases will resume in June 2026.
+
 ## April 2026
 
 Release date: April 21, 2026


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This PR adds an announcement to the compatible track changelog page noting that the May 2026 compatible release will be skipped in order to stabilize the dbt-core 1.12.0 release across the dbt platform.

Compatible releases will resume in June 2026.

Related to Jira issue PRODDOCS-1002.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://dbt-labs.slack.com/archives/C02NCQ9483C/p1779093356768229?thread_ts=1779093356.768229&cid=C02NCQ9483C)

<div><a href="https://cursor.com/agents/bc-11147dd1-5707-53b1-b53f-d74aada683e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11147dd1-5707-53b1-b53f-d74aada683e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

