### PR TITLE
Use dbt build instead of dbt run for `skip_views_but_test_views` selector

### DIFF
--- a/website/docs/docs/platform/billing.md
+++ b/website/docs/docs/platform/billing.md
@@ -283,7 +283,7 @@ Running tests for views in every job run can help keep data quality intact and s
     ```
     
 4. Save the file and commit it to your project.
-5. Modify your dbt jobs to include <VersionBlock lastVersion="1.11">`dbt run --selector skip_views_but_test_views`</VersionBlock><VersionBlock firstVersion="1.12">`dbt run --select selector:skip_views_but_test_views`</VersionBlock>.
+5. Modify your dbt jobs to include <VersionBlock lastVersion="1.11">`dbt build --selector skip_views_but_test_views`</VersionBlock><VersionBlock firstVersion="1.12">`dbt build --select selector:skip_views_but_test_views`</VersionBlock>.
 
 #### Build only changed views
 


### PR DESCRIPTION

## What are you changing in this pull request and why?

The "Exclude views while running tests" section recommends `dbt run --select selector:skip_views_but_test_views`, but `dbt run` doesn't execute tests, only `dbt build` runs both models and tests. Since the section is about preserving view tests, `dbt build` matches the section's intent.

## Checklist
Ensure your PR meets the following items. Feel free to add additional checklist items to the list if additional checks need to happen before the PR is merged, such as:
- [ ] Needs technical review
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.