### PR TITLE
Remove reference to dbt-fusion repo

### DIFF
--- a/website/docs/docs/dbt-versions/dbt-versions.md
+++ b/website/docs/docs/dbt-versions/dbt-versions.md
@@ -124,6 +124,6 @@ While a minor version is officially supported:
 
 Upgrade to new patch versions as soon as they're available. Upgrade to new minor versions when you're ready because you can only get some features and fixes on the latest minor version.
 
-dbt makes all versions available as prereleases before the final release. For minor versions, we aim to release one or more betas 4+ weeks before the final release so you can try new features and share feedback. Release candidates are available about two weeks before the final release for testing in production-like environments. Refer to the [`dbt-fusion` milestones](https://github.com/dbt-labs/dbt-fusion/milestones) or [`dbt-core` milestones](https://github.com/dbt-labs/dbt-core/milestones) for details.
+dbt makes all versions available as prereleases before the final release. For minor versions, we aim to release one or more betas 4+ weeks before the final release so you can try new features and share feedback. Release candidates are available about two weeks before the final release for testing in production-like environments. Refer to the [`dbt-core` milestones](https://github.com/dbt-labs/dbt-core/milestones) for details.
 
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
dbt Versions doc linked to the old dbt-fusion repo's milestones page. Not needed now the dbt-core repo contains both

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-joellabes-patch-4-dbt-labs.vercel.app/docs/dbt-versions/dbt-versions

<!-- end-vercel-deployment-preview -->