### PR TITLE
Add July 2026 compatible release notes

### DIFF
--- a/website/docs/docs/dbt-versions/compatible-track-changelog.md
+++ b/website/docs/docs/dbt-versions/compatible-track-changelog.md
@@ -22,7 +22,7 @@ Release date: July 21, 2026
 
 ### Dependencies
 
-- Pin `pyathena` to <3.35
+- Pin `pyathena` to v3.35 and older
 
 This compatible release includes functionality from the following versions of dbt Core OSS:
 

--- a/website/docs/docs/dbt-versions/compatible-track-changelog.md
+++ b/website/docs/docs/dbt-versions/compatible-track-changelog.md
@@ -10,6 +10,62 @@ Each monthly **Compatible** release includes functionality matching up-to-date o
 
 For more information, see [release tracks](/docs/dbt-versions/dbt-release-tracks).
 
+## July 2026
+
+Release date: July 21, 2026
+
+### dbt cloud-based platform
+
+### Fixes
+
+- Prune stale cross-project dependencies from injected external nodes before linking. A publication can list a transitive public ancestor that has since been deleted upstream; injecting it as a dangling `depends_on` edge previously failed compile with `GraphDependencyNotFoundError`. The dead edge is now dropped with a warning and restored once the producing project's publication is regenerated.
+
+### Dependencies
+
+- Pin `pyathena` to <3.35
+
+This compatible release includes functionality from the following versions of dbt Core OSS:
+
+```
+dbt-core==1.11.12
+
+# shared interfaces
+dbt-adapters==1.22.10
+dbt-common==1.37.5
+dbt-extractor==0.6.0
+dbt-semantic-interfaces==0.9.0
+dbt-sl-sdk[sync]==0.13.4
+
+# adapters
+dbt-athena==1.10.2
+dbt-bigquery==1.11.1
+dbt-databricks==1.12.2
+dbt-fabric==1.9.4
+dbt-postgres==1.10.2
+dbt-redshift==1.10.2
+dbt-snowflake==1.11.6
+dbt-spark==1.10.3
+dbt-synapse==1.8.5
+dbt-teradata==1.10.3
+dbt-trino==1.10.2
+```
+
+Changelogs:
+- [dbt-core 1.11.12](https://github.com/dbt-labs/dbt-core/blob/1.11.latest/CHANGELOG.md)
+- [dbt-adapters 1.22.10](https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-adapters/CHANGELOG.md)
+- [dbt-common 1.37.5](https://github.com/dbt-labs/dbt-common/blob/main/CHANGELOG.md)
+- [dbt-athena 1.10.2](https://github.com/dbt-labs/dbt-adapters/blob/stable/dbt-athena/CHANGELOG.md)
+- [dbt-bigquery 1.11.1](https://github.com/dbt-labs/dbt-adapters/blob/stable/dbt-bigquery/CHANGELOG.md)
+- [dbt-databricks 1.12.2](https://github.com/databricks/dbt-databricks/blob/main/CHANGELOG.md)
+- [dbt-fabric 1.9.4](https://github.com/microsoft/dbt-fabric/releases/tag/v1.9.4)
+- [dbt-postgres 1.10.2](https://github.com/dbt-labs/dbt-adapters/blob/stable/dbt-postgres/CHANGELOG.md)
+- [dbt-redshift 1.10.2](https://github.com/dbt-labs/dbt-adapters/blob/stable/dbt-redshift/CHANGELOG.md)
+- [dbt-snowflake 1.11.6](https://github.com/dbt-labs/dbt-adapters/blob/stable/dbt-snowflake/CHANGELOG.md)
+- [dbt-spark 1.10.3](https://github.com/dbt-labs/dbt-adapters/blob/stable/dbt-spark/CHANGELOG.md)
+- [dbt-synapse 1.8.5](https://github.com/microsoft/dbt-synapse/blob/v1.8.latest/CHANGELOG.md)
+- [dbt-teradata 1.10.3](https://github.com/Teradata/dbt-teradata/releases/tag/v1.10.3)
+- [dbt-trino 1.10.2](https://github.com/starburstdata/dbt-trino/blob/master/CHANGELOG.md)
+
 ## June 2026
 
 Release date: June 15, 2026

--- a/website/docs/docs/dbt-versions/compatible-track-changelog.md
+++ b/website/docs/docs/dbt-versions/compatible-track-changelog.md
@@ -14,7 +14,7 @@ For more information, see [release tracks](/docs/dbt-versions/dbt-release-tracks
 
 Release date: July 21, 2026
 
-### dbt cloud-based platform
+### dbt platform
 
 ### Fixes
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

Adding July 2026 compatible release notes in preparation for release!

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [x] Applied the proper versioning rules if the content is for specific dbt version(s).
- [x] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-compatible-track-july-2026-dbt-labs.vercel.app/docs/dbt-versions/compatible-track-changelog

<!-- end-vercel-deployment-preview -->