### PR TITLE
Clarify Anthropic enterprise licenses unsupported for BYOK

### DIFF
--- a/website/docs/docs/dbt-ai/wizard-byok.md
+++ b/website/docs/docs/dbt-ai/wizard-byok.md
@@ -80,6 +80,10 @@ export OPENAI_API_KEY="sk-..."
 export ANTHROPIC_API_KEY="sk-ant-..."
 ```
 
+:::note
+Anthropic enterprise and subscription licenses (such as Claude Enterprise or a Claude subscription) aren't supported. Anthropic's [terms of service](https://www.anthropic.com/legal/consumer-terms) prohibit using a third-party harness with a Claude subscription or enterprise plan. To use Anthropic with BYOK, you need an Anthropic API key.
+:::
+
 </TabItem>
 </Tabs>
 

--- a/website/docs/docs/dbt-ai/wizard-byok.md
+++ b/website/docs/docs/dbt-ai/wizard-byok.md
@@ -80,10 +80,6 @@ export OPENAI_API_KEY="sk-..."
 export ANTHROPIC_API_KEY="sk-ant-..."
 ```
 
-:::note
-Anthropic enterprise and subscription licenses (such as Claude Enterprise or a Claude subscription) aren't supported. Anthropic's [terms of service](https://www.anthropic.com/legal/consumer-terms) prohibit using a third-party harness with a Claude subscription or enterprise plan. To use Anthropic with BYOK, you need an Anthropic API key.
-:::
-
 </TabItem>
 </Tabs>
 

--- a/website/docs/docs/dbt-ai/wizard-ide.md
+++ b/website/docs/docs/dbt-ai/wizard-ide.md
@@ -37,7 +37,7 @@ The agent comes with the following out of the box, meaning no configuration need
 - A Starter, Enterprise, or Enterprise+ plan
 - A [<Constant name="dbt" /> account](https://www.getdbt.com/signup) and [Developer seat license](/docs/platform/manage-access/seats-and-users).
 - A [development environment](/docs/platform/studio-ide/develop-in-studio#get-started-with-the-studio-ide) and credentials set up in the <Constant name="studio_ide" />.
-- [Enabled AI features](/docs/platform/enable-dbt-ai) for your account.
+- [Enabled AI features](/docs/platform/enable-dbt-ai#enable-ai-features) for your account.
 
 <WizardIde />
 

--- a/website/docs/docs/platform/studio-ide/develop-studio-ai.md
+++ b/website/docs/docs/platform/studio-ide/develop-studio-ai.md
@@ -23,7 +23,7 @@ dbt also supports dbt Copilot, a separate inline AI assistance experience for si
 - A Starter, Enterprise, or Enterprise+ plan
 - A [<Constant name="dbt" /> account](https://www.getdbt.com/signup) and [Developer seat license](/docs/platform/manage-access/seats-and-users).
 - A [development environment](/docs/platform/studio-ide/develop-in-studio#get-started-with-the-studio-ide) and credentials set up in the <Constant name="studio_ide" />.
-- [Enabled AI features](/docs/platform/enable-dbt-ai) for your account.
+- [Enabled AI features](/docs/platform/enable-dbt-ai#enable-ai-features) for your account.
 
 ## dbt Wizard in Studio IDE <Lifecycle status="preview,self_service,managed,managed_plus" />
 

--- a/website/docs/docs/platform/wizard-home.md
+++ b/website/docs/docs/platform/wizard-home.md
@@ -29,7 +29,7 @@ The <Constant name="wizard" /> home tab is complementary to the [<Constant name=
 - A Starter, Enterprise, or Enterprise+ plan
 - A [<Constant name="dbt" /> account](https://www.getdbt.com/signup) and [Developer seat license](/docs/platform/manage-access/seats-and-users).
 - A [development environment](/docs/platform/studio-ide/develop-in-studio#get-started-with-the-studio-ide) and credentials set up in the <Constant name="studio_ide" />.
-- [Enabled AI features](/docs/platform/enable-dbt-ai) for your account.
+- [Enabled AI features](/docs/platform/enable-dbt-ai#enable-ai-features) for your account.
 - If you're using <Constant name="wizard" /> in the home tab, you need to [enable experimental features](/docs/dbt-versions/experimental-features) for your account.
 
 ## What you can do

--- a/website/snippets/_wizard-supported-providers.md
+++ b/website/snippets/_wizard-supported-providers.md
@@ -17,7 +17,7 @@
 
 \* *Managed: <Constant name="dbt" /> Labs manages the AI provider connection; no user provider key is required. Refer to [Billing](/docs/platform/billing?version=2.0&name=Fusion#temporary-dbt-copilot-actions-bridge-through-july-1) for more info.*
 
-<sup>†</sup> *Anthropic enterprise and subscription licenses (such as Claude Enterprise) aren't supported — Anthropic's [terms of service](https://www.anthropic.com/legal/consumer-terms) prohibit third-party harness use. BYOK requires an Anthropic API key.*
+<sup>†</sup> *Anthropic enterprise and subscription licenses (such as Claude Enterprise) aren't supported per Anthropic's [terms of service](https://www.anthropic.com/legal/consumer-terms). BYOK requires an Anthropic API key.*
 
 <br />
 

--- a/website/snippets/_wizard-supported-providers.md
+++ b/website/snippets/_wizard-supported-providers.md
@@ -9,13 +9,15 @@
 | Provider | <Constant name="wizard" /> in <Constant name="dbt_platform" /> | <Constant name="wizard" /> CLI |
 |---|---|---|
 | [OpenAI](https://openai.com/policies/row-terms-of-use/) | ✓ (managed* or BYOK) | ✓ (OpenAI subscription or BYOK) |
-| [Anthropic](https://www.anthropic.com/legal/consumer-terms) | ✓ (BYOK) | ✓ (BYOK) |
+| [Anthropic](https://www.anthropic.com/legal/consumer-terms)<sup>†</sup> | ✓ (BYOK) | ✓ (BYOK) |
 | [Azure AI Foundry](https://www.microsoft.com/licensing/terms) / Azure OpenAI | ✓ (BYOK) | ✓ (BYOK) |
 | [AWS Bedrock](https://aws.amazon.com/service-terms/) |- | ✓ (BYOK) |
 | [Snowflake Cortex](https://www.snowflake.com/en/legal/terms-of-service/) | - | ✓ (BYOK) |
 </SimpleTable>
 
 \* *Managed: <Constant name="dbt" /> Labs manages the AI provider connection; no user provider key is required. Refer to [Billing](/docs/platform/billing?version=2.0&name=Fusion#temporary-dbt-copilot-actions-bridge-through-july-1) for more info.*
+
+<sup>†</sup> *Anthropic enterprise and subscription licenses (such as Claude Enterprise) aren't supported — Anthropic's [terms of service](https://www.anthropic.com/legal/consumer-terms) prohibit third-party harness use. BYOK requires an Anthropic API key.*
 
 <br />
 


### PR DESCRIPTION
## What's changing

Adds a note to the [BYOK configuration doc](https://github.com/dbt-labs/docs.getdbt.com/blob/update/wizard-anthropic/website/docs/docs/dbt-ai/wizard-byok.md) clarifying that Anthropic enterprise and subscription licenses (Claude Enterprise, Claude subscription) aren't supported for dbt Wizard. Anthropic's terms of service prohibit using a third-party harness with a Claude subscription or enterprise plan — BYOK requires an Anthropic API key.

Also includes minor anchor-link fixes pointing the "Enabled AI features" links to `#enable-ai-features`.

Source: internal Slack discussion confirming the Anthropic TOS constraint.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-wizard-anthropic-dbt-labs.vercel.app/docs/dbt-ai/wizard-ide
- https://docs-getdbt-com-git-update-wizard-anthropic-dbt-labs.vercel.app/docs/platform/studio-ide/develop-studio-ai
- https://docs-getdbt-com-git-update-wizard-anthropic-dbt-labs.vercel.app/docs/platform/wizard-home

<!-- end-vercel-deployment-preview -->