### PR TITLE
Surface SCIM license mapping limitation across SCIM docs

### DIFF
--- a/website/docs/docs/platform/manage-access/scim-entra-id.md
+++ b/website/docs/docs/platform/manage-access/scim-entra-id.md
@@ -5,13 +5,13 @@ id: "scim-entra-id"
 sidebar_label: "Set up SCIM with Entra ID"
 ---
 
+import ScimLicenseMappingCallout from '/snippets/_scim-license-mapping-callout.md';
+
 # Set up SCIM with Entra ID <Lifecycle status="managed, managed_plus" />
 
 <Constant name="dbt_platform" /> supports System for Cross-Domain Identity Management (SCIM) with Microsoft Entra ID for user and group provisioning and profile updates.
 
-Microsoft Entra ID doesn't support SCIM-native license mapping (the ability to assign licenses directly via a SCIM attribute, as Okta does). As a workaround, you can use [SSO-based Active Directory group → license mapping](/docs/platform/manage-access/seats-and-users#mapped-configuration) instead. This works even if you have an active Entra ID SCIM integration running alongside it.
-
-When you use the SSO-based Active Directory group → license mapping setup, keep the **Manage user licenses with SCIM** (found in **Account settings > SSO & SCIM**) toggle disabled. Turning it on tells <Constant name="dbt_platform" /> to ignore existing SSO license mappings, which would remove license mapping entirely for Entra ID users.
+<ScimLicenseMappingCallout />
 
 ## Prerequisites
 - Available on [Enterprise or Enterprise+ plans](https://www.getdbt.com/pricing).

--- a/website/docs/docs/platform/manage-access/scim-manage-user-licenses.md
+++ b/website/docs/docs/platform/manage-access/scim-manage-user-licenses.md
@@ -5,13 +5,13 @@ id: "scim-manage-user-licenses"
 sidebar_label: "Manage user licenses with SCIM"
 ---
 
+import ScimLicenseMappingCallout from '/snippets/_scim-license-mapping-callout.md';
+
 # Manage user licenses with SCIM <Lifecycle status="managed, managed_plus" />
 
 You can manage user license assignments using System for Cross-Domain Identity Management (SCIM) and a user attribute in Okta, so the license type is set as users are provisioned and onboarded.
 
-:::info SCIM license mapping available for Okta only
-SCIM license mapping is currently only supported for Okta. For other providers, use [SSO license mapping](/docs/platform/manage-access/seats-and-users#mapped-configuration) or manage [licenses](/docs/platform/manage-access/seats-and-users) in the <Constant name="dbt_platform" /> user interface.
-:::
+<ScimLicenseMappingCallout />
 
 #### Considerations
 Before you enable SCIM license mapping:
@@ -25,12 +25,6 @@ To use license management using SCIM, go to your **Account settings** > **SSO & 
 <Lightbox src="/img/docs/dbt-platform/access-control/scim-managed-licenses.png" width="60%" title="Enable SCIM managed user license distribution." />
 
 We recommend that you complete the setup instructions for your identity provider (IdP) prior to enabling this toggle in your dbt account. Once enabled, any existing license mappings in <Constant name="dbt" /> will be ignored.
-
-:::info Microsoft Entra ID users
-Do not enable the **Manage user licenses with SCIM** if you use Microsoft Entra ID. SCIM-native license attributes aren't supported for Entra ID, so enabling this toggle would disable your existing SSO license mappings without a replacement, leaving users without license mapping.
-
-Instead, keep this toggle _disabled_ and use [SSO-based Active Directory group > license mapping](/docs/platform/manage-access/seats-and-users#mapped-configuration). This setup works alongside an active Entra ID SCIM configuration.
-:::
 
 The recommended steps for migrating to SCIM license mapping are as follows:
 1. Set up SCIM but keep the toggle disabled so existing license mappings continue to work as expected.

--- a/website/docs/docs/platform/manage-access/scim.md
+++ b/website/docs/docs/platform/manage-access/scim.md
@@ -5,6 +5,8 @@ id: "scim"
 sidebar: "Set up SCIM"
 ---
 
+import ScimLicenseMappingCallout from '/snippets/_scim-license-mapping-callout.md';
+
 # Set up SCIM <Lifecycle status="managed, managed_plus" />
 
 The System for Cross-Domain Identity Management (SCIM) makes user data more secure and simplifies the admin and end-user lifecycle experience by automating user identities and groups. You can create or disable user identities in your Identity Provider (IdP), and SCIM will automatically make those changes in near real-time downstream in <Constant name="dbt" />.
@@ -43,6 +45,8 @@ The following IdPs are supported in the <Constant name="dbt" /> user interface:
 - [Set up SCIM with Entra ID](/docs/platform/manage-access/scim-entra-id)
 
 If your IdP isn't on the list, it can be supported using <Constant name="dbt" /> [APIs](/dbt-cloud/api-v3#/operations/Retrieve%20SCIM%20configuration).
+
+<ScimLicenseMappingCallout />
 
 ## Set up dbt {#set-up-dbt}
 

--- a/website/snippets/_scim-license-mapping-callout.md
+++ b/website/snippets/_scim-license-mapping-callout.md
@@ -2,7 +2,6 @@
 
 <Constant name="dbt_platform"/> supports automatic license assignment with SCIM, with these different identity provider options:
 
-Open the following toggle for the option that applies to your identity provider:
 
 <Expandable alt_header="Toggle options per identity provider">
 

--- a/website/snippets/_scim-license-mapping-callout.md
+++ b/website/snippets/_scim-license-mapping-callout.md
@@ -1,4 +1,4 @@
-:::info License mapping with SCIM
+#### License mapping with SCIM
 
 <Constant name="dbt_platform"/> supports automatic license assignment with SCIM, with different options depending on your identity provider:
 
@@ -6,4 +6,3 @@
 - **Entra ID:** Use [SSO-based Active Directory group → license mapping](/docs/platform/manage-access/seats-and-users#mapped-configuration). It works alongside an active Entra ID SCIM setup. Keep the **Manage user licenses with SCIM** toggle _disabled_ as enabling it removes license mapping for Entra ID users.
 
 For more details, refer to the [Does SCIM support automatic license assignment? FAQ](/docs/platform/manage-access/scim-faq#does-scim-support-automatic-license-assignment).
-:::

--- a/website/snippets/_scim-license-mapping-callout.md
+++ b/website/snippets/_scim-license-mapping-callout.md
@@ -11,5 +11,5 @@ Open the following toggle for the option that applies to your identity provider:
 - 
 </Expandable>
 
-For more details, refer to the [Does SCIM support automatic license assignment? FAQ](/docs/platform/manage-access/scim-faq#does-scim-support-automatic-license-assignment).
+For more details, refer to the [Does SCIM support automatic license assignment?](/docs/platform/manage-access/scim-faq#does-scim-support-automatic-license-assignment) FAQ.
 :::

--- a/website/snippets/_scim-license-mapping-callout.md
+++ b/website/snippets/_scim-license-mapping-callout.md
@@ -1,9 +1,9 @@
-:::info SCIM license mapping is only available for Okta
+:::info License mapping with SCIM
 
-SCIM-native license mapping — assigning licenses via a SCIM attribute — is only supported for **Okta**. The behavior differs by identity provider:
+dbt platform supports automatic license assignment via SCIM, with different options depending on your identity provider:
 
 - **Okta:** Enable **Manage user licenses with SCIM** in **Account settings > SSO & SCIM** and follow the [Okta license management guide](/docs/platform/manage-access/scim-manage-user-licenses).
-- **Entra ID:** Keep the **Manage user licenses with SCIM** toggle _disabled_. Use [SSO-based Active Directory group → license mapping](/docs/platform/manage-access/seats-and-users#mapped-configuration) instead — it works alongside an active Entra ID SCIM setup. Enabling the toggle removes license mapping entirely for Entra ID users.
+- **Entra ID:** Use [SSO-based Active Directory group → license mapping](/docs/platform/manage-access/seats-and-users#mapped-configuration) — it works alongside an active Entra ID SCIM setup. Keep the **Manage user licenses with SCIM** toggle _disabled_; enabling it removes license mapping for Entra ID users.
 
 For more details, refer to [Does SCIM support automatic license assignment?](/docs/platform/manage-access/scim-faq#does-scim-support-automatic-license-assignment) in the SCIM FAQ.
 :::

--- a/website/snippets/_scim-license-mapping-callout.md
+++ b/website/snippets/_scim-license-mapping-callout.md
@@ -4,11 +4,11 @@
 
 Open the following toggle for the option that applies to your identity provider:
 
-<Expandable alt_header="Different options">
+<Expandable alt_header="Different options per identity provider">
 
 - **Okta:** Enable **Manage user licenses with SCIM** in **Account settings > SSO & SCIM** and follow the [Okta license management doc](/docs/platform/manage-access/scim-manage-user-licenses).
 - **Entra ID:** Use [SSO-based Active Directory group → license mapping](/docs/platform/manage-access/seats-and-users#mapped-configuration). It works alongside an active Entra ID SCIM setup. Keep the **Manage user licenses with SCIM** toggle _disabled_ as enabling it removes license mapping for Entra ID users.
-- 
+
 </Expandable>
 
 For more details, refer to the [Does SCIM support automatic license assignment?](/docs/platform/manage-access/scim-faq#does-scim-support-automatic-license-assignment) FAQ.

--- a/website/snippets/_scim-license-mapping-callout.md
+++ b/website/snippets/_scim-license-mapping-callout.md
@@ -1,9 +1,9 @@
 :::info License mapping with SCIM
 
-dbt platform supports automatic license assignment via SCIM, with different options depending on your identity provider:
+<Constant name="dbt_platform"/> supports automatic license assignment with SCIM, with different options depending on your identity provider:
 
-- **Okta:** Enable **Manage user licenses with SCIM** in **Account settings > SSO & SCIM** and follow the [Okta license management guide](/docs/platform/manage-access/scim-manage-user-licenses).
-- **Entra ID:** Use [SSO-based Active Directory group → license mapping](/docs/platform/manage-access/seats-and-users#mapped-configuration) — it works alongside an active Entra ID SCIM setup. Keep the **Manage user licenses with SCIM** toggle _disabled_; enabling it removes license mapping for Entra ID users.
+- **Okta:** Enable **Manage user licenses with SCIM** in **Account settings > SSO & SCIM** and follow the [Okta license management doc](/docs/platform/manage-access/scim-manage-user-licenses).
+- **Entra ID:** Use [SSO-based Active Directory group → license mapping](/docs/platform/manage-access/seats-and-users#mapped-configuration). It works alongside an active Entra ID SCIM setup. Keep the **Manage user licenses with SCIM** toggle _disabled_ as enabling it removes license mapping for Entra ID users.
 
-For more details, refer to [Does SCIM support automatic license assignment?](/docs/platform/manage-access/scim-faq#does-scim-support-automatic-license-assignment) in the SCIM FAQ.
+For more details, refer to the [Does SCIM support automatic license assignment? FAQ](/docs/platform/manage-access/scim-faq#does-scim-support-automatic-license-assignment).
 :::

--- a/website/snippets/_scim-license-mapping-callout.md
+++ b/website/snippets/_scim-license-mapping-callout.md
@@ -1,0 +1,9 @@
+:::info SCIM license mapping is only available for Okta
+
+SCIM-native license mapping — assigning licenses via a SCIM attribute — is only supported for **Okta**. The behavior differs by identity provider:
+
+- **Okta:** Enable **Manage user licenses with SCIM** in **Account settings > SSO & SCIM** and follow the [Okta license management guide](/docs/platform/manage-access/scim-manage-user-licenses).
+- **Entra ID:** Keep the **Manage user licenses with SCIM** toggle _disabled_. Use [SSO-based Active Directory group → license mapping](/docs/platform/manage-access/seats-and-users#mapped-configuration) instead — it works alongside an active Entra ID SCIM setup. Enabling the toggle removes license mapping entirely for Entra ID users.
+
+For more details, refer to [Does SCIM support automatic license assignment?](/docs/platform/manage-access/scim-faq#does-scim-support-automatic-license-assignment) in the SCIM FAQ.
+:::

--- a/website/snippets/_scim-license-mapping-callout.md
+++ b/website/snippets/_scim-license-mapping-callout.md
@@ -1,8 +1,15 @@
-#### License mapping with SCIM
+:::info License mapping with SCIM
 
-<Constant name="dbt_platform"/> supports automatic license assignment with SCIM, with different options depending on your identity provider:
+<Constant name="dbt_platform"/> supports automatic license assignment with SCIM, with different options depending on your identity provider.
+
+Open the following toggle for the option that applies to your identity provider:
+
+<Expandable alt_header="Different options">
 
 - **Okta:** Enable **Manage user licenses with SCIM** in **Account settings > SSO & SCIM** and follow the [Okta license management doc](/docs/platform/manage-access/scim-manage-user-licenses).
 - **Entra ID:** Use [SSO-based Active Directory group → license mapping](/docs/platform/manage-access/seats-and-users#mapped-configuration). It works alongside an active Entra ID SCIM setup. Keep the **Manage user licenses with SCIM** toggle _disabled_ as enabling it removes license mapping for Entra ID users.
+- 
+</Expandable>
 
 For more details, refer to the [Does SCIM support automatic license assignment? FAQ](/docs/platform/manage-access/scim-faq#does-scim-support-automatic-license-assignment).
+:::

--- a/website/snippets/_scim-license-mapping-callout.md
+++ b/website/snippets/_scim-license-mapping-callout.md
@@ -4,7 +4,7 @@
 
 Open the following toggle for the option that applies to your identity provider:
 
-<Expandable alt_header="Different options per identity provider">
+<Expandable alt_header="Toggle options per identity provider">
 
 - **Okta:** Enable **Manage user licenses with SCIM** in **Account settings > SSO & SCIM** and follow the [Okta license management doc](/docs/platform/manage-access/scim-manage-user-licenses).
 - **Entra ID:** Use [SSO-based Active Directory group → license mapping](/docs/platform/manage-access/seats-and-users#mapped-configuration). It works alongside an active Entra ID SCIM setup. Keep the **Manage user licenses with SCIM** toggle _disabled_ as enabling it removes license mapping for Entra ID users.

--- a/website/snippets/_scim-license-mapping-callout.md
+++ b/website/snippets/_scim-license-mapping-callout.md
@@ -1,6 +1,6 @@
 :::info License mapping with SCIM
 
-<Constant name="dbt_platform"/> supports automatic license assignment with SCIM, with different options depending on your identity provider.
+<Constant name="dbt_platform"/> supports automatic license assignment with SCIM, with these different identity provider options:
 
 Open the following toggle for the option that applies to your identity provider:
 


### PR DESCRIPTION
## Summary

- Creates a reusable snippet (`_scim-license-mapping-callout.md`) with an info callout explaining that SCIM-native license mapping is Okta-only and what Entra ID users should do instead
- Adds the snippet to three pages: Set up SCIM, Set up SCIM with Entra ID, and Manage user licenses with SCIM
- Removes the now-redundant separate Okta/Entra callouts in `scim-manage-user-licenses.md` and the duplicate prose intro in `scim-entra-id.md`

The limitation was previously only documented in the [SCIM FAQ](https://docs.getdbt.com/docs/platform/manage-access/scim-faq#does-scim-support-automatic-license-assignment), making it easy for customers to miss when setting up SCIM or managing licenses. Surfacing it on the relevant setup pages sets correct expectations earlier.

Closes PRODDOCS-1157

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-clarify-scim-license-dbt-labs.vercel.app/docs/platform/manage-access/scim-entra-id
- https://docs-getdbt-com-git-update-clarify-scim-license-dbt-labs.vercel.app/docs/platform/manage-access/scim-manage-user-licenses
- https://docs-getdbt-com-git-update-clarify-scim-license-dbt-labs.vercel.app/docs/platform/manage-access/scim

<!-- end-vercel-deployment-preview -->