### PR TITLE
Add dbt Wizard demo video link to wizard overview page

### DIFF
--- a/website/docs/docs/dbt-ai/wizard-cli.md
+++ b/website/docs/docs/dbt-ai/wizard-cli.md
@@ -23,6 +23,8 @@ Install the <Constant name="wizard" /> CLI from your terminal for agentic and go
 This guide explains how to install, verify, update, and uninstall the <Constant name="wizard" /> CLI on your local machine.
 (Be warned, the wizard has been known to <WizardPopcorn>cast spells</WizardPopcorn>)
 
+To learn more about <Constant name="wizard" /> and see it in action, check out the [demo video](https://www.youtube.com/watch?v=-lIzh1xQWMA)!
+
 ## Install dbt Wizard CLI
 
 <WizardCliInstall />

--- a/website/docs/docs/platform/wizard-overview.md
+++ b/website/docs/docs/platform/wizard-overview.md
@@ -23,6 +23,8 @@ Your personal dbt agent &mdash; wherever you work.
 
 Think of it like a map of your city: <Constant name="wizard" /> knows how everything connects before it starts, rather than walking every street to figure out the layout.
 
+To learn more about <Constant name="wizard" /> and see it in action, check out the [demo video](https://www.youtube.com/watch?v=-lIzh1xQWMA)!
+
 <Constant name="wizard"/> comes with the following capabilities:
 
 - **Project understanding:** A native dbt metadata engine for lineage, contracts, tests, and runtime context


### PR DESCRIPTION
Adds a sentence linking to the dbt Wizard demo video on the [wizard overview page](https://docs.getdbt.com/docs/platform/wizard-overview).


<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-claude-brave-khorana-d7bd7f-dbt-labs.vercel.app/docs/dbt-ai/wizard-cli
- https://docs-getdbt-com-git-claude-brave-khorana-d7bd7f-dbt-labs.vercel.app/docs/platform/wizard-overview

<!-- end-vercel-deployment-preview -->