### PR TITLE
dbt State usage page

### DIFF
--- a/website/docs/docs/deploy/dbt-state-examples.md
+++ b/website/docs/docs/deploy/dbt-state-examples.md
@@ -12,7 +12,7 @@ pagination_next: "docs/deploy/dbt-state-migration"
 
 <IntroText>
 
-These examples use the Jaffle Shop project to show side-by-side comparisons of CLI output with and without dbt State enabled.
+These examples use the Jaffle Shop project to show side-by-side comparisons of CLI output with and without dbt State enabled. To enable dbt State, follow the steps in [Setting up dbt State](/docs/deploy/dbt-state-setup).
 
 </IntroText>
 
@@ -28,6 +28,9 @@ Each of the following scenarios shows how a run differs between <Constant name="
 | [Second run](#second-run) | `dbt run --target prod` | Reuses unchanged table models; rebuilds views with `select *` |
 | [Selecting a model in a fresh dev environment after changing the customers model](#selecting-a-model-in-a-fresh-dev-environment-after-changing-the-customers-model) | `dbt run --target dev --select "customers"` | Defers to prod for upstream models |
 | [Selecting a model in a new dev schema with no model changes](#selecting-a-model-in-a-new-dev-schema-with-no-model-changes) | `dbt run --target dev --select "customers"` | Defers and clones unchanged models |
+<br></br>
+
+Every skipped model is a model you didn't pay to rebuild. dbt State tracks what's changed and skips the rest &mdash; reducing run time and warehouse costs.
 
 ## Initial run in empty schema
 
@@ -35,7 +38,7 @@ Each of the following scenarios shows how a run differs between <Constant name="
 dbt run --target prod
 ```
 
-You get the same result with and without dbt State.
+With no prior state to compare against, dbt builds every model from scratch. dbt State captures metadata from this run for future comparisons.
 
 <Tabs queryString="initial-run">
 <TabItem value="without" label="Without dbt State">
@@ -133,6 +136,8 @@ Done. PASS=12 WARN=0 ERROR=0 SKIP=0 NO-OP=0 REUSED=0 TOTAL=12
 ```shell
 dbt run --target prod
 ```
+
+For each model, dbt State compares the current logic and upstream data against the previous run. If nothing has changed, dbt State skips the build or clones the result from another environment.
 
 With dbt State enabled, the six table models are reused — nothing changed, so there's nothing to rebuild. The six staging views still rebuild because they use `select *`. [Learn why views with `select *` are always rebuilt.](/faqs/State/views-rebuilt)
 

--- a/website/docs/docs/deploy/dbt-state-setup.md
+++ b/website/docs/docs/deploy/dbt-state-setup.md
@@ -128,6 +128,7 @@ The CLI flags `--manage-state` and `--no-manage-state` are not available in olde
 </TabItem>
 </Tabs>
 
+To see how dbt State optimizes your runs, refer to [dbt State usage examples](/docs/deploy/dbt-state-examples).
 
 ## Inviting team members
 


### PR DESCRIPTION
## What are you changing in this pull request and why?
Closes https://fivetran.atlassian.net/browse/RD-1239732

Updates the dbt State examples page to give users a clearer sense of what to expect before and after enabling dbt State.

**`dbt-state-examples.md`**:
- Added a setup link in the intro for users who land on this page before setting up
- Replaced the generic "you get the same result" intro on the initial run section with a more informative description of what dbt State does on a first run
- Added a "how dbt State works" explanation before the second run scenario
- Added a value prop sentence after the scenario table

**`dbt-state-setup.md`**:
- Added a link to the examples page after the setup steps, so users know what to expect once dbt State is running

Install instructions remain canonical on the setup page — no content was duplicated.

## Checklist
<!-- Ensure your PR meets the following items. Feel free to add additional checklist items to the list if additional checks need to happen before the PR is merged, such as:
- [ ] Needs technical review
- [ ] Change base branch
- [ ] Merge on xyz date
-->
- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).