### PR TITLE
Clarify managed AI provider keys

### DIFF
--- a/website/docs/docs/platform/enable-dbt-ai.md
+++ b/website/docs/docs/platform/enable-dbt-ai.md
@@ -63,7 +63,7 @@ Snowflake Cortex, AWS Bedrock, Azure AI Foundry, and Anthropic aren't supported 
 
 Once AI features have been [enabled](#enable-ai-features), Enterprise and Enterprise+ accounts can configure a custom AI provider. If you bring your own provider, you will incur API calls and associated charges from that provider.
 
-\* *Managed (or Managed by <Constant name="dbt" /> Labs): <Constant name="dbt" /> Labs manages the AI provider connection; no user provider key is required. Refer to [Billing](/docs/platform/billing?version=2.0&name=Fusion#temporary-dbt-copilot-actions-bridge-through-july-1) for more info.*
+\* *Managed (or Managed by <Constant name="dbt" /> Labs): <Constant name="dbt" /> Labs manages the AI provider connection; no user provider key is required. Refer to [Billing](/docs/platform/billing?version=2.0&name=Fusion#temporary-dbt-copilot-actions-bridge-through-july-1) for more information.*
 
 ### dbt Wizard
 
@@ -78,7 +78,7 @@ To configure your AI provider for <Constant name="wizard" />:
 
   <TabItem value="openai" label="OpenAI">
 
-  **Managed\* by <Constant name="dbt" /> Labs** (default, no setup required). Refer to [Billing](/docs/platform/billing?version=2.0&name=Fusion#temporary-dbt-copilot-actions-bridge-through-july-1) for more info.*
+  **Managed\* by <Constant name="dbt" /> Labs** (default, no setup required). Refer to [Billing](/docs/platform/billing?version=2.0&name=Fusion#temporary-dbt-copilot-actions-bridge-through-july-1) for more information.*
 
   1. Select the toggle for **<Constant name="dbt" /> Labs** to use <Constant name="dbt" /> Labs' managed* OpenAI key.
   2. Click **Save**.
@@ -128,7 +128,7 @@ To configure your AI provider for <Constant name="wizard" />:
 
   <TabItem value="anthropic" label="Anthropic">
 
-  **Managed\* by <Constant name="dbt" /> Labs** (default, no setup required). Refer to [Billing](/docs/platform/billing?version=2.0&name=Fusion#temporary-dbt-copilot-actions-bridge-through-july-1) for more info.*
+  **Managed\* by <Constant name="dbt" /> Labs** (default, no setup required). Refer to [Billing](/docs/platform/billing?version=2.0&name=Fusion#temporary-dbt-copilot-actions-bridge-through-july-1) for more information.*
 
   1. Select **<Constant name="dbt" /> Labs** from the list to use <Constant name="dbt" /> Labs' managed* Anthropic key.
   2. Click **Save**.

--- a/website/docs/docs/platform/enable-dbt-ai.md
+++ b/website/docs/docs/platform/enable-dbt-ai.md
@@ -47,7 +47,7 @@ Note: To disable (only after enabled), repeat steps 1 to 3, toggle off in step 4
 
 dbt Copilot supports different AI providers, including bring your own key (BYOK) for Enterprise and Enterprise+ plans:
 
-- dbt Labs-managed* OpenAI API key
+- dbt Labs-<Term id="managed" /> OpenAI API key
 - BYOK OpenAI API key
 - BYOK Azure OpenAI API key
 

--- a/website/docs/docs/platform/enable-dbt-ai.md
+++ b/website/docs/docs/platform/enable-dbt-ai.md
@@ -47,7 +47,7 @@ Note: To disable (only after enabled), repeat steps 1 to 3, toggle off in step 4
 
 dbt Copilot supports different AI providers, including bring your own key (BYOK) for Enterprise and Enterprise+ plans:
 
-- dbt Labs-managed OpenAI API key
+- dbt Labs-managed* OpenAI API key
 - BYOK OpenAI API key
 - BYOK Azure OpenAI API key
 
@@ -63,6 +63,8 @@ Snowflake Cortex, AWS Bedrock, Azure AI Foundry, and Anthropic aren't supported 
 
 Once AI features have been [enabled](#enable-ai-features), Enterprise and Enterprise+ accounts can configure a custom AI provider. If you bring your own provider, you will incur API calls and associated charges from that provider.
 
+\* *Managed (or Managed by <Constant name="dbt" /> Labs): <Constant name="dbt" /> Labs manages the AI provider connection; no user provider key is required.*
+
 ### dbt Wizard
 
 To configure your AI provider for <Constant name="wizard" />:
@@ -76,9 +78,9 @@ To configure your AI provider for <Constant name="wizard" />:
 
   <TabItem value="openai" label="OpenAI">
 
-  **Managed by <Constant name="dbt" /> Labs** (default, no setup required)
+  **Managed\* by <Constant name="dbt" /> Labs** (default, no setup required)
 
-  1. Select the toggle for **<Constant name="dbt" /> Labs** to use <Constant name="dbt" /> Labs' managed OpenAI key.
+  1. Select the toggle for **<Constant name="dbt" /> Labs** to use <Constant name="dbt" /> Labs' managed* OpenAI key.
   2. Click **Save**.
 
   <Lightbox src="/img/docs/dbt-platform/account-integration-dbtlabs.png" width="85%" title="Example of the dbt Labs integration page" />
@@ -126,9 +128,9 @@ To configure your AI provider for <Constant name="wizard" />:
 
   <TabItem value="anthropic" label="Anthropic">
 
-  **Managed by <Constant name="dbt" /> Labs** (default, no setup required)
+  **Managed\* by <Constant name="dbt" /> Labs** (default, no setup required)
 
-  1. Select **<Constant name="dbt" /> Labs** from the list to use <Constant name="dbt" /> Labs' managed Anthropic key.
+  1. Select **<Constant name="dbt" /> Labs** from the list to use <Constant name="dbt" /> Labs' managed* Anthropic key.
   2. Click **Save**.
 
   **Managed by you** (Enterprise or Enterprise+ plans)
@@ -157,7 +159,7 @@ To configure your AI provider for dbt Copilot:
 <Tabs queryString="ai-integration"> 
   <TabItem value="dbtlabs" label="dbt Labs OpenAI">
 
-  1. Select the toggle for **dbt Labs** to use dbt Labs' managed OpenAI key.
+  1. Select the toggle for **dbt Labs** to use dbt Labs' managed* OpenAI key.
   2. Click **Save**.
 
   <Lightbox src="/img/docs/dbt-platform/account-integration-dbtlabs.png" width="85%" title="Example of the dbt Labs integration page" />

--- a/website/docs/docs/platform/enable-dbt-ai.md
+++ b/website/docs/docs/platform/enable-dbt-ai.md
@@ -63,7 +63,7 @@ Snowflake Cortex, AWS Bedrock, Azure AI Foundry, and Anthropic aren't supported 
 
 Once AI features have been [enabled](#enable-ai-features), Enterprise and Enterprise+ accounts can configure a custom AI provider. If you bring your own provider, you will incur API calls and associated charges from that provider.
 
-\* *Managed (or Managed by <Constant name="dbt" /> Labs): <Constant name="dbt" /> Labs manages the AI provider connection; no user provider key is required.*
+\* *Managed (or Managed by <Constant name="dbt" /> Labs): <Constant name="dbt" /> Labs manages the AI provider connection; no user provider key is required. Refer to [Billing](/docs/platform/billing?version=2.0&name=Fusion#temporary-dbt-copilot-actions-bridge-through-july-1) for more info.*
 
 ### dbt Wizard
 
@@ -78,7 +78,7 @@ To configure your AI provider for <Constant name="wizard" />:
 
   <TabItem value="openai" label="OpenAI">
 
-  **Managed\* by <Constant name="dbt" /> Labs** (default, no setup required)
+  **Managed\* by <Constant name="dbt" /> Labs** (default, no setup required). Refer to [Billing](/docs/platform/billing?version=2.0&name=Fusion#temporary-dbt-copilot-actions-bridge-through-july-1) for more info.*
 
   1. Select the toggle for **<Constant name="dbt" /> Labs** to use <Constant name="dbt" /> Labs' managed* OpenAI key.
   2. Click **Save**.
@@ -128,7 +128,7 @@ To configure your AI provider for <Constant name="wizard" />:
 
   <TabItem value="anthropic" label="Anthropic">
 
-  **Managed\* by <Constant name="dbt" /> Labs** (default, no setup required)
+  **Managed\* by <Constant name="dbt" /> Labs** (default, no setup required). Refer to [Billing](/docs/platform/billing?version=2.0&name=Fusion#temporary-dbt-copilot-actions-bridge-through-july-1) for more info.*
 
   1. Select **<Constant name="dbt" /> Labs** from the list to use <Constant name="dbt" /> Labs' managed* Anthropic key.
   2. Click **Save**.

--- a/website/docs/docs/platform/wizard-overview.md
+++ b/website/docs/docs/platform/wizard-overview.md
@@ -36,7 +36,7 @@ Think of it like a map of your city: <Constant name="wizard" /> knows how everyt
 ## Use dbt Wizard
 <Constant name="wizard" /> is available in:
 
-- **[<Constant name="dbt_platform" />](/docs/platform/wizard-platform)**:  Use managed* AI provider keys or bring your own key (BYOK) credentials for a [supported provider](#supported-ai-providers). Available in public preview for <Constant name="studio_ide"/> and in public beta for the <Constant name="wizard"/> home tab.
+- **[<Constant name="dbt_platform" />](/docs/platform/wizard-platform)**:  Use <Term id="managed" /> AI provider keys or bring your own key (BYOK) credentials for a [supported provider](#supported-ai-providers). Available in public preview for <Constant name="studio_ide"/> and in public beta for the <Constant name="wizard"/> home tab.
 - **[Terminal](/docs/dbt-ai/wizard-cli)** (public beta): Use BYOK credentials for a [supported provider](#supported-ai-providers).
 
 For more info on pricing, refer to the [Billing](/docs/platform/billing) page.

--- a/website/docs/docs/platform/wizard-overview.md
+++ b/website/docs/docs/platform/wizard-overview.md
@@ -36,7 +36,7 @@ Think of it like a map of your city: <Constant name="wizard" /> knows how everyt
 ## Use dbt Wizard
 <Constant name="wizard" /> is available in:
 
-- **[<Constant name="dbt_platform" />](/docs/platform/wizard-platform)**:  Use managed AI provider keys or bring your own key (BYOK) credentials for a [supported provider](#supported-ai-providers). Available in public preview for <Constant name="studio_ide"/> and in public beta for the <Constant name="wizard"/> home tab.
+- **[<Constant name="dbt_platform" />](/docs/platform/wizard-platform)**:  Use managed* AI provider keys or bring your own key (BYOK) credentials for a [supported provider](#supported-ai-providers). Available in public preview for <Constant name="studio_ide"/> and in public beta for the <Constant name="wizard"/> home tab.
 - **[Terminal](/docs/dbt-ai/wizard-cli)** (public beta): Use BYOK credentials for a [supported provider](#supported-ai-providers).
 
 For more info on pricing, refer to the [Billing](/docs/platform/billing) page.

--- a/website/docs/terms/hover-terms.md
+++ b/website/docs/terms/hover-terms.md
@@ -99,6 +99,10 @@ lsp:
   displayText: LSP
   hoverSnippet: Language Server Protocol (LSP) enables developer features like live CTE previews, hover info, error highlighting, and more.
 
+managed:
+  displayText: managed
+  hoverSnippet: dbt Labs manages the AI provider connection; no user provider key is required. Refer to Billing for more information.
+
 materialization:
   displayText: materialization
   hoverSnippet: The exact Data Definition Language (DDL) that dbt will use when creating the model’s equivalent in a data warehouse.

--- a/website/snippets/_wizard-supported-providers.md
+++ b/website/snippets/_wizard-supported-providers.md
@@ -15,7 +15,7 @@
 | [Snowflake Cortex](https://www.snowflake.com/en/legal/terms-of-service/) | - | ✓ (BYOK) |
 </SimpleTable>
 
-\* *Managed: <Constant name="dbt" /> Labs manages the AI provider connection; no user provider key is required.*
+\* *Managed: <Constant name="dbt" /> Labs manages the AI provider connection; no user provider key is required. Refer to [Billing](/docs/platform/billing?version=2.0&name=Fusion#temporary-dbt-copilot-actions-bridge-through-july-1) for more info.*
 
 <br />
 

--- a/website/snippets/_wizard-supported-providers.md
+++ b/website/snippets/_wizard-supported-providers.md
@@ -8,12 +8,14 @@
 
 | Provider | <Constant name="wizard" /> in <Constant name="dbt_platform" /> | <Constant name="wizard" /> CLI |
 |---|---|---|
-| [OpenAI](https://openai.com/policies/row-terms-of-use/) | ✓ (managed or BYOK) | ✓ (OpenAI subscription or BYOK) |
+| [OpenAI](https://openai.com/policies/row-terms-of-use/) | ✓ (managed* or BYOK) | ✓ (OpenAI subscription or BYOK) |
 | [Anthropic](https://www.anthropic.com/legal/consumer-terms) | ✓ (BYOK) | ✓ (BYOK) |
 | [Azure AI Foundry](https://www.microsoft.com/licensing/terms) / Azure OpenAI | ✓ (BYOK) | ✓ (BYOK) |
 | [AWS Bedrock](https://aws.amazon.com/service-terms/) |- | ✓ (BYOK) |
 | [Snowflake Cortex](https://www.snowflake.com/en/legal/terms-of-service/) | - | ✓ (BYOK) |
 </SimpleTable>
+
+\* *Managed: <Constant name="dbt" /> Labs manages the AI provider connection; no user provider key is required.*
 
 <br />
 


### PR DESCRIPTION
## What this does

Adds an asterisk (\*) to every "managed" / "dbt Labs-managed" reference tied to AI provider keys, with a footnote explaining: *dbt Labs manages the AI provider connection; no user provider key is required.*

## Files updated

- `website/snippets/_wizard-supported-providers.md` — `managed*` in the OpenAI row plus a footnote below the table (this snippet is embedded in the wizard quickstart and overview pages).
- `website/docs/docs/platform/wizard-overview.md` — `managed*` AI provider keys.
- `website/docs/docs/platform/enable-dbt-ai.md` — asterisks on the dbt Copilot "dbt Labs-managed*" bullet, the OpenAI and Anthropic "Managed* by dbt Labs" labels, the "managed* OpenAI/Anthropic key" steps, plus a footnote under the **Configure AI provider** heading.

## Notes

- "Managed by you" labels are left untouched, since the footnote applies only to dbt Labs–managed connections.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-clarify-managed-dbt-labs.vercel.app/docs/platform/enable-dbt-ai
- https://docs-getdbt-com-git-update-clarify-managed-dbt-labs.vercel.app/docs/platform/wizard-overview

<!-- end-vercel-deployment-preview -->