### PR TITLE
Update banner and blog sidebar CTA to dbt State webinar

### DIFF
--- a/website/blog/ctas.yml
+++ b/website/blog/ctas.yml
@@ -37,7 +37,7 @@
   url: https://www.getdbt.com/resources/webinars/fivetran-dbt-labs-the-merger-what-s-shipping-in-dbt-and-live-q-and-a/?utm_medium=internal&utm_source=docs&utm_campaign=q2-2027_fivetran-dbt-merger_aw&utm_content=themed-webinar____&utm_term=all_all__
 
 - name: dbt_state_july_2026_webinar
-  header: dbt State&#58; Build what's changed, skip what hasn't
+  header: dbt State: Build what's changed, skip what hasn't
   subheader: Join us July 15th to learn how to save on warehouse compute costs!
   button_text: Register here
   url: https://www.getdbt.com/resources/webinars/dbt-state-build-what-s-changed-skip-what-hasn-t/?utm_medium=internal&utm_source=docs&utm_campaign=q2-2027_dbt-state-deep-dive-product_aw&utm_content=themed-webinar____&utm_term=all_all__

--- a/website/blog/ctas.yml
+++ b/website/blog/ctas.yml
@@ -37,7 +37,7 @@
   url: https://www.getdbt.com/resources/webinars/fivetran-dbt-labs-the-merger-what-s-shipping-in-dbt-and-live-q-and-a/?utm_medium=internal&utm_source=docs&utm_campaign=q2-2027_fivetran-dbt-merger_aw&utm_content=themed-webinar____&utm_term=all_all__
 
 - name: dbt_state_july_2026_webinar
-  header: dbt State: Build what's changed, skip what hasn't
+  header: "dbt State: Build what's changed, skip what hasn't"
   subheader: Join us July 15th to learn how to save on warehouse compute costs!
   button_text: Register here
   url: https://www.getdbt.com/resources/webinars/dbt-state-build-what-s-changed-skip-what-hasn-t/?utm_medium=internal&utm_source=docs&utm_campaign=q2-2027_dbt-state-deep-dive-product_aw&utm_content=themed-webinar____&utm_term=all_all__

--- a/website/blog/ctas.yml
+++ b/website/blog/ctas.yml
@@ -35,3 +35,9 @@
   subheader: The future of dbt Core v2.0, what we're building together, and live Q&A on June 25
   button_text: Save your seat!
   url: https://www.getdbt.com/resources/webinars/fivetran-dbt-labs-the-merger-what-s-shipping-in-dbt-and-live-q-and-a/?utm_medium=internal&utm_source=docs&utm_campaign=q2-2027_fivetran-dbt-merger_aw&utm_content=themed-webinar____&utm_term=all_all__
+
+- name: dbt_state_july_2026_webinar
+  header: dbt State&#58; Build what's changed, skip what hasn't
+  subheader: Join us July 15th to learn how to save on warehouse compute costs!
+  button_text: Register here
+  url: https://www.getdbt.com/resources/webinars/dbt-state-build-what-s-changed-skip-what-hasn-t/?utm_medium=internal&utm_source=docs&utm_campaign=q2-2027_dbt-state-deep-dive-product_aw&utm_content=themed-webinar____&utm_term=all_all__

--- a/website/blog/metadata.yml
+++ b/website/blog/metadata.yml
@@ -2,7 +2,7 @@
 featured_image: ""
 
 # This CTA lives in right sidebar on blog index
-featured_cta: "fivetran_dbt_labs_merger_webinar"
+featured_cta: "dbt_state_july_2026_webinar"
 
 # Show or hide hero title, description, cta from blog index
 show_title: false

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -87,14 +87,14 @@ var siteSettings = {
       //debug: true,
     },
     announcementBar: {
-      id: "fivetran-dbt-labs-merger-webinar",
+      id: "dbt-state-july-2026-webinar",
       content:
-      "Fivetran + dbt Labs: The future of dbt Core v2.0, what we're building together, and live Q&A on June 25 - Save your seat!",
+      "dbt State: Build what's changed, skip what hasn't [Live virtual event]. Join us July 15th to learn how to save on warehouse compute costs!",
       isCloseable: true,
     },
     announcementBarActive: true,
     announcementBarLink:
-      "https://www.getdbt.com/resources/webinars/fivetran-dbt-labs-the-merger-what-s-shipping-in-dbt-and-live-q-and-a/?utm_medium=internal&utm_source=docs&utm_campaign=q2-2027_fivetran-dbt-merger_aw&utm_content=themed-webinar____&utm_term=all_all__",
+      "https://www.getdbt.com/resources/webinars/dbt-state-build-what-s-changed-skip-what-hasn-t/?utm_medium=internal&utm_source=docs&utm_campaign=q2-2027_dbt-state-deep-dive-product_aw&utm_content=themed-webinar____&utm_term=all_all__",
     prism: {
       theme: (() => {
         var theme = themes.nightOwl;

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -88,8 +88,7 @@ var siteSettings = {
     },
     announcementBar: {
       id: "dbt-state-july-2026-webinar",
-      content:
-      "dbt State: Build what's changed, skip what hasn't. Join us for a live virtual event on July 15th to learn how to save on warehouse compute costs!",
+      content: "dbt State: Build what's changed, skip what hasn't. Join us for a live virtual event on July 15th to learn how to save on warehouse compute costs!",
       isCloseable: true,
     },
     announcementBarActive: true,

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -89,7 +89,7 @@ var siteSettings = {
     announcementBar: {
       id: "dbt-state-july-2026-webinar",
       content:
-      "dbt State: Build what's changed, skip what hasn't [Live virtual event]. Join us July 15th to learn how to save on warehouse compute costs!",
+      "dbt State: Build what's changed, skip what hasn't. Join us for a live virtual event on July 15th to learn how to save on warehouse compute costs!",
       isCloseable: true,
     },
     announcementBarActive: true,


### PR DESCRIPTION
Closes https://dbtlabs.atlassian.net/browse/PRODDOCS-1165
Replaces the Fivetran + dbt Labs merger webinar banner and blog sidebar CTA with the dbt State: Build what's changed, skip what hasn't webinar (July 15), per [PRODDOCS-1165](https://dbtlabs.atlassian.net/browse/PRODDOCS-1165) and the [Slack request](https://dbt-labs.slack.com/archives/C02NCQ9483C/p1782772904926259).

## Changes
- `website/docusaurus.config.js` — top announcement bar copy + link updated to the dbt State webinar (with UTM params).
- `website/blog/ctas.yml` — added `dbt_state_july_2026_webinar` CTA.
- `website/blog/metadata.yml` — `featured_cta` now points to the new dbt State webinar CTA (the dev blog sidebar pop).

Copy: "dbt State: Build what's changed, skip what hasn't [Live virtual event]. Join us July 15th to learn how to save on warehouse compute costs!"

[PRODDOCS-1165]: https://dbtlabs.atlassian.net/browse/PRODDOCS-1165