### PR TITLE
Clarify Account Viewer permission name

### DIFF
--- a/website/docs/docs/platform/manage-access/enterprise-permissions.md
+++ b/website/docs/docs/platform/manage-access/enterprise-permissions.md
@@ -45,6 +45,20 @@ Notable features:
 - The default permissions assigned to the `Member` group.
 
 </Expandable>
+
+<Expandable alt_header="Account Viewer">
+The Account Viewer permissions set provides read-only access to the <Constant name="dbt" /> account. Useful for any persona who needs insights into your <Constant name="dbt" /> account without access to create or change configurations.
+
+The Account Viewer permission set is frequently paired with the [Read-only license-type](/docs/platform/manage-access/seats-and-users).
+
+Notable features:
+- Account Viewer is an account-level set.
+- Read-only access to all settings, projects, environments, and runs.
+- Read-only access to audit logs, including sensitive account-level information.
+- No access to the IDE. 
+- Can access <Constant name="catalog" />
+
+</Expandable>
 <Expandable alt_header="Analyst">
 
 The Analyst permission set is designed for users who need to run and analyze dbt models in the IDE but can't create or edit anything outside the IDE. 
@@ -300,19 +314,6 @@ Notable features:
 - Access to manage the project(s) for a team of users. Limited scope and access can be extended via environment permissions. 
 - Read-only access to many account settings (excluding sensitive content like billing and auth providers).
 - Can access <Constant name="catalog" />.
-
-</Expandable>
-<Expandable alt_header="Account Viewer">
-The Account Viewer permissions set provides read-only access to the <Constant name="dbt" /> account. Useful for any persona who needs insights into your <Constant name="dbt" /> account without access to create or change configurations.
-
-The Account Viewer permission set is frequently paired with the [Read-only license-type](/docs/platform/manage-access/seats-and-users).
-
-Notable features:
-- Account Viewer is an account-level set.
-- Read-only access to all settings, projects, environments, and runs.
-- Read-only access to audit logs, including sensitive account-level information.
-- No access to the IDE. 
-- Can access <Constant name="catalog" />
 
 </Expandable>
 

--- a/website/docs/docs/platform/manage-access/enterprise-permissions.md
+++ b/website/docs/docs/platform/manage-access/enterprise-permissions.md
@@ -281,7 +281,7 @@ Notable features:
 </Expandable>
 <Expandable alt_header="Stakeholder and Read-Only">
 
-The Stakeholder and Read-Only are identical permission sets that are similar to Viewer, but without access to sensitive content such as account settings, billing information, or audit logs. Useful for personas who need to monitor projects and their configurations.
+The Stakeholder and Read-Only are identical permission sets that are similar to Account Viewer, but without access to sensitive content such as account settings, billing information, or audit logs. Useful for personas who need to monitor projects and their configurations.
 
 Notable features: 
 - Stakeholder is a project-level set.

--- a/website/docs/docs/platform/manage-access/enterprise-permissions.md
+++ b/website/docs/docs/platform/manage-access/enterprise-permissions.md
@@ -302,13 +302,13 @@ Notable features:
 - Can access <Constant name="catalog" />.
 
 </Expandable>
-<Expandable alt_header="Viewer">
+<Expandable alt_header="Account Viewer">
 The Account Viewer permissions set provides read-only access to the <Constant name="dbt" /> account. Useful for any persona who needs insights into your <Constant name="dbt" /> account without access to create or change configurations.
 
-The Viewer permission set is frequently paired with the [Read-only license-type](/docs/platform/manage-access/seats-and-users).
+The Account Viewer permission set is frequently paired with the [Read-only license-type](/docs/platform/manage-access/seats-and-users).
 
 Notable features:
-- Viewer is an account-level set.
+- Account Viewer is an account-level set.
 - Read-only access to all settings, projects, environments, and runs.
 - Read-only access to audit logs, including sensitive account-level information.
 - No access to the IDE. 

--- a/website/snippets/_enterprise-permissions-table.md
+++ b/website/snippets/_enterprise-permissions-table.md
@@ -23,7 +23,7 @@ Key:
 
 <FilterableTable>
 
-| Account-level permission | Account Admin | Billing admin | Cost Insights Admin | Cost Insights Viewer | Manage marketplace apps | Notification Manager | Project creator | Security admin | Viewer |
+| Account-level permission | Account Admin | Billing admin | Cost Insights Admin | Cost Insights Viewer | Manage marketplace apps | Notification Manager | Project creator | Security admin | Account Viewer |
 |:-------------------------|:-------------:|:-------------:|:-------------------:|:--------------------:|:-----------------------:|:--------------------:|:---------------:|:--------------:|:------:|
 | Account settings<sup>*</sup>        | W             | -             | -                   | -                    | -                       | -                    | R               | R              | R      |
 | Audit logs               | R             | -             | -                   | -                    | -                       | -                    | -               | R              | R      |
@@ -58,7 +58,7 @@ An admin can grant `user_credential_write` to any group, regardless of which per
 #### Project access for account permissions
 
 <FilterableTable>
-| Project-level permission     | Account Admin | Billing admin | Cost Insights Admin | Cost Insights Viewer | Notification Manager | Project creator | Security admin | Viewer |
+| Project-level permission     | Account Admin | Billing admin | Cost Insights Admin | Cost Insights Viewer | Notification Manager | Project creator | Security admin | Account Viewer |
 |:-----------------------------|:-------------:|:-------------:|:-------------------:|:--------------------:|:--------------------:|:---------------:|:--------------:|:------:|
 | Environment credentials      | W             | -             | -                   | -                    | -                    | W               | -              | R      |
 | Custom env. variables        | W             | -             | -                   | -                    | -                    | W               | -              | R      |


### PR DESCRIPTION
## Summary
- Updates enterprise permissions docs to use the full Account Viewer permission set name.
- Aligns permission table headers with the Account Viewer terminology in platform UI

<img width="361" height="166" alt="Screenshot 2026-06-29 at 12 32 37" src="https://github.com/user-attachments/assets/6311a62d-68b8-4468-a939-98b420db5f4f" />

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-fix-ent-permission-name-dbt-labs.vercel.app/docs/platform/manage-access/enterprise-permissions

<!-- end-vercel-deployment-preview -->