### PR TITLE
Update Fusion changelog URL to dbt-core repo

### DIFF
--- a/website/src/components/fusionReleases/index.js
+++ b/website/src/components/fusionReleases/index.js
@@ -3,11 +3,11 @@ import { usePluginData } from "@docusaurus/useGlobalData";
 import styles from "./styles.module.css";
 
 const CHANGELOG_BASE =
-  "https://github.com/dbt-labs/dbt-fusion/blob/main/CHANGELOG.md";
+  "https://github.com/dbt-labs/dbt-core/blob/main/CHANGELOG-fusion.md";
 
 /**
  * Fragment for a Fusion release version, matching GitHub’s autolink for the
- * corresponding `## {version}` heading in CHANGELOG.md (e.g. `2.0.0-preview.172` → `200-preview172`).
+ * corresponding `## {version}` heading in CHANGELOG-fusion.md (e.g. `2.0.0-preview.172` → `200-preview172`).
  */
 function versionToChangelogFragment(version) {
   return version


### PR DESCRIPTION
The `dbt-fusion` repo is archived; the Fusion changelog now lives in `dbt-core` as `CHANGELOG-fusion.md`. Updates the changelog base URL in the Fusion releases component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)