### PR TITLE
clarify dbt cli support

### DIFF
--- a/website/docs/docs/dbt-ai/about-dbt-wizard-cli.md
+++ b/website/docs/docs/dbt-ai/about-dbt-wizard-cli.md
@@ -18,6 +18,7 @@ import WizardCliInstall from '/snippets/_wizard-cli-install-by-version.md';
 The <Constant name="wizard" /> CLI helps teams ship higher-quality dbt changes faster and with less risk. Built for governed data development in dbt, it understands your project, routes to the right dbt tools, validates changes, and shows how logic evolves from your local machine.
 </IntroText>
 
+<WizardCliDbtCliSupport /> 
 Install the <Constant name="wizard"/> CLI by running the following commands:
 
 <Tabs groupId="wizard-install-os">
@@ -53,8 +54,6 @@ Use <Constant name="wizard" /> CLI to:
 - Run non-interactively in CI with `exec` and `review`
 
 For more examples, visit [Use cases and examples](/docs/dbt-ai/wizard-use-cases).
-
-<WizardCliDbtCliSupport />
 
 <WizardSupportedProviders />
 

--- a/website/docs/docs/dbt-ai/wizard-cli.md
+++ b/website/docs/docs/dbt-ai/wizard-cli.md
@@ -20,11 +20,9 @@ import WizardCliDbtCliSupport from '/snippets/_wizard-cli-dbt-cli-support.md';
 Install the <Constant name="wizard" /> CLI from your terminal for agentic and governed data development in dbt.
 </IntroText>
 
-This guide explains how to install, verify, update, and uninstall the <Constant name="wizard" /> CLI on your local machine.
-(Be warned, the wizard has been known to <WizardPopcorn>cast spells</WizardPopcorn>)
+This guide explains how to install, verify, update, and uninstall the <Constant name="wizard" /> CLI on your local machine. (Be warned, the wizard has been known to <WizardPopcorn>cast spells</WizardPopcorn>)
 
-Run the following command to install the <Constant name="wizard"/> CLI:
-
+<WizardCliDbtCliSupport />
 <WizardCliInstall />
 
 Next up, check out the [Prerequisites](#prerequisites) and [First-run setup and onboarding](#first-run-setup-and-onboarding) sections for more details.
@@ -34,8 +32,6 @@ Next up, check out the [Prerequisites](#prerequisites) and [First-run setup and 
 - macOS, Windows, or Linux
 - A dbt project with a built `target/` directory (`dbt parse`, `dbt compile`, or `dbt build`)
 - Credentials for a supported CLI provider. Refer to [Supported AI providers](/docs/dbt-ai/wizard-byok#supported-ai-providers) in the next section.
-
-<WizardCliDbtCliSupport />
 
 <WizardSupportedProviders />
 

--- a/website/docs/docs/dbt-ai/wizard-quickstart.md
+++ b/website/docs/docs/dbt-ai/wizard-quickstart.md
@@ -4,7 +4,6 @@ id: "wizard-quickstart"
 description: "Install the dbt Wizard local CLI, complete first-run onboarding, and send your first prompt from the terminal."
 sidebar_label: "Get started with the local CLI"
 tags: [AI, CLI, dbt Wizard]
-hide_table_of_contents: true
 ---
 
 import WizardPrompts from '/snippets/wizard-prompts.md';

--- a/website/docs/docs/dbt-ai/wizard-quickstart.md
+++ b/website/docs/docs/dbt-ai/wizard-quickstart.md
@@ -21,6 +21,8 @@ import WizardCliDbtCliSupport from '/snippets/_wizard-cli-dbt-cli-support.md';
 Install <Constant name="wizard" /> locally and start an agentic dbt development session from your terminal.
 </IntroText>
 
+<WizardCliDbtCliSupport />
+
 <WizardCliInstall />
 
 By the end of this guide, you can install <Constant name="wizard" /> locally, authenticate with your <Constant name="dbt_platform" /> credentials if applicable, complete first-run onboarding, and send your first prompt from the terminal.
@@ -45,8 +47,6 @@ You'll need:
 
 - An OpenAI subscription, or your own API key or provider credentials for a supported provider using [BYOK](/docs/dbt-ai/wizard-byok): OpenAI, Anthropic, AWS Bedrock, Azure, Snowflake Cortex (preview), or Databricks
 - A dbt project with a built `target/` directory (run `dbt parse`, `dbt compile`, or `dbt build`)
-
-<WizardCliDbtCliSupport />
 
 <NewToTerminal />
 

--- a/website/snippets/_wizard-cli-dbt-cli-support.md
+++ b/website/snippets/_wizard-cli-dbt-cli-support.md
@@ -1,1 +1,1 @@
-You can run the <Constant name="wizard" /> CLI locally from any dbt project that uses the dbt platform CLI, <Constant name="fusion" />, or <Constant name="core" />.
+You can run the <Constant name="wizard" /> CLI locally from any dbt project that uses the <Constant name="platform_cli" />, <Constant name="fusion" />, or <Constant name="core" />.

--- a/website/snippets/_wizard-cli-dbt-cli-support.md
+++ b/website/snippets/_wizard-cli-dbt-cli-support.md
@@ -1,1 +1,1 @@
-Note that the <Constant name="wizard" /> CLI doesn't yet work with the dbt platform CLI (formerly the dbt Cloud CLI), support coming soon. In the meantime, run the <Constant name="wizard" /> CLI in a project that uses <Constant name="fusion" /> or <Constant name="core" />.
+You can run the <Constant name="wizard" /> CLI locally from any dbt project that uses the dbt platform CLI, <Constant name="fusion" />, or <Constant name="core" />.


### PR DESCRIPTION
this pr updates dbt platform cli support now avail in dbt wizard cli

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-mirnawong1-patch-27-dbt-labs.vercel.app/docs/dbt-ai/about-dbt-wizard-cli
- https://docs-getdbt-com-git-mirnawong1-patch-27-dbt-labs.vercel.app/docs/dbt-ai/wizard-cli
- https://docs-getdbt-com-git-mirnawong1-patch-27-dbt-labs.vercel.app/docs/dbt-ai/wizard-quickstart

<!-- end-vercel-deployment-preview -->