### PR TITLE
docs(databricks): dbt-databricks adds a new `metric_view` materialization. Set `materialized='metric_view'` on a model and write the body as a Unity Catalog metric view YAML definition (version, source, dimensions, measures, optional filter); dbt creates it via `CREATE OR REPLACE VIEW ... WITH METRICS LANGUAGE YAML`. Supports `databricks_tags`, `tblproperties`, and `grants`. With `view_update_via_alter=true`, YAML definition changes are applied via `ALTER VIEW AS` and tag/tblproperty changes via `ALTER ... SET`, instead of a full replace. (databricks/dbt-databricks#1285)

### DIFF
--- a/website/docs/reference/resource-configs/databricks-configs.md
+++ b/website/docs/reference/resource-configs/databricks-configs.md
@@ -1236,6 +1236,48 @@ For any other supported configuration change, we use `CREATE OR REFRESH` (plus a
 There is currently no mechanism for the adapter to detect if the streaming table query has changed, so in this case, regardless of the behavior requested by on_configuration_change, we will use a `create or refresh` statement (assuming `partitioned by` hasn't changed); this will cause the query to be applied to future rows without rerunning on any previously processed rows.
 If your source data is still available, running with '--full-refresh' will reprocess the available data with the updated current query.
 
+## Metric views
+_Available in versions 1.12 or higher_
+
+Set `materialized='metric_view'` to manage a [Unity Catalog metric view](https://docs.databricks.com/aws/en/metric-views/) with dbt. Instead of SQL, the body of the model is the metric view's YAML definition: a `version`, a `source`, `dimensions`, `measures`, and an optional `filter`. dbt creates the metric view with `CREATE OR REPLACE VIEW ... WITH METRICS LANGUAGE YAML`.
+
+<File name='order_metrics.sql'>
+
+```sql
+{{ config(materialized='metric_view') }}
+
+version: 0.1
+source: "{{ ref('source_orders') }}"
+filter: status = 'completed'
+dimensions:
+  - name: order_date
+    expr: order_date
+  - name: status
+    expr: status
+measures:
+  - name: total_orders
+    expr: count(1)
+  - name: total_revenue
+    expr: sum(revenue)
+```
+
+</File>
+
+Reference the source relation in `source` with `ref()` so dbt resolves dependencies. Query the resulting metric view with the `MEASURE()` function. See the [Databricks metric views documentation](https://docs.databricks.com/aws/en/metric-views/) for the full YAML schema.
+
+You can also set `databricks_tags` and [`grants`](/reference/resource-configs/grants) on a metric view. `tblproperties` are applied only when the view is updated in place (with `view_update_via_alter`) or replaced, not on first creation.
+
+### Updating a metric view
+
+By default, dbt rebuilds the metric view with `CREATE OR REPLACE VIEW` on every run.
+
+When you set [`view_update_via_alter`](/reference/global-configs/databricks-changes#changes-to-the-view-materialization) to `true`, dbt applies incremental changes in place instead of replacing the view:
+
+- Changes to the YAML definition are applied with `ALTER VIEW ... AS`.
+- Changes to `databricks_tags` or `tblproperties` are applied with `ALTER VIEW ... SET`.
+
+If neither the definition nor the tags or properties have changed, dbt skips the update.
+
 ## Setting table properties
 [Table properties](https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-ddl-tblproperties.html) can be set with your configuration for tables or views using `tblproperties`:
 


### PR DESCRIPTION
Docs for databricks/dbt-databricks#1285 (merged to `1.12.latest`). Drafted + adversarially reviewed by docs-sync; see /Users/shubham.dhal/Projects/docs.getdbt.com-worktrees/pr-1285 and the per-run manifest in dbt-databricks/.claude/docs-sync for the edit summary and uncertainty notes.