### PR TITLE
Update static analysis docs for core v2

### DIFF
--- a/website/docs/docs/fusion/new-concepts.md
+++ b/website/docs/docs/fusion/new-concepts.md
@@ -160,15 +160,10 @@ Setting `static_analysis` to `baseline` mode lets you start using <Constant name
 
 ## Recapping the differences between engines
 
-<Constant name="core_v1" />:
+<Constant name="core_v1" /> and [<Constant name="core_v2" />](/docs/dbt-versions/core-upgrade/upgrading-to-v2) (currently in alpha):
 
 - Renders and runs models one at a time.
 - Never runs static analysis.
-
-[<Constant name="core_v2" />](/docs/dbt-versions/core-upgrade/upgrading-to-v2) (currently in alpha):
-
-- Built on the Rust-based <Constant name="fusion_engine" /> as the open-source dbt Core release.
-- Supports static analysis with a subset of <Constant name="fusion" /> features.
 
 The <Constant name="fusion_engine" /> (baseline mode &mdash; default):
 


### PR DESCRIPTION
dbt core v2 does not have any static analysis capabilities. Baseline static analysis is included in the free Fusion binary, and strict static analysis is also free to use after logging in to the free Fusion binary.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-joellabes-patch-4-dbt-labs.vercel.app/docs/fusion/new-concepts

<!-- end-vercel-deployment-preview -->