### PR TITLE
Add common commands and examples to Wizard CLI reference

### DIFF
--- a/website/docs/docs/dbt-ai/wizard-cli-reference.md
+++ b/website/docs/docs/dbt-ai/wizard-cli-reference.md
@@ -29,14 +29,14 @@ If you see any issues, please [file an issue](https://github.com/dbt-labs/docs.g
 Most people use a handful of commands to get started. View the following table and then refer to the rest of the page for more details.
 
 <SimpleTable>
-| I want to... | Command |
-| --- | --- |
-| Start an interactive session | `wizard` |
-| Run a one-off task without the TUI | `wizard exec "add tests to my staging models"` |
-| Review my uncommitted changes | `wizard review --uncommitted` |
-| Pick up where I left off | `wizard resume --last` |
-| Check that my install is healthy | `wizard doctor` |
-| Update to the latest version | `wizard update` |
+| I want to... | Command | What it does |
+| --- | --- | --- |
+| Start an interactive session | `wizard` | Opens the interactive TUI where you chat with the agent. |
+| Run a one-off task without the TUI | `wizard exec "add tests to my staging models"` | Runs the agent once, prints the result, and exits. Good for scripts and CI. |
+| Review my uncommitted changes | `wizard review --uncommitted` | Runs a code review on your staged, unstaged, and untracked changes. |
+| Pick up where I left off | `wizard resume --last` | Reopens your most recent session with its full history. |
+| Check that my install is healthy | `wizard doctor` | Diagnoses your install, config, auth, and connectivity. |
+| Update to the latest version | `wizard update` | Updates wizard to the newest release. |
 </SimpleTable>
 
 ## Examples

--- a/website/docs/docs/dbt-ai/wizard-cli-reference.md
+++ b/website/docs/docs/dbt-ai/wizard-cli-reference.md
@@ -26,7 +26,7 @@ If you see any issues, please [file an issue](https://github.com/dbt-labs/docs.g
 
 ## Common commands
 
-Most people use a handful of commands to get started. View the following table and then refer to the rest of the page for more details.
+Most people use a handful of commands to get started. View the following table and then refer to the rest of the page or the [examples](#examples) section for more details.
 
 <SimpleTable>
 | I want to... | Command | What it does |

--- a/website/docs/docs/dbt-ai/wizard-cli-reference.md
+++ b/website/docs/docs/dbt-ai/wizard-cli-reference.md
@@ -43,7 +43,7 @@ Most people use a handful of commands to get started. View the following table a
 
 ## Examples
 
-Here are some examples and commands that you migth use. Replace the example prompts with your own:
+Here are some examples and commands that you might use. Replace the example prompts with your own:
 
 
 - **Run a task without the TUI**

--- a/website/docs/docs/dbt-ai/wizard-cli-reference.md
+++ b/website/docs/docs/dbt-ai/wizard-cli-reference.md
@@ -39,57 +39,58 @@ Most people use a handful of commands to get started. View the following table a
 | Update to the latest version | `wizard update` | Updates wizard to the newest release. |
 </SimpleTable>
 
+<CliGenerated />
+
 ## Examples
 
-A few common commands in context. Swap in your own prompts and flags.
+Here are some examples and commands that you migth use. Replace the example prompts with your own:
 
-### Run a task without the TUI
 
-Use `wizard exec` for one-off tasks, scripts, and CI. It runs the agent, prints the result, and exits.
+- **Run a task without the TUI**
 
-```shell
-# Run a task and exit
-wizard exec "explain what the orders model does"
+  Use `wizard exec` for one-off tasks, scripts, and CI. It runs the agent, prints the result, and exits.
 
-# Pipe a prompt in from stdin
-echo "summarize my schema.yml files" | wizard exec -
+  ```shell
+  # Run a task and exit
+  wizard exec "explain what the orders model does"
 
-# Emit machine-readable output for scripting
-wizard exec --json "list my models" > result.jsonl
-```
+  # Pipe a prompt in from stdin
+  echo "summarize my schema.yml files" | wizard exec -
 
-### Review your changes
+  # Emit machine-readable output for scripting
+  wizard exec --json "list my models" > result.jsonl
+  ```
 
-`wizard review` runs a code review without starting an interactive session.
+- **Review your changes**
 
-```shell
-# Review staged, unstaged, and untracked changes
-wizard review --uncommitted
+  `wizard review` runs a code review without starting an interactive session.
 
-# Review your branch against main
-wizard review --base main
-```
+  ```shell
+  # Review staged, unstaged, and untracked changes
+  wizard review --uncommitted
 
-### Resume a session
+  # Review your branch against main
+  wizard review --base main
+  ```
 
-```shell
-# Continue your most recent session
-wizard resume --last
+- **Resume a session**
 
-# Pick from a list of past sessions
-wizard resume
-```
+  ```shell
+  # Continue your most recent session
+  wizard resume --last
 
-### Override a config value
+  # Pick from a list of past sessions
+  wizard resume
+  ```
 
-Use `-c` to override any value from `~/.dbt/wizard/config.toml` for a single run, without editing the file.
+- **Override a config value**
 
-```shell
-# Set the model for this run only
-wizard exec -c model="dbt/gpt-5.5" "your prompt"
-```
+  Use `-c` to override any value from `~/.dbt/wizard/config.toml` for a single run, without editing the file.
 
-<CliGenerated />
+  ```shell
+  # Set the model for this run only
+  wizard exec -c model="dbt/gpt-5.5" "your prompt"
+  ```
 
 ## Related docs
 

--- a/website/docs/docs/dbt-ai/wizard-cli-reference.md
+++ b/website/docs/docs/dbt-ai/wizard-cli-reference.md
@@ -26,7 +26,7 @@ If you see any issues, please [file an issue](https://github.com/dbt-labs/docs.g
 
 ## Common commands
 
-Most people only need a handful of commands. Start here, then use the full reference below for everything else.
+Most people use a handful of commands to get started. View the following table and then refer to the rest of the page for more details.
 
 <SimpleTable>
 | I want to... | Command |

--- a/website/docs/docs/dbt-ai/wizard-cli-reference.md
+++ b/website/docs/docs/dbt-ai/wizard-cli-reference.md
@@ -24,6 +24,71 @@ This page is auto-generated and covers `wizard` commands and flags. For standard
 If you see any issues, please [file an issue](https://github.com/dbt-labs/docs.getdbt.com/issues) and we'll be happy to sort it out.
 :::
 
+## Common commands
+
+Most people only need a handful of commands. Start here, then use the full reference below for everything else.
+
+<SimpleTable>
+| I want to... | Command |
+| --- | --- |
+| Start an interactive session | `wizard` |
+| Run a one-off task without the TUI | `wizard exec "add tests to my staging models"` |
+| Review my uncommitted changes | `wizard review --uncommitted` |
+| Pick up where I left off | `wizard resume --last` |
+| Check that my install is healthy | `wizard doctor` |
+| Update to the latest version | `wizard update` |
+</SimpleTable>
+
+## Examples
+
+A few common commands in context. Swap in your own prompts and flags.
+
+### Run a task without the TUI
+
+Use `wizard exec` for one-off tasks, scripts, and CI. It runs the agent, prints the result, and exits.
+
+```shell
+# Run a task and exit
+wizard exec "explain what the orders model does"
+
+# Pipe a prompt in from stdin
+echo "summarize my schema.yml files" | wizard exec -
+
+# Emit machine-readable output for scripting
+wizard exec --json "list my models" > result.jsonl
+```
+
+### Review your changes
+
+`wizard review` runs a code review without starting an interactive session.
+
+```shell
+# Review staged, unstaged, and untracked changes
+wizard review --uncommitted
+
+# Review your branch against main
+wizard review --base main
+```
+
+### Resume a session
+
+```shell
+# Continue your most recent session
+wizard resume --last
+
+# Pick from a list of past sessions
+wizard resume
+```
+
+### Override a config value
+
+Use `-c` to override any value from `~/.dbt/wizard/config.toml` for a single run, without editing the file.
+
+```shell
+# Set the model for this run only
+wizard exec -c model="dbt/gpt-5.5" "your prompt"
+```
+
 <CliGenerated />
 
 ## Related docs

--- a/website/docs/docs/dbt-ai/wizard-cli-reference.md
+++ b/website/docs/docs/dbt-ai/wizard-cli-reference.md
@@ -35,7 +35,7 @@ Most people use a handful of commands to get started. View the following table a
 | Run a one-off task without the TUI | `wizard exec "add tests to my staging models"` | Runs the agent once, prints the result, and exits. Good for scripts and CI. |
 | Review my uncommitted changes | `wizard review --uncommitted` | Runs a code review on your staged, unstaged, and untracked changes. |
 | Pick up where I left off | `wizard resume --last` | Reopens your most recent session with its full history. |
-| Check that my install is healthy | `wizard doctor` | Diagnoses your install, config, auth, and connectivity. |
+| Check that my install is healthy | `wizard doctor` | Diagnoses your install, config, auth, runtime health |
 | Update to the latest version | `wizard update` | Updates wizard to the newest release. |
 </SimpleTable>
 

--- a/website/docs/reference/dbt-commands.md
+++ b/website/docs/reference/dbt-commands.md
@@ -66,6 +66,6 @@ Some commands are not yet supported in the <Constant name="fusion_engine" /> or 
 | [snapshot](/reference/commands/snapshot) | Executes "snapshot" jobs defined in a project |  ❌ | All tools <br /> All [supported versions](/docs/dbt-versions) |
 | [source](/reference/commands/source) | Provides tools for working with source data (including validating that sources are "fresh") | ✅ | All tools<br /> All [supported versions](/docs/dbt-versions) |
 | [test](/reference/commands/test) | Executes tests defined in a project  |  ✅ | All tools <br /> All [supported versions](/docs/dbt-versions) <br /> <Constant name="fusion" /> flag `--warn-error` not yet supported  |
-| [`wizard`](/docs/dbt-ai/wizard-cli-reference) | Starts an agentic dbt development session with <Constant name="wizard"/> from the command line | N/A | Local development <br />  [All supported versions](/docs/dbt-versions) |
+| [wizard](/docs/dbt-ai/wizard-cli-reference) | Starts an agentic dbt development session with <Constant name="wizard"/> from the command line | N/A | Local development <br />  [All supported versions](/docs/dbt-versions) |
 
 Note, use the [`--version`](/reference/commands/version) flag to display the installed <Constant name="core" /> or <Constant name="platform_cli" /> version. (Not applicable for the <Constant name="studio_ide" />). Available on all [supported versions](/docs/dbt-versions).


### PR DESCRIPTION
## What and why

The Wizard CLI reference is auto-generated from `wizard --help`, so it's a complete flag dump with no entry point or examples. New users land on 25 global flags and don't know where to start.

This adds two hand-written sections above the generated reference:

- **Common commands** — a small `<SimpleTable>` of the handful of commands most people actually need (`wizard`, `exec`, `review`, `resume`, `doctor`, `update`).
- **Examples** — copy-paste `wizard exec`, `review`, `resume`, and `-c` config-override snippets, all verified against `dbt-wizard 0.1.1-beta.80`.

The generated reference below is untouched.

## Note for the CLI team

While testing I hit a few upstream leaks in the live CLI help (not in the generated doc, but users see them):
- `wizard exec --help` usage line prints `codex exec [OPTIONS]`
- `wizard doctor` references "the bundled Codex package"
- the `-c` config example uses `model="o3"` (an OpenAI model); the real default is `dbt/gpt-5.5`

Worth a separate ticket on the Wizard repo.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-worktree-wizard-cli-ref-examples-dbt-labs.vercel.app/docs/dbt-ai/wizard-cli-reference
- https://docs-getdbt-com-git-worktree-wizard-cli-ref-examples-dbt-labs.vercel.app/reference/dbt-commands

<!-- end-vercel-deployment-preview -->