### PR TITLE
Re-add user_credential_write entry

### DIFF
--- a/website/docs/docs/dbt-versions/release-notes.md
+++ b/website/docs/docs/dbt-versions/release-notes.md
@@ -46,6 +46,7 @@ The following features are new or enhanced as part of dbt Labs announcements at 
 
 ## May 2026
 
+- **Enhancement:** Users granted `user_credential_write` can access **Your profile** > **Credentials** without `develop_access` (including read-only users). Environment variable overrides and dbt version overrides still require `develop_access`. Refer to [Enterprise permissions](/docs/platform/manage-access/enterprise-permissions) for more information.
 - **New:** The [Job creator permission set](/docs/platform/manage-access/enterprise-permissions#job-creator) is now available for Enterprise accounts. Assign it to users who need to create, edit, and run jobs within assigned projects and environments without access to edit environments or environment variables.
 - **Enhancement:** The admin API toolset (job management and run operations) is now always available in the <Constant name="dbt" /> <Constant name="copilot" /> [<Constant name="dev_agent" />](/docs/dbt-ai/wizard-ide) and no longer requires a feature flag. You no longer need to contact your account manager to enable these tools.
 - **Fix:** When a job cannot clone its repository because no remote URL is configured, the error message now explains the most likely causes (an invalid Git remote URL, a Git provider outage, or a deprecated HTTPS connection) and directs you to verify the URL, confirm your provider is operational, and ensure the repository uses SSH with deploy keys before retrying.

--- a/website/docs/docs/platform/manage-access/about-access.md
+++ b/website/docs/docs/platform/manage-access/about-access.md
@@ -148,9 +148,11 @@ import LicenseOverrideNote from '/snippets/_license-override-note.md';
 
 ### Permissions
 
-Permissions determine what a developer-licensed user can do in your <Constant name="dbt" /> account. By default, members of the `Owner` and `Member` groups have full access to all areas and features. When you want to restrict access to features, assign users to groups with stricter permission sets. Keep in mind that if a user belongs to multiple groups, the most permissive group will take precedence.
+Permissions determine what users can do in your <Constant name="dbt" /> account. By default, members of the `Owner` and `Member` groups have full access to all areas and features. When you want to restrict access to features, assign users to groups with stricter permission sets. Keep in mind that if a user belongs to multiple groups, the most permissive group will take precedence.
 
-The permissions available depends on whether you're on an [Enterprise, Enterprise+](/docs/platform/manage-access/enterprise-permissions), or [self-service Starter](/docs/platform/manage-access/self-service-permissions) plan. Developer accounts only have a single user, so permissions aren't applicable.
+The permissions available depend on whether you're on an [Enterprise, Enterprise+](/docs/platform/manage-access/enterprise-permissions), or [self-service Starter](/docs/platform/manage-access/self-service-permissions) plan. Developer accounts only have a single user, so permissions aren't applicable.
+
+Some access to user settings (for example, under **Your profile**, select **Credentials**) can be granted with additional permissions (such as `user_credential_write`). Refer to [Enterprise permissions](/docs/platform/manage-access/enterprise-permissions) for more information.
 
 <Lightbox src="/img/docs/dbt-platform/dbt-platform-enterprise/access-control/assign-group-permissions.png" width="60%" title="Example permissions dropdown while editing an existing group." />
 

--- a/website/docs/docs/platform/manage-access/about-access.md
+++ b/website/docs/docs/platform/manage-access/about-access.md
@@ -152,7 +152,7 @@ Permissions determine what users can do in your <Constant name="dbt" /> account.
 
 The permissions available depend on whether you're on an [Enterprise, Enterprise+](/docs/platform/manage-access/enterprise-permissions), or [self-service Starter](/docs/platform/manage-access/self-service-permissions) plan. Developer accounts only have a single user, so permissions aren't applicable.
 
-Some access to user settings (for example, under **Your profile**, select **Credentials**) can be granted with additional permissions (such as `user_credential_write`). Refer to [Enterprise permissions](/docs/platform/manage-access/enterprise-permissions) for more information.
+Some access to user settings (for example, **Credentials** settings in **Your profile**) can be granted with additional permissions (such as `user_credential_write`). Refer to [Enterprise permissions](/docs/platform/manage-access/enterprise-permissions) for more information.
 
 <Lightbox src="/img/docs/dbt-platform/dbt-platform-enterprise/access-control/assign-group-permissions.png" width="60%" title="Example permissions dropdown while editing an existing group." />
 

--- a/website/snippets/_enterprise-permissions-table.md
+++ b/website/snippets/_enterprise-permissions-table.md
@@ -48,6 +48,12 @@ Key:
 
 <sup>**</sup>**Cost Insights Admin** can edit [platform metadata credentials](/docs/explore/set-up-cost-insights#configure-platform-metadata-credentials) and [Cost Insights](/docs/explore/set-up-cost-insights) settings in **Connection settings**, even though **Connections** is read-only (**R**) for this permission set.
 
+::::note Credentials access
+Users can access the **Credentials** page under **Your profile** when they have `develop_access` or `user_credential_write` on at least one project.
+
+An admin can grant `user_credential_write` to any group, regardless of which permission set the group is assigned. Environment variable overrides and dbt version overrides still require `develop_access`.
+::::
+
 
 #### Project access for account permissions
 


### PR DESCRIPTION
This PR:

- Re-adds a release note entry to dbt release notes describing expanded access to Your profile > Credentials for users granted user_credential_write.
- Re-add a callout to Enterprise permissions (the table snippet rendered on that page) explaining `user_credential_write` access to Your profile > Credentials, and that env var and dbt version overrides still require develop_access.
Re-adds a short mention to About user access page pointing readers to Enterprise permissions and calling out `user_credential_write` for Your profile > Credentials access.
- Small editorial cleanup

This PR was initially created under: [9116](https://github.com/dbt-labs/docs.getdbt.com/pull/9116) but was removed following a merge conflict.

Used cursor to track the source:

- Source (internal)
Promoted from docs-internal PR [#1899](https://github.com/dbt-labs/docs-internal/pull/1899) — titled "[Megabranch DO NOT MERGE] 
- What it was for
Snowflake Summit / June launch content, including:
- dbt Wizard docs (new pages, CLI reference, renames from Developer agent / Copilot)
- dbt Core v2.0 blog and upgrade docs
- Adapter creation guides
- VS Code extension updates
- New June 2026 section in `release-notes.md`

- How it hit my work
- That merge rebased a lot of files on top of current. My #9116 edits in `release-notes.md, about-access.md`, and `_enterprise-permissions-table.md` were overwritten in the conflict resolutio

Timeline: #9116 merged May 27 → June 1 megabranch landed ~5 days later and reverted those three files.

## Checklist
<!-- Ensure your PR meets the following items. Feel free to add additional checklist items to the list if additional checks need to happen before the PR is merged, such as:
- [ ] Needs technical review
- [ ] Change base branch
- [ ] Merge on xyz date
-->
- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).
<!--
PRE-RELEASE VERSION OF dbt (if so, uncomment):
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
<!-- 
ADDING OR REMOVING PAGES (if so, uncomment):
- [ ] Add/remove page in `website/sidebars.js`
- [ ] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages
-->

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-nfiann-readdentry-dbt-labs.vercel.app/best-practices/how-we-mesh/mesh-6-coordinate-versions
- https://docs-getdbt-com-git-nfiann-readdentry-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/02-upgrading-to-fusion
- https://docs-getdbt-com-git-nfiann-readdentry-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/03-upgrading-to-v1.12
- https://docs-getdbt-com-git-nfiann-readdentry-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/04-upgrading-to-v1.11
- https://docs-getdbt-com-git-nfiann-readdentry-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/05-upgrading-to-v1.10
- https://docs-getdbt-com-git-nfiann-readdentry-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/06-upgrading-to-v1.9
- https://docs-getdbt-com-git-nfiann-readdentry-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/07-upgrading-to-v1.8
- https://docs-getdbt-com-git-nfiann-readdentry-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/08-upgrading-to-v1.7
- https://docs-getdbt-com-git-nfiann-readdentry-dbt-labs.vercel.app/docs/dbt-versions/release-notes
- https://docs-getdbt-com-git-nfiann-readdentry-dbt-labs.vercel.app/docs/platform/manage-access/about-access

<!-- end-vercel-deployment-preview -->