### PR TITLE
Remove WIF not supported note from Fusion supported features

### DIFF
--- a/website/snippets/_fusion-dwh.md
+++ b/website/snippets/_fusion-dwh.md
@@ -2,7 +2,7 @@
     - Service Account / User Token
     - Native OAuth
     - External OAuth 
-      - [Workload Identity Federation](/docs/platform/manage-access/set-up-bigquery-oauth?version=1.12#set-up-bigquery-workload-identity-federation) isn't currently supported in <Constant name="fusion"/>. Use a [Native OAuth connection](/docs/platform/manage-access/set-up-bigquery-oauth#set-up-bigquery-native-oauth) or service account instead. Support coming soon.
+      - [Workload Identity Federation](/docs/platform/manage-access/set-up-bigquery-oauth#set-up-bigquery-workload-identity-federation) (Microsoft Entra)
     - [Required permissions](/docs/local/connect-data-platform/bigquery-setup#required-permissions)
   </Expandable>
 


### PR DESCRIPTION
Updates the BigQuery authentication list in the Fusion supported features page (`_fusion-dwh.md` snippet) to reflect that Workload Identity Federation is now supported in Fusion.

- Removes the "isn't currently supported in Fusion" note for BigQuery WIF.
- Lists Workload Identity Federation (Microsoft Entra) as a supported External OAuth method and links to the setup docs.

Follows up on #9439, which documented WIF support in Fusion.