### PR TITLE
Remove `dbt lineage` command from Fusion features entitlement table

### DIFF
--- a/website/snippets/_fusion-features.md
+++ b/website/snippets/_fusion-features.md
@@ -19,4 +19,3 @@ To access the full set of features, register with your email address or sign in 
 | Auto-deferral | - | - | ✅ |
 | Compare changes | - | - | ✅ |
 | Precise column-level lineage artifact generation | - | - | ✅ |
-| `dbt lineage` command | - | - | ✅ |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What are you changing in this pull request and why?

Removes the `dbt lineage` command row from the Fusion features entitlement table in the `_fusion-features.md` snippet.

This snippet is used on the [Fusion availability page](https://docs.getdbt.com/docs/fusion/fusion-availability?version=2.0&name=Fusion#fusion-and-dbt-core-v2-features).

## Checklist

- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [x] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [x] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).) — N/A, this is a content removal
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://dbt-labs.slack.com/archives/C0A16RWFC4E/p1781563923436919?thread_ts=1781563923.436919&cid=C0A16RWFC4E)

<div><a href="https://cursor.com/agents/bc-118831f5-26c5-52ff-abd5-2e69be82f7fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-118831f5-26c5-52ff-abd5-2e69be82f7fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

