### PR TITLE
Clarify Developer to Starter upgrade does not include a free trial

### DIFF
--- a/website/docs/docs/platform/billing-faqs.md
+++ b/website/docs/docs/platform/billing-faqs.md
@@ -29,6 +29,14 @@ Yes. Your <Constant name="dbt" /> account will be upgraded without impacting you
 
 </Expandable>
 
+<Expandable alt_header="Do I get a free trial when upgrading from Developer to Starter?">
+
+No. The free two-week Starter trial is for new accounts at signup, not for existing Developer plan customers upgrading to Starter.
+
+When you upgrade from Developer to Starter, you move directly to paid Starter billing. You'll need to enter your payment information and select your developer seats before your upgrade is complete. Your existing projects and account settings are not affected.
+
+</Expandable>
+
 <Expandable alt_header="How do I determine the right plan for me?">
 
 The best option is to consult with our sales team. They'll help you figure out what is right for your needs. We also offer a free two-week trial on the Starter plan.

--- a/website/docs/docs/platform/billing-faqs.md
+++ b/website/docs/docs/platform/billing-faqs.md
@@ -35,7 +35,8 @@ The free two-week trial is only available to new accounts at signup &mdash; but 
 
 
 
-When you upgrade from Developer to Starter, you move directly to paid Starter billing. You'll need to enter your payment information and select your developer seats before your upgrade is complete. Your existing projects and account settings are not affected.
+
+When you upgrade from Developer to Starter, you move directly to paid billing &mdash; you'll enter your payment information and select your developer license seats to complete the upgrade. Your existing projects and settings carry over.
 
 </Expandable>
 

--- a/website/docs/docs/platform/billing-faqs.md
+++ b/website/docs/docs/platform/billing-faqs.md
@@ -29,7 +29,7 @@ Yes. Your <Constant name="dbt" /> account will be upgraded without impacting you
 
 </Expandable>
 
-<Expandable alt_header="Do I get a free trial when upgrading from Developer to Starter?">
+<Expandable alt_header="What happens when I upgrade from Developer to Starter?">
 
 No. The free two-week Starter trial is for new accounts at signup, not for existing Developer plan customers upgrading to Starter.
 

--- a/website/docs/docs/platform/billing-faqs.md
+++ b/website/docs/docs/platform/billing-faqs.md
@@ -31,7 +31,9 @@ Yes. Your <Constant name="dbt" /> account will be upgraded without impacting you
 
 <Expandable alt_header="What happens when I upgrade from Developer to Starter?">
 
-No. The free two-week Starter trial is for new accounts at signup, not for existing Developer plan customers upgrading to Starter.
+The free two-week trial is only available to new accounts at signup &mdash; but if you're already on the Developer plan, you can upgrade to Starter and immediately access all Starter features without needing to go through the trial.
+
+
 
 When you upgrade from Developer to Starter, you move directly to paid Starter billing. You'll need to enter your payment information and select your developer seats before your upgrade is complete. Your existing projects and account settings are not affected.
 

--- a/website/docs/docs/platform/billing-faqs.md
+++ b/website/docs/docs/platform/billing-faqs.md
@@ -7,6 +7,8 @@ pagination_next: null
 pagination_prev: null
 ---
 
+import DevToStarterUpgradeBody from '/snippets/_dev-to-starter-upgrade-body.md';
+
 <IntroText>
 Common questions about <Constant name="dbt" /> plans, billing, and usage. For pricing and plan details, refer to [Billing](/docs/platform/billing).
 </IntroText>
@@ -31,12 +33,7 @@ Yes. Your <Constant name="dbt" /> account will be upgraded without impacting you
 
 <Expandable alt_header="What happens when I upgrade from Developer to Starter?">
 
-The free two-week trial is only available to new accounts at signup &mdash; but if you're already on the Developer plan, you can upgrade to Starter and immediately access all Starter features without needing to go through the trial.
-
-
-
-
-When you upgrade from Developer to Starter, you move directly to paid billing &mdash; you'll enter your payment information and select your developer license seats to complete the upgrade. Your existing projects and settings carry over.
+<DevToStarterUpgradeBody />
 
 </Expandable>
 

--- a/website/docs/faqs/Accounts/platform-upgrade-instructions.md
+++ b/website/docs/faqs/Accounts/platform-upgrade-instructions.md
@@ -4,6 +4,8 @@ id: "platform-upgrade-instructions"
 description: "Instructions for upgrading a dbt account after the trial ends."
 ---
 
+import DevToStarterUpgradeBody from '/snippets/_dev-to-starter-upgrade-body.md';
+
 <Constant name="dbt" /> offers [several plans](https://www.getdbt.com/pricing/) with different features that meet your needs. This document is for <Constant name="dbt" /> admins and explains how to select a plan in order to continue using <Constant name="dbt" />. 
 
 ## Prerequisites 
@@ -76,6 +78,12 @@ For commonly asked billings questions, refer to the <Constant name="dbt" /> [pri
   Yes, you can upgrade or downgrade at any time. Account Owners can access their dedicated billing section via the account settings page.
     
   If you’re not sure which plan is right for you, get in touch and we’ll be happy to help you find one that fits your needs.
+
+</details>
+<details>
+  <summary>What happens when I upgrade from Developer to Starter?</summary>
+
+  <DevToStarterUpgradeBody />
 
 </details>
 <details>

--- a/website/snippets/_dev-to-starter-upgrade-body.md
+++ b/website/snippets/_dev-to-starter-upgrade-body.md
@@ -1,0 +1,3 @@
+The free two-week trial is only available to new accounts at signup &mdash; but if you're already on the Developer plan, you can upgrade to Starter and immediately access all Starter features without needing to go through the trial.
+
+When you upgrade from Developer to Starter, you move directly to paid billing &mdash; you'll enter your payment information and select your developer license seats to complete the upgrade. Your existing projects and settings carry over.


### PR DESCRIPTION
## Summary
- Adds a Billing FAQ clarifying that the free two-week Starter trial applies to new accounts at signup, not Developer → Starter upgrades.
- Explains that upgrading from Developer to Starter moves customers directly to paid Starter billing.

Closes [JIRA:PRODDOCS-1131](https://dbtlabs.atlassian.net/browse/PRODDOCS-1131).

## Test plan
- [ ] Preview the Billing FAQs page and confirm the new expandable renders correctly.
- [ ] Verify the new FAQ appears after "I want to upgrade my plan. Will all of my work carry over?"
- [ ] Confirm wording matches expected billing behavior for Developer → Starter upgrades.


Made with [Cursor](https://cursor.com)

[PRODDOCS-1131]: https://dbtlabs.atlassian.net/browse/PRODDOCS-1131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-nfiann-dev2starter-dbt-labs.vercel.app/docs/platform/billing-faqs
- https://docs-getdbt-com-git-nfiann-dev2starter-dbt-labs.vercel.app/faqs/Accounts/platform-upgrade-instructions

<!-- end-vercel-deployment-preview -->