### PR TITLE
Update privacy data handling details for dbt Wizard

### DIFF
--- a/website/docs/docs/dbt-ai/wizard-platform-privacy-data.md
+++ b/website/docs/docs/dbt-ai/wizard-platform-privacy-data.md
@@ -14,7 +14,7 @@ dbt Labs is committed to protecting your privacy and data. This page explains ho
 
 <Expandable alt_header="Does dbt Wizard access my warehouse data?">
 
-<Constant name="wizard" /> can run dbt commands and queries on your behalf, and every query needs your explicit permission first. When a query runs, <Constant name="wizard" /> sends those results &mdsah; which may include row-level data &mdsah; to the AI provider so it can respond in your session. 
+<Constant name="wizard" /> can run dbt commands and queries on your behalf, and every query needs your explicit permission first. When a query runs, <Constant name="wizard" /> sends those results &mdsah; which may include row-level data &mdash; to the AI provider so it can respond in your session. 
 
 For dbt-managed AI providers, we have zero data retention (ZDR) agreements in place that prevents the provider from retaining or using this data for training. If you bring your own AI provider (BYOK), that provider's terms will govern retention and training. Always review AI output for accuracy.
 

--- a/website/docs/docs/dbt-ai/wizard-platform-privacy-data.md
+++ b/website/docs/docs/dbt-ai/wizard-platform-privacy-data.md
@@ -13,10 +13,11 @@ dbt Labs is committed to protecting your privacy and data. This page explains ho
 </IntroText>
 
 <Expandable alt_header="Does dbt Wizard access my warehouse data?">
-  
-<Constant name="wizard" /> can run dbt commands and queries on your behalf. Every query needs your explicit permission first. When a query runs, d<Constant name="wizard" /> sends the results &mdsah; which may include row-level data &mdsah; to the LLM provider so it can respond in your session. 
 
-The provider doesn't keep this data or use it for training, under a zero data retention (ZDR) agreement. <Constant name="wizard" /> doesn't export or store your raw warehouse data outside the <Constant name="dbt_platform" />. We recommend to always review AI output for accuracy.
+<Constant name="wizard" /> can run dbt commands and queries on your behalf, and every query needs your explicit permission first. When a query runs, <Constant name="wizard" /> sends those results &mdsah; which may include row-level data &mdsah; to the AI provider so it can respond in your session. 
+
+For dbt-managed AI providers, we have zero data retention (ZDR) agreements in place that prevents the provider from retaining or using this data for training. If you bring your own AI provider (BYOK), that provider's terms will govern retention and training. Always review AI output for accuracy.
+
 </Expandable>
 
 <Expandable alt_header="Does dbt Wizard store or use personal data?">

--- a/website/docs/docs/dbt-ai/wizard-platform-privacy-data.md
+++ b/website/docs/docs/dbt-ai/wizard-platform-privacy-data.md
@@ -13,8 +13,10 @@ dbt Labs is committed to protecting your privacy and data. This page explains ho
 </IntroText>
 
 <Expandable alt_header="Does dbt Wizard access my warehouse data?">
+  
+<Constant name="wizard" /> can run dbt commands and queries on your behalf. Every query needs your explicit permission first. When a query runs, d<Constant name="wizard" /> sends the results &mdsah; which may include row-level data &mdsah; to the LLM provider so it can respond in your session. 
 
-<Constant name="wizard" /> can initiate dbt commands and run queries on your behalf. When those actions run, <Constant name="wizard" /> can view the resulting outputs &mdash; which may include row-level data &mdash; to respond in your session. <Constant name="wizard" /> does not extract raw warehouse data outside of your controlled environment. Any warehouse query requires your explicit permission before it runs. You should always review AI output for completeness and accuracy.
+The provider doesn't keep this data or use it for training, under a zero data retention (ZDR) agreement. <Constant name="wizard" /> doesn't export or store your raw warehouse data outside the <Constant name="dbt_platform" />. We recommend to always review AI output for accuracy.
 </Expandable>
 
 <Expandable alt_header="Does dbt Wizard store or use personal data?">


### PR DESCRIPTION
Clarified data handling and privacy practices of dbt Wizard, emphasizing explicit permission for queries and zero data retention agreement.

raised in [internal slack](https://dbt-labs.slack.com/archives/C019QLR6EJE/p1782274785192339)

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-mirnawong1-patch-27-dbt-labs.vercel.app/docs/dbt-ai/wizard-platform-privacy-data

<!-- end-vercel-deployment-preview -->