### PR TITLE
documenti WIF support in fusion

### DIFF
--- a/website/docs/docs/fusion/connect-data-platform-fusion/bigquery-setup.md
+++ b/website/docs/docs/fusion/connect-data-platform-fusion/bigquery-setup.md
@@ -123,7 +123,6 @@ default:
 </File>
 
 </TabItem>
-
 </Tabs>
 
 ## More information

--- a/website/docs/docs/local/connect-data-platform/bigquery-setup.md
+++ b/website/docs/docs/local/connect-data-platform/bigquery-setup.md
@@ -134,9 +134,9 @@ Here are the required and optional fields for the WIF config in your `profiles.y
 | Field | Required | Description |
 |-------|----------|-------------|
 | `method` | Yes | Set to `external-oauth-wif`. |
-| `workload_pool_provider_path` | Yes | The full resource path of the GCP workload identity pool provider that trusts your Entra tenant (for example, `//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/my-pool/providers/my-provider`). |
+| `workload_pool_provider_path` | Yes | The full resource path of the GCP workload identity pool provider that trusts your Entra tenant. |
 | `token_endpoint.type` | Yes | The external identity provider type. Only `entra` is currently supported. |
-| `token_endpoint.request_url` | Yes | The Entra OAuth token endpoint (for example, `https://login.microsoftonline.com/<tenant>/oauth2/v2.0/token`). |
+| `token_endpoint.request_url` | Yes | The Entra OAuth token endpoint. |
 | `token_endpoint.request_data` | Yes | The URL-encoded request body used to fetch the Entra token (for example `grant_type`, `client_id`, `client_secret`, and `scope`). |
 | `service_account_impersonation_url` | No | The `generateAccessToken` URL of a service account to impersonate after federation, if you want BigQuery access scoped to that service account's permissions. |
 

--- a/website/docs/docs/local/connect-data-platform/bigquery-setup.md
+++ b/website/docs/docs/local/connect-data-platform/bigquery-setup.md
@@ -127,7 +127,9 @@ Workload Identity Federation (WIF) lets you authenticate to BigQuery using crede
 Before selecting this method, an administrator must configure a workload identity pool and provider in GCP that trusts your Entra tenant. You'll need the resulting workload pool provider path.
 
 #### Required fields
-Here are the required fields for the Workload Identity Federation configuration:
+Here are the required fields for the WIF config in your `profiles.yml` file:
+
+<SimpleTable>
 
 | Field | Required | Description |
 |-------|----------|-------------|
@@ -138,8 +140,10 @@ Here are the required fields for the Workload Identity Federation configuration:
 | `token_endpoint.request_data` | Yes | The URL-encoded request body used to fetch the Entra token (for example `grant_type`, `client_id`, `client_secret`, and `scope`). |
 | `service_account_impersonation_url` | No | The `generateAccessToken` URL of a service account to impersonate after federation, if you want BigQuery access scoped to that service account's permissions. |
 
-#### Example Workload Identity Federation configuration
-The following code snippet is an example of a Workload Identity Federation configuration in your `profiles.yml` file:
+</SimpleTable>
+
+#### WIF config example in `profiles.yml`
+The following code snippet is an example of a WIF config in your `profiles.yml`:
 
 <File name="profiles.yml">
 

--- a/website/docs/docs/local/connect-data-platform/bigquery-setup.md
+++ b/website/docs/docs/local/connect-data-platform/bigquery-setup.md
@@ -127,7 +127,7 @@ Workload Identity Federation (WIF) lets you authenticate to BigQuery using crede
 Before selecting this method, an administrator must configure a workload identity pool and provider in GCP that trusts your Entra tenant. You'll need the resulting workload pool provider path.
 
 #### Configuration fields
-Here are the required fields for the WIF config in your `profiles.yml` file:
+Here are the required or optional fields for the WIF config in your `profiles.yml` file:
 
 <SimpleTable>
 

--- a/website/docs/docs/local/connect-data-platform/bigquery-setup.md
+++ b/website/docs/docs/local/connect-data-platform/bigquery-setup.md
@@ -24,6 +24,7 @@ You can configure the BigQuery adapter by running `dbt init` in your CLI or manu
 The BigQuery adapter for Fusion supports the following [authentication methods](#supported-authentication-types):
 - Service account (JSON file)
 - gcloud OAuth
+- Workload Identity Federation (Microsoft Entra)
 
 ## Warehouse permissions
 
@@ -117,6 +118,54 @@ default:
 
 </TabItem>
 
+<TabItem value="Workload Identity Federation (Microsoft Entra)">
+
+Workload Identity Federation (WIF) lets you authenticate to BigQuery using credentials issued by an external OAuth identity provider &mdash; currently Microsoft Entra &mdash; without managing a Google service account key file. 
+
+<Constant name="fusion" /> exchanges an Entra-issued token for short-lived Google credentials through a BigQuery [workload identity pool](https://cloud.google.com/iam/docs/workload-identity-federation).
+
+Before selecting this method, an administrator must configure a workload identity pool and provider in GCP that trusts your Entra tenant. You'll need the resulting workload pool provider path.
+
+#### Required fields
+Here are the required fields for the Workload Identity Federation configuration:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `method` | Yes | Set to `external-oauth-wif`. |
+| `workload_pool_provider_path` | Yes | Full resource path of the GCP workload identity pool provider that trusts your Entra tenant, for example `//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/my-pool/providers/my-provider`. |
+| `token_endpoint.type` | Yes | The external identity provider type. Only `entra` is currently supported. |
+| `token_endpoint.request_url` | Yes | The Entra OAuth token endpoint, for example `https://login.microsoftonline.com/<tenant>/oauth2/v2.0/token`. |
+| `token_endpoint.request_data` | Yes | The URL-encoded request body used to fetch the Entra token (for example `grant_type`, `client_id`, `client_secret`, and `scope`). |
+| `service_account_impersonation_url` | No | The `generateAccessToken` URL of a service account to impersonate after federation, if you want BigQuery access scoped to that service account's permissions. |
+
+#### Example Workload Identity Federation configuration
+The following code snippet is an example of a Workload Identity Federation configuration in your `profiles.yml` file:
+
+<File name="profiles.yml">
+
+```yaml
+default:
+  target: dev
+  outputs:
+    dev:
+      type: bigquery
+      threads: 16
+      database: ABC123
+      schema: JAFFLE_SHOP
+      method: external-oauth-wif
+      location: us-east1
+      workload_pool_provider_path: //iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/my-pool/providers/my-provider
+      token_endpoint:
+        type: entra
+        request_url: https://login.microsoftonline.com/<tenant>/oauth2/v2.0/token
+        request_data: "grant_type=client_credentials&client_id={{ env_var('ENTRA_CLIENT_ID') }}&client_secret={{ env_var('ENTRA_CLIENT_SECRET') }}&scope=<scope>/.default"
+        
+      # Optional: include only if your workload identity pool doesn't have direct resource access and needs to impersonate a service account.
+      # service_account_impersonation_url: https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/sa@project.iam.gserviceaccount.com:generateAccessToken
+```
+
+</File>
+</TabItem>
 </Tabs>
 
 ## More information
@@ -147,6 +196,8 @@ import SetUpPages from '/snippets/_setup-pages-intro.md';
 
 import BigQueryPerms from '/snippets/_bigquery-permissions.md';
 
+
+
 <BigQueryPerms />
 
 ## Authentication Methods
@@ -159,6 +210,10 @@ BigQuery targets can be specified using one of four methods:
 4. [service account JSON](#service-account-json)
 
 For local development, we recommend using the OAuth method. If you're scheduling dbt on a server, you should use the service account auth method instead.
+
+:::tip Workload Identity Federation
+WIF authentication (`external-oauth-wif`) is available in [<Constant name="fusion" />](/docs/fusion/connect-data-platform/bigquery-setup?version=2.0#workload-identity-federation-microsoft-entra). It's not supported in dbt Core v1.12 and earlier.
+:::
 
 BigQuery targets should be set up using the following configuration in your `profiles.yml` file. There are a number of [optional configurations](#optional-configurations) you may specify as well.
 

--- a/website/docs/docs/local/connect-data-platform/bigquery-setup.md
+++ b/website/docs/docs/local/connect-data-platform/bigquery-setup.md
@@ -122,7 +122,7 @@ default:
 
 Workload Identity Federation (WIF) lets you authenticate to BigQuery using credentials issued by an external OAuth identity provider &mdash; currently Microsoft Entra &mdash; without managing a Google service account key file. 
 
-<Constant name="fusion" /> exchanges an Entra-issued token for short-lived Google credentials through a BigQuery [workload identity pool](https://cloud.google.com/iam/docs/workload-identity-federation).
+<Constant name="fusion" /> exchanges an Entra-issued token for short-lived Google credentials through a Google Cloud [workload identity pool](https://cloud.google.com/iam/docs/workload-identity-federation).
 
 Before selecting this method, an administrator must configure a workload identity pool and provider in GCP that trusts your Entra tenant. You'll need the resulting workload pool provider path.
 

--- a/website/docs/docs/local/connect-data-platform/bigquery-setup.md
+++ b/website/docs/docs/local/connect-data-platform/bigquery-setup.md
@@ -216,7 +216,7 @@ BigQuery targets can be specified using one of four methods:
 For local development, we recommend using the OAuth method. If you're scheduling dbt on a server, you should use the service account auth method instead.
 
 :::tip Workload Identity Federation
-WIF authentication (`external-oauth-wif`) is available in [<Constant name="fusion" />](/docs/fusion/connect-data-platform/bigquery-setup?version=2.0#workload-identity-federation-microsoft-entra). It's not supported in dbt Core v1.12 and earlier.
+WIF authentication (`external-oauth-wif`) is available in [<Constant name="fusion" />](/docs/local/connect-data-platform/bigquery-setup?version=2.0&name=Fusion#supported-authentication-types). It's not supported in dbt Core v1.12 and earlier.
 :::
 
 BigQuery targets should be set up using the following configuration in your `profiles.yml` file. There are a number of [optional configurations](#optional-configurations) you may specify as well.

--- a/website/docs/docs/local/connect-data-platform/bigquery-setup.md
+++ b/website/docs/docs/local/connect-data-platform/bigquery-setup.md
@@ -143,7 +143,7 @@ Here are the required fields for the WIF config in your `profiles.yml` file:
 </SimpleTable>
 
 #### WIF config example in `profiles.yml`
-The following code snippet is an example of a WIF config in your `profiles.yml`:
+The following code snippet is an example of a WIF config in your `profiles.yml`, replacing the values with your own:
 
 <File name="profiles.yml">
 
@@ -161,8 +161,8 @@ default:
       workload_pool_provider_path: //iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/my-pool/providers/my-provider
       token_endpoint:
         type: entra
-        request_url: https://login.microsoftonline.com/<tenant>/oauth2/v2.0/token
-        request_data: "grant_type=client_credentials&client_id={{ env_var('ENTRA_CLIENT_ID') }}&client_secret={{ env_var('ENTRA_CLIENT_SECRET') }}&scope=<scope>/.default"
+        request_url: https://login.microsoftonline.com/TENANT_ID/oauth2/v2.0/token
+        request_data: "grant_type=client_credentials&client_id={{ env_var('ENTRA_CLIENT_ID') }}&client_secret={{ env_var('ENTRA_CLIENT_SECRET') }}&scope=SCOPE/.default"
         
       # Optional: include only if your workload identity pool doesn't have direct resource access and needs to impersonate a service account.
       # service_account_impersonation_url: https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/sa@project.iam.gserviceaccount.com:generateAccessToken

--- a/website/docs/docs/local/connect-data-platform/bigquery-setup.md
+++ b/website/docs/docs/local/connect-data-platform/bigquery-setup.md
@@ -127,7 +127,7 @@ Workload Identity Federation (WIF) lets you authenticate to BigQuery using crede
 Before selecting this method, an administrator must configure a workload identity pool and provider in GCP that trusts your Entra tenant. You'll need the resulting workload pool provider path.
 
 #### Configuration fields
-Here are the required or optional fields for the WIF config in your `profiles.yml` file:
+Here are the required and optional fields for the WIF config in your `profiles.yml` file:
 
 <SimpleTable>
 

--- a/website/docs/docs/local/connect-data-platform/bigquery-setup.md
+++ b/website/docs/docs/local/connect-data-platform/bigquery-setup.md
@@ -126,7 +126,7 @@ Workload Identity Federation (WIF) lets you authenticate to BigQuery using crede
 
 Before selecting this method, an administrator must configure a workload identity pool and provider in GCP that trusts your Entra tenant. You'll need the resulting workload pool provider path.
 
-#### Required fields
+#### Configuration fields
 Here are the required fields for the WIF config in your `profiles.yml` file:
 
 <SimpleTable>

--- a/website/docs/docs/local/connect-data-platform/bigquery-setup.md
+++ b/website/docs/docs/local/connect-data-platform/bigquery-setup.md
@@ -122,7 +122,7 @@ default:
 
 Workload Identity Federation (WIF) lets you authenticate to BigQuery using credentials issued by an external OAuth identity provider &mdash; currently Microsoft Entra &mdash; without managing a Google service account key file. 
 
-<Constant name="fusion" /> exchanges an Entra-issued token for short-lived Google credentials through a Google Cloud [workload identity pool](https://cloud.google.com/iam/docs/workload-identity-federation).
+<Constant name="fusion" /> exchanges an Entra-issued token for short-lived Google credentials through a Google Cloud [workload identity pool](https://docs.cloud.google.com/iam/docs/workload-identity-federation#pools).
 
 Before selecting this method, an administrator must configure a workload identity pool and provider in GCP that trusts your Entra tenant. You'll need the resulting workload pool provider path.
 

--- a/website/docs/docs/local/connect-data-platform/bigquery-setup.md
+++ b/website/docs/docs/local/connect-data-platform/bigquery-setup.md
@@ -134,16 +134,16 @@ Here are the required and optional fields for the WIF config in your `profiles.y
 | Field | Required | Description |
 |-------|----------|-------------|
 | `method` | Yes | Set to `external-oauth-wif`. |
-| `workload_pool_provider_path` | Yes | Full resource path of the GCP workload identity pool provider that trusts your Entra tenant, for example `//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/my-pool/providers/my-provider`. |
+| `workload_pool_provider_path` | Yes | The full resource path of the GCP workload identity pool provider that trusts your Entra tenant (for example, `//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/my-pool/providers/my-provider`). |
 | `token_endpoint.type` | Yes | The external identity provider type. Only `entra` is currently supported. |
-| `token_endpoint.request_url` | Yes | The Entra OAuth token endpoint, for example `https://login.microsoftonline.com/<tenant>/oauth2/v2.0/token`. |
+| `token_endpoint.request_url` | Yes | The Entra OAuth token endpoint (for example, `https://login.microsoftonline.com/<tenant>/oauth2/v2.0/token`). |
 | `token_endpoint.request_data` | Yes | The URL-encoded request body used to fetch the Entra token (for example `grant_type`, `client_id`, `client_secret`, and `scope`). |
 | `service_account_impersonation_url` | No | The `generateAccessToken` URL of a service account to impersonate after federation, if you want BigQuery access scoped to that service account's permissions. |
 
 </SimpleTable>
 
 #### WIF config example in `profiles.yml`
-The following code snippet is an example of a WIF config in your `profiles.yml`, replacing the values with your own:
+The following code snippet is an example of a WIF config in your `profiles.yml`. Make sure to replace the values with your own:
 
 <File name="profiles.yml">
 
@@ -216,7 +216,7 @@ BigQuery targets can be specified using one of four methods:
 For local development, we recommend using the OAuth method. If you're scheduling dbt on a server, you should use the service account auth method instead.
 
 :::tip Workload Identity Federation
-WIF authentication (`external-oauth-wif`) is available in [<Constant name="fusion" />](/docs/local/connect-data-platform/bigquery-setup?version=2.0&name=Fusion#supported-authentication-types). It's not supported in dbt Core v1.12 and earlier.
+WIF authentication (`external-oauth-wif`) is available in [<Constant name="fusion" />](/docs/local/connect-data-platform/bigquery-setup?version=2.0&name=Fusion#supported-authentication-types). It's not supported in <Constant name="core" /> v1.12 and earlier.
 :::
 
 BigQuery targets should be set up using the following configuration in your `profiles.yml` file. There are a number of [optional configurations](#optional-configurations) you may specify as well.

--- a/website/docs/docs/platform/manage-access/set-up-bigquery-oauth.md
+++ b/website/docs/docs/platform/manage-access/set-up-bigquery-oauth.md
@@ -107,10 +107,6 @@ Select **Allow**. This redirects you back to the <Constant name="dbt_platform" /
 Workload Identity Federation (WIF) allows application workloads, running outside the <Constant name="dbt_platform" />, to act as a service account without the need to manage service accounts or other keys for deployment environments. The following instructions will enable you to authenticate your BigQuery connection in the <Constant name="dbt_platform" /> using WIF. 
 Currently, Microsoft Entra ID is the only supported identity provider (IdP). If you need additional IdP support, please contact your account team.
 
-:::info WIF not supported in <Constant name="fusion_engine"/>
-WIF is not currently supported in [<Constant name="fusion"/>](/docs/fusion/supported-features?version=2.0#bigquery). Use a [Native OAuth connection](#set-up-bigquery-native-oauth) or service account instead. [Support for WIF](https://github.com/dbt-labs/dbt-fusion/issues/1629) is coming soon.
-:::
-
 ### 1. Set up Entra ID
 
 Create an app in Entra where dbt will request access tokens when authenticating to BigQuery via the workload identity pool:


### PR DESCRIPTION
this pr adds WIF support in fusion local BQ set up

raised internally https://dbt-labs.slack.com/archives/C02NCQ9483C/p1781668785697959

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-udpate-add-bq-wif-dbt-labs.vercel.app/docs/community-adapters
- https://docs-getdbt-com-git-udpate-add-bq-wif-dbt-labs.vercel.app/docs/dbt-versions/release-notes
- https://docs-getdbt-com-git-udpate-add-bq-wif-dbt-labs.vercel.app/docs/fusion/connect-data-platform-fusion/bigquery-setup
- https://docs-getdbt-com-git-udpate-add-bq-wif-dbt-labs.vercel.app/docs/local/connect-data-platform/bigquery-setup
- https://docs-getdbt-com-git-udpate-add-bq-wif-dbt-labs.vercel.app/docs/local/connect-data-platform/confluent-setup
- https://docs-getdbt-com-git-udpate-add-bq-wif-dbt-labs.vercel.app/docs/platform/manage-access/set-up-bigquery-oauth
- https://docs-getdbt-com-git-udpate-add-bq-wif-dbt-labs.vercel.app/reference/global-configs/behavior-flag-maturity
- https://docs-getdbt-com-git-udpate-add-bq-wif-dbt-labs.vercel.app/reference/resource-configs/confluent-configs

<!-- end-vercel-deployment-preview -->