### PR TITLE
Add generic test definition example to CustomKeyInObjectDeprecation docs

### DIFF
--- a/website/docs/reference/deprecations.md
+++ b/website/docs/reference/deprecations.md
@@ -307,6 +307,34 @@ models:
             some_key: some_value
 ```
 
+The same resolution applies to generic test definitions. If you define a custom key directly under a test in a `tests:` block, nest it under `config.meta`:
+
+Example that results in the warning:
+
+```yaml
+tests:
+  - name: custom_generic_test
+    description: My custom generic test
+    arguments:
+      - name: active_timestamp
+        type: timestamp
+        description: The active timestamp for the model
+```
+
+Example of the resolution:
+
+```yaml
+tests:
+  - name: custom_generic_test
+    description: My custom generic test
+    config:
+      meta:
+        arguments:
+          - name: active_timestamp
+            type: timestamp
+            description: The active timestamp for the model
+```
+
 To access custom configurations nested under attributes of `meta`, use `config.get('meta')` and then index the meta dictionary by the name of your custom attribute. Users will need to adjust their code that accesses the custom config keys directly as top-level keys.
 
 Example before custom configurations were nested under meta:

--- a/website/docs/reference/deprecations.md
+++ b/website/docs/reference/deprecations.md
@@ -349,6 +349,8 @@ tests:
 
 </Tabs>
 
+#### Accessing nested configurations
+
 To access custom configurations nested under attributes of `meta`, use `config.get('meta')` and then index the meta dictionary by the name of your custom attribute. Users will need to adjust their code that accesses the custom config keys directly as top-level keys.
 
 Example before custom configurations were nested under meta:

--- a/website/docs/reference/deprecations.md
+++ b/website/docs/reference/deprecations.md
@@ -279,7 +279,13 @@ import DeprecationWarnings4 from '/snippets/_deprecation-warnings.md';
 
 Nest custom configs under `meta` and ensure `meta` is nested under `config` (similar to [`PropertyMovedToConfigDeprecation`](#propertymovedtoconfigdeprecation)).
 
-Example that results in the warning: 
+The same resolution applies whether the custom key is in a model config or a generic test definition. Select the relevant tab for an example:
+
+<Tabs>
+
+<TabItem value="model" label="Model config">
+
+Example that results in the warning:
 
 ```yaml
 models:
@@ -307,7 +313,11 @@ models:
             some_key: some_value
 ```
 
-The same resolution applies to generic test definitions. If you define a custom key directly under a test in a `tests:` block, nest it under `config.meta`:
+</TabItem>
+
+<TabItem value="test" label="Generic test definition">
+
+If you define a custom key directly under a test in a `tests:` block, nest it under `config.meta`.
 
 Example that results in the warning:
 
@@ -334,6 +344,10 @@ tests:
             type: timestamp
             description: The active timestamp for the model
 ```
+
+</TabItem>
+
+</Tabs>
 
 To access custom configurations nested under attributes of `meta`, use `config.get('meta')` and then index the meta dictionary by the name of your custom attribute. Users will need to adjust their code that accesses the custom config keys directly as top-level keys.
 


### PR DESCRIPTION
Adds a generic test definition YAML example to the `CustomKeyInObjectDeprecation` resolution section in the deprecations reference.

The current docs only show `models:` config YAML, which made it hard for users with custom keys in a `tests:` block to map the documented resolution to their setup. This adds a parallel example showing the same fix — nest the custom key under `config.meta` — in the context of a generic test definition.

Resolves PRODDOCS-1133.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-customkey-generic-test-example-dbt-labs.vercel.app/reference/deprecations

<!-- end-vercel-deployment-preview -->