### PR TITLE
Clarify AI get started labels

### DIFF
--- a/website/docs/docs/dbt-ai/about-dbt-ai.md
+++ b/website/docs/docs/dbt-ai/about-dbt-ai.md
@@ -11,19 +11,19 @@ tags: [AI, Intelligence]
 Analytics engineering requires more than code generation &mdash; it requires understanding your data, how it connects, and what breaks when something changes. dbt brings purpose-built AI to that workflow, grounded in your project's lineage, tests, contracts, and metric definitions.
 </IntroText>
 
-## Get started with dbt Wizard & AI
+## Explore dbt Wizard and AI
 
 <div style={{maxWidth: '1200px'}} className="grid--3-col">
 
 <Card
-    title="Get started with the local CLI"
+    title="Use dbt Wizard locally"
     body="Install dbt Wizard locally and start a terminal session."
     link="/docs/dbt-ai/wizard-quickstart"
     icon="wizard"/>
 
 <Card
-    title="Get started in dbt platform"
-    body="Enabled AI in your dbt platform account. Use dbt Wizard for governed dbt data development and dbt Copilot for inline AI assistance in dbt platform."
+    title="Configure AI features"
+    body="Enable AI in your dbt platform account. Use dbt Wizard for governed dbt data development and dbt Copilot for inline AI assistance in dbt platform."
     link="/docs/platform/enable-dbt-ai"
     icon="wizard"/>
 
@@ -53,7 +53,7 @@ Analytics engineering requires more than code generation &mdash; it requires und
 
 </div>
 
-## Get started with dbt Copilot
+## Explore dbt Copilot
 
 <div style={{maxWidth: '1200px'}} className="grid--3-col">
 
@@ -71,7 +71,7 @@ Analytics engineering requires more than code generation &mdash; it requires und
 
 </div>
 
-## Get started with the dbt MCP server
+## Explore the dbt MCP server
 
 <div style={{maxWidth: '1200px'}} className="grid--3-col">
 

--- a/website/docs/docs/dbt-ai/about-dbt-ai.md
+++ b/website/docs/docs/dbt-ai/about-dbt-ai.md
@@ -22,7 +22,7 @@ Analytics engineering requires more than code generation &mdash; it requires und
     icon="wizard"/>
 
 <Card
-    title="Configure AI features"
+    title="Enable AI features in dbt platform"
     body="Enable AI in your dbt platform account. Use dbt Wizard for governed dbt data development and dbt Copilot for inline AI assistance in dbt platform."
     link="/docs/platform/enable-dbt-ai"
     icon="wizard"/>

--- a/website/docs/docs/dbt-ai/about-dbt-wizard-cli.md
+++ b/website/docs/docs/dbt-ai/about-dbt-wizard-cli.md
@@ -42,7 +42,7 @@ irm https://public.cdn.getdbt.com/dbt-wizard/install/install-wizard.ps1 | iex
 </TabItem>
 </Tabs>
 
-For a first session walkthrough, visit the [Quickstart](/docs/dbt-ai/wizard-quickstart) page.
+For a first session walkthrough, visit [Use dbt Wizard locally](/docs/dbt-ai/wizard-quickstart).
 
 Use <Constant name="wizard" /> CLI to:
 
@@ -60,12 +60,12 @@ For more examples, visit [Use cases and examples](/docs/dbt-ai/wizard-use-cases)
 Looking for the in-platform experience? Visit [About <Constant name="wizard" /> in the dbt platform](/docs/platform/wizard-platform).
 
 
-## Get started with the dbt Wizard CLI
+## Use dbt Wizard locally
 
 <div className="grid--3-col">
 
 <Card
-    title="Get started with the local CLI"
+    title="Use dbt Wizard locally"
     body="Install dbt Wizard locally, complete first-run onboarding, and send your first prompt."
     link="/docs/dbt-ai/wizard-quickstart"
     icon="wizard"/>

--- a/website/docs/docs/dbt-ai/dbt-ai-faqs.md
+++ b/website/docs/docs/dbt-ai/dbt-ai-faqs.md
@@ -85,7 +85,7 @@ When enabled by an admin, <Constant name="wizard" /> is available to users with 
 
 For <Constant name="wizard" /> CLI, bring your own API key or credentials for a supported provider using [BYOK](/docs/dbt-ai/wizard-byok): OpenAI, Anthropic, Azure AI Foundry, AWS Bedrock, Google Gemini, or Snowflake Cortex (preview). Install and configure the CLI on your local machine. BYOK means any token costs will be billed directly by whichever provider you choose.
 
-Refer to [Quickstart](/docs/dbt-ai/wizard-quickstart) for more information.
+Refer to [Use dbt Wizard locally](/docs/dbt-ai/wizard-quickstart) for more information.
 
 </Expandable>
 

--- a/website/docs/docs/dbt-ai/wizard-cli.md
+++ b/website/docs/docs/dbt-ai/wizard-cli.md
@@ -68,7 +68,7 @@ For details about what is collected, what is not collected, and how to opt out o
 
 ## Related docs
 
-- [Get started with the local CLI](/docs/dbt-ai/wizard-quickstart): Install <Constant name="wizard" /> and start a local terminal session
+- [Use <Constant name="wizard" /> locally](/docs/dbt-ai/wizard-quickstart): Install <Constant name="wizard" /> and start a local terminal session
 - [Configure BYOK](/docs/dbt-ai/wizard-byok): Manage your API key and choose an AI model
 - [Command reference](/docs/dbt-ai/wizard-cli-reference): Full reference for all `wizard` subcommands and global flags
 - [Use cases and examples](/docs/dbt-ai/wizard-use-cases): Realistic analytics engineering scenarios

--- a/website/docs/docs/dbt-ai/wizard-how-it-works.md
+++ b/website/docs/docs/dbt-ai/wizard-how-it-works.md
@@ -235,7 +235,7 @@ Each CLI session is saved locally. This is separate from platform conversations,
 
 - [<Constant name="wizard" /> overview](/docs/platform/wizard-overview)
 - [<Constant name="wizard" /> in the dbt platform](/docs/platform/wizard-platform)
-- [<Constant name="wizard" /> quickstart](/docs/dbt-ai/wizard-quickstart)
+- [Use <Constant name="wizard" /> locally](/docs/dbt-ai/wizard-quickstart)
 - [Use cases and examples](/docs/dbt-ai/wizard-use-cases)
 - [Skills](/docs/dbt-ai/wizard-skills)
 - [<Constant name="wizard" /> command reference](/docs/dbt-ai/wizard-cli-reference)

--- a/website/docs/docs/dbt-ai/wizard-migrate.md
+++ b/website/docs/docs/dbt-ai/wizard-migrate.md
@@ -10,7 +10,7 @@ tags: [AI, Wizard]
 Move from Claude Code to <Constant name="wizard" /> while keeping your project conventions.
 </IntroText>
 
-<Constant name="wizard" /> automatically imports Claude Code instructions, skills, and settings from your repo. Use this page if you already use Claude Code on dbt projects and want to bring over project context, skills, or model settings. If you're new to AI agents, start with the [Quickstart](/docs/dbt-ai/wizard-quickstart).
+<Constant name="wizard" /> automatically imports Claude Code instructions, skills, and settings from your repo. Use this page if you already use Claude Code on dbt projects and want to bring over project context, skills, or model settings. If you're new to AI agents, start with [Use dbt Wizard locally](/docs/dbt-ai/wizard-quickstart).
 
 ## Prerequisites
 
@@ -100,7 +100,7 @@ And if your conventions aren't applied, check:
 
 ## Related docs
 
-- [Quickstart](/docs/dbt-ai/wizard-quickstart)
+- [Use dbt Wizard locally](/docs/dbt-ai/wizard-quickstart)
 - [Skills](/docs/dbt-ai/wizard-skills)
 - [Configure BYOK](/docs/dbt-ai/wizard-byok)
 - [Use cases and examples](/docs/dbt-ai/wizard-use-cases)

--- a/website/docs/docs/dbt-ai/wizard-quickstart.md
+++ b/website/docs/docs/dbt-ai/wizard-quickstart.md
@@ -1,8 +1,8 @@
 ---
-title: "Get started with the dbt Wizard local CLI"
+title: "Use dbt Wizard locally"
 id: "wizard-quickstart"
 description: "Install the dbt Wizard local CLI, complete first-run onboarding, and send your first prompt from the terminal."
-sidebar_label: "Get started with the local CLI"
+sidebar_label: "Use dbt Wizard locally"
 tags: [AI, CLI, dbt Wizard]
 ---
 
@@ -14,7 +14,7 @@ import NewToTerminal from '/snippets/_new-to-terminal.md';
 import WizardFeedbackCallout from '/snippets/_wizard-feedback-callout.md';
 import WizardCliDbtCliSupport from '/snippets/_wizard-cli-dbt-cli-support.md';
 
-# Get started with the <Constant name="wizard" /> local CLI
+# Use <Constant name="wizard" /> locally
 
 <IntroText>
 Install <Constant name="wizard" /> locally and start an agentic dbt development session from your terminal.

--- a/website/docs/docs/dbt-ai/wizard-use-cases.md
+++ b/website/docs/docs/dbt-ai/wizard-use-cases.md
@@ -243,7 +243,7 @@ wizard exec --json "summarize test coverage by schema"
 
 ## Related docs
 
-- [dbt Wizard quickstart](/docs/dbt-ai/wizard-quickstart)
+- [Use dbt Wizard locally](/docs/dbt-ai/wizard-quickstart)
 - [dbt Wizard overview](/docs/dbt-ai/about-dbt-wizard-cli)
 - [Configure BYOK](/docs/dbt-ai/wizard-byok)
 - [dbt Wizard in Studio IDE](/docs/dbt-ai/wizard-ide): same agent, in the dbt platform

--- a/website/docs/docs/platform/enable-dbt-ai.md
+++ b/website/docs/docs/platform/enable-dbt-ai.md
@@ -9,7 +9,7 @@ import WizardSupportedProviders from '/snippets/_wizard-supported-providers.md';
 import WizardPlatformPreviewDisclaimer from '/snippets/_wizard-platform-preview-disclaimer.md';
 import CopilotWizardDifferences from '/snippets/_copilot-wizard-diff.md';
 
-# Configure AI features in <Constant name="dbt_platform" /> <Lifecycle status="self_service,managed,managed_plus" />
+# Enable AI features in <Constant name="dbt_platform" /> <Lifecycle status="self_service,managed,managed_plus" />
 
 <IntroText>
 Enable AI features in <Constant name="dbt_platform" /> to speed up your development and focus on delivering quality data.

--- a/website/docs/docs/platform/enable-dbt-ai.md
+++ b/website/docs/docs/platform/enable-dbt-ai.md
@@ -1,7 +1,7 @@
 ---
-title: "Configure AI features in dbt platform"
-sidebar_label: "Configure AI features"
-description: "Configure AI features in the dbt platform, including dbt Wizard and dbt Copilot, to speed up your development."
+title: "Enable AI in dbt platform"
+sidebar_label: "Enable AI in dbt platform"
+description: "Enable AI features in the dbt platform, including dbt Wizard and dbt Copilot, to speed up your development."
 ---
 
 import OpenAiProjectRegion from '/snippets/_open-ai-project-region.md';

--- a/website/docs/docs/platform/enable-dbt-ai.md
+++ b/website/docs/docs/platform/enable-dbt-ai.md
@@ -1,7 +1,7 @@
 ---
-title: "Get started in dbt platform"
-sidebar_label: "Get started in dbt platform"
-description: "Get started with AI features in the dbt platform, including dbt Wizard and dbt Copilot, to speed up your development."
+title: "Configure AI features in dbt platform"
+sidebar_label: "Configure AI features"
+description: "Configure AI features in the dbt platform, including dbt Wizard and dbt Copilot, to speed up your development."
 ---
 
 import OpenAiProjectRegion from '/snippets/_open-ai-project-region.md';
@@ -9,7 +9,7 @@ import WizardSupportedProviders from '/snippets/_wizard-supported-providers.md';
 import WizardPlatformPreviewDisclaimer from '/snippets/_wizard-platform-preview-disclaimer.md';
 import CopilotWizardDifferences from '/snippets/_copilot-wizard-diff.md';
 
-# Get started in dbt platform <Lifecycle status="self_service,managed,managed_plus" />
+# Configure AI features in <Constant name="dbt_platform" /> <Lifecycle status="self_service,managed,managed_plus" />
 
 <IntroText>
 Enable AI features in <Constant name="dbt_platform" /> to speed up your development and focus on delivering quality data.

--- a/website/docs/docs/platform/wizard-overview.md
+++ b/website/docs/docs/platform/wizard-overview.md
@@ -53,7 +53,7 @@ For included action limits by plan and how managed usage is metered, refer to th
 
 <WizardSupportedProviders />
 
-## Get started with dbt Wizard
+## Choose a dbt Wizard experience
 
 <Tabs>
 <TabItem value="terminal" label={<span className="tabs-lifecycle-label">Terminal <Lifecycle status="beta" size="90%" /></span>} default>
@@ -102,7 +102,7 @@ Refer to [Use cases and examples](/docs/dbt-ai/wizard-use-cases) for more prompt
 
 ## Next steps
 
-Now that you know where to start, continue with **[Get started with the local CLI](/docs/dbt-ai/wizard-quickstart)** for local installation and onboarding, or **[Get started in dbt platform](/docs/platform/enable-dbt-ai)** for the platform setup flow.
+Now that you know where to start, continue with **[Use dbt Wizard locally](/docs/dbt-ai/wizard-quickstart)** for local installation and onboarding, or **[Configure AI features in dbt platform](/docs/platform/enable-dbt-ai)** for the platform setup flow.
 
 
 ## Related docs

--- a/website/docs/docs/platform/wizard-overview.md
+++ b/website/docs/docs/platform/wizard-overview.md
@@ -102,7 +102,7 @@ Refer to [Use cases and examples](/docs/dbt-ai/wizard-use-cases) for more prompt
 
 ## Next steps
 
-Now that you know where to start, continue with **[Use dbt Wizard locally](/docs/dbt-ai/wizard-quickstart)** for local installation and onboarding, or **[Configure AI features in dbt platform](/docs/platform/enable-dbt-ai)** for the platform setup flow.
+Now that you know where to start, continue with **[Use dbt Wizard locally](/docs/dbt-ai/wizard-quickstart)** for local installation and onboarding, or **[Enable AI features in dbt platform](/docs/platform/enable-dbt-ai)** for the platform setup flow.
 
 
 ## Related docs

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -401,6 +401,11 @@ const sidebarSettings = {
           items: [
             "docs/platform/wizard-overview",
             "docs/dbt-ai/wizard-quickstart",
+            {
+              type: "link",
+              label: "Configure AI features",
+              href: "/docs/platform/enable-dbt-ai",
+            },
             "docs/dbt-ai/wizard-use-cases",
             "docs/dbt-ai/wizard-how-it-works",
             {

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -400,6 +400,8 @@ const sidebarSettings = {
           link: { type: "doc", id: "docs/platform/wizard-overview" },
           items: [
             "docs/platform/wizard-overview",
+            "docs/dbt-ai/wizard-quickstart",
+            "docs/platform/enable-dbt-ai",
             "docs/dbt-ai/wizard-use-cases",
             "docs/dbt-ai/wizard-how-it-works",
             {

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -401,7 +401,6 @@ const sidebarSettings = {
           items: [
             "docs/platform/wizard-overview",
             "docs/dbt-ai/wizard-quickstart",
-            "docs/platform/enable-dbt-ai",
             "docs/dbt-ai/wizard-use-cases",
             "docs/dbt-ai/wizard-how-it-works",
             {

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -436,7 +436,6 @@ const sidebarSettings = {
               link: { type: "doc", id: "docs/platform/wizard-platform" },
               items: [
                 "docs/platform/wizard-platform",
-                "docs/platform/enable-dbt-ai",
                 "docs/dbt-ai/wizard-ide",
                 "docs/platform/wizard-home",
                 "docs/dbt-ai/wizard-platform-skills",

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -403,7 +403,7 @@ const sidebarSettings = {
             "docs/dbt-ai/wizard-quickstart",
             {
               type: "link",
-              label: "Configure AI features",
+              label: "Enable AI in dbt platform",
               href: "/docs/platform/enable-dbt-ai",
             },
             "docs/dbt-ai/wizard-use-cases",
@@ -415,7 +415,6 @@ const sidebarSettings = {
               link: { type: "doc", id: "docs/dbt-ai/about-dbt-wizard-cli" },
               items: [
                 "docs/dbt-ai/about-dbt-wizard-cli",
-                "docs/dbt-ai/wizard-quickstart",
                 "docs/dbt-ai/wizard-cli",
                 "docs/dbt-ai/wizard-byok",
                 "docs/dbt-ai/wizard-skills",

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -393,8 +393,6 @@ const sidebarSettings = {
       className: 'sidebar-title',
     },
         "docs/dbt-ai/about-dbt-ai",
-        "docs/dbt-ai/wizard-quickstart",
-        "docs/platform/enable-dbt-ai",
         {
           type: "category",
           label: "dbt Wizard",
@@ -402,8 +400,6 @@ const sidebarSettings = {
           link: { type: "doc", id: "docs/platform/wizard-overview" },
           items: [
             "docs/platform/wizard-overview",
-            "docs/dbt-ai/wizard-quickstart",
-            "docs/platform/enable-dbt-ai",
             "docs/dbt-ai/wizard-use-cases",
             "docs/dbt-ai/wizard-how-it-works",
             {
@@ -413,6 +409,7 @@ const sidebarSettings = {
               link: { type: "doc", id: "docs/dbt-ai/about-dbt-wizard-cli" },
               items: [
                 "docs/dbt-ai/about-dbt-wizard-cli",
+                "docs/dbt-ai/wizard-quickstart",
                 "docs/dbt-ai/wizard-cli",
                 "docs/dbt-ai/wizard-byok",
                 "docs/dbt-ai/wizard-skills",


### PR DESCRIPTION
## What changed

- Removed duplicate AI get-started pages from the top-level AI overview/sidebar placement.
- Kept the Wizard local CLI page under Wizard CLI and the platform AI configuration page under Wizard in platform.
- Renamed the affected labels to "Use dbt Wizard locally" and "Configure AI features in dbt platform".

## Validation

- npm run build
- pre-commit lint hook via git commit

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-get-started-label-dbt-labs.vercel.app/docs/dbt-ai/about-dbt-ai
- https://docs-getdbt-com-git-update-get-started-label-dbt-labs.vercel.app/docs/dbt-ai/about-dbt-wizard-cli
- https://docs-getdbt-com-git-update-get-started-label-dbt-labs.vercel.app/docs/dbt-ai/dbt-ai-faqs
- https://docs-getdbt-com-git-update-get-started-label-dbt-labs.vercel.app/docs/dbt-ai/wizard-cli
- https://docs-getdbt-com-git-update-get-started-label-dbt-labs.vercel.app/docs/dbt-ai/wizard-how-it-works
- https://docs-getdbt-com-git-update-get-started-label-dbt-labs.vercel.app/docs/dbt-ai/wizard-migrate
- https://docs-getdbt-com-git-update-get-started-label-dbt-labs.vercel.app/docs/dbt-ai/wizard-quickstart
- https://docs-getdbt-com-git-update-get-started-label-dbt-labs.vercel.app/docs/dbt-ai/wizard-use-cases
- https://docs-getdbt-com-git-update-get-started-label-dbt-labs.vercel.app/docs/platform/enable-dbt-ai
- https://docs-getdbt-com-git-update-get-started-label-dbt-labs.vercel.app/docs/platform/wizard-overview

<!-- end-vercel-deployment-preview -->