### PR TITLE
Fix broken deep links in API docs (api-v2 / api-v3)

### DIFF
--- a/website/src/components/stoplight/index.js
+++ b/website/src/components/stoplight/index.js
@@ -18,7 +18,8 @@ export default function Stoplight({ version }) {
           ".yaml"
         }
         platformUrl={useBaseUrl("/")}
-        basePath={useBaseUrl("/dbt-cloud/api-" + version) + "#"}
+        router="hash"
+        basePath="/"
         hideSchemas
       />
     </>


### PR DESCRIPTION
## Problem

Direct or shared links to a specific operation in the API docs, e.g. /dbt-cloud/api-v3#/operations/Update%20User%20Credentials, landed on the top-level API page instead of the operation. Clicking around within the page worked; only fresh page loads and shared links broke.

## Cause

The Stoplight Elements <API> component was using the default history router while a trailing # was appended to basePath to fake hash-style URLs. The history router reads the URL path and ignores everything after #, so on a fresh load the #/operations/... fragment was thrown away and no operation matched, falling back to the top-level view.

## Fix

Switch the component to the hash router, which reads the route from the # fragment:

- basePath={useBaseUrl("/dbt-cloud/api-" + version) + "#"}
+ router="hash"
+ basePath="/"

The generated URL format is unchanged (…/api-v3#/operations/...), so all existing internal doc links and external bookmarks keep working, they now resolve correctly on direct load instead of only after an in-app click.

## Preview

Verify going to the link directly opens the page, rather than redirecting to `/dbt-cloud/api-v<number>`
- https://docs-getdbt-com-git-worktree-fix-stoplight-hash-aa03a1-dbt-labs.vercel.app/dbt-cloud/api-v3#/operations/Create%20Group
- https://docs-getdbt-com-git-worktree-fix-stoplight-hash-aa03a1-dbt-labs.vercel.app/dbt-cloud/api-v2?version=2.0&name=Fusion#/operations/List%20Environments
- https://docs-getdbt-com-git-worktree-fix-stoplight-hash-aa03a1-dbt-labs.vercel.app/dbt-cloud/api-v2?version=2.0&name=Fusion#/operations/Retrieve%20Environment

## Additional Notes

You can confirm the issue on the live site by going directly to an api doc url, for example: https://docs.getdbt.com/dbt-cloud/api-v3#/operations/Create%20Account%20Connection. This will land you on `/api-v3`