### PR TITLE
PRODDOCS-814: Snapshot and var

### DIFF
--- a/website/docs/reference/commands/snapshot.md
+++ b/website/docs/reference/commands/snapshot.md
@@ -21,6 +21,7 @@ Use `--select` or `--exclude` to choose which snapshots run. For selection synta
 
 Use `--vars` when your snapshot SQL references values with the `var()` function. For syntax, precedence, and more examples, refer to [Defining variables on the command line](/docs/build/project-variables#defining-variables-on-the-command-line).
 
+```shell
 dbt snapshot --select my_snapshot --vars '{"cutoff_date": "2026-01-01"}'
 ```
 

--- a/website/docs/reference/commands/snapshot.md
+++ b/website/docs/reference/commands/snapshot.md
@@ -21,7 +21,6 @@ Use `--select` or `--exclude` to choose which snapshots run. For selection synta
 
 Use `--vars` when your snapshot SQL references values with the `var()` function. For syntax, precedence, and more examples, refer to [Defining variables on the command line](/docs/build/project-variables#defining-variables-on-the-command-line).
 
-```
 dbt snapshot --select my_snapshot --vars '{"cutoff_date": "2026-01-01"}'
 ```
 

--- a/website/docs/reference/commands/snapshot.md
+++ b/website/docs/reference/commands/snapshot.md
@@ -14,7 +14,7 @@ dbt looks for snapshots in the directories listed in `snapshot-paths` in your `d
 
 To view the full list of supported options in your terminal, run:
 
-```
+```shell
 dbt snapshot --help
 ```
 Use `--select` or `--exclude` to choose which snapshots run. For selection syntax, refer to [Node selection syntax](/reference/node-selection/syntax). `dbt snapshot` also supports common command-line options, such as `--target` and `--threads`. For flag details (including logging options), refer to [About flags (global configs)](/reference/global-configs/about-global-configs).

--- a/website/docs/reference/commands/snapshot.md
+++ b/website/docs/reference/commands/snapshot.md
@@ -17,7 +17,13 @@ To view the full list of supported options in your terminal, run:
 ```
 dbt snapshot --help
 ```
-Use `--select` or `--exclude` to choose which snapshots run. For selection syntax, refer to [Node selection syntax](/reference/node-selection/syntax). For other flags (such as `--threads`, `--target`, and logging options), see [About flags (global configs)](/reference/global-configs/about-global-configs).
+Use `--select` or `--exclude` to choose which snapshots run. For selection syntax, refer to [Node selection syntax](/reference/node-selection/syntax). `dbt snapshot` also supports common command-line options, such as `--target` and `--threads`. For flag details (including logging options), refer to [About flags (global configs)](/reference/global-configs/about-global-configs).
+
+Use `--vars` when your snapshot SQL references values with the `var()` function. For syntax, precedence, and more examples, refer to [Defining variables on the command line](/docs/build/project-variables#defining-variables-on-the-command-line).
+
+```
+dbt snapshot --select my_snapshot --vars '{"cutoff_date": "2026-01-01"}'
+```
 
 import SnapshotCompiledSql from '/snippets/_snapshot-compiled-sql.md';
 

--- a/website/snippets/_command-line-variables.md
+++ b/website/snippets/_command-line-variables.md
@@ -12,6 +12,7 @@ $ dbt run --vars '{"event_type": "signup"}'
 
 You can use the same `--vars` syntax with other dbt commands, such as `dbt snapshot`:
 
+```shell
 $ dbt snapshot --select my_snapshot --vars '{"cutoff_date": "2026-01-01"}'
 ```
 

--- a/website/snippets/_command-line-variables.md
+++ b/website/snippets/_command-line-variables.md
@@ -10,7 +10,13 @@ For example:
 $ dbt run --vars '{"event_type": "signup"}'
 ```
 
-Inside a model or macro, access the value using the `var()` function:
+You can use the same `--vars` syntax with other dbt commands, such as `dbt snapshot`:
+
+```
+$ dbt snapshot --select my_snapshot --vars '{"cutoff_date": "2026-01-01"}'
+```
+
+Inside a model, snapshot, or macro, access the value using the `var()` function:
 
 ```
 select '{{ var("event_type") }}' as event_type

--- a/website/snippets/_command-line-variables.md
+++ b/website/snippets/_command-line-variables.md
@@ -12,7 +12,6 @@ $ dbt run --vars '{"event_type": "signup"}'
 
 You can use the same `--vars` syntax with other dbt commands, such as `dbt snapshot`:
 
-```
 $ dbt snapshot --select my_snapshot --vars '{"cutoff_date": "2026-01-01"}'
 ```
 

--- a/website/snippets/_command-line-variables.md
+++ b/website/snippets/_command-line-variables.md
@@ -6,7 +6,7 @@ Use `--vars` to pass one or more variables to a dbt command. Provide the argumen
 
 For example:
 
-```
+```shell
 $ dbt run --vars '{"event_type": "signup"}'
 ```
 
@@ -18,19 +18,19 @@ $ dbt snapshot --select my_snapshot --vars '{"cutoff_date": "2026-01-01"}'
 
 Inside a model, snapshot, or macro, access the value using the `var()` function:
 
-```
+```shell
 select '{{ var("event_type") }}' as event_type
 ```
 
 When you pass variables using `--vars`, you can access them anywhere you use the `var()` function in your project.
 
 You can pass multiple variables at once:
-```
+```shell
 $ dbt run --vars '{event_type: signup, region: us}'
 ```
 
 If only one variable is being set, the brackets are optional:
-```
+```shell
 $ dbt run --vars 'event_type: signup'
 ```
 
@@ -38,7 +38,8 @@ The `--vars` argument accepts a YAML dictionary as a string on the command line.
 YAML is convenient because it does not require strict quoting as with <Term id="json" />.
 
 Both of the following are valid and equivalent:
-```
+
+```shell
 $ dbt run --vars '{"key": "value", "date": 20180101}'
 $ dbt run --vars '{key: value, date: 20180101}'
 ```


### PR DESCRIPTION
Resolves [JIRA:PRODDOCS-814](https://dbtlabs.atlassian.net/browse/PRODDOCS-814)

This PR:

- Documents that `dbt snapshot` supports the `--vars` command-line option for passing runtime values to snapshot SQL that uses `var()`.
- Updates the [snapshot command reference](/reference/commands/snapshot) with a dedicated `--vars` note, example, and link to [Project variables](/docs/build/project-variables#defining-variables-on-the-command-line).
- Keeps `--vars` separate from global flags (`--target`, `--threads`, logging) since variables are not documented on [About flags (global configs)](/reference/global-configs/about-global-configs).
- Adds a `dbt snapshot` example to the shared command-line variables snippet, which also surfaces on [Project variables](/docs/build/project-variables#defining-variables-on-the-command-line) and [About `var` function](/reference/dbt-jinja-functions/var#command-line-variables).
- Clarifies that `var()` can be used in models, snapshots, and macros.

## Checklist
<!-- Ensure your PR meets the following items. Feel free to add additional checklist items to the list if additional checks need to happen before the PR is merged, such as:
- [ ] Needs technical review
- [ ] Change base branch
- [ ] Merge on xyz date
-->
- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).
<!--
PRE-RELEASE VERSION OF dbt (if so, uncomment):
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
<!-- 
ADDING OR REMOVING PAGES (if so, uncomment):
- [ ] Add/remove page in `website/sidebars.js`
- [ ] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages
-->

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/docs/build/documentation
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/docs/build/incremental-microbatch
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/docs/build/incremental-strategy
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/docs/build/projects
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/docs/build/sql-models
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/docs/dbt-versions/2024-release-notes
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/03-upgrading-to-v1.12
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/04-upgrading-to-v1.11
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/05-upgrading-to-v1.10
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/06-upgrading-to-v1.9
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/07-upgrading-to-v1.8
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/docs/dbt-versions/release-notes
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/docs/mesh/govern/model-versions
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/docs/platform/about-platform/architecture
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/docs/platform/build-canvas-copilot
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/docs/platform/canvas-interface
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/docs/platform/canvas
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/docs/platform/use-canvas
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/faqs/Project/example-projects
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/guides/_config
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/guides/clone-jaffle-shop
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/commands/snapshot
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/data-test-configs
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/dbt-jinja-functions/cross-database-macros
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/deprecations
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/global-configs/about-global-configs
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/global-configs/behavior-changes
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/global-configs/behavior-flag-introduction
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/global-configs/behavior-flag-maturity
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/global-configs/behavior-flag-removed
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/global-configs/behavior-flags/allow_jinja_file_extensions
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/global-configs/behavior-flags/enable_truthy_nulls_equals_macro
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/global-configs/behavior-flags/latest_version_pointer_enabled_by_default
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_all_warnings_handled_by_warn_error
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_batched_execution_for_custom_microbatch_strategy
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_corrected_analysis_fqns
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_explicit_package_overrides_for_builtin_materializations
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_generic_test_arguments_property
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_nested_cumulative_type_params
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_ref_searches_node_package_before_root
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_resource_names_without_spaces
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_source_and_semantic_model_names_without_spaces
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_sql_header_in_test_configs
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_unique_project_resource_names
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_valid_schema_from_generate_schema_name
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_yaml_configuration_for_mf_time_spines
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/global-configs/behavior-flags/skip_nodes_if_on_run_start_fails
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/global-configs/behavior-flags/source_freshness_run_project_hooks
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/global-configs/behavior-flags/state_modified_compare_more_unrendered_values
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/global-configs/behavior-flags/validate_macro_args
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/node-selection/state-comparison-caveats
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/resource-configs/databricks-configs
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/resource-configs/enabled
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/resource-configs/latest_version_pointer
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/resource-configs/plus-prefix
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/resource-configs/sql_header
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/resource-properties/arguments
- https://docs-getdbt-com-git-nfiann-varsandsnapshot-dbt-labs.vercel.app/reference/resource-properties/versions

<!-- end-vercel-deployment-preview -->