### PR TITLE
Change OAuth status to beta and update prerequisites

### DIFF
--- a/website/docs/docs/dbt-ai/setup-remote-mcp.md
+++ b/website/docs/docs/dbt-ai/setup-remote-mcp.md
@@ -29,7 +29,7 @@ The remote MCP server is the ideal choice when:
 
 | If you need... | Use... |
 | --- | --- |
-| Fastest first-time setup and your MCP client supports OAuth for HTTP servers | **OAuth (remote)** <br /> Available in private beta for Enterprise and Enterprise+ accounts |
+| Fastest first-time setup and your MCP client supports OAuth for HTTP servers | **OAuth (remote)** <br /> Available in beta for Enterprise and Enterprise+ accounts |
 | `execute_sql` with a PAT, automation, or clients without OAuth | **Token-based** (PAT or service token) |
 | Shared or team setup | **Service token** (token-based) |
 | CI or automation | **Service token** (token-based) |
@@ -38,7 +38,7 @@ The remote MCP server is the ideal choice when:
 The `execute_sql` tool does **not** work with service tokens. You must use a [Personal Access Token (PAT)](/docs/dbt-apis/user-tokens) in the `Authorization` header when using this tool.
 :::
 
-## OAuth (remote MCP) <Lifecycle status="private_beta,managed,managed_plus" /> {#oauth-remote-mcp}
+## OAuth (remote MCP) <Lifecycle status="beta,managed,managed_plus" /> {#oauth-remote-mcp}
 
 OAuth lets you connect to the remote MCP server without copying API tokens into your MCP client, when your client supports OAuth for HTTP-based MCP servers.
 
@@ -47,7 +47,7 @@ OAuth lets you connect to the remote MCP server without copying API tokens into 
 ### Prerequisites
 
 - [AI features](https://docs.getdbt.com/docs/cloud/enable-dbt-copilot) enabled for your account.
-- Enterprise or Enterprise+ account and join the private beta by contacting your account manager.
+- Enterprise or Enterprise+ account
 - An MCP client that supports OAuth for remote (HTTP) MCP servers.
 - Your **MCP URL** from **Account settings** &rarr; **Access URLs** &rarr; **MCP Endpoint URL** in <Constant name="dbt_platform"/>. Check out the next section [MCP URL](#mcp-url) for more information.
 


### PR DESCRIPTION
Updated OAuth lifecycle status from private beta to beta and removed reference to contacting account manager for access.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-mirnawong1-patch-27-dbt-labs.vercel.app/docs/dbt-ai/setup-remote-mcp

<!-- end-vercel-deployment-preview -->