### PR TITLE
Upgrade guide updates for dbt State + dbt login

### DIFF
--- a/website/docs/docs/dbt-versions/core-upgrade/02-upgrading-to-fusion.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/02-upgrading-to-fusion.md
@@ -53,14 +53,6 @@ The most popular `dbt-labs` packages (`dbt_utils`, `audit_helper`, `dbt_external
 
 ## New and changed features and functionality
 
-### dbt State <Lifecycle status="preview" />
-
-dbt State makes dbt smarter about what to build &mdash; instead of rebuilding every node on every run, dbt reuses nodes by cloning from another location or skipping a rebuild when the logic and data haven't changed. dbt State is natively available in the <Constant name="fusion_engine" />.
-
-To enable dbt State locally, run [`dbt login`](/reference/commands/login#dbt-login-with-dbt-state) from your CLI. It opens a browser window to sign in to your <Constant name="dbt_platform" /> account or create a free one, then automatically writes `manage_state: true` to [`~/.dbt/user_settings.yml`](/reference/global-configs/user-settings) &mdash; enabling dbt State on every `dbt run` or `dbt build` for you. 
-
-To enable dbt State for everyone on your project, add [`manage_state: true`](/reference/global-configs/about-global-configs) to the `flags:` block in `dbt_project.yml`. You can also enable or disable dbt State per run using [CLI flags](/reference/global-configs/about-global-configs): `--manage-state` or `--no-manage-state`, or set the `DBT_ENGINE_MANAGE_STATE=1` environment variable. For more information, refer to [About dbt State](/docs/deploy/dbt-state-about) and [Setting up dbt State](/docs/deploy/dbt-state-setup).
-
 ### Changed functionality
 
 When developing the Fusion engine, there were opportunities to improve the dbt framework - failing earlier (when possible), fixing bugs, optimizing run order, and deprecating flags that are no longer relevant. The result is a handful of specific and nuanced changes to existing behavior.

--- a/website/docs/docs/dbt-versions/core-upgrade/03-upgrading-to-v1.12.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/03-upgrading-to-v1.12.md
@@ -24,15 +24,15 @@ dbt Labs is committed to providing backward compatibility for all versions 1.x. 
 
 dbt State makes dbt smarter about what to build &mdash; instead of rebuilding every node on every run, dbt reuses nodes by cloning from another location or skipping a rebuild when the logic and data haven't changed. dbt State is natively available in <Constant name="core" /> v1.12.
 
-To enable dbt State locally, run [`dbt login`](/reference/commands/login#dbt-login-with-dbt-state). It opens a browser window to sign in to your <Constant name="dbt_platform" /> account or create a free one, then automatically writes `manage_state: true` to [`~/.dbt/user_settings.yml`](/reference/global-configs/user-settings); enabling dbt State on every `dbt run` or `dbt build` for you. 
+To enable dbt State locally, run [`dbt login`](/reference/commands/login#dbt-login-with-dbt-state).
 
 To enable dbt State for everyone on your project, add [`manage_state: true`](/reference/global-configs/about-global-configs) to the `flags:` block in `dbt_project.yml` instead. You can also enable or disable dbt State per run using [CLI flags](/reference/global-configs/about-global-configs): `--manage-state` or `--no-manage-state`, or set the `DBT_ENGINE_MANAGE_STATE=1` environment variable. For more information, refer to [About dbt State](/docs/deploy/dbt-state-about) and [Setting up dbt State](/docs/deploy/dbt-state-setup).
 
 ### `dbt login`
 
-`dbt login` signs you in to dbt from the command line to access features that require authentication. It opens a browser prompt to sign in to an existing dbt platform account or create a free one. Run `dbt login` status to check your current authentication status.
+In <Constant name="core" /> v1.12, [`dbt login`](/reference/commands/login) is used exclusively to enable [dbt State](/reference/commands/login#dbt-login-with-dbt-state). It opens a browser window prompting you to sign in to your <Constant name="dbt_platform" /> account or create a free one. It automatically sets `manage_state: true` in [`~/.dbt/user_settings.yml`](/reference/global-configs/user-settings), enabling dbt State on every `dbt run` or `dbt build`.
 
-Use `dbt login` for [dbt State](/reference/commands/login#dbt-login-with-dbt-state) or local development (interactive authentication) on macOS, Linux, or Windows. Refer to [`dbt login`](/reference/commands/login) for more info.
+In the <Constant name="fusion_engine" />, `dbt login` unlocks a broader set of features beyond dbt State, such as advanced features in the [dbt VS Code extension](/docs/about-dbt-extension) and the v2.0 CLI. It also checks whether dbt State is enabled in your <Constant name="dbt_platform" /> account and on your machine, and prompts you before making any local changes. For details, refer to [`dbt login` with dbt State](/reference/commands/login#dbt-login-with-dbt-state).
 
 ### Opt-in v2 parser <Lifecycle status="beta" />
 

--- a/website/docs/docs/dbt-versions/core-upgrade/04-upgrading-to-v1.11.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/04-upgrading-to-v1.11.md
@@ -23,10 +23,6 @@ Starting in 2024, <Constant name="dbt" /> provides the functionality from new ve
 
 New features and functionality available in <Constant name="core" /> v1.11
 
-### dbt State <Lifecycle status="preview" />
-
-dbt State makes dbt smarter about what to build &mdash; instead of rebuilding every node on every run, dbt reuses nodes by cloning from another location or skipping a rebuild when the logic and data haven't changed. dbt State is available as a plugin for <Constant name="core" /> v1.11. For more information, refer to [About dbt State](/docs/deploy/dbt-state-about) and [Setting up dbt State](/docs/deploy/dbt-state-setup).
-
 ### User-defined functions (UDFs)
 
 dbt Core v1.11 introduces support for user-defined functions (UDFs), which enable you to define and register custom functions in your warehouse. Like macros, UDFs promote code reuse, but they are objects in the warehouse so you can reuse the same logic in tools outside dbt.

--- a/website/docs/docs/dbt-versions/core-upgrade/05-upgrading-to-v1.10.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/05-upgrading-to-v1.10.md
@@ -21,11 +21,6 @@ Starting in 2024, <Constant name="dbt" /> provides the functionality from new ve
 
 New features and functionality available in <Constant name="core" /> v1.10
 
-### dbt State <Lifecycle status="preview" />
-
-dbt State makes dbt smarter about what to build &mdash; instead of rebuilding every node on every run, dbt reuses nodes by cloning from another location or skipping a rebuild when the logic and data haven't changed. dbt State is available as a plugin for <Constant name="core" /> v1.10. For more information, refer to [About dbt State](/docs/deploy/dbt-state-about) and [Setting up dbt State](/docs/deploy/dbt-state-setup).
-
-
 ### The `--sample` flag
 
 Large data sets can slow down dbt build times, making it harder for developers to test new code efficiently. The [`--sample` flag](/docs/build/sample-flag), available for the `run` and `build` commands, helps reduce build times and warehouse costs by running dbt in sample mode. It generates filtered refs and sources using time-based sampling, allowing developers to validate outputs without building entire models.

--- a/website/docs/docs/dbt-versions/core-upgrade/06-upgrading-to-v1.9.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/06-upgrading-to-v1.9.md
@@ -21,11 +21,6 @@ Starting in 2024, <Constant name="dbt" /> provides the functionality from new ve
 
 Features and functionality new in dbt v1.9.
 
-### dbt State <Lifecycle status="preview" />
-
-dbt State makes dbt smarter about what to build &mdash; instead of rebuilding every node on every run, dbt reuses nodes by cloning from another location or skipping a rebuild when the logic and data haven't changed. dbt State is available as a plugin for <Constant name="core" /> v1.9. For more information, refer to [About dbt State](/docs/deploy/dbt-state-about) and [Setting up dbt State](/docs/deploy/dbt-state-setup).
-
-
 ### Microbatch `incremental_strategy`
 
 :::info 

--- a/website/docs/docs/dbt-versions/core-upgrade/07-upgrading-to-v1.8.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/07-upgrading-to-v1.8.md
@@ -27,10 +27,6 @@ import SnowflakeColumn from '/snippets/_snowflake-column-size.md';
 
 <SnowflakeColumn />
 
-### dbt State <Lifecycle status="preview" />
-
-dbt State makes dbt smarter about what to build &mdash; instead of rebuilding every node on every run, dbt reuses nodes by cloning from another location or skipping a rebuild when the logic and data haven't changed. dbt State is available as a plugin for <Constant name="core" /> v1.8. For more information, refer to [About dbt State](/docs/deploy/dbt-state-about) and [Setting up dbt State](/docs/deploy/dbt-state-setup).
-
 ### Unit Tests
 
 Historically, dbt's test coverage was confined to [“data” tests](/docs/build/data-tests), assessing the quality of input data or resulting datasets' structure.

--- a/website/docs/docs/dbt-versions/core-upgrade/08-upgrading-to-v1.7.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/08-upgrading-to-v1.7.md
@@ -41,10 +41,6 @@ To retain the behavior prior to v1.7, there are two main options:
 - [`dbt docs generate`](/reference/commands/cmd-docs) now supports `--select` to generate [catalog metadata](/reference/artifacts/catalog-json) for a subset of your project.
 - [Source freshness](/docs/deploy/source-freshness) can now be generated from warehouse metadata tables.
 
-### dbt State <Lifecycle status="preview" />
-
-dbt State makes dbt smarter about what to build &mdash; instead of rebuilding every node on every run, dbt reuses nodes by cloning from another location or skipping a rebuild when the logic and data haven't changed. dbt State is available as a plugin for <Constant name="core" /> v1.7. For more information, refer to [About dbt State](/docs/deploy/dbt-state-about) and [Setting up dbt State](/docs/deploy/dbt-state-setup).
-
 ### MetricFlow enhancements
 
 - Automatically create metrics on measures with [`create_metric: true`](/docs/build/semantic-models).


### PR DESCRIPTION
## Summary

Following feedback in [this Slack thread](https://dbt-labs.slack.com/archives/C08PYQS8B7Z/p1780496922355509?thread_ts=1780410113.211389&cid=C08PYQS8B7Z), dbt State is not exclusive to Fusion or any specific version — it's available across dbt Core v1.7+ and should not be called out in individual upgrade guides as a version-specific feature.

- **Removed** the `### dbt State` section from upgrade guides for v1.7, v1.8, v1.9, v1.10, v1.11, and the Fusion upgrade guide
- **Kept** the `### dbt State` section in the v1.12 upgrade guide — v1.12 is the first version where dbt State is natively available (no `pip install dbt-state` plugin required)
- **Updated** the `### dbt login` section in v1.12 to clarify that in v1.12, `dbt login` is used exclusively to enable dbt State, whereas in Fusion it unlocks a broader set of features (dbt VS Code extension, v2.0 CLI) and prompts you before making any local changes rather than auto-enabling dbt State locally


🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preview
- [Upgrade guide for 1.12](https://docs-getdbt-com-git-upgrade-guide-update-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/upgrading-to-v1.12?version=2.0)

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-upgrade-guide-update-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/02-upgrading-to-fusion
- https://docs-getdbt-com-git-upgrade-guide-update-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/03-upgrading-to-v1.12
- https://docs-getdbt-com-git-upgrade-guide-update-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/04-upgrading-to-v1.11
- https://docs-getdbt-com-git-upgrade-guide-update-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/05-upgrading-to-v1.10
- https://docs-getdbt-com-git-upgrade-guide-update-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/06-upgrading-to-v1.9
- https://docs-getdbt-com-git-upgrade-guide-update-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/07-upgrading-to-v1.8
- https://docs-getdbt-com-git-upgrade-guide-update-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/08-upgrading-to-v1.7

<!-- end-vercel-deployment-preview -->