### PR TITLE
Update Claude Desktop remote OAuth to custom connector route

### DIFF
--- a/website/docs/docs/dbt-ai/integrate-mcp-claude.md
+++ b/website/docs/docs/dbt-ai/integrate-mcp-claude.md
@@ -69,39 +69,36 @@ The remote dbt MCP server runs in <Constant name="dbt_platform" /> &mdash; no `u
 
 <MCPRemoteOauthBetaCallout />
 
+Get your MCP URL first &mdash; you'll need it for both auth methods:
+
+<MCPRemoteServerUrl />
+
+Then follow the tab that matches your auth method:
+
+<Tabs>
+<TabItem value="oauth" label="OAuth (remote)">
+
+_OAuth is in private beta for Enterprise and Enterprise+ accounts._
+
+<MCPOauthPreflight />
+
+For OAuth, add dbt as a custom connector through Claude Desktop's settings &mdash; you don't need to edit `claude_desktop_config.json`. Claude Desktop opens a browser for sign-in and consent the first time it connects.
+
+1. In Claude Desktop, go to **Settings &rarr; Connectors**.
+2. Click **Add custom connector**.
+3. Enter a name (for example, `dbt`) and paste your MCP URL (for example, `https://abc123.us1.dbt.com/api/ai/v1/mcp`), then click **Add**.
+4. Click **Connect** on the new dbt connector. Claude Desktop redirects you to dbt to complete the OAuth consent flow, where you can approve or deny individual [scopes](/docs/platform/manage-access/connect-apps-oauth#scopes-and-consent).
+5. After you approve, the connector shows as connected. Ask Claude a data question to confirm.
+
+For the full custom connector flow and screenshots, see [Use with remote MCP](/docs/platform/manage-access/connect-apps-oauth#use-with-remote-mcp).
+
+</TabItem>
+<TabItem value="token" label="Token-based">
+
+Use token-based auth when your client doesn't yet support OAuth for HTTP MCP servers, or when you need a shared/CI setup.
+
 1. From Claude Desktop, go to **Settings &rarr; Developer &rarr; Edit Config** to open `claude_desktop_config.json`.
-2. Get your MCP URL:
-
-    <MCPRemoteServerUrl />
-
-3. Add a `dbt` entry under `mcpServers`, using the tab that matches your auth method:
-
-    <Tabs>
-    <TabItem value="oauth" label="OAuth (remote)">
-
-    _OAuth is in private beta for Enterprise and Enterprise+ accounts._
-
-    <MCPOauthPreflight />
-
-    Add the following to `claude_desktop_config.json`. Claude Desktop opens a browser for sign-in and consent the first time the server connects.
-
-    ```json
-    {
-      "mcpServers": {
-        "dbt": {
-          "type": "http",
-          "url": "https://YOUR_DBT_HOST_URL/api/ai/v1/mcp/"
-        }
-      }
-    }
-    ```
-
-    Replace `YOUR_DBT_HOST_URL` with your hostname (for example, `abc123.us1.dbt.com`). You can find the URL in <Constant name="dbt_platform"/> under **Account settings** &rarr; **Access URLs** &rarr; **MCP Endpoint URL**.
-
-    </TabItem>
-    <TabItem value="token" label="Token-based">
-
-    Use token-based auth when your client doesn't yet support OAuth for HTTP MCP servers, or when you need a shared/CI setup.
+2. Add a `dbt` entry under `mcpServers`:
 
     ```json
     {
@@ -122,10 +119,10 @@ The remote dbt MCP server runs in <Constant name="dbt_platform" /> &mdash; no `u
 
     <MCPRemoteTokenHeaders />
 
-    </TabItem>
-    </Tabs>
+3. Save the file and restart Claude Desktop. Ask Claude a data question to confirm the server is connected.
 
-4. Save the file and restart Claude Desktop. Ask Claude a data question to confirm the server is connected.
+</TabItem>
+</Tabs>
 
 ## Claude Code
 

--- a/website/docs/docs/dbt-ai/integrate-mcp-claude.md
+++ b/website/docs/docs/dbt-ai/integrate-mcp-claude.md
@@ -85,7 +85,7 @@ _OAuth is in private beta for Enterprise and Enterprise+ accounts._
 For OAuth, add dbt as a custom connector through Claude Desktop's settings &mdash; you don't need to edit `claude_desktop_config.json`. Claude Desktop opens a browser for sign-in and consent the first time it connects.
 
 1. In Claude Desktop, go to **Chat** &rarr; Customize**.
-2. Click **Add custom connector**.
+2. Click **Connectors** and then **Add custom connector**.
 3. Enter a name (for example, `dbt`) and paste your MCP URL (for example, `https://abc123.us1.dbt.com/api/ai/v1/mcp`), then click **Add**.
 4. Click **Connect** on the new dbt connector. Claude Desktop redirects you to dbt to complete the OAuth consent flow, where you can approve or deny individual [scopes](/docs/platform/manage-access/connect-apps-oauth#scopes-and-consent).
 5. After you approve, the connector shows as connected. Ask Claude a data question to confirm.

--- a/website/docs/docs/dbt-ai/integrate-mcp-claude.md
+++ b/website/docs/docs/dbt-ai/integrate-mcp-claude.md
@@ -11,6 +11,7 @@ import MCPRemoteOauthBetaCallout from '/snippets/_mcp-remote-oauth-beta-callout.
 import MCPRemoteServerUrl from '/snippets/_mcp-remote-server-url.md';
 import MCPRemoteTokenHeaders from '/snippets/_mcp-remote-token-headers.md';
 import MCPOauthPreflight from '/snippets/_mcp-oauth-preflight.md';
+import MCPCustomConnectorOauth from '/snippets/_mcp-custom-connector-oauth.md';
 
 Claude is an AI assistant from Anthropic with two primary interfaces:
 - [Claude Desktop](#claude-desktop): A GUI with MCP support for file access and commands, plus basic coding features.
@@ -82,15 +83,9 @@ _OAuth is in private beta for Enterprise and Enterprise+ accounts._
 
 <MCPOauthPreflight />
 
-For OAuth, add dbt as a custom connector through Claude Desktop's settings &mdash; you don't need to edit `claude_desktop_config.json`. Claude Desktop opens a browser for sign-in and consent the first time it connects.
+For OAuth, add dbt as a custom connector through Claude Desktop's settings &mdash; you don't need to edit `claude_desktop_config.json`.
 
-1. In Claude Desktop, go to **Chat** &rarr; Customize**.
-2. Click **Connectors** and then **Add custom connector**.
-3. Enter a name (for example, `dbt`) and paste your MCP URL (for example, `https://abc123.us1.dbt.com/api/ai/v1/mcp`), then click **Add**.
-4. Click **Connect** on the new dbt connector. Claude Desktop redirects you to dbt to complete the OAuth consent flow, where you can approve or deny individual [scopes](/docs/platform/manage-access/connect-apps-oauth#scopes-and-consent).
-5. After you approve, the connector shows as connected. Ask Claude a data question to confirm.
-
-For the full custom connector flow and screenshots, see [Use with remote MCP](/docs/platform/manage-access/connect-apps-oauth#use-with-remote-mcp).
+<MCPCustomConnectorOauth />
 
 </TabItem>
 <TabItem value="token" label="Token-based">

--- a/website/docs/docs/dbt-ai/integrate-mcp-claude.md
+++ b/website/docs/docs/dbt-ai/integrate-mcp-claude.md
@@ -84,7 +84,7 @@ _OAuth is in private beta for Enterprise and Enterprise+ accounts._
 
 For OAuth, add dbt as a custom connector through Claude Desktop's settings &mdash; you don't need to edit `claude_desktop_config.json`. Claude Desktop opens a browser for sign-in and consent the first time it connects.
 
-1. In Claude Desktop, go to **Settings &rarr; Connectors**.
+1. In Claude Desktop, go to **Chat** &rarr; Customize**.
 2. Click **Add custom connector**.
 3. Enter a name (for example, `dbt`) and paste your MCP URL (for example, `https://abc123.us1.dbt.com/api/ai/v1/mcp`), then click **Add**.
 4. Click **Connect** on the new dbt connector. Claude Desktop redirects you to dbt to complete the OAuth consent flow, where you can approve or deny individual [scopes](/docs/platform/manage-access/connect-apps-oauth#scopes-and-consent).

--- a/website/docs/docs/dbt-ai/mcp-quickstart-remote.md
+++ b/website/docs/docs/dbt-ai/mcp-quickstart-remote.md
@@ -9,6 +9,7 @@ import MCPCreditUsage from '/snippets/_mcp-credit-usage.md';
 import MCPRemoteServerUrl from '/snippets/_mcp-remote-server-url.md';
 import MCPRemoteOauthBetaCallout from '/snippets/_mcp-remote-oauth-beta-callout.md';
 import MCPOauthPreflight from '/snippets/_mcp-oauth-preflight.md';
+import MCPCustomConnectorOauth from '/snippets/_mcp-custom-connector-oauth.md';
 
 # Connect to the remote dbt MCP server <Lifecycle status="self_service,managed,managed_plus"/>
 
@@ -72,6 +73,12 @@ Configure your MCP client with the MCP URL and headers from the previous step.
 <MCPOauthPreflight />
 
 Configure your client with the MCP URL from the previous step. On first connect, your client opens a browser for sign-in and consent.
+
+Some tools (like Claude Desktop) let you add dbt as a custom connector through their UI instead of editing a config file:
+
+<MCPCustomConnectorOauth />
+
+For tools configured with a JSON file, use the tab that matches your client:
 
 <Tabs groupId="client">
 <TabItem value="claude" label="Claude Code">

--- a/website/docs/docs/platform/manage-access/connect-apps-oauth.md
+++ b/website/docs/docs/platform/manage-access/connect-apps-oauth.md
@@ -7,7 +7,7 @@ sidebar_label: "Connect apps with OAuth"
 
 import MCPCustomConnectorOauth from '/snippets/_mcp-custom-connector-oauth.md';
 
-# Connect apps with OAuth <Lifecycle status="beta,managed,managed_plus" />
+# Connect apps with OAuth <Lifecycle status="beta,self_service,managed,managed_plus" />
 
 The **App integrations** section in <Constant name="dbt_platform" /> lets admins manage OAuth 2.0 client registrations &mdash; a standard that lets external apps connect to dbt securely without sharing API tokens. Use it for:
 

--- a/website/docs/docs/platform/manage-access/connect-apps-oauth.md
+++ b/website/docs/docs/platform/manage-access/connect-apps-oauth.md
@@ -5,6 +5,8 @@ id: "connect-apps-oauth"
 sidebar_label: "Connect apps with OAuth"
 ---
 
+import MCPCustomConnectorOauth from '/snippets/_mcp-custom-connector-oauth.md';
+
 # Connect apps with OAuth <Lifecycle status="beta,managed,managed_plus" />
 
 The **App integrations** section in <Constant name="dbt_platform" /> lets admins manage OAuth 2.0 client registrations &mdash; a standard that lets external apps connect to dbt securely without sharing API tokens. Use it for:
@@ -65,18 +67,7 @@ When you connect an MCP client to the [remote dbt MCP server](/docs/dbt-ai/setup
 
 Clients that support dynamic registration complete the registration step automatically &mdash; you'll see them appear in the **Dynamically registered** table after first use.
 
-1. To connect a custom MCP client to dbt, navigate to your AI tool's connector settings and enter your <Constant name="dbt_platform" /> MCP URL. The following example shows how to connect dbt to a custom MCP in Claude Desktop.
-  
-2. Enter a name and paste your MCP URL (for example, `https://abc123.us1.dbt.com/api/ai/v1/mcp`), then click **Add**.
-     <Lightbox src="/img/docs/dbt-cloud/oauth-add-custom-connector.png" title="Custom connector dialog showing the dbt MCP URL" />
-
-3. The tool will redirect you to dbt to complete the OAuth consent flow where you can approve or deny individual [scopes](#scopes-and-consent].
-    <Lightbox src="/img/docs/dbt-cloud/oauth-consent-screen.png" width="60%" title="OAuth consent screen showing requested scopes and project access" />
-
-4. The tool will be added to the **Custom connectors** table and you can then connect it to dbt by clicking **Connect**.
-   <Lightbox src="/img/docs/dbt-cloud/oauth-connectors-page.png" title="Adding a custom dbt connector in an AI tool's connector settings" />
-
-5. That's it 🎉! You can now use the tool to connect to dbt. Ask your tool a question like "What is the total revenue for the last 30 days?" go on from there!
+<MCPCustomConnectorOauth />
 
 For more information on remote MCP OAuth setup, see [Use the remote dbt MCP server](/docs/dbt-ai/mcp-quickstart-remote).
 

--- a/website/snippets/_mcp-custom-connector-oauth.md
+++ b/website/snippets/_mcp-custom-connector-oauth.md
@@ -1,0 +1,10 @@
+The following steps show how to connect dbt as a custom connector in Claude Desktop. The exact UI varies by tool, but the flow is the same: add a custom connector with your MCP URL, complete the OAuth consent flow, then connect.
+
+1. In your AI tool, go to its connector settings and choose to add a custom connector (in Claude Desktop, go to **Chat &rarr; Customize &rarr; Connectors**, then click **Add custom connector**).
+2. Enter a name (for example, `dbt`) and paste your <Constant name="dbt_platform" /> MCP URL (for example, `https://abc123.us1.dbt.com/api/ai/v1/mcp`), then click **Add**.
+   <Lightbox src="/img/docs/dbt-cloud/oauth-add-custom-connector.png" title="Custom connector dialog showing the dbt MCP URL" />
+3. Click **Connect**. The tool redirects you to dbt to complete the OAuth consent flow, where you can approve or deny individual [scopes](/docs/platform/manage-access/connect-apps-oauth#scopes-and-consent).
+   <Lightbox src="/img/docs/dbt-cloud/oauth-consent-screen.png" width="60%" title="OAuth consent screen showing requested scopes and project access" />
+4. After you approve, the connector is added to the **Custom connectors** table and shows as connected.
+   <Lightbox src="/img/docs/dbt-cloud/oauth-connectors-page.png" title="Adding a custom dbt connector in an AI tool's connector settings" />
+5. That's it 🎉! Ask your tool a data question like _"What is the total revenue for the last 30 days?"_ to confirm the connection.

--- a/website/snippets/_mcp-remote-oauth-beta-callout.md
+++ b/website/snippets/_mcp-remote-oauth-beta-callout.md
@@ -1,5 +1,5 @@
 :::info
 
-Remote MCP OAuth is available for Enterprise and Enterprise+ accounts. Contact your account manager to join the private beta.
+Remote MCP OAuth is available for Starter, Enterprise, and Enterprise+ accounts. 
 
 :::


### PR DESCRIPTION
Updates the OAuth (remote) path in the [Set up with remote dbt MCP server](https://docs.getdbt.com/docs/dbt-ai/integrate-mcp-claude#desktop-remote) section to match the custom connector route documented on the [Connect apps with OAuth](https://docs.getdbt.com/docs/platform/manage-access/connect-apps-oauth#use-with-remote-mcp) page. The two pages had drifted, and the custom connector route (until we have a listed connector) has been easier for users to set up.

## Changes
- **OAuth (remote) tab** in `#desktop-remote` now uses the custom connector UI flow (**Settings → Connectors → Add custom connector**, paste the MCP URL, **Connect**, complete OAuth consent) instead of hand-editing `claude_desktop_config.json`. Links out to the OAuth page for the full flow and screenshots.
- Moved "Get your MCP URL" above the tabs so it applies to both auth methods.
- **Token-based tab** keeps the `claude_desktop_config.json` JSON route, with self-contained step numbering.
- Left the Claude Code `#code-remote` section unchanged, since the custom connector UI is a Claude Desktop feature (Claude Code uses `.mcp.json` / `claude mcp add`).

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-remote-connector-dbt-labs.vercel.app/docs/dbt-ai/integrate-mcp-claude
- https://docs-getdbt-com-git-update-remote-connector-dbt-labs.vercel.app/docs/dbt-ai/mcp-quickstart-remote
- https://docs-getdbt-com-git-update-remote-connector-dbt-labs.vercel.app/docs/platform/manage-access/connect-apps-oauth

<!-- end-vercel-deployment-preview -->