### PR TITLE
Canvas does not require dbt Copilot to be enabled

### DIFF
--- a/website/docs/docs/platform/build-canvas-copilot.md
+++ b/website/docs/docs/platform/build-canvas-copilot.md
@@ -15,7 +15,7 @@ dbt Copilot integrates with [<Constant name="canvas" />](/docs/platform/canvas),
 
 ## Considerations
 
-- dbt Copilot in <Constant name="canvas" /> is available from the <Constant name="canvas" /> interface. Refer to [About Canvas](/docs/platform/canvas) for <Constant name="canvas" /> setup.
+- dbt Copilot is available in the <Constant name="canvas" /> interface. Refer to [About Canvas](/docs/platform/canvas) for setup instructions.
 - Natural language prompts in <Constant name="canvas" /> are available on [Enterprise and Enterprise+](https://www.getdbt.com/pricing) plans.
 - dbt Copilot requires AI features to be [enabled](/docs/platform/enable-dbt-ai) for your account. Some accounts must also accept applicable AI terms, such as the AI & Beta Addendum. Refer to [dbt AI FAQs](/docs/dbt-ai/dbt-ai-faqs#does-dbt-labs-have-terms-in-place) for details.
 - Your development environment must be on a supported [release track](/docs/dbt-versions/dbt-release-tracks).

--- a/website/docs/docs/platform/build-canvas-copilot.md
+++ b/website/docs/docs/platform/build-canvas-copilot.md
@@ -11,7 +11,15 @@ Use dbt Copilot to build visual models in the <Constant name="canvas" /> with na
 
 </IntroText>
 
-dbt Copilot seamlessly integrates with [<Constant name="canvas" />](/docs/platform/canvas), a drag-and-drop experience that helps you with build your visual models using natural language prompts. Before you begin, make sure you can access [<Constant name="canvas" />](/docs/platform/use-canvas#access-canvas).
+dbt Copilot integrates with [<Constant name="canvas" />](/docs/platform/canvas), a drag-and-drop experience for building visual models with natural language prompts.
+
+## Considerations
+
+- dbt Copilot in <Constant name="canvas" /> is available from the <Constant name="canvas" /> interface. Refer to [About Canvas](/docs/platform/canvas) for <Constant name="canvas" /> setup.
+- Natural language prompts in <Constant name="canvas" /> are available on [Enterprise and Enterprise+](https://www.getdbt.com/pricing) plans.
+- dbt Copilot requires AI features to be [enabled](/docs/platform/enable-dbt-ai) for your account. Some accounts must also accept applicable AI terms, such as the AI & Beta Addendum. Refer to [dbt AI FAQs](/docs/dbt-ai/dbt-ai-faqs#does-dbt-labs-have-terms-in-place) for details.
+- Your development environment must be on a supported [release track](/docs/dbt-versions/dbt-release-tracks).
+- Refer to [Billing](/docs/platform/billing) for dbt Copilot usage limits.
 
 import CopilotVE from '/snippets/_use-copilot-ve.md';
 

--- a/website/docs/docs/platform/build-canvas-copilot.md
+++ b/website/docs/docs/platform/build-canvas-copilot.md
@@ -15,6 +15,8 @@ dbt Copilot integrates with [<Constant name="canvas" />](/docs/platform/canvas),
 
 ## Considerations
 
+dbt Copilot in <Constant name="canvas" /> has specific plan, setup, and AI requirements. Confirm the following before you begin.
+
 - dbt Copilot is available in the <Constant name="canvas" /> interface. Refer to [About Canvas](/docs/platform/canvas) for setup instructions.
 - Natural language prompts in <Constant name="canvas" /> are available on [Enterprise and Enterprise+](https://www.getdbt.com/pricing) plans.
 - dbt Copilot requires AI features to be [enabled](/docs/platform/enable-dbt-ai) for your account. AI terms and conditions apply. Refer to [dbt AI FAQs](/docs/dbt-ai/dbt-ai-faqs#does-dbt-labs-have-terms-in-place) for details.

--- a/website/docs/docs/platform/build-canvas-copilot.md
+++ b/website/docs/docs/platform/build-canvas-copilot.md
@@ -17,7 +17,7 @@ dbt Copilot integrates with [<Constant name="canvas" />](/docs/platform/canvas),
 
 - dbt Copilot is available in the <Constant name="canvas" /> interface. Refer to [About Canvas](/docs/platform/canvas) for setup instructions.
 - Natural language prompts in <Constant name="canvas" /> are available on [Enterprise and Enterprise+](https://www.getdbt.com/pricing) plans.
-- dbt Copilot requires AI features to be [enabled](/docs/platform/enable-dbt-ai) for your account. Some accounts must also accept applicable AI terms, such as the AI & Beta Addendum. Refer to [dbt AI FAQs](/docs/dbt-ai/dbt-ai-faqs#does-dbt-labs-have-terms-in-place) for details.
+- dbt Copilot requires AI features to be [enabled](/docs/platform/enable-dbt-ai) for your account. AI terms and conditions apply. Refer to [dbt AI FAQs](/docs/dbt-ai/dbt-ai-faqs#does-dbt-labs-have-terms-in-place) for details.
 - Your development environment must be on a supported [release track](/docs/dbt-versions/dbt-release-tracks).
 - Refer to [Billing](/docs/platform/billing) for dbt Copilot usage limits.
 

--- a/website/docs/docs/platform/build-canvas-copilot.md
+++ b/website/docs/docs/platform/build-canvas-copilot.md
@@ -15,7 +15,7 @@ dbt Copilot integrates with [<Constant name="canvas" />](/docs/platform/canvas),
 
 ## Considerations
 
-dbt Copilot in <Constant name="canvas" /> has specific plan, setup, and AI requirements. Confirm the following before you begin.
+dbt Copilot in <Constant name="canvas" /> has setup and AI requirements. Confirm the following before you begin.
 
 - dbt Copilot is available in the <Constant name="canvas" /> interface. Refer to [About Canvas](/docs/platform/canvas) for setup instructions.
 - Natural language prompts in <Constant name="canvas" /> are available on [Enterprise and Enterprise+](https://www.getdbt.com/pricing) plans.

--- a/website/docs/docs/platform/canvas-interface.md
+++ b/website/docs/docs/platform/canvas-interface.md
@@ -12,7 +12,7 @@ image: /img/docs/dbt-platform/canvas/canvas.png
 
 <p style={{ color: '#717d7d', fontSize: '1.1em' }}>
 
-The <Constant name="canvas" /> interface contains an operator toolbar, operators, canvas, built-in AI, and more to help you access and transform data through a seamless drag-and-drop dbt model creation experience in <Constant name="dbt" />.
+The <Constant name="canvas" /> interface contains an operator toolbar, operators, canvas, and more to help you access and transform data through a seamless drag-and-drop dbt model creation experience in <Constant name="dbt" />.
 
 </p>
 
@@ -48,8 +48,8 @@ Input operators configure source data:
 Transform operators shape your data:
 - **Join**: Define the join conditions and choose columns from both tables.
 - **Union:** Perform a `UNION` to remove duplicates or `UNION ALL` to prevent deduplicaation.
-- **Formula**: Add the formula to create a new column. Use the built-AI code generator to help 
-- **Aggregate**: Specify the aggregation functions and the columns they apply to generate SQL code by clicking on the question mark (?) icon. Enter your prompt and wait to see the results.
+- **Formula**: Add the formula to create a new column. Use [dbt Copilot](/docs/platform/build-canvas-copilot) to help generate SQL.
+- **Aggregate**: Specify the aggregation functions and the columns they apply to. To generate SQL with a natural language prompt, click the question mark (?) icon and use [dbt Copilot](/docs/platform/build-canvas-copilot).
 - **Pivot:** Select the column and values to create a pivot.
 - **Limit**: Set the maximum number of rows you want to return.  
 - **Order**: Select the columns to sort by and the sort order.
@@ -72,7 +72,7 @@ If you have any feedback on additional operators that you might need, we'd love 
 <Constant name="canvas" /> has a sleek drag-and-drop interface for creating and modifying dbt SQL models. It's like a digital whiteboard space for easily viewing and delivering trustworthy data. Use the canvas to:
 
 - Drag-and-drop operators to create and configure your model(s)
-- Generate SQL code using the built-in AI generator
+- Generate SQL code using [dbt Copilot](/docs/platform/build-canvas-copilot)
 - Zoom in or out for better visualization
 - Version-control your dbt models
 - [Coming soon] Test and document your created models
@@ -93,7 +93,7 @@ Connectors allow you to connect your operators to create dbt models. Once you've
 Each operator has a configuration side panel that opens when you click on it. The configuration panel allows you to configure the operator, review the current model, preview changes, view the SQL code for the operator, and delete the operator.
 
 The configuration side panel has the following:
-- Configure tab &mdash; This section allows you to configure the operator to your specified requirements, such as using the built-in AI code generator to generate SQL.
+- Configure tab &mdash; This section allows you to configure the operator to your specified requirements, such as using [dbt Copilot](/docs/platform/build-canvas-copilot) to generate SQL.
 - Input tab &mdash; This section allows you to view the data for the current source table. Not available for model operators.
 - Output tab &mdash; This section allows you to preview the data for the modified source model.
 - Code &mdash; This section allows you to view the underlying SQL code for the data transformation.

--- a/website/docs/docs/platform/canvas.md
+++ b/website/docs/docs/platform/canvas.md
@@ -13,10 +13,10 @@ import Prerequisites from '/snippets/_canvas-prerequisites.md';
 # About Canvas <Lifecycle status='managed,managed_plus'/> 
 
 <p style={{ color: '#717d7d', fontSize: '1.1em' }}>
-<Constant name="canvas" /> helps you quickly access and transform data through a visual, drag-and-drop experience and with a built-in AI for custom code generation.
+<Constant name="canvas" /> helps you quickly access and transform data through a visual, drag-and-drop experience.
 </p>
 
-<Constant name="canvas" /> allows organizations to enjoy the many benefits of code-driven development—such as increased precision, ease of debugging, and ease of validation &mdash; while retaining the flexibility to have different contributors develop wherever they are most comfortable. Users can also take advantage of built-in AI for custom code generation, making it an end-to-end frictionless experience.
+<Constant name="canvas" /> allows organizations to enjoy the many benefits of code-driven development, such as increased precision, ease of debugging, and ease of validation, while retaining the flexibility to have different contributors develop wherever they are most comfortable. For natural language and AI-assisted workflows, use [dbt Copilot in <Constant name="canvas" />](/docs/platform/build-canvas-copilot).
 
 These models compile directly to SQL and are indistinguishable from other dbt models in your projects:
 - Visual models are version-controlled in your backing <Constant name="git" /> provider.
@@ -40,8 +40,8 @@ To give feedback, please reach out to your dbt Labs account team. We appreciate 
 
 ## Resources
 
-Learn more about Canvas: 
+Learn more about <Constant name="canvas" />: 
 
-- How to [use Canvas](/docs/platform/use-canvas)
-- The Canvas [quickstart guide](/guides/canvas)
-- [Canvas fundamentals course](https://learn.getdbt.com/learn/course/canvas-fundamentals) on [dbt Learn](https://learn.getdbt.com/catalog)
+- How to [use <Constant name="canvas" />](/docs/platform/use-canvas)
+- The <Constant name="canvas" /> [quickstart guide](/guides/canvas)
+- [<Constant name="canvas" /> fundamentals course](https://learn.getdbt.com/learn/course/canvas-fundamentals) on [dbt Learn](https://learn.getdbt.com/catalog)

--- a/website/docs/docs/platform/use-canvas.md
+++ b/website/docs/docs/platform/use-canvas.md
@@ -13,7 +13,7 @@ import Prerequisites from '/snippets/_canvas-prerequisites.md';
 # Edit and create dbt models <Lifecycle status='managed, managed_plus'/> 
 
 <p style={{ color: '#717d7d', fontSize: '1.1em' }}>
-Access and use <Constant name="canvas" /> to create or edit dbt models through a visual, drag-and-drop experience. Use the built-in AI for custom code generation in your development experience.
+Access and use <Constant name="canvas" /> to create or edit dbt models through a visual, drag-and-drop experience.
 </p>
 
 ## Access Canvas

--- a/website/snippets/_canvas-prerequisites.md
+++ b/website/snippets/_canvas-prerequisites.md
@@ -15,4 +15,3 @@ Before using <Constant name="canvas" />, you should:
 - Have an existing <Constant name="dbt" /> project already created with a Staging or Production run completed.
 - Verify your Development environment is on a supported [release track](/docs/dbt-versions/dbt-release-tracks) to receive ongoing updates.
 - Have read-only access to the [Staging environment](/docs/deploy/deploy-environments#staging-environment) with the data to be able to execute `run` in the <Constant name="canvas" />. To customize the required access for the <Constant name="canvas" /> user group, refer to [Set up environment-level permissions](/docs/platform/manage-access/environment-permissions-setup) for more information.
-- Have the AI-powered features toggle [enabled](/docs/dbt-ai/wizard-ide#enable-dbt-wizard) for dbt Copilot.


### PR DESCRIPTION
Resolves [JIRA:PRODDOCS-1185](https://dbtlabs.atlassian.net/browse/PRODDOCS-1185)

This PR makes changes to the following files - Canvas does not require dbt Copilot to be enabled"

- **`website/snippets/_canvas-prerequisites.md`** — Removed AI toggle / dbt Copilot from Canvas prerequisites (fixes canvas, use-canvas, and canvas quickstart via shared snippet)
- **`website/docs/docs/platform/canvas.md`** — Intro focuses on drag-and-drop; Copilot linked only as optional workflow for natural language / AI-assisted use
- **`website/docs/docs/platform/use-canvas.md`** — Removed "built-in AI for custom code generation" from intro
- **`website/docs/docs/platform/canvas-interface.md`** — Removed "built-in AI" from intro; linked SQL generation and prompts to dbt Copilot; clarified Aggregate operator prompt flow is Copilot-only
- **`website/docs/docs/platform/build-canvas-copilot.md`** — Added Considerations section for Copilot-specific requirements (Canvas setup, Enterprise+, AI features enabled, release track, billing)

## Checklist
<!-- Ensure your PR meets the following items. Feel free to add additional checklist items to the list if additional checks need to happen before the PR is merged, such as:
- [ ] Needs technical review
- [ ] Change base branch
- [ ] Merge on xyz date
-->
- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).
<!--
PRE-RELEASE VERSION OF dbt (if so, uncomment):
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
<!-- 
ADDING OR REMOVING PAGES (if so, uncomment):
- [ ] Add/remove page in `website/sidebars.js`
- [ ] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages
-->

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-nfiann-canvas-dbt-labs.vercel.app/docs/platform/build-canvas-copilot
- https://docs-getdbt-com-git-nfiann-canvas-dbt-labs.vercel.app/docs/platform/canvas-interface
- https://docs-getdbt-com-git-nfiann-canvas-dbt-labs.vercel.app/docs/platform/canvas
- https://docs-getdbt-com-git-nfiann-canvas-dbt-labs.vercel.app/docs/platform/use-canvas

<!-- end-vercel-deployment-preview -->