### PR TITLE
Update stale bridge anchor links in enable-dbt-ai.md

### DIFF
--- a/website/docs/docs/platform/enable-dbt-ai.md
+++ b/website/docs/docs/platform/enable-dbt-ai.md
@@ -81,7 +81,7 @@ Snowflake Cortex, AWS Bedrock, Azure AI Foundry, and Anthropic aren't supported 
 
 Once AI features have been [enabled](#enable-ai-features), Enterprise and Enterprise+ accounts can configure a custom AI provider. If you bring your own provider, you will incur API calls and associated charges from that provider.
 
-\* *Managed (or Managed by <Constant name="dbt" /> Labs): <Constant name="dbt" /> Labs manages the AI provider connection; no user provider key is required. Refer to [Billing](/docs/platform/billing?version=2.0&name=Fusion#temporary-dbt-copilot-actions-bridge-through-july-1) for more information.*
+\* *Managed (or Managed by <Constant name="dbt" /> Labs): <Constant name="dbt" /> Labs manages the AI provider connection; no user provider key is required. Refer to [Billing](/docs/platform/billing?version=2.0&name=Fusion#temporary-dbt-copilot-actions-bridge-through-july-13-2026) for more information.*
 
 ### dbt Wizard
 
@@ -96,7 +96,7 @@ To configure your AI provider for <Constant name="wizard" />:
 
   <TabItem value="openai" label="OpenAI">
 
-  **Managed\* by <Constant name="dbt" /> Labs** (default, no setup required). Refer to [Billing](/docs/platform/billing?version=2.0&name=Fusion#temporary-dbt-copilot-actions-bridge-through-july-1) for more information.*
+  **Managed\* by <Constant name="dbt" /> Labs** (default, no setup required). Refer to [Billing](/docs/platform/billing?version=2.0&name=Fusion#temporary-dbt-copilot-actions-bridge-through-july-13-2026) for more information.*
 
   1. Select the toggle for **<Constant name="dbt" /> Labs** to use <Constant name="dbt" /> Labs' managed* OpenAI key.
   2. Click **Save**.
@@ -146,7 +146,7 @@ To configure your AI provider for <Constant name="wizard" />:
 
   <TabItem value="anthropic" label="Anthropic">
 
-  **Managed\* by <Constant name="dbt" /> Labs** (default, no setup required). Refer to [Billing](/docs/platform/billing?version=2.0&name=Fusion#temporary-dbt-copilot-actions-bridge-through-july-1) for more information.*
+  **Managed\* by <Constant name="dbt" /> Labs** (default, no setup required). Refer to [Billing](/docs/platform/billing?version=2.0&name=Fusion#temporary-dbt-copilot-actions-bridge-through-july-13-2026) for more information.*
 
   1. Select **<Constant name="dbt" /> Labs** from the list to use <Constant name="dbt" /> Labs' managed* Anthropic key.
   2. Click **Save**.


### PR DESCRIPTION
## What are you changing in this pull request and why?
PR #9583 renames the billing.md heading anchor for the temporary dbt Copilot Actions bridge from `#temporary-dbt-copilot-actions-bridge-through-july-1` to `#temporary-dbt-copilot-actions-bridge-through-july-13-2026`. `enable-dbt-ai.md` links to that anchor in three places and needs to be updated to match so the links don't break.

## Checklist
- [x] The changes in this PR meet the docs style guide/fundamentals required for all content.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-fix-copilot-bridge-anchor-links-dbt-labs.vercel.app/docs/platform/enable-dbt-ai

<!-- end-vercel-deployment-preview -->