### PR TITLE
Adding RSS MT and ST release notes

### DIFF
--- a/website/docs/docs/dbt-versions/dbt-platform-release-notes-gen.md
+++ b/website/docs/docs/dbt-versions/dbt-platform-release-notes-gen.md
@@ -17,6 +17,8 @@ unlisted: true
 
 Release notes are grouped by date for single-tenant environments.
 
+<span><img src="/img/fontawesome/rss.svg" alt="RSS" className="rss-icon" />Subscribe to release note updates via [RSS](/feeds/release-notes-st-rss.xml), [Atom](/feeds/release-notes-st-atom.xml), or [JSON Feed](/feeds/release-notes-st-rss.json).</span>
+
 ## July 13, 2026
 
 ## Behavior change

--- a/website/docs/docs/dbt-versions/release-notes.md
+++ b/website/docs/docs/dbt-versions/release-notes.md
@@ -14,11 +14,9 @@ pagination_prev: null
 - **Fix:** Bug and security fixes
 - **Behavior change:** A change to existing behavior that doesn't fit into the other categories, such as feature deprecations or changes to default settings
 
-Release notes are grouped by month for both multi-tenant and virtual private cloud (VPC) environments.
+Release notes are grouped by month for both multi-tenant and virtual private cloud (VPC) environments. <span><img src="/img/fontawesome/rss.svg" alt="RSS" className="rss-icon" />Subscribe to release note updates via [RSS](/feeds/release-notes-rss.xml), [Atom](/feeds/release-notes-atom.xml), or [JSON Feed](/feeds/release-notes-rss.json).</span>
 
 For <Constant name="fusion_engine" /> updates, refer to the [dbt-fusion changelog](https://github.com/dbt-labs/dbt-core/blob/main/CHANGELOG-fusion.md).
-
-<span><img src="/img/fontawesome/rss.svg" alt="RSS" className="rss-icon" />Subscribe to release note updates via [RSS](/feeds/release-notes-rss.xml), [Atom](/feeds/release-notes-atom.xml), or [JSON Feed](/feeds/release-notes-rss.json).</span>
 
 ## July 2026
 

--- a/website/docs/docs/dbt-versions/release-notes.md
+++ b/website/docs/docs/dbt-versions/release-notes.md
@@ -18,6 +18,7 @@ Release notes are grouped by month for both multi-tenant and virtual private clo
 
 For <Constant name="fusion_engine" /> updates, refer to the [dbt-fusion changelog](https://github.com/dbt-labs/dbt-core/blob/main/CHANGELOG-fusion.md).
 
+<span><img src="/img/fontawesome/rss.svg" alt="RSS" className="rss-icon" />Subscribe to release note updates via [RSS](/feeds/release-notes-rss.xml), [Atom](/feeds/release-notes-atom.xml), or [JSON Feed](/feeds/release-notes-rss.json).</span>
 
 ## July 2026
 

--- a/website/plugins/buildRSSFeeds/index.js
+++ b/website/plugins/buildRSSFeeds/index.js
@@ -18,6 +18,19 @@ function parseMonthYearHeading(heading) {
   return new Date(year, monthIdx, 1)
 }
 
+// Parses a "Month Day, Year" heading (for example, "July 13, 2026") into a
+// Date. Returns null for anything that isn't a full date heading, so category
+// headings such as "Enhancements" or "Fixes" are skipped.
+function parseFullDateHeading(heading) {
+  const match = heading.trim().match(/^([a-z]+)\s+(\d{1,2}),\s*(\d{4})$/i)
+  if (!match) return null
+  const monthIdx = MONTH_NAMES.indexOf(match[1].toLowerCase())
+  const day = parseInt(match[2], 10)
+  const year = parseInt(match[3], 10)
+  if (monthIdx === -1 || isNaN(day) || isNaN(year)) return null
+  return new Date(year, monthIdx, day)
+}
+
 function headingToAnchor(heading) {
   return heading.toLowerCase().replace(/[^a-z0-9\s-]/g, '').replace(/\s+/g, '-')
 }
@@ -73,6 +86,35 @@ function parseItems(content, pageUrl) {
   return items
 }
 
+// Parses the single-tenant release notes into RSS items — one item per weekly
+// release date. Dates are H2 headings in "Month Day, Year" form; the category
+// headings nested under each date ("New", "Enhancements", "Fixes", and so on)
+// are skipped so each weekly release surfaces as a single feed entry.
+function parseDatedItems(content, pageUrl) {
+  const items = []
+
+  content.split('\n').forEach((line, order) => {
+    const h2Match = line.match(/^##\s+(.+)$/)
+    if (!h2Match) return
+
+    const heading = h2Match[1].trim()
+    const date = parseFullDateHeading(heading)
+    if (!date) return
+
+    const link = `${pageUrl}#${headingToAnchor(heading)}`
+    items.push({
+      title: `dbt single-tenant release notes — ${heading}`,
+      id: link,
+      link,
+      description: `New dbt single-tenant release notes for ${heading}. Visit the page to see what's new, updated, and fixed.`,
+      date,
+      order,
+    })
+  })
+
+  return items
+}
+
 function buildFeed({ title, description, pageUrl, feedPathPrefix, items }) {
   const today = new Date()
   const feed = new Feed({
@@ -98,6 +140,27 @@ function buildFeed({ title, description, pageUrl, feedPathPrefix, items }) {
   console.log(`"${title}" feed created with ${items.length} entries. Latest: ${items[0].title}`)
 }
 
+// Each entry describes one feed: the source page to read, the parser to run
+// over it, the public page URL its items link to, and the feed metadata.
+const FEEDS = [
+  {
+    sourcePath: 'docs/docs/dbt-versions/release-notes.md',
+    parse: parseItems,
+    pageUrl: `${siteUrl}/docs/dbt-versions/dbt-cloud-release-notes`,
+    feedPathPrefix: 'release-notes',
+    title: 'dbt platform release notes',
+    description: 'dbt provides release notes for the dbt platform so you can see recent and historical changes.',
+  },
+  {
+    sourcePath: 'docs/docs/dbt-versions/dbt-platform-release-notes-gen.md',
+    parse: parseDatedItems,
+    pageUrl: `${siteUrl}/docs/dbt-versions/dbt-platform-release-notes-gen`,
+    feedPathPrefix: 'release-notes-st',
+    title: 'dbt single-tenant release notes',
+    description: 'dbt provides release notes for single-tenant so you can see recent and historical changes.',
+  },
+]
+
 module.exports = function buildRSSFeedsPlugin() {
   return {
     name: 'docusaurus-build-rss-feeds-plugin',
@@ -107,35 +170,30 @@ module.exports = function buildRSSFeedsPlugin() {
         return null
       }
 
-      console.log('Generating RSS Feeds for dbt platform release notes')
+      console.log('Generating RSS Feeds for dbt release notes')
 
-      try {
-        const raw = fs.readFileSync('docs/docs/dbt-versions/release-notes.md', 'utf8')
-        const { content } = matter(raw)
-        const pageUrl = `${siteUrl}/docs/dbt-versions/dbt-cloud-release-notes`
-        const items = parseItems(content, pageUrl)
+      FEEDS.forEach(({ sourcePath, parse, pageUrl, feedPathPrefix, title, description }) => {
+        try {
+          const raw = fs.readFileSync(sourcePath, 'utf8')
+          const { content } = matter(raw)
+          const items = parse(content, pageUrl)
 
-        if (!items.length) {
-          console.warn('No items found in release-notes.md. Skipping feed generation.')
-          return null
+          if (!items.length) {
+            console.warn(`No items found in ${sourcePath}. Skipping feed generation.`)
+            return
+          }
+
+          items.sort((a, b) =>
+            a.date.getTime() !== b.date.getTime()
+              ? b.date - a.date
+              : a.order - b.order
+          )
+
+          buildFeed({ title, description, pageUrl, feedPathPrefix, items })
+        } catch (e) {
+          console.warn(`Could not generate ${title} feed: ${e.message}`)
         }
-
-        items.sort((a, b) =>
-          a.date.getTime() !== b.date.getTime()
-            ? b.date - a.date
-            : a.order - b.order
-        )
-
-        buildFeed({
-          title: 'dbt platform release notes',
-          description: 'dbt provides release notes for the dbt platform so you can see recent and historical changes.',
-          pageUrl,
-          feedPathPrefix: 'release-notes',
-          items,
-        })
-      } catch (e) {
-        console.warn(`Could not generate release notes feed: ${e.message}`)
-      }
+      })
     },
   }
 }

--- a/website/static/feeds/release-notes-st-atom.xml
+++ b/website/static/feeds/release-notes-st-atom.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>dbt single-tenant release notes</title>
+  <link href="https://docs.getdbt.com/docs/dbt-versions/dbt-platform-release-notes-gen"/>
+  <subtitle>dbt provides release notes for single-tenant so you can see recent and historical changes.</subtitle>
+</feed>

--- a/website/static/feeds/release-notes-st-rss.json
+++ b/website/static/feeds/release-notes-st-rss.json
@@ -1,0 +1,7 @@
+{
+  "version": "https://jsonfeed.org/version/1",
+  "title": "dbt single-tenant release notes",
+  "home_page_url": "https://docs.getdbt.com/docs/dbt-versions/dbt-platform-release-notes-gen",
+  "description": "dbt provides release notes for single-tenant so you can see recent and historical changes.",
+  "items": []
+}

--- a/website/static/feeds/release-notes-st-rss.xml
+++ b/website/static/feeds/release-notes-st-rss.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0">
+  <channel>
+    <title>dbt single-tenant release notes</title>
+    <link>https://docs.getdbt.com/docs/dbt-versions/dbt-platform-release-notes-gen</link>
+    <description>dbt provides release notes for single-tenant so you can see recent and historical changes.</description>
+  </channel>
+</rss>


### PR DESCRIPTION
## What are you changing in this pull request and why?

We added the RSS feed in this PR https://github.com/dbt-labs/docs.getdbt.com/pull/9045 and tested subscription and triggers and it looks good. This PR:
- Adds the customer facing subscription links into the release notes
- Adds an RSS feed for the single-tenant release notes
- Adds those subscription links to the ST page

## Checklist
<!-- Ensure your PR meets the following items. Feel free to add additional checklist items to the list if additional checks need to happen before the PR is merged, such as:
- [ ] Needs technical review
- [ ] Change base branch
- [ ] Merge on xyz date
-->
- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).
<!--
PRE-RELEASE VERSION OF dbt (if so, uncomment):
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
<!-- 
ADDING OR REMOVING PAGES (if so, uncomment):
- [ ] Add/remove page in `website/sidebars.js`
- [ ] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages
-->

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-rss-st-dbt-labs.vercel.app/docs/dbt-versions/dbt-platform-release-notes-gen
- https://docs-getdbt-com-git-rss-st-dbt-labs.vercel.app/docs/dbt-versions/release-notes

<!-- end-vercel-deployment-preview -->