### PR TITLE
Update dbt Fusion changelog link in documentation

### DIFF
--- a/website/docs/docs/fusion/fusion-releases.md
+++ b/website/docs/docs/fusion/fusion-releases.md
@@ -18,7 +18,7 @@ This page shows release information for local builds of <Constant name="fusion" 
 
 Track current versions and full release history for the <Constant name="fusion_engine" />. This data updates live from dbt release channels.
 
-Each of the versions on this page links to the matching section in the [dbt Fusion changelog](https://github.com/dbt-labs/dbt-fusion/blob/main/CHANGELOG.md) on GitHub.
+Each of the versions on this page links to the matching section in the [dbt Fusion changelog](https://github.com/dbt-labs/dbt-core/blob/main/CHANGELOG-fusion.md) on GitHub.
 
 ## Release channels
 


### PR DESCRIPTION
update fusion changelog link. raised by community slack https://getdbt.slack.com/archives/C088YCAB6GH/p1782311823236309?thread_ts=1781187655.951259&cid=C088YCAB6GH

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-mirnawong1-patch-27-dbt-labs.vercel.app/docs/fusion/fusion-releases

<!-- end-vercel-deployment-preview -->