### PR TITLE
Typo: Fix duplicate heading in studio about page

### DIFF
--- a/website/docs/docs/platform/studio-ide/develop-in-studio.md
+++ b/website/docs/docs/platform/studio-ide/develop-in-studio.md
@@ -81,9 +81,6 @@ If a warning looks wrong but <Constant name="dbt" /> commands succeed, trust you
 
 ### dbt Wizard
 
-
-### dbt Wizard
-
 [<Constant name="wizard" />](/docs/dbt-ai/wizard-ide) helps you develop trusted dbt projects faster in the <Constant name="studio_ide" />. It understands more than the file you’re editing. It uses dbt's native metadata engine to understand your project’s lineage, model health, test coverage, and semantic definitions, so it can provide answers and suggestions based on your _full_ project context.
 
 With <Constant name="wizard" />, you can:


### PR DESCRIPTION
## What are you changing in this pull request and why?
Removed a duplicate subheader for the dbt Wizard feature block in the Studio IDE about page. Not much more to say ;)

## Checklist
- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
