### PR TITLE
Add ST to MT release notes automation (sync + Friday Slack)

### DIFF
--- a/.github/scripts/extract_release_notes.py
+++ b/.github/scripts/extract_release_notes.py
@@ -22,6 +22,11 @@ CATEGORY_MAP = {
     "behavior change": "Behavior change",
 }
 
+MT_CATEGORY_PREFIX_RE = re.compile(
+    r"^\*\*(New|Enhancement|Fix|Behavior change|Beta|Alpha|Preview|Private beta)\*\*:?\s*",
+    re.IGNORECASE,
+)
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -106,6 +111,44 @@ def format_mt_bullet(category: str, body: str) -> str:
     return f"- **{category}:** {body}"
 
 
+def bullet_signature(text: str) -> str:
+    """Return a normalized title key used to detect duplicate bullets."""
+    line = text.strip()
+    if line.startswith("- "):
+        line = line[2:].strip()
+    line = MT_CATEGORY_PREFIX_RE.sub("", line, count=1)
+    title_match = re.match(r"\*\*([^*]+)\*\*", line)
+    if title_match:
+        return re.sub(r"\s+", " ", title_match.group(1).strip().lower())
+    return re.sub(r"\s+", " ", line[:120].lower())
+
+
+def collect_existing_signatures(mt_lines: list[str]) -> set[str]:
+    return {
+        bullet_signature(line)
+        for line in mt_lines
+        if line.strip().startswith("- ")
+    }
+
+
+def filter_duplicates(
+    formatted: list[str], existing: set[str]
+) -> tuple[list[str], list[str]]:
+    new_bullets: list[str] = []
+    skipped: list[str] = []
+    seen = set(existing)
+
+    for bullet in formatted:
+        signature = bullet_signature(bullet)
+        if signature in seen:
+            skipped.append(bullet)
+            continue
+        new_bullets.append(bullet)
+        seen.add(signature)
+
+    return new_bullets, skipped
+
+
 def find_month_insert_line(lines: list[str], month_heading: str) -> int:
     target = f"## {month_heading}"
     for index, line in enumerate(lines):
@@ -141,13 +184,31 @@ def main() -> int:
     insert_at = find_month_insert_line(mt_lines, month_heading)
 
     formatted = [format_mt_bullet(category, body) for category, body in bullets]
+    existing_signatures = collect_existing_signatures(mt_lines)
+    to_insert, skipped = filter_duplicates(formatted, existing_signatures)
 
     print(f"Week: {args.week}")
     print(f"Target month section: ## {month_heading}")
     print(f"Bullets found: {len(formatted)}")
+    print(f"Skipped (already in MT file): {len(skipped)}")
+    print(f"Would add: {len(to_insert)}")
     print()
+
+    if skipped:
+        print("--- Skipped duplicates ---")
+        for bullet in skipped:
+            print(bullet)
+        print("--- End skipped ---")
+        print()
+
+    if not to_insert:
+        print("No new bullets to add — all entries already exist in the MT file.")
+        if args.dry_run:
+            print("Dry run only — no files were changed.")
+        return 0
+
     print("--- Preview (what would be added to the monthly file) ---")
-    for bullet in formatted:
+    for bullet in to_insert:
         print(bullet)
     print("--- End preview ---")
 
@@ -156,7 +217,7 @@ def main() -> int:
         print("Dry run only — no files were changed.")
         return 0
 
-    new_mt_lines = mt_lines[:insert_at] + formatted + [""] + mt_lines[insert_at:]
+    new_mt_lines = mt_lines[:insert_at] + to_insert + [""] + mt_lines[insert_at:]
     mt_path.write_text("\n".join(new_mt_lines) + "\n", encoding="utf-8")
     print(f"Updated {mt_path}")
     return 0

--- a/.github/scripts/extract_release_notes.py
+++ b/.github/scripts/extract_release_notes.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Extract weekly single-tenant release notes for multi-tenant release notes."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+WEEK_HEADING_RE = re.compile(r"^##\s+([A-Za-z]+\s+\d{1,2},\s+\d{4})\s*$")
+MONTH_HEADING_RE = re.compile(r"^##\s+([A-Za-z]+\s+\d{4})\s*$")
+
+CATEGORY_MAP = {
+    "new": "New",
+    "enhancements": "Enhancement",
+    "enhancement": "Enhancement",
+    "fixes": "Fix",
+    "fix": "Fix",
+    "behavior changes": "Behavior change",
+    "behavior change": "Behavior change",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Extract a week from ST release notes for MT release notes."
+    )
+    parser.add_argument(
+        "--st-file",
+        required=True,
+        help="Path to dbt-platform-release-notes-gen.md",
+    )
+    parser.add_argument(
+        "--mt-file",
+        required=True,
+        help="Path to release-notes.md",
+    )
+    parser.add_argument(
+        "--week",
+        required=True,
+        help='Week heading date, e.g. "June 17, 2026"',
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print preview only; do not write files.",
+    )
+    return parser.parse_args()
+
+
+def normalize_category(heading: str) -> str:
+    key = heading.strip().lower()
+    if key not in CATEGORY_MAP:
+        raise ValueError(f"Unknown release note category heading: {heading!r}")
+    return CATEGORY_MAP[key]
+
+
+def week_to_month_heading(week: str) -> str:
+    parsed = datetime.strptime(week, "%B %d, %Y")
+    return parsed.strftime("%B %Y")
+
+
+def extract_week_section(lines: list[str], week: str) -> tuple[int, int]:
+    target = f"## {week}"
+    start = None
+    for index, line in enumerate(lines):
+        if line.strip() == target:
+            start = index
+            break
+    if start is None:
+        raise ValueError(f'Week heading not found: "{week}"')
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        match = WEEK_HEADING_RE.match(lines[index].strip())
+        if match:
+            end = index
+            break
+    return start, end
+
+
+def extract_bullets(week_lines: list[str]) -> list[tuple[str, str]]:
+    category = None
+    bullets: list[tuple[str, str]] = []
+
+    for line in week_lines:
+        stripped = line.strip()
+        if stripped.startswith("## ") and not WEEK_HEADING_RE.match(stripped):
+            category = normalize_category(stripped[3:])
+            continue
+        if stripped.startswith("### "):
+            continue
+        if stripped.startswith("- ") and category:
+            bullets.append((category, stripped[2:].strip()))
+
+    if not bullets:
+        raise ValueError(f'No bullets found under week "{week_lines[0].strip()[3:]}"')
+    return bullets
+
+
+def format_mt_bullet(category: str, body: str) -> str:
+    if body.startswith("**") and "**:" in body[:80]:
+        return f"- {body}"
+    return f"- **{category}:** {body}"
+
+
+def find_month_insert_line(lines: list[str], month_heading: str) -> int:
+    target = f"## {month_heading}"
+    for index, line in enumerate(lines):
+        if line.strip() == target:
+            for next_index in range(index + 1, len(lines)):
+                if lines[next_index].startswith("## "):
+                    return next_index
+                if lines[next_index].startswith("- "):
+                    return next_index
+            return index + 1
+    raise ValueError(f'Month heading not found in MT file: "{month_heading}"')
+
+
+def main() -> int:
+    args = parse_args()
+    st_path = Path(args.st_file)
+    mt_path = Path(args.mt_file)
+
+    if not st_path.is_file():
+        print(f"ERROR: ST file not found: {st_path}", file=sys.stderr)
+        return 1
+    if not mt_path.is_file():
+        print(f"ERROR: MT file not found: {mt_path}", file=sys.stderr)
+        return 1
+
+    st_lines = st_path.read_text(encoding="utf-8").splitlines()
+    mt_lines = mt_path.read_text(encoding="utf-8").splitlines()
+
+    start, end = extract_week_section(st_lines, args.week)
+    week_lines = st_lines[start:end]
+    bullets = extract_bullets(week_lines)
+    month_heading = week_to_month_heading(args.week)
+    insert_at = find_month_insert_line(mt_lines, month_heading)
+
+    formatted = [format_mt_bullet(category, body) for category, body in bullets]
+
+    print(f"Week: {args.week}")
+    print(f"Target month section: ## {month_heading}")
+    print(f"Bullets found: {len(formatted)}")
+    print()
+    print("--- Preview (what would be added to the monthly file) ---")
+    for bullet in formatted:
+        print(bullet)
+    print("--- End preview ---")
+
+    if args.dry_run:
+        print()
+        print("Dry run only — no files were changed.")
+        return 0
+
+    new_mt_lines = mt_lines[:insert_at] + formatted + [""] + mt_lines[insert_at:]
+    mt_path.write_text("\n".join(new_mt_lines) + "\n", encoding="utf-8")
+    print(f"Updated {mt_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ValueError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        raise SystemExit(1) from error

--- a/.github/workflows/publish-release-notes.yml
+++ b/.github/workflows/publish-release-notes.yml
@@ -1,0 +1,67 @@
+name: Publish release notes PR
+
+on:
+  schedule:
+    - cron: '0 8 * * 5' # Fridays 8am UTC (~9am UK during BST)
+  workflow_dispatch: {}
+
+jobs:
+  publish:
+    if: github.repository == 'dbt-labs/docs.getdbt.com'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+
+    concurrency:
+      group: publish-release-notes
+      cancel-in-progress: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Find draft release-notes PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_JSON=$(gh pr list --state open --label release-notes --json number,title,url,isDraft --jq '[.[] | select(.isDraft == true)] | .[0]')
+          if [ "$PR_JSON" = "null" ] || [ -z "$PR_JSON" ]; then
+            echo "::error::No open draft PR with release-notes label found"
+            exit 1
+          fi
+          echo "number=$(echo "$PR_JSON" | jq -r .number)" >> "$GITHUB_OUTPUT"
+          echo "title=$(echo "$PR_JSON" | jq -r .title)" >> "$GITHUB_OUTPUT"
+          echo "url=$(echo "$PR_JSON" | jq -r .url)" >> "$GITHUB_OUTPUT"
+
+      - name: Extract week from PR title
+        id: week
+        run: |
+          TITLE="${{ steps.pr.outputs.title }}"
+          WEEK=$(echo "$TITLE" | sed -n 's/.*for \(.*\)$/\1/p')
+          if [ -z "$WEEK" ]; then
+            WEEK="unknown"
+          fi
+          echo "value=$WEEK" >> "$GITHUB_OUTPUT"
+
+      - name: Mark PR ready for review
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr ready ${{ steps.pr.outputs.number }}
+
+      - name: Notify Slack via Zapier
+        env:
+          WEBHOOK_URL: ${{ secrets.ST_MT_RELEASE_NOTES_SLACK_WEBHOOK }}
+        run: |
+          if [ -z "$WEBHOOK_URL" ]; then
+            echo "::error::ST_MT_RELEASE_NOTES_SLACK_WEBHOOK secret is not set"
+            exit 1
+          fi
+          curl -fsS -X POST "$WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n \
+              --arg message "Release notes draft PR ready for Friday review" \
+              --arg pr_title "${{ steps.pr.outputs.title }}" \
+              --arg pr_url "${{ steps.pr.outputs.url }}" \
+              --arg week "${{ steps.week.outputs.value }}" \
+              '{message: $message, pr_title: $pr_title, pr_url: $pr_url, week: $week}')"

--- a/.github/workflows/sync-release-notes.yml
+++ b/.github/workflows/sync-release-notes.yml
@@ -1,0 +1,106 @@
+name: Sync ST release notes to MT
+
+on:
+  push:
+    branches:
+      - current
+    paths:
+      - website/docs/docs/dbt-versions/dbt-platform-release-notes-gen.md
+  workflow_dispatch:
+    inputs:
+      week:
+        description: 'Week heading to sync (e.g. June 17, 2026). Required for manual test runs.'
+        required: true
+        type: string
+
+jobs:
+  sync:
+    if: github.repository == 'dbt-labs/docs.getdbt.com'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    concurrency:
+      group: sync-release-notes
+      cancel-in-progress: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Determine week to sync
+        id: week
+        env:
+          WEEK_INPUT: ${{ github.event.inputs.week }}
+        run: |
+          if [ -n "$WEEK_INPUT" ]; then
+            echo "value=$WEEK_INPUT" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          WEEK=$(python3 - <<'PY'
+          import re
+          from pathlib import Path
+
+          path = Path("website/docs/docs/dbt-versions/dbt-platform-release-notes-gen.md")
+          pattern = re.compile(r"^##\s+([A-Za-z]+\s+\d{1,2},\s+\d{4})\s*$")
+          for line in path.read_text(encoding="utf-8").splitlines():
+              match = pattern.match(line.strip())
+              if match:
+                  print(match.group(1))
+                  break
+          else:
+              raise SystemExit("No week heading found in ST release notes file")
+          PY
+          )
+          echo "value=$WEEK" >> "$GITHUB_OUTPUT"
+
+      - name: Extract and update MT release notes
+        run: |
+          python3 .github/scripts/extract_release_notes.py \
+            --st-file website/docs/docs/dbt-versions/dbt-platform-release-notes-gen.md \
+            --mt-file website/docs/docs/dbt-versions/release-notes.md \
+            --week "${{ steps.week.outputs.value }}"
+
+      - name: Open draft PR if MT file changed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add website/docs/docs/dbt-versions/release-notes.md
+          if git diff --staged --quiet; then
+            echo "No MT release notes changes for week ${{ steps.week.outputs.value }}"
+            exit 0
+          fi
+
+          BRANCH="automation/sync-mt-release-notes-${{ steps.week.outputs.value }}"
+          BRANCH="${BRANCH// /-}"
+
+          git checkout -b "$BRANCH"
+          git commit -m "docs: sync MT release notes for ${{ steps.week.outputs.value }}"
+
+          git push --force origin "$BRANCH"
+
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' || true)
+          if [ -n "$EXISTING_PR" ]; then
+            echo "Draft PR already open: #$EXISTING_PR"
+            exit 0
+          fi
+
+          gh pr create \
+            --draft \
+            --base current \
+            --head "$BRANCH" \
+            --title "docs: sync MT release notes for ${{ steps.week.outputs.value }}" \
+            --body "Automated sync of weekly single-tenant release notes into the monthly multi-tenant/VPC release notes.
+
+          Week synced: **${{ steps.week.outputs.value }}**
+
+          Please review for accuracy and add any MT-only items manually." \
+            --label release-notes \
+            --assignee nataliefiann


### PR DESCRIPTION
## What are you changing in this pull request and why?

This PR adds automation to sync weekly **single-tenant** release notes into monthly **multi-tenant/VPC** release notes, plus a Friday review reminder in Slack.

**Files added:**
- `.github/scripts/extract_release_notes.py` — extracts bullets from a week section in `dbt-platform-release-notes-gen.md` and inserts them into `release-notes.md`
- `.github/workflows/sync-release-notes.yml` — runs the script and opens a **draft PR** when the MT file changes
- `.github/workflows/publish-release-notes.yml` — on **Fridays (~9 AM UK)**, marks the open draft PR ready for review and pings Slack via Zapier

**Why:** This replaces the manual ST → MT copy process. The docs team reviews the generated draft PR before merge. The Friday workflow sends a Slack reminder that the PR is ready.

**Related:** [Single tenant → Multi-tenant automation (Notion)](https://app.notion.com/p/382bb38ebda780679aa4f2db709b5d32) · [Test workflow (Notion)](https://app.notion.com/p/388bb38ebda780daa885e831b8afb888)

**Test status:**
- **Test 1 (local dry run):** Pass — preview matched weekly content for `June 17, 2026` (3 bullets → June 2026)
- **Test 2 (GitHub draft PR):** Pending merge — run **Sync ST release notes to MT** from Actions after merge
- **Test 3 (Friday Slack ping):** Pending merge — Zapier already set up (`ST_MT_RELEASE_NOTES_SLACK_WEBHOOK` → `#tmp-test-agents`); run **Publish release notes PR** from Actions after Test 2 creates a draft PR

**Notes:**
- Does **not** change release notes content in this PR — only adds automation
- Zapier webhook + repo secret are already configured and tested
- Test draft PRs from Test 2 / Test 3 will **not** be merged — tooling verification only
- Automation syncs ST → MT overlap only; MT-only items still need manual adds during review

## Checklist

- [x] This PR does not change docs content (automation only)
- [x] Zapier webhook configured (`ST_MT_RELEASE_NOTES_SLACK_WEBHOOK`)
- [ ] Docs team review
- [ ] After merge: run **Sync ST release notes to MT** manually from Actions to complete Test 2
- [ ] Confirm draft PR is created with `release-notes` label and correct assignee(s)
- [ ] After Test 2: run **Publish release notes PR** manually from Actions to complete Test 3
- [ ] Confirm Slack message appears in `#tmp-test-agents`