### PR TITLE
Document legacy Team plan ineligibility for dbt State

### DIFF
--- a/website/docs/docs/deploy/dbt-state-about.md
+++ b/website/docs/docs/deploy/dbt-state-about.md
@@ -56,7 +56,7 @@ To use dbt State, you need:
     - A current <Constant name="dbt_platform" /> account
     - A standalone dbt State account
 
-Note that dbt State isn't available to legacy Starter <Constant name="dbt_platform" /> accounts. If you're on a legacy account, [reach out to dbt Labs](https://www.getdbt.com/contact) for guidance. 
+Note that dbt State isn't available to [legacy Starter](/docs/platform/billing#legacy-plans) <Constant name="dbt_platform" /> accounts. If you're on a legacy account, [reach out to dbt Labs](https://www.getdbt.com/contact) for guidance. 
 
 More data warehouses are on the roadmap. If you're using another data warehouse and are interested in dbt State, [let us know](https://www.getdbt.com/contact).
 

--- a/website/docs/docs/deploy/dbt-state-about.md
+++ b/website/docs/docs/deploy/dbt-state-about.md
@@ -63,10 +63,6 @@ More data warehouses are on the roadmap. If you're using another data warehouse 
 
 ## Signing up for dbt State
 
-:::note
-dbt State is available on current dbt platform plans (Starter, Developer, Team, and Enterprise). Legacy Team plan accounts are not eligible.
-:::
-
 When you sign up for dbt State, you'll choose one of two paths:
 
 - **<Constant name="dbt_platform" /> account** — dbt State is connected to your existing <Constant name="dbt_platform" /> account. Your dbt State credentials are the same as your platform credentials, and dbt State has access to your platform environments and jobs.

--- a/website/docs/docs/deploy/dbt-state-about.md
+++ b/website/docs/docs/deploy/dbt-state-about.md
@@ -56,7 +56,7 @@ To use dbt State, you need:
     - A current <Constant name="dbt_platform" /> account
     - A standalone dbt State account
 
-Note that dbt State isn't available to legacy <Constant name="dbt_platform" /> accounts. If you're on a legacy account, [reach out to dbt Labs](https://www.getdbt.com/contact) for guidance. 
+Note that dbt State isn't available to legacy Starter <Constant name="dbt_platform" /> accounts. If you're on a legacy account, [reach out to dbt Labs](https://www.getdbt.com/contact) for guidance. 
 
 More data warehouses are on the roadmap. If you're using another data warehouse and are interested in dbt State, [let us know](https://www.getdbt.com/contact).
 

--- a/website/docs/docs/deploy/dbt-state-about.md
+++ b/website/docs/docs/deploy/dbt-state-about.md
@@ -50,8 +50,8 @@ To use dbt State, you need:
 - A supported data platform. dbt State currently supports Snowflake, Databricks, BigQuery, and Redshift
 - A supported dbt State account type, which you can learn more about in [Signing up for dbt State](#signing-up-for-dbt-state):
     - A current <Constant name="dbt_platform" /> account
+          - dbt State isn't available to users on [legacy Starter](/docs/platform/billing#legacy-plans) plans. If you're on a legacy Starter plan, [reach out to dbt Labs](https://www.getdbt.com/contact) for guidance.
     - A standalone dbt State account
-      - dbt State isn't available to users on [legacy Starter](/docs/platform/billing#legacy-plans) plans. If you're on a legacy Starter plan, [reach out to dbt Labs](https://www.getdbt.com/contact) for guidance.
 
 
 More data warehouses are on the roadmap. If you're using another data warehouse and are interested in dbt State, [let us know](https://www.getdbt.com/contact).

--- a/website/docs/docs/deploy/dbt-state-about.md
+++ b/website/docs/docs/deploy/dbt-state-about.md
@@ -45,7 +45,7 @@ For the full list of available configs, see [dbt State configs](/reference/resou
 To use dbt State, you need:
 
 - A supported version of dbt. 
-    - Natively available for <Constant name="core" /> v1.12+ and the <Constant name="fusion_engine" /> both in <Constant name="dbt_platform" /> and locally in <Constant name="core" />. 
+    - Natively available for <Constant name="core" /> v1.12+ and the <Constant name="fusion_engine" /> both in <Constant name="dbt_platform" /> and locally.
     - Available as a plugin for older versions of <Constant name="core" /> (1.7-1.11).
 - A supported data platform. dbt State currently supports:
     - Snowflake

--- a/website/docs/docs/deploy/dbt-state-about.md
+++ b/website/docs/docs/deploy/dbt-state-about.md
@@ -54,6 +54,10 @@ More data warehouses are on the roadmap. If you're using another data warehouse 
 
 ## Signing up for dbt State
 
+:::note
+dbt State is available on current dbt platform plans (Starter, Developer, Team, and Enterprise). Legacy Team plan accounts are not eligible.
+:::
+
 When you sign up for dbt State, you'll choose one of two paths:
 
 - **<Constant name="dbt_platform" /> account** — dbt State is connected to your existing <Constant name="dbt_platform" /> account. Your dbt State credentials are the same as your platform credentials, and dbt State has access to your platform environments and jobs.

--- a/website/docs/docs/deploy/dbt-state-about.md
+++ b/website/docs/docs/deploy/dbt-state-about.md
@@ -44,7 +44,7 @@ For the full list of available configs, see [dbt State configs](/reference/resou
 
 To use dbt State, you need:
 
-- Using a supported version of dbt. 
+- A supported version of dbt. 
     - Natively available for <Constant name="core" /> v1.12+ and the <Constant name="fusion_engine" /> both in <Constant name="dbt_platform" /> and locally in <Constant name="core" />. 
     - Available as a plugin for older versions of <Constant name="core" /> (1.7-1.11).
 - A supported data platform. dbt State currently supports:

--- a/website/docs/docs/deploy/dbt-state-about.md
+++ b/website/docs/docs/deploy/dbt-state-about.md
@@ -47,11 +47,7 @@ To use dbt State, you need:
 - A supported version of dbt. 
     - Natively available for <Constant name="core" /> v1.12+ and the <Constant name="fusion_engine" /> both in <Constant name="dbt_platform" /> and locally.
     - Available as a plugin for older versions of <Constant name="core" /> (1.7-1.11).
-- A supported data platform. dbt State currently supports:
-    - Snowflake
-    - Databricks
-    - BigQuery
-    - Redshift
+- A supported data platform. dbt State currently supports, Snowflake, Databricks, BigQuery, and Redshift
 - A supported dbt State account type, which you can learn more about in [Signing up for dbt State](#signing-up-for-dbt-state):
     - A current <Constant name="dbt_platform" /> account
     - A standalone dbt State account

--- a/website/docs/docs/deploy/dbt-state-about.md
+++ b/website/docs/docs/deploy/dbt-state-about.md
@@ -24,9 +24,9 @@ dbt State works with <Constant name="core" />, the <Constant name="dbt_platform"
 
 dbt State delivers efficiency gains across both production and development environments:
 
-- **Fresher data, lower costs** — Nodes only rebuild when the result would be different (new data or code changes), reducing warehouse compute while keeping production data fresh.
-- **Faster iteration cycles** — In development, dbt automatically clones selected nodes from production whenever possible, so you spend less time waiting for builds and more time writing code.
-- **Smarter than standard deferral** — Unlike standard deferral, which always builds selected nodes and only defers unselected upstream references, dbt State decides whether transformations need to run at all, or whether an existing table can simply be cloned.
+- **Fresher data, lower costs**: Nodes only rebuild when the result would be different (new data or code changes), reducing warehouse compute while keeping production data fresh.
+- **Faster iteration cycles**: In development, dbt automatically clones selected nodes from production whenever possible, so you spend less time waiting for builds and more time writing code.
+- **Smarter than standard deferral**: Unlike standard deferral, which always builds selected nodes and only defers unselected upstream references, dbt State decides whether transformations need to run at all, or whether an existing table can simply be cloned.
 
 ## How dbt State works
 
@@ -40,14 +40,23 @@ Without dbt State, every selected node rebuilds on every run regardless of wheth
 
 For the full list of available configs, see [dbt State configs](/reference/resource-configs/dbt-state-configs).
 
-## Supported data warehouses
+## Prerequisites
 
-dbt State is supported on the following data warehouses:
+To use dbt State, you need:
 
-- Snowflake
-- Databricks
-- BigQuery
-- Redshift
+- Using a supported version of dbt. 
+    - Natively available for <Constant name="core" /> v1.12+ and the <Constant name="fusion_engine" /> both in <Constant name="dbt_platform" /> and locally in <Constant name="core" />. 
+    - Available as a plugin for older versions of <Constant name="core" /> (1.7-1.11).
+- A supported data platform. dbt State currently supports:
+    - Snowflake
+    - Databricks
+    - BigQuery
+    - Redshift
+- A supported dbt State account type, which you can learn more about in [Signing up for dbt State](#signing-up-for-dbt-state):
+    - A current <Constant name="dbt_platform" /> account
+    - A standalone dbt State account
+
+Note that dbt State isn't available to legacy <Constant name="dbt_platform" /> accounts. If you're on a legacy account, [reach out to dbt Labs](https://www.getdbt.com/contact) for guidance. 
 
 More data warehouses are on the roadmap. If you're using another data warehouse and are interested in dbt State, [let us know](https://www.getdbt.com/contact).
 

--- a/website/docs/docs/deploy/dbt-state-about.md
+++ b/website/docs/docs/deploy/dbt-state-about.md
@@ -47,12 +47,12 @@ To use dbt State, you need:
 - A supported version of dbt. 
     - Natively available for <Constant name="core" /> v1.12+ and the <Constant name="fusion_engine" /> both in <Constant name="dbt_platform" /> and locally.
     - Available as a plugin for older versions of <Constant name="core" /> (1.7-1.11).
-- A supported data platform. dbt State currently supports, Snowflake, Databricks, BigQuery, and Redshift
+- A supported data platform. dbt State currently supports Snowflake, Databricks, BigQuery, and Redshift
 - A supported dbt State account type, which you can learn more about in [Signing up for dbt State](#signing-up-for-dbt-state):
     - A current <Constant name="dbt_platform" /> account
     - A standalone dbt State account
+      - dbt State isn't available to users on [legacy Starter](/docs/platform/billing#legacy-plans) plans. If you're on a legacy Starter plan, [reach out to dbt Labs](https://www.getdbt.com/contact) for guidance.
 
-Note that dbt State isn't available to [legacy Starter](/docs/platform/billing#legacy-plans) <Constant name="dbt_platform" /> accounts. If you're on a legacy account, [reach out to dbt Labs](https://www.getdbt.com/contact) for guidance. 
 
 More data warehouses are on the roadmap. If you're using another data warehouse and are interested in dbt State, [let us know](https://www.getdbt.com/contact).
 

--- a/website/docs/docs/deploy/dbt-state-setup.md
+++ b/website/docs/docs/deploy/dbt-state-setup.md
@@ -8,17 +8,33 @@ tags: ['dbt State']
 
 # Setting up dbt State <Lifecycle status="preview" />
 
-dbt State is natively available in <Constant name="dbt_platform" /> and locally in <Constant name="core" /> v1.12+ and the <Constant name="fusion_engine" />. It is also available as a plugin for older versions of <Constant name="core" /> (1.7-1.11).
+This page walks you through setting up dbt State across <Constant name="core" />, <Constant name="dbt_platform" />, and <Constant name="fusion" />.
 
-Once enabled, dbt State runs automatically on every `dbt run` or `dbt build`.
+## Prerequisites
 
-Before you begin:
+Before you set up dbt State, make sure you have:
 
-- dbt State is available on current dbt platform plans (Starter, Developer, Team, and Enterprise). Legacy Team plan accounts are not eligible.
-- dbt State supports Snowflake, Databricks, BigQuery, and Redshift.
-- dbt State requires authentication either through a <Constant name="dbt_platform" /> account, or a [standalone account](https://app.state.dbt.com) that's independent of <Constant name="dbt_platform" />. For details on which option is right for you, refer to [About dbt State](/docs/deploy/dbt-state-about#signing-up-for-dbt-state). For pricing information, refer to [dbt State usage and pricing](/docs/platform/billing#dbt-state-usage).
+- A supported dbt version or experience. dbt State is:
+    - Natively available in <Constant name="dbt_platform" />, <Constant name="core" /> v1.12 and later, and the <Constant name="fusion_engine" />
+    - Available as a plugin for <Constant name="core" /> v1.7 through v1.11
+- A supported data platform. dbt State currently supports:
+    - Snowflake
+    - Databricks
+    - BigQuery
+    - Redshift
+- A supported dbt State account type. dbt State requires authentication through either:
+   - A current <Constant name="dbt_platform" /> account
+   - A standalone dbt State account that's independent of <Constant name="dbt_platform" />
+   
+   To learn more about which account option is right for you, refer to [About dbt State](/docs/deploy/dbt-state-about#signing-up-for-dbt-state). For pricing information, refer to [dbt State usage and pricing](/docs/platform/billing#dbt-state-usage).
 
-Select the option that matches your setup:
+Note that dbt State isn't available to legacy <Constant name="dbt_platform" /> accounts. If you're on a legacy account, [reach out to dbt Labs](https://www.getdbt.com/contact) for guidance. 
+
+More data warehouses are on the roadmap. If you're using another data warehouse and are interested in dbt State, [let us know](https://www.getdbt.com/contact).
+
+## Setting up dbt State
+
+Set up dbt State either in <Constant name="dbt_platform" /> or locally in <Constant name="core" /> by using the following steps depending on how you're using dbt.
 
 <Tabs>
 <TabItem value="platform" label="dbt platform">

--- a/website/docs/docs/deploy/dbt-state-setup.md
+++ b/website/docs/docs/deploy/dbt-state-setup.md
@@ -17,14 +17,15 @@ Before you set up dbt State, make sure you have:
 - A supported dbt version or experience. dbt State is:
     - Natively available in <Constant name="dbt_platform" />, <Constant name="core" /> v1.12 and later, and the <Constant name="fusion_engine" />
     - Available as a plugin for <Constant name="core" /> v1.7 through v1.11
-- A supported data platform. dbt State currently supports, Snowflake, Databricks, BigQuery, and Redshift
+- A supported data platform. dbt State currently supports Snowflake, Databricks, BigQuery, and Redshift
 - A supported dbt State account type. dbt State requires authentication through either:
    - A current <Constant name="dbt_platform" /> account
    - A standalone dbt State account that's independent of <Constant name="dbt_platform" />
    
+    dbt State isn't available to users on [legacy Starter](/docs/platform/billing#legacy-plans) plans. If you're on a legacy Starter plan, [reach out to dbt Labs](https://www.getdbt.com/contact) for guidance.
+   
    To learn more about which account option is right for you, refer to [About dbt State](/docs/deploy/dbt-state-about#signing-up-for-dbt-state). For pricing information, refer to [dbt State usage and pricing](/docs/platform/billing#dbt-state-usage).
 
-Note that dbt State isn't available to [legacy Starter](/docs/platform/billing#legacy-plans) <Constant name="dbt_platform" /> accounts. If you're on a legacy account, [reach out to dbt Labs](https://www.getdbt.com/contact) for guidance. 
 
 More data warehouses are on the roadmap. If you're using another data warehouse and are interested in dbt State, [let us know](https://www.getdbt.com/contact).
 

--- a/website/docs/docs/deploy/dbt-state-setup.md
+++ b/website/docs/docs/deploy/dbt-state-setup.md
@@ -28,7 +28,7 @@ Before you set up dbt State, make sure you have:
    
    To learn more about which account option is right for you, refer to [About dbt State](/docs/deploy/dbt-state-about#signing-up-for-dbt-state). For pricing information, refer to [dbt State usage and pricing](/docs/platform/billing#dbt-state-usage).
 
-Note that dbt State isn't available to legacy Starter <Constant name="dbt_platform" /> accounts. If you're on a legacy account, [reach out to dbt Labs](https://www.getdbt.com/contact) for guidance. 
+Note that dbt State isn't available to [legacy Starter](/docs/platform/billing#legacy-plans) <Constant name="dbt_platform" /> accounts. If you're on a legacy account, [reach out to dbt Labs](https://www.getdbt.com/contact) for guidance. 
 
 More data warehouses are on the roadmap. If you're using another data warehouse and are interested in dbt State, [let us know](https://www.getdbt.com/contact).
 

--- a/website/docs/docs/deploy/dbt-state-setup.md
+++ b/website/docs/docs/deploy/dbt-state-setup.md
@@ -20,9 +20,9 @@ Before you set up dbt State, make sure you have:
 - A supported data platform. dbt State currently supports Snowflake, Databricks, BigQuery, and Redshift
 - A supported dbt State account type. dbt State requires authentication through either:
    - A current <Constant name="dbt_platform" /> account
+         - dbt State isn't available to users on [legacy Starter](/docs/platform/billing#legacy-plans) plans. If you're on a legacy Starter plan, [reach out to dbt Labs](https://www.getdbt.com/contact) for guidance.
    - A standalone dbt State account that's independent of <Constant name="dbt_platform" />
    
-    dbt State isn't available to users on [legacy Starter](/docs/platform/billing#legacy-plans) plans. If you're on a legacy Starter plan, [reach out to dbt Labs](https://www.getdbt.com/contact) for guidance.
    
    To learn more about which account option is right for you, refer to [About dbt State](/docs/deploy/dbt-state-about#signing-up-for-dbt-state). For pricing information, refer to [dbt State usage and pricing](/docs/platform/billing#dbt-state-usage).
 

--- a/website/docs/docs/deploy/dbt-state-setup.md
+++ b/website/docs/docs/deploy/dbt-state-setup.md
@@ -14,6 +14,7 @@ Once enabled, dbt State runs automatically on every `dbt run` or `dbt build`.
 
 Before you begin:
 
+- dbt State is available on current dbt platform plans (Starter, Developer, Team, and Enterprise). Legacy Team plan accounts are not eligible.
 - dbt State supports Snowflake, Databricks, BigQuery, and Redshift.
 - dbt State requires authentication either through a <Constant name="dbt_platform" /> account, or a [standalone account](https://app.state.dbt.com) that's independent of <Constant name="dbt_platform" />. For details on which option is right for you, refer to [About dbt State](/docs/deploy/dbt-state-about#signing-up-for-dbt-state). For pricing information, refer to [dbt State usage and pricing](/docs/platform/billing#dbt-state-usage).
 

--- a/website/docs/docs/deploy/dbt-state-setup.md
+++ b/website/docs/docs/deploy/dbt-state-setup.md
@@ -17,11 +17,7 @@ Before you set up dbt State, make sure you have:
 - A supported dbt version or experience. dbt State is:
     - Natively available in <Constant name="dbt_platform" />, <Constant name="core" /> v1.12 and later, and the <Constant name="fusion_engine" />
     - Available as a plugin for <Constant name="core" /> v1.7 through v1.11
-- A supported data platform. dbt State currently supports:
-    - Snowflake
-    - Databricks
-    - BigQuery
-    - Redshift
+- A supported data platform. dbt State currently supports, Snowflake, Databricks, BigQuery, and Redshift
 - A supported dbt State account type. dbt State requires authentication through either:
    - A current <Constant name="dbt_platform" /> account
    - A standalone dbt State account that's independent of <Constant name="dbt_platform" />

--- a/website/docs/docs/deploy/dbt-state-setup.md
+++ b/website/docs/docs/deploy/dbt-state-setup.md
@@ -28,7 +28,7 @@ Before you set up dbt State, make sure you have:
    
    To learn more about which account option is right for you, refer to [About dbt State](/docs/deploy/dbt-state-about#signing-up-for-dbt-state). For pricing information, refer to [dbt State usage and pricing](/docs/platform/billing#dbt-state-usage).
 
-Note that dbt State isn't available to legacy <Constant name="dbt_platform" /> accounts. If you're on a legacy account, [reach out to dbt Labs](https://www.getdbt.com/contact) for guidance. 
+Note that dbt State isn't available to legacy Starter <Constant name="dbt_platform" /> accounts. If you're on a legacy account, [reach out to dbt Labs](https://www.getdbt.com/contact) for guidance. 
 
 More data warehouses are on the roadmap. If you're using another data warehouse and are interested in dbt State, [let us know](https://www.getdbt.com/contact).
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -856,7 +856,7 @@ const sidebarSettings = {
           type: "category",
           label: "Set up dbt State",
           link: { type: "doc", id: "docs/deploy/dbt-state-setup" },
-          items: ["docs/deploy/dbt-state-cicd", "docs/deploy/dbt-state-deferral"],
+          items: ["docs/deploy/dbt-state-setup", "docs/deploy/dbt-state-cicd", "docs/deploy/dbt-state-deferral"],
         },
 
         "docs/deploy/dbt-state-examples",


### PR DESCRIPTION
clarify confusion around dbt state availability for legacy Team plan users

## Changes

- added prerequisites in the about dbt state and set up dbt state pages
- added some intro sentences to separate sections
- added 'set up dbt state' to the sidebar by adding an array

## Preview links
[staging 1](https://docs-getdbt-com-git-add-legacy-team-state-eligi-737e00-dbt-labs.vercel.app/docs/deploy/dbt-state-about?version=2.0&name=Fusion)
[staging 2](https://docs-getdbt-com-git-add-legacy-team-state-eligi-737e00-dbt-labs.vercel.app/docs/deploy/dbt-state-setup?version=2.0) (