### PR TITLE
Dupe entry

### DIFF
--- a/website/docs/docs/deploy/job-notifications.md
+++ b/website/docs/docs/deploy/job-notifications.md
@@ -227,14 +227,7 @@ The banner appears when all of the following are true:
 
 Before migrating, you must unlink the legacy Slack integration and link the <Constant name="dbt_platform" /> app. Unlinking the legacy integration is a manual step, and only one Slack app can be linked at a time.
 
-The banner appears when all of the following are true:
-
-- You have notification settings from a previous Slack integration.
-- Your account is connected to the <Constant name="dbt_platform" /> app.
-- You have not configured Slack notification settings with the <Constant name="dbt_platform" /> app yet.
-
 The <Constant name="dbt_platform" /> Slack app sends job notifications to _public_ channels in your workspace. Private channels are different: notifications are not delivered there until you invite the <Constant name="dbt_platform" /> app to each private channel you use.
-
 
 1. Click **Migrate settings** to copy your existing settings to the <Constant name="dbt_platform" /> app, including:
 
@@ -243,28 +236,12 @@ The <Constant name="dbt_platform" /> Slack app sends job notifications to _publi
   - Your notification toggles (for example, **Succeeds**, **Warns**, **Fails**, and **Is canceled**)
 
 2. Click **Dismiss** to hide the banner for your current session &mdash; it reappears on reload until migration completes.
-3 After migration, if needed, dbt shows an informational message listing private Slack channels that still need setup.
-  - If any of your channels are private, invite the <Constant name="dbt_platform" /> app to each one after migrating so notifications can be delivered. 
-  
+3. After migration, if needed, dbt shows an informational message listing private Slack channels that still need setup.
+  - If any of your channels are private, invite the <Constant name="dbt_platform" /> app to each one after migrating so notifications can be delivered.
+
 When migration succeeds, dbt hides the banner and refreshes your Slack notification settings. If migration fails, the banner remains so you can try again.
-
-- Your selected **Notification channel**
-- Your selected **Environment**
-- Your selected jobs
-- Your notification toggles (for example, **Succeeds**, **Warns**, **Fails**, and **Is canceled**)
-
-If any of your notification channels are private, invite the <Constant name="dbt_platform" /> app to those channels after migrating, or use the list dbt may show you after migration, so notifications can be delivered.
-
-To migrate your settings:
-
-1. Click **Migrate settings** to migrate your settings to the <Constant name="dbt_platform" /> app.
-2. Click **Dismiss** to hide the banner for your current session. The banner appears again when you reload the page unless migration has completed successfully.
-
-After migration, if needed, dbt shows an informational message listing private Slack channels that still need setup.
 
 <Lightbox src="/img/docs/deploy/dbt-platform-slack-invite.png" width="100%" title="Example of private channel invite guidance for the dbt platform app"/>
-
-When migration succeeds, dbt hides the banner and refreshes your Slack notification settings. If migration fails, the banner remains so you can try again.
 
 ### Disable the Slack integration
 In this step, you'll disable the Slack integration and remove the account-level Slack credentials. You can always re-enable the integration by following the [Set up the Slack integration](#set-up-the-slack-integration-1) steps.

--- a/website/docs/docs/deploy/job-notifications.md
+++ b/website/docs/docs/deploy/job-notifications.md
@@ -231,13 +231,13 @@ The <Constant name="dbt_platform" /> Slack app sends job notifications to _publi
 
 1. Click **Migrate settings** to copy your existing settings to the <Constant name="dbt_platform" /> app, including:
 
-  - Your selected **Notification channel** and **Environment**
-  - Your selected jobs
-  - Your notification toggles (for example, **Succeeds**, **Warns**, **Fails**, and **Is canceled**)
+    - Your selected **Notification channel** and **Environment**
+    - Your selected jobs
+    - Your notification toggles (for example, **Succeeds**, **Warns**, **Fails**, and **Is canceled**)
 
 2. Click **Dismiss** to hide the banner for your current session &mdash; it reappears on reload until migration completes.
 3. After migration, if needed, dbt shows an informational message listing private Slack channels that still need setup.
-  - If any of your channels are private, invite the <Constant name="dbt_platform" /> app to each one after migrating so notifications can be delivered.
+    - If any of your channels are private, invite the <Constant name="dbt_platform" /> app to each one after migrating so notifications can be delivered.
 
 When migration succeeds, dbt hides the banner and refreshes your Slack notification settings. If migration fails, the banner remains so you can try again.
 


### PR DESCRIPTION
Resolves [JIRA:PRODDOCS-1109](https://dbtlabs.atlassian.net/browse/PRODDOCS-1109)

This PR removes dupe entry in the [Migrating legacy Slack notification settings](https://docs.getdbt.com/docs/deploy/job-notifications?version=2.0&name=Fusion#migrating-legacy-slack-notification-settings) section in the [Job notifications](https://docs.getdbt.com/docs/deploy/job-notifications) page

Background
- Original section added in [#9043 — Slack migration settings](https://github.com/dbt-labs/docs.getdbt.com/pull/9043) (nfiann-slacknotifications, opened Apr 24, merged Apr 28, 2026)
- Apr 24 — Section written once; no duplication
- Apr 28 — Rewritten to address Mirna's review feedback (made some changes and rolled in feedback); still clean
- Apr 28 (~11:04 & ~11:08) — Two GitHub Commit suggestion commits applied on top of that rewrite (Committer: GitHub <noreply@github.com>)
- Suggestions added new copy without removing the rewritten version below, which created the duplicates — not from manual re-editing in the editor


## Checklist
<!-- Ensure your PR meets the following items. Feel free to add additional checklist items to the list if additional checks need to happen before the PR is merged, such as:
- [ ] Needs technical review
- [ ] Change base branch
- [ ] Merge on xyz date
-->
- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).
<!--
PRE-RELEASE VERSION OF dbt (if so, uncomment):
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
<!-- 
ADDING OR REMOVING PAGES (if so, uncomment):
- [ ] Add/remove page in `website/sidebars.js`
- [ ] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages
-->

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-nfiann-slackmigrate-dbt-labs.vercel.app/docs/deploy/job-notifications
- https://docs-getdbt-com-git-nfiann-slackmigrate-dbt-labs.vercel.app/docs/deploy/orchestrate-exposures
- https://docs-getdbt-com-git-nfiann-slackmigrate-dbt-labs.vercel.app/docs/explore/explore-projects
- https://docs-getdbt-com-git-nfiann-slackmigrate-dbt-labs.vercel.app/docs/explore/view-downstream-exposures
- https://docs-getdbt-com-git-nfiann-slackmigrate-dbt-labs.vercel.app/docs/platform-integrations/downstream-exposures-tableau
- https://docs-getdbt-com-git-nfiann-slackmigrate-dbt-labs.vercel.app/docs/platform-integrations/downstream-exposures
- https://docs-getdbt-com-git-nfiann-slackmigrate-dbt-labs.vercel.app/docs/platform-integrations/orchestrate-exposures

<!-- end-vercel-deployment-preview -->