### PR TITLE
Rename installation method: CDN -> Standalone

### DIFF
--- a/website/snippets/_fusion-manual-install.md
+++ b/website/snippets/_fusion-manual-install.md
@@ -14,7 +14,7 @@ python -m pip install --upgrade --pre dbt
 
 </Expandable>
 
-<Expandable alt_header="CDN installation for macOS and Linux">
+<Expandable alt_header="Standalone installation for macOS and Linux">
 
 ```shell
 curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh -s -- --update
@@ -38,7 +38,7 @@ dbt system update
 
 </Expandable>
 
-<Expandable alt_header="CDN installation for Windows">
+<Expandable alt_header="Standalone installation for Windows">
 
 ```powershell
 irm https://public.cdn.getdbt.com/fs/install/install.ps1 | iex


### PR DESCRIPTION
## What are you changing in this pull request and why?

Use the more descriptive and intuitive "standalone" terminology. The term "CDN installation" is not commonly used among developer tools, and it is also ambiguous since PyPI, Homebrew, etc. also distribute their packages via CDN.

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [x] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)