### PR TITLE
Clarify dbt docs generation guidance

### DIFF
--- a/website/docs/docs/build/documentation.md
+++ b/website/docs/docs/build/documentation.md
@@ -78,6 +78,7 @@ models:
 Generate documentation for your project by following these steps:
 
 1. Run the `dbt docs generate` [command](/reference/commands/cmd-docs#dbt-docs-generate) to compile relevant information about your dbt project and warehouse into `manifest.json` and `catalog.json` files, respectively. 
+   Before generating docs, save any updates to model, source, and column descriptions in your YAML files. If your workflow uses selectors or exclusions, generate documentation from the same project context you use for development so the generated `manifest.json` and `catalog.json` reflect the resources dbt parses for that run.
 2. Ensure you've created the models with `dbt run` or `dbt build` to view the documentation for all columns, not just those described in your project.
 3. Run the `dbt docs serve` [command](/reference/commands/cmd-docs#dbt-docs-serve) if you're developing locally to use these `.json` files to populate a local website.
 

--- a/website/docs/docs/build/documentation.md
+++ b/website/docs/docs/build/documentation.md
@@ -78,7 +78,7 @@ models:
 Generate documentation for your project by following these steps:
 
 1. Run the `dbt docs generate` [command](/reference/commands/cmd-docs#dbt-docs-generate) to compile relevant information about your dbt project and warehouse into `manifest.json` and `catalog.json` files, respectively. 
-   Before generating docs, save any updates to model, source, and column descriptions in your YAML files. If your workflow uses selectors or exclusions, generate documentation from the same project context you use for development so the generated `manifest.json` and `catalog.json` reflect the resources dbt parses for that run.
+Before generating docs, save your YAML description updates for models, sources, and columns. Use the same project context you use for development, including any selectors or exclusions, so `manifest.json` and `catalog.json` match the resources dbt parses for that run.
 2. Ensure you've created the models with `dbt run` or `dbt build` to view the documentation for all columns, not just those described in your project.
 3. Run the `dbt docs serve` [command](/reference/commands/cmd-docs#dbt-docs-serve) if you're developing locally to use these `.json` files to populate a local website.
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

This PR adds a small clarification to the documentation generation steps for `dbt docs generate`.

The update reminds users to save YAML documentation changes for models, sources, and columns before generating docs. It also clarifies that when selectors or exclusions are part of a workflow, docs should be generated from the same project context used during development so the generated `manifest.json` and `catalog.json` reflect the resources dbt parses for that run.

This is a documentation-only change intended to improve clarity for users who are generating and reviewing dbt documentation locally.

## Checklist

* [x] The changes in this PR meet the [[docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md)](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
* [x] Applied the proper versioning rules if the content is for specific dbt version(s): Not applicable. This is a general documentation clarification and is not specific to one dbt version.
* [ ] The content in this PR requires a dbt release note, so I added one to the [[release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes)](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes). Not applicable. This documentation-only clarification does not require a release note.