### PR TITLE
fix: clarify --resource-type flag is used by build, test, clone, and list

### DIFF
--- a/website/docs/reference/node-selection/methods.md
+++ b/website/docs/reference/node-selection/methods.md
@@ -216,7 +216,7 @@ selectors unambiguous.
 
 <VersionBlock lastVersion="1.10">
 
-Use the `resource_type` method to select nodes of a particular type (`model`, `test`, `exposure`, and so on). This is similar to the `--resource-type` flag used by the [`dbt ls` command](/reference/commands/list).
+Use the `resource_type` method to select nodes of a particular type (`model`, `test`, `exposure`, and so on). This is similar to the `--resource-type` flag used by the `dbt build`, `dbt test`, `dbt clone`, and [`dbt list`](/reference/commands/list) commands.
 
 ```bash
 dbt build --select "resource_type:exposure"    # build all resources upstream of exposures
@@ -228,7 +228,7 @@ dbt list --select "resource_type:source"       # list all sources in your projec
 
 <VersionBlock firstVersion="1.11">
 
-Use the `resource_type` method to select nodes of a particular type (`model`, `test`, `exposure`, `function`, and so on). This is similar to the `--resource-type` flag used by the [`dbt ls` command](/reference/commands/list).
+Use the `resource_type` method to select nodes of a particular type (`model`, `test`, `exposure`, `function`, and so on). This is similar to the `--resource-type` flag used by the `dbt build`, `dbt test`, `dbt clone`, and [`dbt list`](/reference/commands/list) commands.
 
 ```bash
 dbt build --select "resource_type:exposure"    # build all resources upstream of exposures

--- a/website/docs/reference/node-selection/methods.md
+++ b/website/docs/reference/node-selection/methods.md
@@ -216,7 +216,7 @@ selectors unambiguous.
 
 <VersionBlock lastVersion="1.10">
 
-Use the `resource_type` method to select nodes of a particular type (`model`, `test`, `exposure`, and so on). This is similar to the `--resource-type` flag used by the `dbt build`, `dbt test`, `dbt clone`, and [`dbt list`](/reference/commands/list) commands.
+Use the `resource_type` method to select nodes of a particular type (`model`, `test`, `exposure`, and so on). This is similar to the `--resource-type` flag used by the `dbt build`, `dbt test`, `dbt clone`, and `dbt list` [commands](/reference/dbt-commands#available-commands).
 
 ```bash
 dbt build --select "resource_type:exposure"    # build all resources upstream of exposures
@@ -228,7 +228,7 @@ dbt list --select "resource_type:source"       # list all sources in your projec
 
 <VersionBlock firstVersion="1.11">
 
-Use the `resource_type` method to select nodes of a particular type (`model`, `test`, `exposure`, `function`, and so on). This is similar to the `--resource-type` flag used by the `dbt build`, `dbt test`, `dbt clone`, and [`dbt list`](/reference/commands/list) commands.
+Use the `resource_type` method to select nodes of a particular type (`model`, `test`, `exposure`, `function`, and so on). This is similar to the `--resource-type` flag used by the `dbt build`, `dbt test`, `dbt clone`, and `dbt list` [commands](/reference/dbt-commands#available-commands).
 
 ```bash
 dbt build --select "resource_type:exposure"    # build all resources upstream of exposures


### PR DESCRIPTION
## Summary

Fixes #8908

The `resource_type` method docs incorrectly stated that `--resource-type` is only used by the `dbt ls` command. Per the [global configs page](https://docs.getdbt.com/reference/global-configs/resource-type), the flag is supported by `dbt build`, `dbt test`, `dbt clone`, and `dbt list`.

**Change:** Updated the description in both `<VersionBlock>` sections (≤1.10 and ≥1.11) to list all four supported commands instead of only `dbt ls`.

## Before

> This is similar to the `--resource-type` flag used by the `dbt ls` command.

## After

> This is similar to the `--resource-type` flag used by the `dbt build`, `dbt test`, `dbt clone`, and `dbt list` commands.

## Test plan

- [x] Verified the updated text is consistent with the [resource-type global configs page](https://docs.getdbt.com/reference/global-configs/resource-type)
- [x] Both `<VersionBlock>` sections updated (lastVersion="1.10" and firstVersion="1.11")
- [x] Docs preview renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)