### PR TITLE
Promote dbt Summit 2026 in docs and blog

### DIFF
--- a/website/blog/ctas.yml
+++ b/website/blog/ctas.yml
@@ -43,7 +43,7 @@
   url: https://www.getdbt.com/resources/webinars/dbt-state-build-what-s-changed-skip-what-hasn-t/?utm_medium=internal&utm_source=docs&utm_campaign=q2-2027_dbt-state-deep-dive-product_aw&utm_content=themed-webinar____&utm_term=all_all__
 
 - name: dbt_summit_2026
-  header: Ready to level up at dbt Summit?
-  subheader: Bring your boldest data ideas to Las Vegas, September 16–18, for three days of learning, connecting, and building what's next.
-  button_text: Save my spot
+  header: Join us at dbt Summit
+  subheader: Meet us in Las Vegas, September 16–18, to learn from other dbt practitioners, swap ideas, and share what you're building.
+  button_text: Learn more
   url: https://www.getdbt.com/dbt-summit

--- a/website/blog/ctas.yml
+++ b/website/blog/ctas.yml
@@ -44,6 +44,6 @@
 
 - name: dbt_summit_2026
   header: Join us at dbt Summit
-  subheader: Meet us in Las Vegas, September 16–18, to learn from other dbt practitioners, swap ideas, and share what you're building.
+  subheader: Meet us in Las Vegas, September 16–18, to learn from other dbt practitioners, swap ideas, and come together to shape the future of data and AI.
   button_text: Learn more
   url: https://www.getdbt.com/dbt-summit

--- a/website/blog/ctas.yml
+++ b/website/blog/ctas.yml
@@ -44,6 +44,6 @@
 
 - name: dbt_summit_2026
   header: dbt Summit 2026
-  subheader: Join the dbt community in Las Vegas, September 16–18, to shape the future of data and AI.
+  subheader: Join us at dbt Summit in Las Vegas, September 16–18, to shape the future of data and AI.
   button_text: Register now
   url: https://www.getdbt.com/dbt-summit

--- a/website/blog/ctas.yml
+++ b/website/blog/ctas.yml
@@ -44,6 +44,6 @@
 
 - name: dbt_summit_2026
   header: Join us at dbt Summit
-  subheader: Meet us in Las Vegas, September 16–18, to learn from other dbt practitioners, swap ideas, and come together to shape the future of data and AI.
+  subheader: Meet us in Las Vegas, September 15–18, to learn from other dbt practitioners, swap ideas, and come together to shape the future of data and AI.
   button_text: Learn more
-  url: https://www.getdbt.com/dbt-summit
+  url: https://www.getdbt.com/dbt-summit/?utm_medium=internal&utm_source=docs&utm_campaign=q3-2027_dbt-summit-2026_aw&utm_content=dbt-summit____&utm_term=all_all__

--- a/website/blog/ctas.yml
+++ b/website/blog/ctas.yml
@@ -43,7 +43,7 @@
   url: https://www.getdbt.com/resources/webinars/dbt-state-build-what-s-changed-skip-what-hasn-t/?utm_medium=internal&utm_source=docs&utm_campaign=q2-2027_dbt-state-deep-dive-product_aw&utm_content=themed-webinar____&utm_term=all_all__
 
 - name: dbt_summit_2026
-  header: dbt Summit 2026
-  subheader: Join us at dbt Summit in Las Vegas, September 16–18, to shape the future of data and AI.
-  button_text: Register now
+  header: Ready to level up at dbt Summit?
+  subheader: Bring your boldest data ideas to Las Vegas, September 16–18, for three days of learning, connecting, and building what's next.
+  button_text: Save my spot
   url: https://www.getdbt.com/dbt-summit

--- a/website/blog/ctas.yml
+++ b/website/blog/ctas.yml
@@ -41,3 +41,9 @@
   subheader: Join us July 15th to learn how to save on warehouse compute costs!
   button_text: Register here
   url: https://www.getdbt.com/resources/webinars/dbt-state-build-what-s-changed-skip-what-hasn-t/?utm_medium=internal&utm_source=docs&utm_campaign=q2-2027_dbt-state-deep-dive-product_aw&utm_content=themed-webinar____&utm_term=all_all__
+
+- name: dbt_summit_2026
+  header: dbt Summit 2026
+  subheader: Join the dbt community in Las Vegas, September 16–18, to shape the future of data and AI.
+  button_text: Register now
+  url: https://www.getdbt.com/dbt-summit

--- a/website/blog/metadata.yml
+++ b/website/blog/metadata.yml
@@ -2,7 +2,7 @@
 featured_image: ""
 
 # This CTA lives in right sidebar on blog index
-featured_cta: "dbt_state_july_2026_webinar"
+featured_cta: "dbt_summit_2026"
 
 # Show or hide hero title, description, cta from blog index
 show_title: false

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -87,13 +87,13 @@ var siteSettings = {
       //debug: true,
     },
     announcementBar: {
-      id: "dbt-state-july-2026-webinar",
-      content: "dbt State: Build what's changed, skip what hasn't. Join us for a live virtual event on July 15th to learn how to save on warehouse compute costs!",
+      id: "dbt-summit-2026",
+      content: "dbt Summit is happening September 16–18 in Las Vegas. Join the world's largest gathering of dbt users!",
       isCloseable: true,
     },
     announcementBarActive: true,
     announcementBarLink:
-      "https://www.getdbt.com/resources/webinars/dbt-state-build-what-s-changed-skip-what-hasn-t/?utm_medium=internal&utm_source=docs&utm_campaign=q2-2027_dbt-state-deep-dive-product_aw&utm_content=themed-webinar____&utm_term=all_all__",
+      "https://www.getdbt.com/dbt-summit",
     prism: {
       theme: (() => {
         var theme = themes.nightOwl;

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -88,7 +88,7 @@ var siteSettings = {
     },
     announcementBar: {
       id: "dbt-summit-2026",
-      content: "dbt Summit is September 16–18 in Las Vegas. Come learn, share what you're building, and spend time with the dbt community.",
+      content: "Join us at dbt Summit, September 16–18 in Las Vegas. Come learn, swap ideas, and spend time with the dbt community as we shape the future of data and AI.",
       isCloseable: true,
     },
     announcementBarActive: true,

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -88,12 +88,12 @@ var siteSettings = {
     },
     announcementBar: {
       id: "dbt-summit-2026",
-      content: "Join us at dbt Summit, September 16–18 in Las Vegas. Come learn, swap ideas, and spend time with the dbt community as we shape the future of data and AI.",
+      content: "Join us at dbt Summit, September 15–18 in Las Vegas. Come learn, swap ideas, and spend time with the dbt community as we shape the future of data and AI.",
       isCloseable: true,
     },
     announcementBarActive: true,
     announcementBarLink:
-      "https://www.getdbt.com/dbt-summit",
+      "https://www.getdbt.com/dbt-summit/?utm_medium=internal&utm_source=docs&utm_campaign=q3-2027_dbt-summit-2026_aw&utm_content=dbt-summit____&utm_term=all_all__",
     prism: {
       theme: (() => {
         var theme = themes.nightOwl;

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -88,7 +88,7 @@ var siteSettings = {
     },
     announcementBar: {
       id: "dbt-summit-2026",
-      content: "Your next level starts at dbt Summit! Join the dbt community in Las Vegas, September 16–18, for big ideas, hands-on learning, and plenty of data magic.",
+      content: "dbt Summit is September 16–18 in Las Vegas. Come learn, share what you're building, and spend time with the dbt community.",
       isCloseable: true,
     },
     announcementBarActive: true,

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -88,7 +88,7 @@ var siteSettings = {
     },
     announcementBar: {
       id: "dbt-summit-2026",
-      content: "dbt Summit is happening September 16–18 in Las Vegas. Join the world's largest gathering of dbt users!",
+      content: "Your next level starts at dbt Summit! Join the dbt community in Las Vegas, September 16–18, for big ideas, hands-on learning, and plenty of data magic.",
       isCloseable: true,
     },
     announcementBarActive: true,


### PR DESCRIPTION
## What changed
- update the docs announcement banner to promote dbt Summit in Las Vegas, September 16–18
- add a dbt Summit CTA to the blog sidebar
- link both promotions to the dbt Summit registration page

## Validation
- `node --check website/docusaurus.config.js`
- parsed `website/blog/ctas.yml` and `website/blog/metadata.yml` with `js-yaml`
- pre-commit lint passed