### PR TITLE
Update remote MCP OAuth availability

### DIFF
--- a/website/docs/docs/dbt-ai/integrate-mcp-claude.md
+++ b/website/docs/docs/dbt-ai/integrate-mcp-claude.md
@@ -25,6 +25,7 @@ Both interfaces can connect to either:
 
 - You use Claude for AI or agentic work
 - For OAuth (local or remote), use your [access URL with a static subdomain](/docs/platform/about-platform/access-regions-ip-addresses).
+  - Remote MCP OAuth is available for Starter, Enterprise, and Enterprise+ accounts.
 
 <StaticSubdomainRequired />
 

--- a/website/docs/docs/dbt-ai/integrate-mcp-claude.md
+++ b/website/docs/docs/dbt-ai/integrate-mcp-claude.md
@@ -79,7 +79,7 @@ Then follow the tab that matches your auth method:
 <Tabs>
 <TabItem value="oauth" label="OAuth (remote)">
 
-_OAuth is in private beta for Enterprise and Enterprise+ accounts._
+_Remote MCP OAuth is available in public beta for Starter, Enterprise, and Enterprise+ accounts._
 
 <MCPOauthPreflight />
 
@@ -157,7 +157,7 @@ Claude Code can connect to the remote dbt MCP server over HTTP &mdash; same JSON
     <Tabs>
     <TabItem value="oauth" label="OAuth (remote)">
 
-    _OAuth is in private beta for Enterprise and Enterprise+ accounts._
+    _Remote MCP OAuth is available in public beta for Starter, Enterprise, and Enterprise+ accounts._
 
     <MCPOauthPreflight />
 

--- a/website/docs/docs/dbt-ai/integrate-mcp-cursor.md
+++ b/website/docs/docs/dbt-ai/integrate-mcp-cursor.md
@@ -41,7 +41,7 @@ After clicking:
 
 <TabItem value="OAuth with dbt platform">
 
-_Remote MCP OAuth is available in public beta for Starter, Enterprise, and Enterprise+ accounts._
+_OAuth with the local dbt MCP server is available for Starter, Enterprise, and Enterprise+ accounts._
 
 Configuration settings for users who want OAuth authentication with the <Constant name="dbt_platform" />.
 

--- a/website/docs/docs/dbt-ai/integrate-mcp-cursor.md
+++ b/website/docs/docs/dbt-ai/integrate-mcp-cursor.md
@@ -41,7 +41,7 @@ After clicking:
 
 <TabItem value="OAuth with dbt platform">
 
-Configuration settings for users who want OAuth authentication with the <Constant name="dbt_platform" /> <Lifecycle status="managed, managed_plus" />.
+Configuration settings for users who want OAuth authentication with the <Constant name="dbt_platform" /> <Lifecycle status="self_service, managed, managed_plus" />.
 
 Before you begin, make sure your account admin has enabled AI features on your <Constant name="dbt_platform"/> account. Refer to [Enable dbt AI](/docs/platform/enable-dbt-ai) for more info.
 
@@ -81,7 +81,7 @@ Then update `env-file-path` with the absolute path to your `.env` file (for exam
 
 Remote MCP supports **OAuth** or **token-based** headers.
 
-- _OAuth is in private beta for Enterprise and Enterprise+ accounts._
+- _Remote MCP OAuth is available in public beta for Starter, Enterprise, and Enterprise+ accounts._
 - For either method, the MCP URL is `https://<Access URL>/api/ai/v1/mcp`. You can find the URL in <Constant name="dbt_platform"/> under **Account settings** &rarr; **Access URLs** &rarr; **MCP Endpoint URL**.
 
 <MCPOauthPreflight />
@@ -103,4 +103,3 @@ The deeplink below configures **token-based** authentication (URL and headers). 
    ```
    :::
 3. Save, and now you have access to the dbt MCP server!
-

--- a/website/docs/docs/dbt-ai/integrate-mcp-cursor.md
+++ b/website/docs/docs/dbt-ai/integrate-mcp-cursor.md
@@ -41,7 +41,9 @@ After clicking:
 
 <TabItem value="OAuth with dbt platform">
 
-Configuration settings for users who want OAuth authentication with the <Constant name="dbt_platform" /> <Lifecycle status="self_service, managed, managed_plus" />.
+_Remote MCP OAuth is available in public beta for Starter, Enterprise, and Enterprise+ accounts._
+
+Configuration settings for users who want OAuth authentication with the <Constant name="dbt_platform" />.
 
 Before you begin, make sure your account admin has enabled AI features on your <Constant name="dbt_platform"/> account. Refer to [Enable dbt AI](/docs/platform/enable-dbt-ai) for more info.
 

--- a/website/docs/docs/dbt-ai/integrate-mcp-vscode.md
+++ b/website/docs/docs/dbt-ai/integrate-mcp-vscode.md
@@ -209,7 +209,7 @@ The remote dbt MCP server runs in <Constant name="dbt_platform" /> &mdash; no `u
     <Tabs>
     <TabItem value="oauth" label="OAuth (remote)">
 
-    _OAuth is in private beta for Enterprise and Enterprise+ accounts._
+    _Remote MCP OAuth is available in public beta for Starter, Enterprise, and Enterprise+ accounts._
 
     <MCPOauthPreflight />
 

--- a/website/docs/docs/dbt-ai/mcp-quickstart-remote.md
+++ b/website/docs/docs/dbt-ai/mcp-quickstart-remote.md
@@ -49,7 +49,7 @@ Obtain the following information from <Constant name="dbt_platform"/>:
 | ---- | ---- |
 | **OAuth (remote) |  No API tokens in your client config. Requires an OAuth-capable MCP client.<br /><br /> Available for Starter, Enterprise, and Enterprise+ accounts. |
 | **Token-based** | PAT or service token in the `Authorization` header. Works with any client and is required for shared/CI setups and for `execute_sql` (which needs a PAT). |
-
+</SimpleTable>
 <MCPRemoteOauthBetaCallout />
 
 ### 4. Get your MCP URL and IDs

--- a/website/docs/docs/dbt-ai/mcp-quickstart-remote.md
+++ b/website/docs/docs/dbt-ai/mcp-quickstart-remote.md
@@ -50,6 +50,7 @@ Obtain the following information from <Constant name="dbt_platform"/>:
 | **OAuth (remote) |  No API tokens in your client config. Requires an OAuth-capable MCP client.<br /><br /> Available for Starter, Enterprise, and Enterprise+ accounts. |
 | **Token-based** | PAT or service token in the `Authorization` header. Works with any client and is required for shared/CI setups and for `execute_sql` (which needs a PAT). |
 </SimpleTable>
+
 <MCPRemoteOauthBetaCallout />
 
 ### 4. Get your MCP URL and IDs

--- a/website/docs/docs/dbt-ai/mcp-quickstart-remote.md
+++ b/website/docs/docs/dbt-ai/mcp-quickstart-remote.md
@@ -47,7 +47,7 @@ Obtain the following information from <Constant name="dbt_platform"/>:
 <SimpleTable>
 | Type | Info | 
 | ---- | ---- |
-| **OAuth (remote) |  No API tokens in your client config. Requires an OAuth-capable MCP client.<br /><br /> Available for Starter, Enterprise, and Enterprise+ accounts. |
+| **OAuth (remote)** |  No API tokens in your client config. Requires an OAuth-capable MCP client.<br /><br /> Available for Starter, Enterprise, and Enterprise+ accounts. |
 | **Token-based** | PAT or service token in the `Authorization` header. Works with any client and is required for shared/CI setups and for `execute_sql` (which needs a PAT). |
 </SimpleTable>
 

--- a/website/docs/docs/dbt-ai/mcp-quickstart-remote.md
+++ b/website/docs/docs/dbt-ai/mcp-quickstart-remote.md
@@ -46,7 +46,7 @@ Obtain the following information from <Constant name="dbt_platform"/>:
 
 ### 3. Choose authentication: OAuth or tokens
 
-- **OAuth (remote)** &mdash; No API tokens in your client config. Requires an OAuth-capable MCP client. Available in private beta for Enterprise and Enterprise+ accounts.
+- **OAuth (remote)** &mdash; No API tokens in your client config. Requires an OAuth-capable MCP client. Available in public beta for Starter, Enterprise, and Enterprise+ accounts.
 - **Token-based** &mdash; PAT or service token in the `Authorization` header. Works with any client and is required for shared/CI setups and for `execute_sql` (which needs a PAT).
 
 <MCPRemoteOauthBetaCallout />

--- a/website/docs/docs/dbt-ai/mcp-quickstart-remote.md
+++ b/website/docs/docs/dbt-ai/mcp-quickstart-remote.md
@@ -70,6 +70,7 @@ Configure your MCP client with the MCP URL and headers from the previous step.
 
 <Tabs groupId="auth-method">
 <TabItem value="oauth" label="OAuth">
+
 _Available for Starter, Enterprise, and Enterprise+ accounts_
 
 <MCPOauthPreflight />

--- a/website/docs/docs/dbt-ai/mcp-quickstart-remote.md
+++ b/website/docs/docs/dbt-ai/mcp-quickstart-remote.md
@@ -11,8 +11,6 @@ import MCPRemoteOauthBetaCallout from '/snippets/_mcp-remote-oauth-beta-callout.
 import MCPOauthPreflight from '/snippets/_mcp-oauth-preflight.md';
 import MCPCustomConnectorOauth from '/snippets/_mcp-custom-connector-oauth.md';
 
-# Connect to the remote dbt MCP server <Lifecycle status="self_service,managed,managed_plus"/>
-
 The remote MCP server connects to <Constant name="dbt_platform"/> using HTTP. No local installation is required &mdash; you configure your MCP client with a URL and headers instead of running `uvx dbt-mcp`.
 
 <Lightbox src="/img/mcp/remote-dbt-mcp.jpg" title="Remote dbt MCP server architecture" />
@@ -46,8 +44,11 @@ Obtain the following information from <Constant name="dbt_platform"/>:
 
 ### 3. Choose authentication: OAuth or tokens
 
-- **OAuth (remote)** &mdash; No API tokens in your client config. Requires an OAuth-capable MCP client. Available in public beta for Starter, Enterprise, and Enterprise+ accounts.
-- **Token-based** &mdash; PAT or service token in the `Authorization` header. Works with any client and is required for shared/CI setups and for `execute_sql` (which needs a PAT).
+<SimpleTable>
+| Type | Info | 
+| ---- | ---- |
+| **OAuth (remote) |  No API tokens in your client config. Requires an OAuth-capable MCP client.<br /><br /> Available for Starter, Enterprise, and Enterprise+ accounts. |
+| **Token-based** | PAT or service token in the `Authorization` header. Works with any client and is required for shared/CI setups and for `execute_sql` (which needs a PAT). |
 
 <MCPRemoteOauthBetaCallout />
 
@@ -69,6 +70,7 @@ Configure your MCP client with the MCP URL and headers from the previous step.
 
 <Tabs groupId="auth-method">
 <TabItem value="oauth" label="OAuth">
+_Available for Starter, Enterprise, and Enterprise+ accounts_
 
 <MCPOauthPreflight />
 

--- a/website/docs/docs/dbt-ai/setup-local-mcp.md
+++ b/website/docs/docs/dbt-ai/setup-local-mcp.md
@@ -61,7 +61,7 @@ The `execute_sql` tool does _not_ work with service tokens. You must use a [Pers
 
 Choose the setup method that best fits your workflow:
 
-### OAuth authentication with dbt platform <Lifecycle status="managed, managed_plus" />
+### OAuth authentication with dbt platform <Lifecycle status="self_service, managed, managed_plus" />
 
 This method uses OAuth to authenticate with your <Constant name="dbt_platform" /> account. It's the simplest setup and doesn't require managing tokens or environment variables manually.
 

--- a/website/docs/docs/dbt-ai/setup-remote-mcp.md
+++ b/website/docs/docs/dbt-ai/setup-remote-mcp.md
@@ -88,7 +88,7 @@ Token-based authentication lets you connect to the remote MCP server without OAu
 
 ### Setup instructions
 
-1. Ensure that you have a Starter, Enterprise, or Enterprise+ account with [AI features](https://docs.getdbt.com/docs/platform/enable-dbt-ai) turned on.
+1. Ensure that you have [AI features](https://docs.getdbt.com/docs/platform/enable-dbt-ai) turned on.
 2. Obtain the following information from <Constant name="dbt_platform"/>:
 
   - **<Constant name="dbt_platform"/> host**: Use this to form the full URL. For example, replace `YOUR_DBT_HOST_URL` here: `https://YOUR_DBT_HOST_URL/api/ai/v1/mcp/`. It may look like: `https://cloud.getdbt.com/api/ai/v1/mcp/`. If you have a multi-cell account, the host URL will be in the `ACCOUNT_PREFIX.us1.dbt.com` format. For more information, refer to [Access, Regions, & IP addresses](/docs/platform/about-platform/access-regions-ip-addresses).

--- a/website/docs/docs/dbt-ai/setup-remote-mcp.md
+++ b/website/docs/docs/dbt-ai/setup-remote-mcp.md
@@ -7,7 +7,6 @@ id: "setup-remote-mcp"
 
 import MCPCreditUsage from '/snippets/_mcp-credit-usage.md';
 import MCPRemoteServerUrl from '/snippets/_mcp-remote-server-url.md';
-import MCPRemoteOauthBetaCallout from '/snippets/_mcp-remote-oauth-beta-callout.md';
 
 # Set up the remote MCP server <Lifecycle status="self_service,managed,managed_plus"/>
 
@@ -41,8 +40,6 @@ The `execute_sql` tool does **not** work with service tokens. You must use a [Pe
 ## OAuth (remote MCP) <Lifecycle status="beta,self_service,managed,managed_plus" /> {#oauth-remote-mcp}
 
 OAuth lets you connect to the remote MCP server without copying API tokens into your MCP client, when your client supports OAuth for HTTP-based MCP servers.
-
-<MCPRemoteOauthBetaCallout />
 
 ### Prerequisites
 

--- a/website/docs/docs/dbt-ai/setup-remote-mcp.md
+++ b/website/docs/docs/dbt-ai/setup-remote-mcp.md
@@ -29,8 +29,8 @@ The remote MCP server is the ideal choice when:
 
 | If you need... | Use... |
 | --- | --- |
-| Fastest first-time setup and your MCP client supports OAuth for HTTP servers | **OAuth (remote)** <br /> Available in beta for Enterprise and Enterprise+ accounts |
-| `execute_sql` with a PAT, automation, or clients without OAuth | **Token-based** (PAT or service token) |
+| Fastest first-time setup and your MCP client supports OAuth for HTTP servers | **OAuth (remote)** <br /> Available in public beta for Starter, Enterprise, and Enterprise+ accounts |
+| `execute_sql` with a PAT, automation, shared setup, or clients without OAuth | **Token-based** (PAT or service token) |
 | Shared or team setup | **Service token** (token-based) |
 | CI or automation | **Service token** (token-based) |
 
@@ -38,7 +38,7 @@ The remote MCP server is the ideal choice when:
 The `execute_sql` tool does **not** work with service tokens. You must use a [Personal Access Token (PAT)](/docs/dbt-apis/user-tokens) in the `Authorization` header when using this tool.
 :::
 
-## OAuth (remote MCP) <Lifecycle status="beta,managed,managed_plus" /> {#oauth-remote-mcp}
+## OAuth (remote MCP) <Lifecycle status="beta,self_service,managed,managed_plus" /> {#oauth-remote-mcp}
 
 OAuth lets you connect to the remote MCP server without copying API tokens into your MCP client, when your client supports OAuth for HTTP-based MCP servers.
 
@@ -47,7 +47,7 @@ OAuth lets you connect to the remote MCP server without copying API tokens into 
 ### Prerequisites
 
 - [AI features](https://docs.getdbt.com/docs/cloud/enable-dbt-copilot) enabled for your account.
-- Enterprise or Enterprise+ account
+- Starter, Enterprise, or Enterprise+ account
 - An MCP client that supports OAuth for remote (HTTP) MCP servers.
 - Your **MCP URL** from **Account settings** &rarr; **Access URLs** &rarr; **MCP Endpoint URL** in <Constant name="dbt_platform"/>. Check out the next section [MCP URL](#mcp-url) for more information.
 
@@ -87,11 +87,13 @@ For client-specific steps, see [Integrate Claude with MCP](/docs/dbt-ai/integrat
 
 ## Token-based authentication {#token-based-authentication}
 
-Token-based authentication lets you connect to the remote MCP server without OAuth, when your client doesn't support OAuth for HTTP-based MCP servers.
+_OAuth remote MCP is for Starter, Enterprise, and Enterprise+ accounts._
+
+Token-based authentication lets you connect to the remote MCP server without OAuth by passing a PAT or service token in your MCP client config. Use it when your client doesn't support OAuth for HTTP-based MCP servers, when you need a shared or CI setup, or when you need `execute_sql`, which requires a PAT.
 
 ### Setup instructions
 
-1. Ensure that you have [AI features](https://docs.getdbt.com/docs/platform/enable-dbt-ai) turned on.
+1. Ensure that you have a Starter, Enterprise, or Enterprise+ account with [AI features](https://docs.getdbt.com/docs/platform/enable-dbt-ai) turned on.
 2. Obtain the following information from <Constant name="dbt_platform"/>:
 
   - **<Constant name="dbt_platform"/> host**: Use this to form the full URL. For example, replace `YOUR_DBT_HOST_URL` here: `https://YOUR_DBT_HOST_URL/api/ai/v1/mcp/`. It may look like: `https://cloud.getdbt.com/api/ai/v1/mcp/`. If you have a multi-cell account, the host URL will be in the `ACCOUNT_PREFIX.us1.dbt.com` format. For more information, refer to [Access, Regions, & IP addresses](/docs/platform/about-platform/access-regions-ip-addresses).

--- a/website/docs/docs/dbt-ai/setup-remote-mcp.md
+++ b/website/docs/docs/dbt-ai/setup-remote-mcp.md
@@ -8,8 +8,6 @@ id: "setup-remote-mcp"
 import MCPCreditUsage from '/snippets/_mcp-credit-usage.md';
 import MCPRemoteServerUrl from '/snippets/_mcp-remote-server-url.md';
 
-# Set up the remote MCP server <Lifecycle status="self_service,managed,managed_plus"/>
-
 The remote MCP server uses an HTTP connection and makes calls to dbt-mcp hosted on the cloud-based <Constant name="dbt_platform" />. This setup requires no local installation and is ideal for data consumption use cases.
 
 <Lightbox src="/img/mcp/remote-dbt-mcp.jpg" title="Remote dbt MCP server architecture" />

--- a/website/docs/docs/dbt-ai/setup-remote-mcp.md
+++ b/website/docs/docs/dbt-ai/setup-remote-mcp.md
@@ -84,8 +84,6 @@ For client-specific steps, see [Integrate Claude with MCP](/docs/dbt-ai/integrat
 
 ## Token-based authentication {#token-based-authentication}
 
-_OAuth remote MCP is for Starter, Enterprise, and Enterprise+ accounts._
-
 Token-based authentication lets you connect to the remote MCP server without OAuth by passing a PAT or service token in your MCP client config. Use it when your client doesn't support OAuth for HTTP-based MCP servers, when you need a shared or CI setup, or when you need `execute_sql`, which requires a PAT.
 
 ### Setup instructions

--- a/website/snippets/_mcp-claude-local-json-expandables.md
+++ b/website/snippets/_mcp-claude-local-json-expandables.md
@@ -1,6 +1,6 @@
 import MCPExample from '/snippets/_mcp-config-files.md';
 
-<Expandable alt_header="Local MCP with OAuth" lifecycle="managed,managed_plus">
+<Expandable alt_header="Local MCP with OAuth" lifecycle="self_service,managed,managed_plus">
 
 Configuration for users who want seamless OAuth authentication with the <Constant name="dbt_platform" />. 
 

--- a/website/snippets/_mcp-qs-platform.md
+++ b/website/snippets/_mcp-qs-platform.md
@@ -19,7 +19,7 @@ For local CLI only (with or without a <Constant name="dbt_platform"/> account), 
 - [Install uv](https://docs.astral.sh/uv/getting-started/installation/)
 - A [<Constant name="dbt_platform"/> account](https://www.getdbt.com/signup)
 - For OAuth connections:
-  - OAuth for the remote MCP is available for Starter, Enterprise, and Enterprise+ plans.
+  - MCP OAuth is available for Starter, Enterprise, and Enterprise+ plans.
   - An account admin has to enable AI features on your <Constant name="dbt_platform"/> account. Refer to [Enable AI features](/docs/platform/enable-dbt-ai) for more info.
 
 ## Step 1: Choose your auth method and configure
@@ -28,9 +28,9 @@ For local CLI only (with or without a <Constant name="dbt_platform"/> account), 
 
 <TabItem value="oauth" label="OAuth">
 
-_Remote MCP OAuth is available in public beta for Starter, Enterprise, and Enterprise+ accounts._
+_MCP OAuth is available in public beta for Starter, Enterprise, and Enterprise+ accounts._
 
-OAuth is the fastest setup for <Constant name="dbt_platform"/> Enterprise and Enterprise+ accounts, no tokens to copy or manage. A browser window opens to authenticate the first time you connect. 
+OAuth is the fastest setup for <Constant name="dbt_platform"/> accounts, no tokens to copy or manage. A browser window opens to authenticate the first time you connect. 
 
 For OAuth _without_ a local install, use the [remote MCP server](/docs/dbt-ai/mcp-quickstart-remote). If your client does not support OAuth or you need token-based access, use [token-based authentication](/docs/dbt-ai/setup-remote-mcp#token-based-authentication).
 

--- a/website/snippets/_mcp-qs-platform.md
+++ b/website/snippets/_mcp-qs-platform.md
@@ -18,7 +18,9 @@ For local CLI only (with or without a <Constant name="dbt_platform"/> account), 
 
 - [Install uv](https://docs.astral.sh/uv/getting-started/installation/)
 - A [<Constant name="dbt_platform"/> account](https://www.getdbt.com/signup)
-- If you're using OAuth, your account admin has to enable AI features on your <Constant name="dbt_platform"/> account. Refer to [Enable dbt Wizard](/docs/platform/enable-dbt-ai) for more info.
+- For OAuth connections:
+  - OAuth for the remote MCP is available for Starter, Enterprise, and Enterprise+ plans.
+  - An account admin has to enable AI features on your <Constant name="dbt_platform"/> account. Refer to [Enable AI features](/docs/platform/enable-dbt-ai) for more info.
 
 ## Step 1: Choose your auth method and configure
 

--- a/website/snippets/_mcp-qs-platform.md
+++ b/website/snippets/_mcp-qs-platform.md
@@ -30,7 +30,7 @@ For local CLI only (with or without a <Constant name="dbt_platform"/> account), 
 
 _Remote MCP OAuth is available in public beta for Starter, Enterprise, and Enterprise+ accounts._
 
-OAuth is the fastest setup for <Constant name="dbt_platform"/> , no tokens to copy or manage. A browser window opens to authenticate the first time you connect. 
+OAuth is the fastest setup for <Constant name="dbt_platform"/> Enterprise and Enterprise+ accounts, no tokens to copy or manage. A browser window opens to authenticate the first time you connect. 
 
 For OAuth _without_ a local install, use the [remote MCP server](/docs/dbt-ai/mcp-quickstart-remote). If your client does not support OAuth or you need token-based access, use [token-based authentication](/docs/dbt-ai/setup-remote-mcp#token-based-authentication).
 

--- a/website/snippets/_mcp-qs-platform.md
+++ b/website/snippets/_mcp-qs-platform.md
@@ -12,7 +12,7 @@ This quickstart uses the local MCP server: it runs on your machine using `uvx db
 
 For local CLI only (with or without a <Constant name="dbt_platform"/> account), see [Run dbt locally](/docs/dbt-ai/mcp-quickstart-cli) or [Run dbt Wizard locally](/docs/dbt-ai/wizard-quickstart).
 
- To configure or disable specific tools, see the [Environment variables reference](/docs/dbt-ai/mcp-environment-variables). Choose _OAuth_ (available for Enterprise and Enterprise+ accounts) or _Tokens_ (more control, better for shared setups).
+ To configure or disable specific tools, see the [Environment variables reference](/docs/dbt-ai/mcp-environment-variables). Choose _OAuth_ (available for Starter, Enterprise, and Enterprise+ accounts) or _Tokens_ (more control, better for shared setups).
 
 ## Prerequisites
 
@@ -26,9 +26,9 @@ For local CLI only (with or without a <Constant name="dbt_platform"/> account), 
 
 <TabItem value="oauth" label="OAuth">
 
-OAuth is the fastest setup for <Constant name="dbt_platform"/> Enterprise and Enterprise+ accounts &mdash; no tokens to copy or manage. A browser window opens to authenticate the first time you connect. 
+OAuth is the fastest setup for <Constant name="dbt_platform"/> Starter, Enterprise, and Enterprise+ accounts &mdash; no tokens to copy or manage. A browser window opens to authenticate the first time you connect. 
 
-For OAuth _without_ a local install, use the [remote MCP server](/docs/dbt-ai/mcp-quickstart-remote) (Enterprise and Enterprise+, private beta). If your client does not support OAuth or you need token-based access, use [token-based authentication](/docs/dbt-ai/setup-remote-mcp#token-based-authentication).
+For OAuth _without_ a local install, use the [remote MCP server](/docs/dbt-ai/mcp-quickstart-remote), available in public beta for Starter, Enterprise, and Enterprise+ accounts. If your client does not support OAuth or you need token-based access, use [token-based authentication](/docs/dbt-ai/setup-remote-mcp#token-based-authentication).
 
 <StaticSubdomainRequired />
 

--- a/website/snippets/_mcp-qs-platform.md
+++ b/website/snippets/_mcp-qs-platform.md
@@ -12,7 +12,7 @@ This quickstart uses the local MCP server: it runs on your machine using `uvx db
 
 For local CLI only (with or without a <Constant name="dbt_platform"/> account), see [Run dbt locally](/docs/dbt-ai/mcp-quickstart-cli) or [Run dbt Wizard locally](/docs/dbt-ai/wizard-quickstart).
 
- To configure or disable specific tools, see the [Environment variables reference](/docs/dbt-ai/mcp-environment-variables). Choose _OAuth_ (available for Starter, Enterprise, and Enterprise+ accounts) or _Tokens_ (more control, better for shared setups).
+ To configure or disable specific tools, see the [Environment variables reference](/docs/dbt-ai/mcp-environment-variables). 
 
 ## Prerequisites
 
@@ -26,9 +26,11 @@ For local CLI only (with or without a <Constant name="dbt_platform"/> account), 
 
 <TabItem value="oauth" label="OAuth">
 
-OAuth is the fastest setup for <Constant name="dbt_platform"/> Starter, Enterprise, and Enterprise+ accounts &mdash; no tokens to copy or manage. A browser window opens to authenticate the first time you connect. 
+_Remote MCP OAuth is available in public beta for Starter, Enterprise, and Enterprise+ accounts._
 
-For OAuth _without_ a local install, use the [remote MCP server](/docs/dbt-ai/mcp-quickstart-remote), available in public beta for Starter, Enterprise, and Enterprise+ accounts. If your client does not support OAuth or you need token-based access, use [token-based authentication](/docs/dbt-ai/setup-remote-mcp#token-based-authentication).
+OAuth is the fastest setup for <Constant name="dbt_platform"/> , no tokens to copy or manage. A browser window opens to authenticate the first time you connect. 
+
+For OAuth _without_ a local install, use the [remote MCP server](/docs/dbt-ai/mcp-quickstart-remote). If your client does not support OAuth or you need token-based access, use [token-based authentication](/docs/dbt-ai/setup-remote-mcp#token-based-authentication).
 
 <StaticSubdomainRequired />
 

--- a/website/snippets/_mcp-remote-oauth-beta-callout.md
+++ b/website/snippets/_mcp-remote-oauth-beta-callout.md
@@ -1,5 +1,5 @@
 :::info
 
-Remote MCP OAuth is available for Starter, Enterprise, and Enterprise+ accounts. 
+Remote MCP OAuth is available in public beta for Starter, Enterprise, and Enterprise+ accounts. 
 
 :::


### PR DESCRIPTION
## What changed
- Updated remote MCP OAuth availability language to include Starter, Enterprise, and Enterprise+ accounts.
- Changed stale private beta references to public beta.
- Clarified token-based authentication wording for remote MCP.

## Why
Remote MCP OAuth is available to Starter accounts too, so the docs should not imply it is Enterprise-only.

## Validation
- npm run build
- lint-staged ran npm run lint during commit

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-fix-remote-mcp-preq-dbt-labs.vercel.app/docs/dbt-ai/integrate-mcp-claude
- https://docs-getdbt-com-git-fix-remote-mcp-preq-dbt-labs.vercel.app/docs/dbt-ai/integrate-mcp-cursor
- https://docs-getdbt-com-git-fix-remote-mcp-preq-dbt-labs.vercel.app/docs/dbt-ai/integrate-mcp-vscode
- https://docs-getdbt-com-git-fix-remote-mcp-preq-dbt-labs.vercel.app/docs/dbt-ai/mcp-quickstart-remote
- https://docs-getdbt-com-git-fix-remote-mcp-preq-dbt-labs.vercel.app/docs/dbt-ai/setup-local-mcp
- https://docs-getdbt-com-git-fix-remote-mcp-preq-dbt-labs.vercel.app/docs/dbt-ai/setup-remote-mcp

<!-- end-vercel-deployment-preview -->