### PR TITLE
Clarify --resource-type flag works with multiple commands

### DIFF
--- a/website/docs/reference/node-selection/methods.md
+++ b/website/docs/reference/node-selection/methods.md
@@ -216,19 +216,19 @@ selectors unambiguous.
 
 <VersionBlock lastVersion="1.10">
 
-Use the `resource_type` method to select nodes of a particular type (`model`, `test`, `exposure`, and so on). This is similar to the `--resource-type` flag used by the [`dbt ls` command](/reference/commands/list).
+Use the `resource_type` method to select nodes of a particular type (`model`, `test`, `exposure`, and so on). This is similar to the [`--resource-type` flag](/reference/global-configs/resource-type), which can be used with the `dbt build`, `dbt test`, `dbt clone`, and `dbt list` commands.
 
 ```bash
 dbt build --select "resource_type:exposure"    # build all resources upstream of exposures
 dbt list --select "resource_type:test"         # list all tests in your project
-dbt list --select "resource_type:source"       # list all sources in your project
+dbt list --select "resource_type:source" 
 ```
 
 </VersionBlock>
 
 <VersionBlock firstVersion="1.11">
 
-Use the `resource_type` method to select nodes of a particular type (`model`, `test`, `exposure`, `function`, and so on). This is similar to the `--resource-type` flag used by the [`dbt ls` command](/reference/commands/list).
+Use the `resource_type` method to select nodes of a particular type (`model`, `test`, `exposure`, `function`, and so on). This is similar to the [`--resource-type` flag](/reference/global-configs/resource-type), which can be used with the `dbt build`, `dbt test`, `dbt clone`, and `dbt list` commands.
 
 ```bash
 dbt build --select "resource_type:exposure"    # build all resources upstream of exposures


### PR DESCRIPTION
Fixes #8908

Updated the `resource_type` method documentation to clarify that the `--resource-type` flag is not limited to `dbt ls`. The flag works with `dbt build`, `dbt test`, `dbt clone`, and `dbt list` as documented on the resource-type configs page. This aligns the two pages for consistency, as requested in the issue.

Updated the link to point to the broader resource-type configs page rather than just the `dbt ls` command page.