### PR TITLE
docs: clarify usage stats env vars for dbt Core 1.x and 2.x

### DIFF
--- a/website/docs/reference/global-configs/usage-stats.md
+++ b/website/docs/reference/global-configs/usage-stats.md
@@ -30,4 +30,10 @@ For full transparency, you can see all the event definitions in [`tracking.py`](
 
   dbt Core users can also use the `DO_NOT_TRACK` environment variable to enable or disable sending anonymous data. For more information, see [Environment variables](/docs/build/environment-variables).
 
-  `DO_NOT_TRACK=1` is the same as <VersionBlock lastVersion="1.10">`DBT_SEND_ANONYMOUS_USAGE_STATS=False`</VersionBlock><VersionBlock firstVersion="1.11">`DBT_ENGINE_SEND_ANONYMOUS_USAGE_STATS=False`</VersionBlock>.
+  `DO_NOT_TRACK=1` is the same as <VersionBlock lastVersion="1.10">`DBT_SEND_ANONYMOUS_USAGE_STATS=False`</VersionBlock><VersionBlock firstVersion="1.11" lastVersion="1.99">`DBT_SEND_ANONYMOUS_USAGE_STATS=False` or `DBT_ENGINE_SEND_ANONYMOUS_USAGE_STATS=False`</VersionBlock><VersionBlock firstVersion="2.0">`DBT_SEND_ANONYMOUS_USAGE_STATS=False`</VersionBlock>.
+
+  <VersionBlock firstVersion="1.11" lastVersion="1.99">
+
+  In dbt Core 1.x, both `DBT_SEND_ANONYMOUS_USAGE_STATS` and `DBT_ENGINE_SEND_ANONYMOUS_USAGE_STATS` are accepted environment variables for the same setting. dbt Core 2.x uses `DBT_SEND_ANONYMOUS_USAGE_STATS` only.
+
+  </VersionBlock>


### PR DESCRIPTION
## Summary
Clarifies that dbt Core 1.x accepts both \DBT_SEND_ANONYMOUS_USAGE_STATS\ and \DBT_ENGINE_SEND_ANONYMOUS_USAGE_STATS\, while dbt Core 2.x uses \DBT_SEND_ANONYMOUS_USAGE_STATS\ only.

Fixes dbt-labs/dbt-core#15629