### PR TITLE
Add standalone quickstart for cloning Jaffle Shop using Git

### DIFF
--- a/website/docs/guides/_config.md
+++ b/website/docs/guides/_config.md
@@ -14,6 +14,7 @@ categories:
   - title: Foundations
     guides:
       - terminal-guide
+      - clone-jaffle-shop
 
   - title: Popular
     guides:

--- a/website/docs/guides/clone-jaffle-shop-qs.md
+++ b/website/docs/guides/clone-jaffle-shop-qs.md
@@ -95,11 +95,11 @@ You should see files and folders including:
 - `seeds/`
 - `packages.yml`
 
-You have now cloned Jaffle Shop. No further steps are required unless you want to run the project.
+Cloning is complete. You now have the Jaffle Shop project files on your machine.
 
 ## Next steps
 
-Cloning is complete. If you want to do more with the project, use these links:
+To run or develop the project, you need dbt installed and a database connected. These links can help:
 
 - **[Install dbt Core](/docs/local/install-dbt)** &mdash; Cloning doesn't install dbt. You need it to run commands.
 - **[Set up a virtual environment](/docs/local/install-dbt)** &mdash; Keeps dbt separate from other Python projects on your machine.

--- a/website/docs/guides/clone-jaffle-shop-qs.md
+++ b/website/docs/guides/clone-jaffle-shop-qs.md
@@ -1,0 +1,134 @@
+---
+title: Quickstart for cloning Jaffle Shop using Git
+id: clone-jaffle-shop
+description: "Clone the Jaffle Shop sample dbt project from GitHub or GitLab."
+hoverSnippet: "Clone the Jaffle Shop sample dbt project from GitHub or GitLab."
+platform: 'dbt-core'
+icon: 'git'
+level: 'Beginner'
+hide_table_of_contents: true
+tags: ['dbt Core','Quickstart']
+---
+
+<div style={{maxWidth: '900px'}}>
+
+## Introduction
+
+[Jaffle Shop](https://github.com/dbt-labs/jaffle-shop) is dbt Labs' canonical sample dbt project for a fictional café business. This quickstart shows you how to clone the project using Git from GitHub or GitLab.
+
+Cloning downloads the dbt project files to your machine: models, seeds, tests, and configuration. It does not install dbt or set up a database. If you only need the project files, follow the steps below and stop after **Verify the clone**.
+
+To run dbt commands like `dbt seed`, `dbt run`, and `dbt test`, you also need dbt installed and a database to connect to. See [Next steps](#next-steps) for links to warehouse quickstarts.
+
+### Related content
+
+- [Install dbt Core](/docs/local/install-dbt)
+- [About dbt projects](/docs/build/projects)
+- [Example dbt projects](/faqs/Project/example-projects)
+
+## Prerequisites
+
+- [Git](https://git-scm.com/downloads) installed
+- A terminal
+- A [GitHub](https://github.com/join) or [GitLab](https://gitlab.com/users/sign_up) account (only if you plan to fork the repo, push changes, or clone from a private repository)
+
+Verify Git is installed:
+
+```bash
+git --version
+```
+
+## Clone the repository
+
+### Clone from GitHub
+
+1. Open your terminal and navigate to where you keep projects:
+
+    ```bash
+    cd ~/Documents/Github
+    ```
+
+2. Clone the repository:
+
+    ```bash
+    git clone https://github.com/dbt-labs/jaffle-shop.git
+    ```
+
+3. Change into the project directory:
+
+    ```bash
+    cd jaffle-shop
+    ```
+
+### Clone from GitLab
+
+If your organization hosts Jaffle Shop on GitLab, or you have forked the repo there, clone from your GitLab URL instead:
+
+```bash
+git clone https://gitlab.com/YOUR_USERNAME/jaffle-shop.git
+cd jaffle-shop
+```
+
+Replace `YOUR_USERNAME` with your GitLab username or group.
+
+### Other git platforms
+
+If your organization has mirrored or forked Jaffle Shop on Bitbucket, Azure DevOps, or another git host, use the clone URL from that platform. The `git clone` command works the same way:
+
+```bash
+git clone <your-repo-clone-url>
+cd jaffle-shop
+```
+
+## Verify the clone
+
+Confirm the project files are present:
+
+```bash
+ls
+```
+
+You should see files and folders including:
+
+- `dbt_project.yml`
+- `models/`
+- `seeds/`
+- `packages.yml`
+
+You have now cloned Jaffle Shop. No further steps are required unless you want to run the project.
+
+## Next steps
+
+Cloning is complete. If you want to do more with the project, use these links:
+
+- **[Install dbt Core](/docs/local/install-dbt)** &mdash; Cloning doesn't install dbt. You need it to run commands.
+- **[Set up a virtual environment](/docs/local/install-dbt)** &mdash; Keeps dbt separate from other Python projects on your machine.
+- **[Install dependencies](/reference/commands/deps)** &mdash; The repo lists packages in `packages.yml`. Run `dbt deps` after dbt is installed.
+- **[About dbt projects](/docs/build/projects)** &mdash; Learn the project structure before editing models.
+- **[dbt Learn](https://learn.getdbt.com/)** &mdash; Interactive courses for new users.
+
+### Warehouse quickstarts
+
+To run the project, you need a database and adapter configured in `profiles.yml`. Choose the quickstart for your warehouse or local setup:
+
+| Path | Guide |
+|------|-------|
+| Snowflake | [Snowflake quickstart](/guides/snowflake) |
+| BigQuery | [BigQuery quickstart](/guides/bigquery) |
+| Databricks | [Databricks quickstart](/guides/databricks) |
+| Redshift | [Redshift quickstart](/guides/redshift) |
+| Local DuckDB | Clone [`jaffle_shop_duckdb`](https://github.com/dbt-labs/jaffle_shop_duckdb) and follow the [DuckDB quickstart](/guides/duckdb) |
+
+You can also browse [all quickstart guides](/guides?tags=Quickstart) or other [example dbt projects](/faqs/Project/example-projects).
+
+## Optional cleanup
+
+If you cloned the repo only to test these steps and do not need the project anymore, you can remove the folder:
+
+```bash
+rm -rf ~/Documents/Github/jaffle-shop
+```
+
+This deletes the cloned project from your machine. It does not affect the GitHub or GitLab repository.
+
+</div>


### PR DESCRIPTION
This PR:

- Adds a new quickstart at `/guides/clone-jaffle-shop` for cloning the Jaffle Shop sample dbt project using Git.
- Covers cloning from GitHub, GitLab, and other git platforms (Bitbucket, Azure DevOps).
- Links to warehouse quickstarts for running the project after cloning.
- Surfaces the guide on the Guides page under Foundations.

Related project: [Quickstart for cloning jaffleshop using git (GitHub)](https://app.notion.com/p/dbtlabs/Quickstart-for-cloning-jaffleshop-using-git-GitHub-1cbbb38ebda780d3925ee2ea8b90a366)

Epic [PRODDOCS-1177](https://dbtlabs.atlassian.net/browse/PRODDOCS-1177)

## Testing

- Clone from GitHub: tested on macOS (2026-07-03) — passed
- Clone from GitLab: tested on macOS (2026-07-03) — passed
- Not tested: Windows, fresh machine without Git

## Checklist

- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).


Made with [Cursor](https://cursor.com)

[PRODDOCS-1177]: https://dbtlabs.atlassian.net/browse/PRODDOCS-1177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-nfiann-jaffleshopcloneqs-dbt-labs.vercel.app/guides/_config
- https://docs-getdbt-com-git-nfiann-jaffleshopcloneqs-dbt-labs.vercel.app/guides/clone-jaffle-shop-qs

<!-- end-vercel-deployment-preview -->