### PR TITLE
PRODDOCS-871: Plus prefix

### DIFF
--- a/website/docs/reference/resource-configs/plus-prefix.md
+++ b/website/docs/reference/resource-configs/plus-prefix.md
@@ -31,15 +31,21 @@ models:
 
 </File>
 
-Throughout this documentation, we've tried to be consistent in using the `+` prefix in `dbt_project.yml` files.
+Throughout this documentation, we use the `+` prefix on configuration keys in `dbt_project.yml` files.
 
-However, the leading `+` is in fact _only required_ when you need to disambiguate between resource paths and configs. For example, when:
-- A config accepts a dictionary as its inputs. As an example, the [`persist_docs` config](/reference/resource-configs/persist_docs).
-- Or, a config shares a key with part of a resource path. For example, if you had a directory of models named `tags`.
+For projects using [`config-version`](/reference/project-configs/config-version) 2, dbt expects configuration keys to use the `+` prefix. Specifying configurations without the `+` prefix is [deprecated](/reference/deprecations#missingplusprefixdeprecation). Folder and file names within resource configurations still do not use the `+` prefix.
+
+The `+` prefix is especially important when you need to disambiguate between [resource paths](/reference/resource-configs/resource-path) and configs. For example, when:
+- A config accepts a dictionary as its input, such as [`persist_docs`](/reference/resource-configs/persist_docs).
+- A config shares a key with part of a resource path, such as a directory of models named `tags`.
 
 import MissingPrefix from '/snippets/_missing-prefix.md';
 
 <MissingPrefix />
+
+import DeprecationWarnings from '/snippets/_deprecation-warnings.md';
+
+<DeprecationWarnings />
 
 <File name='dbt_project.yml'>
 
@@ -55,17 +61,14 @@ models:
     columns: true
 
   jaffle_shop:
-    schema: my_schema # a plus prefix is optional here
-    +tags: # this is the tag config
+    +schema: my_schema
+    +tags: # this is the tags config
       - "hello"
     config:
-      tags: # whereas this is the tag resource path
-        # changed to config in v1.10
-        # The below config applies to models in the
-        # models/tags/ directory.
-        # Note: you don't _need_ a leading + here,
-        # but it wouldn't hurt.
-        materialized: view
+      tags: # resource path (models/tags/), not the tags config
+        # config: disambiguates path vs. config (required in v1.10+)
+        # The below config applies to models in the models/tags/ directory.
+        +materialized: view
 
 
 ```


### PR DESCRIPTION
Resolves [JIRA:PRODDOCS-871](https://dbtlabs.atlassian.net/browse/PRODDOCS-871)

This PR fixes inconsistent guidance on the [Using the + prefix](https://docs.getdbt.com/reference/resource-configs/plus-prefix).
The page includes a deprecation callout (added in #7650) stating that configs without the `+` prefix are deprecated in `dbt_project.yml`. However, Example 2 still showed `schema:` and `materialized:` without `+`, and the prose described the prefix as "only required" when disambiguating paths from configs. This PR aligns the examples and prose with the deprecation guidance.

## Changes
- **Prose:** Clarify that for `config-version` 2, configuration keys should use the `+` prefix, and omitting it is deprecated. Folder and file names still do not use `+`. Keep disambiguation cases (`persist_docs`, `tags` folder) as examples of when `+` is especially important.
- **Example 2:** Update `schema:` → `+schema:` and `materialized:` → `+materialized:` so the example matches the deprecation guidance.
- **Comments:** Remove language suggesting the `+` prefix is optional; clarify the `config:` / `tags` path disambiguation pattern.
- **Adapter note:** Add the deprecation warnings snippet noting that `MissingPlusPrefixDeprecation` is raised on Snowflake, Databricks, BigQuery, and Redshift.

## Checklist
<!-- Ensure your PR meets the following items. Feel free to add additional checklist items to the list if additional checks need to happen before the PR is merged, such as:
- [ ] Needs technical review
- [ ] Change base branch
- [ ] Merge on xyz date
-->
- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).
<!--
PRE-RELEASE VERSION OF dbt (if so, uncomment):
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
<!-- 
ADDING OR REMOVING PAGES (if so, uncomment):
- [ ] Add/remove page in `website/sidebars.js`
- [ ] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages
-->

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-nfiann-plusprefix-dbt-labs.vercel.app/reference/resource-configs/plus-prefix

<!-- end-vercel-deployment-preview -->