### PR TITLE
docs(failing-fast): include `dbt build`/`dbt test` and clarify trigger

### DIFF
--- a/website/docs/reference/global-configs/failing-fast.md
+++ b/website/docs/reference/global-configs/failing-fast.md
@@ -4,7 +4,7 @@ id: "failing-fast"
 sidebar: "Failing fast"
 ---
 
-Supply the `-x` or `--fail-fast` flag to `dbt run` to make dbt exit immediately if a single resource fails to build. If other models are in-progress when the first model fails, then dbt will terminate the connections for these still-running models.
+Supply the `-x` or `--fail-fast` flag to `dbt run`, `dbt build`, or `dbt test` to make dbt exit immediately if a single resource fails to build or a test fails. If other resources are in-progress when the first failure occurs, then dbt will terminate the connections for these still-running resources.
 
 For example, you can select four models to run, but if a failure occurs in the first model, the failure will prevent other models from running:
 


### PR DESCRIPTION
> **Dear maintainer** — this PR has a permanent home with methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good). A one-line "no thanks" → auto-close + blacklist. Sorry for the notification this edit caused.
>
> ---

Closes #8584

## What

The `failing-fast` reference page currently says `--fail-fast` only
works with `dbt run`. It actually works with `dbt build` and
`dbt test` as well, and the fast-fail trigger covers both run errors
and test failures. This PR updates the prose to reflect that.

## Why

Avoid surprising users who try `--fail-fast` with `build`/`test` and
think it doesn't apply, when it does.

## AI disclosure

Per project norms — this PR is AI-generated and unattended, written by
a Cursor Anthropic Claude Opus 4.7 agent under @adv0r as a personal
token-burn initiative before my Cursor billing cycle ends. Opened as
**draft** for review. Base branch is `current` per AGENTS.md. CLA
signature will be handled separately if the bot prompts.

Happy to iterate.

Made with [Cursor](https://cursor.com)
