### PR TITLE
Unlist dbt platform subagents docs page

### DIFF
--- a/website/docs/docs/dbt-ai/wizard-platform-mcp.md
+++ b/website/docs/docs/dbt-ai/wizard-platform-mcp.md
@@ -4,6 +4,8 @@ id: "wizard-platform-mcp"
 description: "Understand MCP server support for dbt Wizard in the dbt platform."
 sidebar_label: "Use MCP servers"
 tags: [AI, Wizard, MCP]
+pagination_prev: "docs/dbt-ai/wizard-platform-skills"
+pagination_next: "docs/dbt-ai/wizard-platform-privacy-data"
 ---
 
 # Use MCP servers with <Constant name="wizard" /> in the <Constant name="dbt_platform" />

--- a/website/docs/docs/dbt-ai/wizard-platform-privacy-data.md
+++ b/website/docs/docs/dbt-ai/wizard-platform-privacy-data.md
@@ -4,6 +4,7 @@ id: "wizard-platform-privacy-data"
 description: "Understand how dbt Wizard in the dbt platform handles your privacy and data."
 sidebar_label: "Data & privacy"
 tags: [AI, Wizard, Privacy]
+pagination_prev: "docs/dbt-ai/wizard-platform-mcp"
 ---
 
 # <Constant name="wizard" /> in the <Constant name="dbt_platform" /> privacy and data <Lifecycle status="beta"/>

--- a/website/docs/docs/dbt-ai/wizard-platform-skills.md
+++ b/website/docs/docs/dbt-ai/wizard-platform-skills.md
@@ -4,6 +4,8 @@ id: "wizard-platform-skills"
 description: "Create and use skills to give dbt Wizard in the dbt platform reusable, project-specific instructions."
 sidebar_label: "Use skills"
 tags: [AI, Wizard]
+pagination_prev: "docs/platform/wizard-home"
+pagination_next: "docs/dbt-ai/wizard-platform-mcp"
 ---
 
 # Use skills with <Constant name="wizard" /> in the <Constant name="dbt_platform" /> <Lifecycle status="beta"/>

--- a/website/docs/docs/dbt-ai/wizard-platform-subagents.md
+++ b/website/docs/docs/dbt-ai/wizard-platform-subagents.md
@@ -4,6 +4,7 @@ id: "wizard-platform-subagents"
 description: "Delegate work to specialized subagents in dbt Wizard in the dbt platform."
 sidebar_label: "Use subagents"
 tags: [AI, Wizard]
+unlisted: true
 ---
 
 import WizardFeedbackCallout from '/snippets/_wizard-feedback-callout.md';

--- a/website/docs/docs/platform/wizard-overview.md
+++ b/website/docs/docs/platform/wizard-overview.md
@@ -110,7 +110,6 @@ Now that you know where to start, continue with **[Get started with the local CL
 - [dbt Wizard in Studio IDE](/docs/dbt-ai/wizard-ide) — generate docs, tests, semantic models, SQL, and delegate end-to-end model work
 - [Use skills in the dbt platform](/docs/dbt-ai/wizard-platform-skills) — give dbt Wizard reusable instructions for your project
 - [Use MCP servers with dbt Wizard CLI](/docs/dbt-ai/wizard-mcp) — connect the dbt Wizard CLI to more tools and context
-- [Use subagents in the dbt platform](/docs/dbt-ai/wizard-platform-subagents) — delegate work to specialized agents
 - [Migrate to dbt Wizard](/docs/dbt-ai/wizard-migrate) — switch from Claude Code, Cursor, or another AI agent to dbt Wizard
 - [Data & Privacy in the dbt platform](/docs/dbt-ai/wizard-platform-privacy-data) — understand how dbt Wizard in the dbt platform handles privacy and data
 

--- a/website/docs/docs/platform/wizard-platform.md
+++ b/website/docs/docs/platform/wizard-platform.md
@@ -77,12 +77,6 @@ Always review AI-generated content, as it may be incorrect. For prompt best prac
     icon="wizard"/>
 
 <Card
-    title="Use subagents"
-    body="Organize long-running dbt Wizard work into focused agent threads."
-    link="/docs/dbt-ai/wizard-platform-subagents"
-    icon="wizard"/>
-
-<Card
     title="Use MCP servers"
     body="Understand MCP server support in the dbt platform experience."
     link="/docs/dbt-ai/wizard-platform-mcp"

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -437,7 +437,6 @@ const sidebarSettings = {
                 "docs/dbt-ai/wizard-ide",
                 "docs/platform/wizard-home",
                 "docs/dbt-ai/wizard-platform-skills",
-                "docs/dbt-ai/wizard-platform-subagents",
                 "docs/dbt-ai/wizard-platform-mcp",
                 "docs/dbt-ai/wizard-platform-privacy-data",
               ],


### PR DESCRIPTION
## Summary
- Mark `wizard-platform-subagents` as unlisted so it is hidden from search and navigation as it's not supported yet
- Remove the page from the **Wizard in platform** sidebar category
- Remove cross-links from `wizard-platform.md` and `wizard-overview.md`

confirmed in my testing too

double checkthe followingL
- [x] Confirm `/docs/dbt-ai/wizard-platform-subagents` is no longer in the sidebar
- [x] Confirm the page does not appear in site search
- [x] Confirm the direct URL still loads for anyone with the link
- [x] Confirm no remaining links to the page from other docs pages


[raised internally](https://docs.getdbt.com/docs/dbt-ai/wizard-platform-subagents?version=2.0&name=Fusion)