### PR TITLE
fix: restore inline code colors in card bodies in dark mode

### DIFF
--- a/website/src/components/card/styles.module.css
+++ b/website/src/components/card/styles.module.css
@@ -69,6 +69,14 @@ html[data-theme="dark"] {
   .cardBody {
     color: var(--text-inverse-secondary);
   }
+
+  /* Counteract the `a article *` wildcard rule in custom.css which sets
+     all children of linked cards to white in dark mode, overriding the
+     :not(pre) > code colors from custom.css and making code chips unreadable. */
+  .cardBody code {
+    background-color: rgba(246, 245, 255, 1);
+    color: rgba(61, 24, 154, 1);
+  }
 }
 
 


### PR DESCRIPTION
## Problem

`<code>` tags inside `Card` component `body` props are unreadable in dark mode. Only one page is affected: `/docs/build/organize-your-outputs`.

The cause is a wildcard rule in `custom.css`:

```css
html[data-theme="dark"] main .row .col:first-of-type a article * {
  color: white;
}
```

This sets all children of linked cards to `white` in dark mode — including `<code>` elements — overriding the `background-color: rgba(246, 245, 255, 1)` and `color: rgba(61, 24, 154, 1)` set by `:not(pre) > code`. The result is white text on a near-white background.

## Fix

One file, three lines added to `website/src/components/card/styles.module.css` — scoped inside the existing dark mode block:

```css
.cardBody code {
  background-color: rgba(246, 245, 255, 1);
  color: rgba(61, 24, 154, 1);
}
```

This restores exactly the same values that `:not(pre) > code` sets in `custom.css`, counteracting the wildcard override specifically for code chips inside card bodies.

## Testing

Check `/docs/build/organize-your-outputs` in dark mode — `schema`, `database`, and `alias` code chips should match the appearance of inline backtick code elsewhere on the site.