### PR TITLE
docs(cost-insights): document Snowflake query-attribution limitations

### DIFF
--- a/website/docs/docs/explore/cost-insights.md
+++ b/website/docs/docs/explore/cost-insights.md
@@ -61,7 +61,7 @@ The following sections explain how costs are calculated for each supported wareh
 
 <Expandable alt_header="Snowflake">
 
-dbt computes Snowflake query costs using Snowflake's query attribution data and your credit price (`price_per_credit`). Query attribution data is always available for Snowflake. dbt pulls the `per_credit` price directly from Snowflake when available; otherwise, dbt uses the configured or default value in the <Constant name="dbt_platform" />. For more information about configuring or viewing these values, see [Configure Cost Insights settings](/docs/explore/set-up-cost-insights#configure-cost-insights-settings-optional).
+dbt computes Snowflake query costs using Snowflake's query attribution data and your credit price (`price_per_credit`). dbt pulls the `per_credit` price directly from Snowflake when available; otherwise, dbt uses the configured or default value in the <Constant name="dbt_platform" />. For more information about configuring or viewing these values, see [Configure Cost Insights settings](/docs/explore/set-up-cost-insights#configure-cost-insights-settings-optional).
 
 Formula:
 ```
@@ -71,6 +71,17 @@ credits_per_query * price_per_credit
 Where:
 - `credits_per_query` - Cloud services, compute, and query acceleration credits attributed to the query. dbt sources this value from `QUERY_ATTRIBUTION_HISTORY`. For more information, see the [Snowflake documentation](https://docs.snowflake.com/en/sql-reference/account-usage/query_attribution_history).      
 - `price_per_credit` - Your Snowflake credit price (from Snowflake system tables when available, otherwise from your configured input or the default rate).
+
+:::info Snowflake attribution limitations
+dbt attributes Snowflake costs at the query level using the `QUERY_ATTRIBUTION_HISTORY` view. Because of how Snowflake populates that view, some warehouse spend can't be attributed to a dbt model and won't appear in Cost Insights:
+
+- **Short-running queries**: Snowflake doesn't attribute per-query cost to queries that run in roughly 100 milliseconds or less.
+- **Adaptive Warehouses**: Queries run on Snowflake Adaptive Warehouses aren't included in `QUERY_ATTRIBUTION_HISTORY`.
+- **Non-execution costs**: Attribution covers warehouse execution credits only. It excludes warehouse idle time, data transfer, storage, serverless features, and AI-service costs.
+- **Data availability**: Attribution data is available from mid-August 2024 onward, and Snowflake can take several hours to populate it.
+
+As a result, Cost Insights totals can be _lower_ than the compute spend shown in your Snowflake billing dashboards. For more information, see the [Snowflake documentation](https://docs.snowflake.com/en/sql-reference/account-usage/query_attribution_history#usage-notes).
+:::
 </Expandable>
 
 <Expandable alt_header="BigQuery">

--- a/website/docs/faqs/Cost optimizations/actual-vs-displayed-costs.md
+++ b/website/docs/faqs/Cost optimizations/actual-vs-displayed-costs.md
@@ -9,6 +9,7 @@ Cost Insights shows estimates based on warehouse-reported usage and your configu
 
 - Your warehouse has custom pricing that differs from the default compute credit unit.
 - There are discounts or credits applied at the billing level that aren't reflected in usage tables.
-- Costs include other charges beyond compute. 
+- Costs include other charges beyond compute.
+- **(Snowflake)** Some query cost can't be attributed to a model and is excluded &mdash; specifically short-running queries (roughly 100 milliseconds or less) and queries run on Adaptive Warehouses. Because of these exclusions, Cost Insights totals are typically lower than your Snowflake billing dashboards. For more information, see [Understanding cost and reduction estimates](/docs/explore/cost-insights#understanding-cost-and-reduction-estimates).
 
 Costs Insights in the <Constant name="dbt_platform" /> is designed to be directionally accurate, showing you dbt-specific components rather than matching your billing exactly.


### PR DESCRIPTION
## What are you changing in this pull request and why?

Cost Insights attributes Snowflake cost at the query grain via Snowflake's [`QUERY_ATTRIBUTION_HISTORY`](https://docs.snowflake.com/en/sql-reference/account-usage/query_attribution_history#usage-notes) view. Per Snowflake's own usage notes, that view **excludes** two material classes of spend:

- **Short-running queries** (roughly 100 ms or less)
- **Queries run on Adaptive Warehouses** (not present in the view at all)

Because of this, Cost Insights totals are typically **lower** than a customer's Snowflake billing dashboards. These gaps are known internally (raised in a customer feedback session as a "$39K vs $44K" trust concern, and re-confirmed recently while debugging an Adaptive-warehouse cost sawtooth) but were **surfaced nowhere customer-facing**. Worse, the page asserted "Query attribution data is always available for Snowflake," which directly contradicts Snowflake's usage notes.

This PR:
- **Removes** the inaccurate "always available for Snowflake" sentence.
- **Adds** a `:::info Snowflake attribution limitations` callout to the Snowflake cost-calculation section (short queries, Adaptive Warehouses, non-execution costs, data availability), matching the existing `:::info` precedent in the Redshift section.
- **Extends** the "Why might my actual warehouse costs differ from displayed costs?" FAQ with the Snowflake-specific exclusions.

### Design decisions
- Removed the "always available" claim rather than softening it, since leaving it alongside a limitations callout would be self-contradictory.
- Kept the "~100 ms" figure approximate, matching Snowflake's own hedged wording ("<= ~100ms").

## Checklist
- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.

> [!NOTE]
> **Open item before merge:** the Adaptive Warehouse bullet reflects behavior as of today. If an in-flight fix sources Adaptive-warehouse queries from `QUERY_METERING_HISTORY` (tracked under META-7919), that bullet may need to be removed or reworded. Please confirm with the META-7919 owner / PMM before publishing.