### PR TITLE
clarify exports in studio ide

### DIFF
--- a/website/docs/docs/use-dbt-semantic-layer/exports.md
+++ b/website/docs/docs/use-dbt-semantic-layer/exports.md
@@ -56,7 +56,7 @@ Before you're able to run exports in development or production, you'll need to m
 
 There are two ways to run an export:
   
-- [Run exports in development](#exports-in-development) to test the output before production. In <Constant name="studio_ide" /> or any environment on the <Constant name="fusion_engine" />, run `dbt build` instead &mdash; enable the [environment variable](#set-environment-variable) first. In the [<Constant name="dbt" /> CLI](/docs/platform/dbt-cli-installation) outside Fusion, run `dbt sl export` or `dbt sl export-all`.
+- [Run exports in development](#exports-in-development) to test the output before production. In <Constant name="studio_ide" /> or any environment on the <Constant name="fusion_engine" />, run `dbt build` instead &mdash; enable the [environment variable](#set-environment-variable) first. In the [<Constant name="dbt" /> CLI](/docs/platform/dbt-cli-installation) outside <Constant name="fusion" />, run `dbt sl export` or `dbt sl export-all`.
 - [Run exports in production](#exports-in-production) using the [<Constant name="dbt" /> job scheduler](/docs/deploy/job-scheduler) to write these queries within your data platform.
 
 ## Exports in development
@@ -73,7 +73,7 @@ If your environment runs on the <Constant name="fusion_engine" /> (including <Co
 
 ### Exports for single saved query
 
-These commands apply when you're using the <Constant name="dbt" /> CLI outside <Constant name="studio_ide" /> or the <Constant name="fusion_engine" />. If your environment runs on Fusion, use `dbt build` instead &mdash; see [Run exports](#run-exports) for details.
+These commands apply when you're using the <Constant name="dbt" /> CLI outside <Constant name="studio_ide" /> or the <Constant name="fusion_engine" />. If your environment runs on <Constant name="fusion" />, use `dbt build` instead. For more info, check out [Run exports](#run-exports).
 
 Use the following command to run exports in the <Constant name="dbt" /> CLI:
 

--- a/website/docs/docs/use-dbt-semantic-layer/exports.md
+++ b/website/docs/docs/use-dbt-semantic-layer/exports.md
@@ -59,7 +59,7 @@ Before you're able to run exports in development or production, you'll need to m
 There are two ways to run an export:
   
 - [Run exports in development](#exports-in-development) using the [<Constant name="dbt" /> CLI](/docs/platform/dbt-cli-installation) to test the output before production.
-  - To work in <Constant name="studio_ide" />, use `dbt build` to run exports, and make sure you have the [environment variable](#set-environment-variable) enabled. To work in the <Constant name="dbt" /> CLI, use the `dbt sl export` or dbt sl export-all commands to run exports.
+  - To work in <Constant name="studio_ide" />, use `dbt build` to run exports, and make sure you have the [environment variable](#set-environment-variable) enabled. To work in the <Constant name="dbt" /> CLI, use the `dbt sl export` or `dbt sl export-all` commands to run exports.
 - [Run exports in production](#exports-in-production) using the [<Constant name="dbt" /> job scheduler](/docs/deploy/job-scheduler) to write these queries within your data platform.
 
 ## Exports in development
@@ -72,7 +72,8 @@ This section explains the different commands and options available to run export
 
 - Use the [`dbt sl export-all` command](#exports-for-multiple-saved-queries) to run exports for multiple saved queries at once. This command provides a convenient way to manage and execute exports for several queries simultaneously, saving time and effort. 
 
-- If you're using the <Constant name="studio_ide" />, you can configure exports, but the `dbt sl export` and `dbt sl export-all` commands aren't supported. Use `dbt build` to run exports, and make sure you have the [environment variable](#set-environment-variable) enabled before running the command.
+- If you're using the <Constant name="studio_ide" />, use `dbt build` to run exports and make sure you have the [environment variable](#set-environment-variable) enabled before running the command. Commands `dbt sl export` or `dbt sl export-all` are supported in the <Constant name="dbt"> CLI only.
+
 
 ### Exports for single saved query
 

--- a/website/docs/docs/use-dbt-semantic-layer/exports.md
+++ b/website/docs/docs/use-dbt-semantic-layer/exports.md
@@ -22,8 +22,6 @@ Essentially, exports are like any other table in your data platform &mdash; they
 - You have the <Constant name="semantic_layer" /> [configured](/docs/use-dbt-semantic-layer/setup-sl) in your dbt project.
 - You have a <Constant name="dbt" /> environment with the [job scheduler](/docs/deploy/job-scheduler) enabled.
 - You have a [saved query](/docs/build/saved-queries) and [export configured](/docs/build/saved-queries#configure-exports) in your dbt project. In your configuration, leverage [caching](/docs/use-dbt-semantic-layer/sl-cache) to cache common queries, speed up performance, and reduce compute costs.
-- You have the [<Constant name="dbt" /> CLI](/docs/platform/dbt-cli-installation) installed. 
-  - In <Constant name="studio_ide" />, run `dbt build` instead of `dbt sl export` or `dbt sl export-all.`
 
 ## Benefits of exports
 
@@ -58,8 +56,7 @@ Before you're able to run exports in development or production, you'll need to m
 
 There are two ways to run an export:
   
-- [Run exports in development](#exports-in-development) using the [<Constant name="dbt" /> CLI](/docs/platform/dbt-cli-installation) to test the output before production.
-  - To work in <Constant name="studio_ide" />, use `dbt build` to run exports, and make sure you have the [environment variable](#set-environment-variable) enabled. To work in the <Constant name="dbt" /> CLI, use the `dbt sl export` or `dbt sl export-all` commands to run exports.
+- [Run exports in development](#exports-in-development) to test the output before production. In <Constant name="studio_ide" /> or any environment on the <Constant name="fusion_engine" />, run `dbt build` instead &mdash; enable the [environment variable](#set-environment-variable) first. In the [<Constant name="dbt" /> CLI](/docs/platform/dbt-cli-installation) outside Fusion, run `dbt sl export` or `dbt sl export-all`.
 - [Run exports in production](#exports-in-production) using the [<Constant name="dbt" /> job scheduler](/docs/deploy/job-scheduler) to write these queries within your data platform.
 
 ## Exports in development
@@ -68,14 +65,15 @@ You can run an export in your development environment if you want to test its ou
 
 This section explains the different commands and options available to run exports in development.
 
+If your environment runs on the <Constant name="fusion_engine" /> (including <Constant name="studio_ide" />), use `dbt build` instead of the commands below &mdash; see [Run exports](#run-exports) for details.
+
 - Use the [`dbt sl export` command](#exports-for-single-saved-query) to test and generate exports in your development environment for a singular saved query. You can also use the `--select` flag to specify particular exports from a saved query.
 
 - Use the [`dbt sl export-all` command](#exports-for-multiple-saved-queries) to run exports for multiple saved queries at once. This command provides a convenient way to manage and execute exports for several queries simultaneously, saving time and effort. 
 
-- If you're using the <Constant name="studio_ide" />, use `dbt build` to run exports and make sure you have the [environment variable](#set-environment-variable) enabled before running the command. Commands `dbt sl export` or `dbt sl export-all` are supported in the <Constant name="dbt" /> CLI only.
-
-
 ### Exports for single saved query
+
+These commands apply when you're using the <Constant name="dbt" /> CLI outside <Constant name="studio_ide" /> or the <Constant name="fusion_engine" />. If your environment runs on Fusion, use `dbt build` instead &mdash; see [Run exports](#run-exports) for details.
 
 Use the following command to run exports in the <Constant name="dbt" /> CLI:
 
@@ -207,7 +205,7 @@ Yes, this is possible. However, the difference would be the name, schema, and ma
 <DetailsToggle alt_header="How do I run all exports for a saved query?">
 
 - In production runs, you can build the saved query by calling it directly in the build command, or you build a model and any exports downstream of that model.
-- In development, you can run all exports by running `dbt sl export --saved-query sq_name`.
+- In development, run all exports by running `dbt sl export --saved-query sq_name`. If your environment runs on the <Constant name="fusion_engine" /> (including <Constant name="studio_ide" />), run `dbt build` instead.
 
 </DetailsToggle>
 

--- a/website/docs/docs/use-dbt-semantic-layer/exports.md
+++ b/website/docs/docs/use-dbt-semantic-layer/exports.md
@@ -22,7 +22,8 @@ Essentially, exports are like any other table in your data platform &mdash; they
 - You have the <Constant name="semantic_layer" /> [configured](/docs/use-dbt-semantic-layer/setup-sl) in your dbt project.
 - You have a <Constant name="dbt" /> environment with the [job scheduler](/docs/deploy/job-scheduler) enabled.
 - You have a [saved query](/docs/build/saved-queries) and [export configured](/docs/build/saved-queries#configure-exports) in your dbt project. In your configuration, leverage [caching](/docs/use-dbt-semantic-layer/sl-cache) to cache common queries, speed up performance, and reduce compute costs.
-- You have the [<Constant name="dbt" /> CLI](/docs/platform/dbt-cli-installation) installed. The `dbt sl export` and `dbt sl export-all` commands aren't supported in <Constant name="studio_ide" />.
+- You have the [<Constant name="dbt" /> CLI](/docs/platform/dbt-cli-installation) installed. 
+  - In <Constant name="studio_ide" />, run `dbt build` instead of `dbt sl export` or `dbt sl export-all.`
 
 ## Benefits of exports
 

--- a/website/docs/docs/use-dbt-semantic-layer/exports.md
+++ b/website/docs/docs/use-dbt-semantic-layer/exports.md
@@ -65,7 +65,7 @@ You can run an export in your development environment if you want to test its ou
 
 This section explains the different commands and options available to run exports in development.
 
-If your environment runs on the <Constant name="fusion_engine" /> (including <Constant name="studio_ide" />), use `dbt build` instead of the commands below &mdash; see [Run exports](#run-exports) for details.
+If your environment runs on the <Constant name="fusion_engine" /> (including <Constant name="studio_ide" />), use `dbt build` instead of the following commands. Check out [Run exports](#run-exports) for details.
 
 - Use the [`dbt sl export` command](#exports-for-single-saved-query) to test and generate exports in your development environment for a singular saved query. You can also use the `--select` flag to specify particular exports from a saved query.
 

--- a/website/docs/docs/use-dbt-semantic-layer/exports.md
+++ b/website/docs/docs/use-dbt-semantic-layer/exports.md
@@ -72,7 +72,7 @@ This section explains the different commands and options available to run export
 
 - Use the [`dbt sl export-all` command](#exports-for-multiple-saved-queries) to run exports for multiple saved queries at once. This command provides a convenient way to manage and execute exports for several queries simultaneously, saving time and effort. 
 
-- If you're using the <Constant name="studio_ide" />, use `dbt build` to run exports and make sure you have the [environment variable](#set-environment-variable) enabled before running the command. Commands `dbt sl export` or `dbt sl export-all` are supported in the <Constant name="dbt"> CLI only.
+- If you're using the <Constant name="studio_ide" />, use `dbt build` to run exports and make sure you have the [environment variable](#set-environment-variable) enabled before running the command. Commands `dbt sl export` or `dbt sl export-all` are supported in the <Constant name="dbt" /> CLI only.
 
 
 ### Exports for single saved query

--- a/website/docs/docs/use-dbt-semantic-layer/exports.md
+++ b/website/docs/docs/use-dbt-semantic-layer/exports.md
@@ -56,7 +56,7 @@ Before you're able to run exports in development or production, you'll need to m
 
 There are two ways to run an export:
   
-- [Run exports in development](#exports-in-development) to test the output before production. In <Constant name="studio_ide" /> or any environment on the <Constant name="fusion_engine" />, run `dbt build` instead &mdash; enable the [environment variable](#set-environment-variable) first. In the [<Constant name="dbt" /> CLI](/docs/platform/dbt-cli-installation) outside <Constant name="fusion" />, run `dbt sl export` or `dbt sl export-all`.
+- [Run exports in development](#exports-in-development) to test the output before production. In <Constant name="studio_ide" /> or any environment on the <Constant name="fusion_engine" />, run `dbt build` instead &mdash; enable the [environment variable](#set-environment-variable) first. In the [<Constant name="platform_cli" />](/docs/platform/dbt-cli-installation) outside <Constant name="fusion" />, run `dbt sl export` or `dbt sl export-all`.
 - [Run exports in production](#exports-in-production) using the [<Constant name="dbt" /> job scheduler](/docs/deploy/job-scheduler) to write these queries within your data platform.
 
 ## Exports in development
@@ -73,9 +73,9 @@ If your environment runs on the <Constant name="fusion_engine" /> (including <Co
 
 ### Exports for single saved query
 
-These commands apply when you're using the <Constant name="dbt" /> CLI outside <Constant name="studio_ide" /> or the <Constant name="fusion_engine" />. If your environment runs on <Constant name="fusion" />, use `dbt build` instead. For more info, check out [Run exports](#run-exports).
+These commands apply when you're using the <Constant name="platform_cli" /> outside <Constant name="studio_ide" /> or the <Constant name="fusion_engine" />. If your environment runs on <Constant name="fusion" />, use `dbt build` instead. For more info, check out [Run exports](#run-exports).
 
-Use the following command to run exports in the <Constant name="dbt" /> CLI:
+Use the following command to run exports in the <Constant name="platform_cli" />:
 
 ```bash
 dbt sl export

--- a/website/docs/docs/use-dbt-semantic-layer/exports.md
+++ b/website/docs/docs/use-dbt-semantic-layer/exports.md
@@ -10,7 +10,7 @@ keywords: [DBT_ENGINE_INCLUDE_SAVED_QUERY, DBT_ENGINE_EXPORT_SAVED_QUERIES, expo
 Exports enhance [saved queries](/docs/build/saved-queries) by running your saved queries and writing the output to a table or view within your data platform. Saved queries are a way to save and reuse commonly used queries in MetricFlow, exports take this functionality a step further by:
 
 - Enabling you to write these queries within your data platform using the <Constant name="dbt" /> job scheduler.
-- Proving an integration path for tools that don't natively support the <Constant name="semantic_layer" /> by exposing tables of metrics and dimensions.
+- Providing an integration path for tools that don't natively support the <Constant name="semantic_layer" /> by exposing tables of metrics and dimensions.
 
 Essentially, exports are like any other table in your data platform &mdash; they enable you to query metric definitions through any SQL interface or connect to downstream tools without a first-class [<Constant name="semantic_layer" /> integration](/docs/platform-integrations/avail-sl-integrations). Running an export counts towards [queried metrics](/docs/platform/billing#what-counts-as-a-queried-metric) usage. Querying the resulting table or view from the export does not count toward queried metric usage.
 
@@ -22,7 +22,7 @@ Essentially, exports are like any other table in your data platform &mdash; they
 - You have the <Constant name="semantic_layer" /> [configured](/docs/use-dbt-semantic-layer/setup-sl) in your dbt project.
 - You have a <Constant name="dbt" /> environment with the [job scheduler](/docs/deploy/job-scheduler) enabled.
 - You have a [saved query](/docs/build/saved-queries) and [export configured](/docs/build/saved-queries#configure-exports) in your dbt project. In your configuration, leverage [caching](/docs/use-dbt-semantic-layer/sl-cache) to cache common queries, speed up performance, and reduce compute costs.
-- You have the [<Constant name="dbt" /> CLI](/docs/platform/dbt-cli-installation) installed. Note, that exports aren't supported in <Constant name="studio_ide" /> yet.
+- You have the [<Constant name="dbt" /> CLI](/docs/platform/dbt-cli-installation) installed. The `dbt sl export` and `dbt sl export-all` commands aren't supported in <Constant name="studio_ide" />.
 
 ## Benefits of exports
 
@@ -57,8 +57,8 @@ Before you're able to run exports in development or production, you'll need to m
 
 There are two ways to run an export:
   
-- [Run exports in development](#exports-in-development) using the [<Constant name="dbt" /> CLI](/docs/platform/dbt-cli-installation) to test the output before production (You can configure exports in the <Constant name="studio_ide" />, however running them directly in the <Constant name="studio_ide" /> isn't supported yet). 
-  - If you're using the <Constant name="studio_ide" />, use `dbt build` to run exports. Make sure you have the [environment variable](#set-environment-variable) enabled. 
+- [Run exports in development](#exports-in-development) using the [<Constant name="dbt" /> CLI](/docs/platform/dbt-cli-installation) to test the output before production.
+  - If you're using the <Constant name="studio_ide" />, you can configure exports, but the `dbt sl export` and `dbt sl export-all` commands aren't supported. Use `dbt build` to run exports, and make sure you have the [environment variable](#set-environment-variable) enabled.
 - [Run exports in production](#exports-in-production) using the [<Constant name="dbt" /> job scheduler](/docs/deploy/job-scheduler) to write these queries within your data platform.
 
 ## Exports in development
@@ -71,7 +71,7 @@ This section explains the different commands and options available to run export
 
 - Use the [`dbt sl export-all` command](#exports-for-multiple-saved-queries) to run exports for multiple saved queries at once. This command provides a convenient way to manage and execute exports for several queries simultaneously, saving time and effort. 
 
-- If you're using the <Constant name="studio_ide" />, use `dbt build` to run exports. Make sure you have the [environment variable](#set-environment-variable) enabled before running the command.
+- If you're using the <Constant name="studio_ide" />, you can configure exports, but the `dbt sl export` and `dbt sl export-all` commands aren't supported. Use `dbt build` to run exports, and make sure you have the [environment variable](#set-environment-variable) enabled before running the command.
 
 ### Exports for single saved query
 
@@ -108,7 +108,7 @@ Export completed.
 
 ### Use the select flag
 
-You can have multiple exports for a saved query and by default, all exports are run for a saved query. You can use the `select` flag in [development](#exports-in-development) to select specific or multiple exports. Note, you can’t sub-select metrics or dimensions from the saved query, it’s just to change the export configuration i.e table format or schema
+You can have multiple exports for a saved query and by default, all exports are run for a saved query. You can use the `select` flag in [development](#exports-in-development) to select specific or multiple exports. You can't sub-select metrics or dimensions from the saved query. You can only change the export configuration, such as the table format or schema.
 
 For example, the following command runs `export_1` and `export_2` and doesn't work with the `--alias` or `--export_as` flags:
 

--- a/website/docs/docs/use-dbt-semantic-layer/exports.md
+++ b/website/docs/docs/use-dbt-semantic-layer/exports.md
@@ -59,7 +59,7 @@ Before you're able to run exports in development or production, you'll need to m
 There are two ways to run an export:
   
 - [Run exports in development](#exports-in-development) using the [<Constant name="dbt" /> CLI](/docs/platform/dbt-cli-installation) to test the output before production.
-  - If you're using the <Constant name="studio_ide" />, you can configure exports, but the `dbt sl export` and `dbt sl export-all` commands aren't supported. Use `dbt build` to run exports, and make sure you have the [environment variable](#set-environment-variable) enabled.
+  - To work in <Constant name="studio_ide" />, use `dbt build` to run exports, and make sure you have the [environment variable](#set-environment-variable) enabled. To work in the <Constant name="dbt" /> CLI, use the `dbt sl export` or dbt sl export-all commands to run exports.
 - [Run exports in production](#exports-in-production) using the [<Constant name="dbt" /> job scheduler](/docs/deploy/job-scheduler) to write these queries within your data platform.
 
 ## Exports in development


### PR DESCRIPTION
## What changed
- Clarified that dbt sl export and dbt sl export-all are not supported in Studio IDE.
- Clarified that Studio IDE users should use dbt build with the exports environment variable enabled.
- Fixed nearby wording in the exports doc.

[Raised internally](https://dbt-labs.slack.com/archives/C08PYQS8B7Z/p1782828094646019)

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-fix-sl-exports-development-docs-dbt-labs.vercel.app/docs/use-dbt-semantic-layer/exports

<!-- end-vercel-deployment-preview -->