### PR TITLE
Add data retention section to dbt MCP server docs

### DIFF
--- a/website/docs/docs/dbt-ai/about-mcp.md
+++ b/website/docs/docs/dbt-ai/about-mcp.md
@@ -107,9 +107,9 @@ The dbt MCP server integrates with any [MCP client](https://modelcontextprotocol
 
 ## Data retention
 
-The dbt MCP server doesn't store or retain any production data or job run results itself. It's a read-only access layer that reads metadata, job results, and Semantic Layer data from the dbt platform in real time when a tool is called.
+The dbt MCP server doesn't store or retain any production data or job run results itself. It's a read-only access layer that reads metadata, job results, and <Constant name="semantic_layer"/> data from the <Constant name="dbt_platform"/> in real time when a tool is called.
 
-How long job runs and artifacts are available to query depends on your [dbt platform data retention policy](https://docs.getdbt.com/docs/dbt-cloud-apis/data-retention), not the MCP server. As long as a job or artifact exists in dbt platform, the MCP server can access it.
+How long job runs and artifacts are available to query depends on your [dbt platform data retention policy](https://www.getdbt.com/security), not the MCP server. As long as a job or artifact exists in dbt platform, the MCP server can access it.
 
 ## Resources
 - [Environment variables reference](/docs/dbt-ai/mcp-environment-variables) &mdash; full list of variables and tool configuration for local MCP

--- a/website/docs/docs/dbt-ai/about-mcp.md
+++ b/website/docs/docs/dbt-ai/about-mcp.md
@@ -105,6 +105,12 @@ The dbt MCP server integrates with any [MCP client](https://modelcontextprotocol
 - [Cursor](/docs/dbt-ai/integrate-mcp-cursor)
 - [VS Code](/docs/dbt-ai/integrate-mcp-vscode).
 
+## Data retention
+
+The dbt MCP server doesn't store or retain any production data or job run results itself. It's a read-only access layer that reads metadata, job results, and Semantic Layer data from the dbt platform in real time when a tool is called.
+
+How long job runs and artifacts are available to query depends on your [dbt platform data retention policy](https://docs.getdbt.com/docs/dbt-cloud-apis/data-retention), not the MCP server. As long as a job or artifact exists in dbt platform, the MCP server can access it.
+
 ## Resources
 - [Environment variables reference](/docs/dbt-ai/mcp-environment-variables) &mdash; full list of variables and tool configuration for local MCP
 - For more information, refer to our blog on [Introducing the dbt MCP Server](/blog/introducing-dbt-mcp-server#getting-started).

--- a/website/docs/docs/dbt-ai/about-mcp.md
+++ b/website/docs/docs/dbt-ai/about-mcp.md
@@ -107,9 +107,10 @@ The dbt MCP server integrates with any [MCP client](https://modelcontextprotocol
 
 ## Data retention
 
-The dbt MCP server doesn't store or retain any production data or job run results itself. It's a read-only access layer that reads metadata, job results, and <Constant name="semantic_layer"/> data from the <Constant name="dbt_platform"/> in real time when a tool is called.
+The dbt MCP server doesn't store or retain any production data or job run results. It's a read-only access layer that reads metadata, job results, and <Constant name="semantic_layer"/> data from the <Constant name="dbt_platform"/> in real time when a tool is called.
 
-How long job runs and artifacts are available to query depends on your [dbt platform data retention policy](https://www.getdbt.com/security), not the MCP server. As long as a job or artifact exists in dbt platform, the MCP server can access it.
+Your [dbt platform data retention policy](https://www.getdbt.com/security) determines how long job runs and artifacts are available, not the MCP server. As long as a job or artifact exists in dbt platform, the MCP server can read it.
+
 
 ## Resources
 - [Environment variables reference](/docs/dbt-ai/mcp-environment-variables) &mdash; full list of variables and tool configuration for local MCP


### PR DESCRIPTION
## Summary

- Adds a new "Data retention" H2 section to the dbt MCP server overview page
- Clarifies that the MCP server is a read-only access layer and retains no data itself
- Explains that retention is governed by the dbt platform data retention policy, not the MCP server

## Context

Surfaced via a support question ([Slack thread](https://dbt-labs.slack.com/archives/C08GXNELQV7/p1780956193600459)) — customers were unsure whether the remote MCP server had its own retention window. It doesn't; confirmed by Jairus Martinez.

## Test plan

- [x] Preview the docs page and confirm the new section renders correctly
- [x] Verify the data retention policy link resolves

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-mcp-retention-dbt-labs.vercel.app/docs/dbt-ai/about-mcp

<!-- end-vercel-deployment-preview -->