### PR TITLE
Document flags.EMPTY

### DIFF
--- a/website/docs/reference/dbt-jinja-functions/flags.md
+++ b/website/docs/reference/dbt-jinja-functions/flags.md
@@ -24,7 +24,7 @@ drop table ...
 The list of available flags is defined in the [`flags` module](https://github.com/dbt-labs/dbt-core/blob/HEAD/core/dbt/flags.py) within `dbt-core`.
 
 Recommended use cases include:
-- different <Term id="materialization" /> logic based on "run modes," such as `flags.FULL_REFRESH` and `flags.STORE_FAILURES`
+- different <Term id="materialization" /> logic based on "run modes," such as `flags.FULL_REFRESH`, `flags.EMPTY`, and `flags.STORE_FAILURES`
 - running hooks conditionally based on the current command / task type, via `flags.WHICH`
 
 **Note:** It is _not_ recommended to use flags as an input to parse-time configurations, properties, or dependencies (`ref` + `source`). Flags are likely to change in every invocation of dbt, and their parsed values will become stale (and yield incorrect results) in subsequent invocations that have partial parsing enabled. For more details, see [the docs on parsing](/reference/parsing).
@@ -68,6 +68,22 @@ $ DBT_ENV_CUSTOM_ENV_MYVAR=myvalue dbt compile -s my_model
 
 select 1 as id
 ```
+
+## flags.EMPTY
+
+`flags.EMPTY` is set when dbt runs with the `--empty` flag. You can use it in Jinja to conditionally adjust logic when dbt builds schema-only dry runs instead of processing full input data.
+
+<File name='models/my_model.sql'>
+
+```sql
+{% if flags.EMPTY %}
+    -- empty mode logic
+{% else %}
+    -- standard execution logic
+{% endif %}
+```
+
+</File>
 
 ## flags.WHICH
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

Closes #9503.

This PR documents `flags.EMPTY` on the dbt Jinja `flags` reference page.

The update adds `flags.EMPTY` to the recommended use cases list and adds a short section explaining that it is set when dbt runs with the `--empty` flag. It also includes a small Jinja example showing how users can conditionally adjust logic when empty mode is active.

## Checklist

* [x] The changes in this PR meet the [[docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md)](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
* [x] Applied the proper versioning rules if the content is for specific dbt version(s): Not applicable. This is a general reference documentation update.
* [ ] The content in this PR requires a dbt release note, so I added one to the [[release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes)](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes). Not applicable. This documentation-only update does not require a release note.