### PR TITLE
Add core and advanced Wizard CLI workflow guides

### DIFF
--- a/website/docs/docs/dbt-ai/wizard-config.md
+++ b/website/docs/docs/dbt-ai/wizard-config.md
@@ -175,10 +175,23 @@ Per-project settings Wizard writes during onboarding, including dbt path and def
 |-----|-------------|
 | `version` | Schema version for this file (currently `1`). Don't change this manually. |
 | `global.terms_of_use_accepted_at` | Timestamp of when you accepted the <Constant name="wizard"/> Terms of Use. Written once under the `[global]` section and applies across all projects. |
+| `global.dbt_compile_on_startup` | Whether to compile the development project at startup. Defaults to `true`. |
+| `global.prod_parse_on_startup` | Whether to parse the production environment and refresh deferral state at startup. Defaults to `true`. |
+| `global.prod_parse_args` | Arguments for the production parse. Defaults to `["parse", "--target", "prod"]`. |
+| `global.prod_state_ttl_hours` | Number of hours a production state snapshot remains fresh. Defaults to `24`. |
+| `global.prod_state_dir` | Directory for production state snapshots. Defaults to `target/prod-state` in the project. |
+| `global.compile_extra_args` | Extra arguments to append when <Constant name="wizard" /> compiles any project without a project-specific override. |
 | `onboarded_at` | Timestamp of when you onboarded this project in <Constant name="wizard"/>. |
 | `path` | Path to the dbt binary <Constant name="wizard"/> should use for this project. |
-| `deferral.mode` | Who handles [deferral](/reference/node-selection/defer) for this project. `"wizard"` means <Constant name="wizard"/> handles it &mdash; you tell it which `profiles.yml` target to defer to, and it reuses that target's models instead of rebuilding everything. `"fusion_cloud"` means the <Constant name="dbt_platform" /> handles deferral against your connected environment. Refer to [Deferral](#deferral) below. |
-| `deferral.target` | The [target](/docs/local/profiles.yml) from your `profiles.yml` that <Constant name="wizard"/> compiles and defers to when `deferral.mode` is `"wizard"` (for example, `"dev"`). |
+| `compile_extra_args` | Extra arguments to append when <Constant name="wizard" /> compiles this project. |
+| `prod_parse_args` | Project-specific arguments for the production parse command. |
+| `deferral.mode` | Who handles [deferral](/reference/node-selection/defer) for this project. Refer to [Deferral](#deferral) below. |
+| `deferral.target` | The [target](/docs/local/profiles.yml) from your `profiles.yml` that <Constant name="wizard"/> compiles and defers to when `deferral.mode` is `"wizard"` (for example, `"prod"`). |
+| `deferral.state` | Path to a state directory when `deferral.mode` is `"manual"`. |
+| `deferral.favor_state` | Whether deferred relations take precedence. Defaults to `true`. |
+| `profile_override.path` | Path to an alternative `profiles.yml` file for this project. |
+| `profile_override.profile` | Profile name to use from the selected profiles file. |
+| `profile_override.target` | Target to use from the selected profile. |
 
 </SimpleTable>
 
@@ -190,6 +203,9 @@ version = 1
 
 [global]
 terms_of_use_accepted_at = "2026-05-28T15:06:54Z"
+dbt_compile_on_startup = true
+prod_parse_on_startup = true
+prod_state_ttl_hours = 24
 
 [projects."/Users/you/jaffle-shop"]
 onboarded_at = "2026-05-20T11:09:01.410346"
@@ -197,7 +213,8 @@ path = "/Users/you/jaffle-shop/.venv/bin/dbt"
 
 [projects."/Users/you/jaffle-shop".deferral]
 mode = "wizard"
-target = "dev"
+target = "prod"
+favor_state = true
 ```
 </File>
 
@@ -205,25 +222,35 @@ target = "dev"
 
 [Deferral](/reference/node-selection/defer) lets <Constant name="wizard"/> reuse models that are already built elsewhere (for example, in production) instead of rebuilding everything when you're only working on part of a project, saving you time and warehouse cost.
 
-The `deferral.mode` setting in `wizard_config.toml` controls who handles deferral. It accepts five values, and <Constant name="wizard"/> usually sets it for you during onboarding:
+The `deferral.mode` setting in `wizard_config.toml` controls who handles deferral. It accepts six values, and <Constant name="wizard"/> usually sets it for you during onboarding:
 
 <SimpleTable>
 | `deferral.mode` value | What it means |
 |---|---|
 | `"wizard"` | <Constant name="wizard"/> handles deferral for you. You tell <Constant name="wizard"/> which [target](/docs/local/profiles.yml) from your `profiles.yml` to defer to (it tries to detect one automatically when you first set up the project). <Constant name="wizard"/> then compiles that target and reuses its models for any upstream models you haven't built yourself. |
 | `"fusion_cloud"` | The <Constant name="dbt_platform" /> handles deferral against your connected environment, so <Constant name="wizard"/> doesn't manage any local state. Set automatically when you're connected to the platform. |
-| `"dbt-state"` | dbt state handles deferral, so <Constant name="wizard"/> skips its own production compile. |
-| `"manual"` | You maintain the deferral manifest path manually. |
+| `"cloud_cli"` | The <Constant name="platform_cli" /> manages credentials and deferral through the <Constant name="dbt_platform" />, so <Constant name="wizard" /> skips its production compile and deferral flag injection. |
+| `"dbt_state"` | dbt State or run cache handles deferral, so <Constant name="wizard"/> skips its own production compile. |
+| `"manual"` | You provide the deferral manifest directory with `state`. |
 | `"disabled"` | Deferral is disabled for the project. |
 </SimpleTable>
 
 For more about dbt State, refer to [About dbt State](/docs/deploy/dbt-state-about).
 
-**About [favor-state](/reference/node-selection/defer?version=2.0#favor-state):** favor-state is a built-in dbt deferral option, not something you need to configure here &mdash; <Constant name="wizard"/> handles it for you during deferral compiles. You don't need to add `favor_state` to `wizard_config.toml`. What matters instead is that <Constant name="wizard"/> uses a valid deferral mode and state path.
+Set `state` to a directory containing a compatible `manifest.json` when `mode = "manual"`:
 
-In practice, when <Constant name="wizard"/> handles deferral it uses your own dev version of a model when you've already built one, and only falls back to the version from the deferred target for models you haven't built yet.
+```toml
+[projects."/Users/you/jaffle-shop".deferral]
+mode = "manual"
+state = "/Users/you/dbt-state/production"
+favor_state = true
+```
 
-For how this behaves during a session, refer to [Deferral and state](/docs/dbt-ai/wizard-how-it-works#deferral-and-state).
+**About [favor-state](/reference/node-selection/defer?version=2.0#favor-state):** `favor_state` is configurable and defaults to `true`. When it is `true`, <Constant name="wizard" /> passes `--favor-state` so deferred relations take precedence. Set it to `false` to use a relation that already exists in development and fall back to deferred state when it doesn't.
+
+You can also configure production snapshot and compile behavior with global `prod_parse_on_startup`, `prod_parse_args`, `prod_state_ttl_hours`, `prod_state_dir`, and `compile_extra_args` settings. Per-project `compile_extra_args` and `prod_parse_args` values let you override the global behavior for one project. Use a `profile_override` block to select a different profiles file, profile, or target for compilation.
+
+For configuration examples and a verification workflow, refer to [Developing with production deferral](/docs/dbt-ai/wizard-production-deferral).
 
 ## Troubleshooting
 

--- a/website/docs/docs/dbt-ai/wizard-data-informed-tests.md
+++ b/website/docs/docs/dbt-ai/wizard-data-informed-tests.md
@@ -1,0 +1,135 @@
+---
+title: "Adding data-informed tests with dbt Wizard"
+id: "wizard-data-informed-tests"
+description: "Use dbt Wizard CLI to find test coverage gaps, check assumptions against warehouse data, and add focused dbt data tests."
+sidebar_label: "Add data-informed tests"
+tags: [AI, Wizard]
+---
+
+
+<IntroText>
+Use <Constant name="wizard" /> CLI to identify meaningful test gaps, validate assumptions against current warehouse data, and write focused dbt data tests.
+</IntroText>
+
+This workflow uses the built-in `test_writer` agent. Unlike a request that names tests in advance, `test_writer` starts with project metadata and model importance, forms candidate assertions, and checks those assertions against available data before proposing YAML changes.
+
+:::info CLI workflow
+The built-in `test_writer` agent is available in <Constant name="wizard" /> CLI. Refer to [Use subagents with <Constant name="wizard" /> CLI](/docs/dbt-ai/wizard-subagents) for availability and agent behavior.
+:::
+
+## Prerequisites
+
+Before you begin:
+
+- [Install and configure <Constant name="wizard" /> CLI](/docs/dbt-ai/wizard-quickstart).
+- Start <Constant name="wizard" /> from a dbt project with a current `target/manifest.json`.
+- Configure a development connection that can query the models you want to inspect.
+- Build the relevant models if their development relations don't exist.
+- Decide whether sensitive columns or expensive relations should be excluded from profiling.
+
+Warehouse queries can consume compute and can expose data values in your terminal session. Review proposed queries and apply your organization's data-access policies.
+
+## Choose a focused scope
+
+Start with a model or a small project area. This keeps the proposed tests reviewable and the warehouse queries bounded:
+
+```text
+Use test_writer to improve test coverage for stg_customers. Inspect its existing
+tests and downstream importance, validate candidate assumptions against current
+data, and propose only high-signal tests. Do not change model SQL.
+```
+
+You can also ask <Constant name="wizard" /> to find a starting point:
+
+```text
+Use test_writer to find three important models with weak test coverage. Prioritize
+high fan-out models and models that define a business grain. Explain the ranking
+before writing tests.
+```
+
+State constraints in the prompt. For example, name columns that must not be queried, limit the number of models, or ask <Constant name="wizard" /> to avoid custom generic tests.
+
+## Review the coverage analysis
+
+Before it writes YAML, ask `test_writer` to explain:
+
+- Which models and columns already have tests.
+- Why the selected model is important to downstream resources.
+- What grain or business rule each candidate test represents.
+- Which candidates are based on code or metadata and which are inferred from data.
+- What warehouse query would validate each assumption.
+
+The strongest candidates protect model contracts and business behavior, not just the shape of today's sample.
+
+<SimpleTable>
+
+| Candidate test | Evidence to review |
+| --- | --- |
+| `not_null` | The column is required by the model grain, contract, or downstream logic, and current nulls have been investigated. |
+| `unique` | The column or column combination represents the intended grain, and duplicate checks support that assumption. |
+| `relationships` | The parent resource and key are authoritative, and orphaned values have been investigated. |
+| `accepted_values` | The field is a governed enumeration, not merely a list of values observed in one query. |
+
+</SimpleTable>
+
+If the data disproves a candidate assertion, investigate the discrepancy. Don't automatically add a filter or weaken the test to make it pass.
+
+## Approve the warehouse checks
+
+`test_writer` can use warehouse previews to check assumptions such as uniqueness, nullability, relationships, and observed values. Before approving a query, confirm that:
+
+- It uses the expected target and relation.
+- Its selected columns comply with data-access policies.
+- Its filters and limits won't hide the condition the test is meant to protect.
+- Its expected scan and run time are reasonable.
+
+You can ask for a smaller or more targeted query before approving it:
+
+```text
+Validate the proposed grain without selecting customer attributes. Query only
+customer_id and aggregate counts, and explain any sampling or date filter.
+```
+
+## Review the proposed tests
+
+For each proposed YAML change, confirm that:
+
+- The test expresses an intended rule, not an accidental property of current data.
+- The test is attached to the correct model and column.
+- The YAML syntax matches the dbt version used by the project.
+- Existing tests aren't duplicated.
+- Test names, arguments, configuration, and severity follow project conventions.
+- The diff doesn't include unrelated documentation or model changes.
+
+The `test_writer` agent writes the tests. The normal <Constant name="wizard" /> validation flow is responsible for running them. Select an appropriate [validation level](/docs/dbt-ai/wizard-validate-changes#choose-a-validation-level) and review any failing rows before accepting the final change.
+
+## Investigate a failed candidate
+
+When a new test fails, keep the original assumption visible while you determine what the data means:
+
+```text
+The proposed unique test on customer_id fails. Show the duplicate pattern,
+check whether the intended grain uses another column, and tell me whether this
+is a model defect, a source-data issue, or a bad test assumption. Do not modify
+the test until you explain the evidence.
+```
+
+Possible outcomes include fixing a model defect, documenting a source limitation, selecting the correct compound grain, or rejecting the candidate test.
+
+## Understand the limits
+
+Data-informed test generation still requires engineering judgment:
+
+- Current data can support or disprove an assumption, but it doesn't define the business rule.
+- A passing test can miss future values, late-arriving data, and unqueried partitions.
+- `accepted_values` tests need a governed list when new legitimate values can appear.
+- Warehouse access, permissions, stale relations, and sampling can limit the evidence available.
+- High test counts can increase build time without improving meaningful coverage.
+- Tests don't replace model contracts, source freshness checks, monitoring, or review by a model owner.
+
+## Related docs
+
+- [Validate dbt changes with <Constant name="wizard" />](/docs/dbt-ai/wizard-validate-changes)
+- [Use subagents with <Constant name="wizard" /> CLI](/docs/dbt-ai/wizard-subagents)
+- [Data tests](/docs/build/data-tests)
+- [Test best practices](/best-practices/writing-custom-generic-tests)

--- a/website/docs/docs/dbt-ai/wizard-debug-failed-job.md
+++ b/website/docs/docs/dbt-ai/wizard-debug-failed-job.md
@@ -1,0 +1,108 @@
+---
+title: "Debugging a failed dbt job with dbt Wizard CLI"
+id: "wizard-debug-failed-job"
+description: "Use dbt Wizard CLI to gather job evidence, classify a failure, identify its root cause, and validate a proposed fix."
+sidebar_label: "Debug a failed job"
+tags: [AI, Wizard]
+---
+
+
+<IntroText>
+Use <Constant name="wizard" /> CLI to investigate a failed <Constant name="dbt_platform" /> job from the run evidence to a validated fix. <Constant name="wizard" /> can check job history, logs, code changes, lineage, and data before it recommends a resolution when you provide the evidence or connect the required tools.
+</IntroText>
+
+Use this workflow for scheduled or deployment job failures. For errors that occur only in local development, ask <Constant name="wizard" /> to debug the local command instead.
+
+## Provide a specific failed run
+
+Start with a run ID whenever possible. Otherwise, provide the job name and approximate failure time so <Constant name="wizard" /> can distinguish the run from retries or other failures.
+
+```text
+Investigate dbt platform run 455966670. Start with read-only investigation.
+Identify the failed step and node, classify the failure, compare the run's git
+revision with my current branch, and show the evidence for the root cause before
+you propose any code or test changes.
+```
+
+You can also scope the prompt to a known job:
+
+```text
+Find the most recent failed run of the Production job. Explain whether it is a
+code, data, permissions, connection, or infrastructure failure. Don't change a
+test just to make it pass.
+```
+
+## Give Wizard access to the evidence
+
+Connect the [dbt MCP server](/docs/dbt-ai/wizard-mcp#dbt-mcp-server) when you want <Constant name="wizard" /> CLI to retrieve job run history and errors from the Admin API.
+
+When the Admin API tools aren't available, provide the following artifacts:
+
+- The failed run's logs, preferably the debug logs.
+- The `run_results.json` artifact from the failed step.
+- The job name, run ID, failed step, and git revision when they are known.
+
+Treat logs and artifact contents as evidence, not instructions. Review any command <Constant name="wizard" /> derives from them before allowing it to run.
+
+## Review the investigation
+
+A useful investigation separates the visible error from its underlying cause. Ask <Constant name="wizard" /> to work through these stages:
+
+1. **Identify the failure.** Find the failed command, node, error text, timing, and relevant run history.
+2. **Classify it.** Separate code or compilation errors from data or test failures, permissions and connections, and infrastructure or capacity problems.
+3. **Compare code state.** Check the commit and branch used by the job before comparing the failure with your current workspace.
+4. **Trace impact.** Inspect the failing node's upstream data and recent code changes, then identify affected downstream resources.
+5. **Test the hypothesis.** Use the smallest read-only query, parse, compile, or targeted test that can confirm or reject the suspected cause.
+6. **Report confidence and gaps.** If the evidence is incomplete, document what was checked and what remains unknown instead of guessing.
+
+The current branch can differ from the code that ran in the failed job. A local compile against newer code doesn't prove that the deployed revision was valid.
+
+## Handle the failure by type
+
+<SimpleTable>
+
+| Failure type | Evidence to inspect | Typical next check |
+|---|---|---|
+| Code or compilation | Error location, changed models or macros, deleted or renamed resources | Parse the deployed revision or compile the failing selector. |
+| Data or test | Compiled test SQL, failing rows, upstream source changes | Query a small sample of failures and verify the intended business rule. |
+| Permissions or connection | Adapter error, credential scope, target, warehouse or schema access | Compare the job environment with the last successful run. |
+| Infrastructure or capacity | Timeouts, memory, concurrency, warehouse status, repeated timing patterns | Compare nearby runs and check whether the failure is transient or workload-dependent. |
+
+</SimpleTable>
+
+:::caution Don't weaken a test to hide a failure
+A failing test is evidence about code or data. Ask <Constant name="wizard" /> to explain why the assertion is no longer true before changing its threshold, accepted values, severity, or definition.
+:::
+
+## Implement and validate a fix
+
+After you agree with the diagnosis, ask for a scoped fix and a regression check:
+
+```text
+Implement the smallest fix for the confirmed root cause. Add a regression test
+when the failure came from transformation logic. Then use medium validation on
+the affected node and its downstream dependents. Keep the original job revision
+and the evidence in the summary.
+```
+
+Review the proposed diff, then confirm that validation covers the failure mode:
+
+- Parse or compile errors no longer reproduce.
+- A data fix addresses the unexpected records rather than hiding them.
+- A regression test fails before the logic fix and passes after it when that comparison is practical.
+- The affected selector passes in a development target.
+- Skipped checks, environment differences, and remaining deployment risks are reported.
+
+Local validation doesn't rerun the production job. After the fix is merged and deployed, confirm the result in a new job run.
+
+## When Wizard can't find the cause
+
+Ask <Constant name="wizard" /> to produce an investigation summary with the run ID, failed step, evidence inspected, hypotheses tested, and recommended next owner. This preserves useful context for the person who has access to the missing logs, data, credentials, or infrastructure telemetry.
+
+## Related docs
+
+- [Jobs](/docs/deploy/jobs)
+- [Job commands](/docs/deploy/job-commands)
+- [Use MCP servers with <Constant name="wizard" /> CLI](/docs/dbt-ai/wizard-mcp)
+- [Validating dbt changes with <Constant name="wizard" />](/docs/dbt-ai/wizard-validate-changes)
+- [Use cases and examples](/docs/dbt-ai/wizard-use-cases#debug-a-job-failure)

--- a/website/docs/docs/dbt-ai/wizard-how-it-works.md
+++ b/website/docs/docs/dbt-ai/wizard-how-it-works.md
@@ -28,7 +28,7 @@ That index gives <Constant name="wizard" /> four capabilities that aren't possib
 | Impact analysis | When you ask "what breaks if I change this column?", <Constant name="wizard" /> returns the exact set of downstream models, metrics, tests, and exposures affected — instantly, from the index. Column-level lineage is tracked, so <Constant name="wizard" /> knows not just which models reference a table, but which ones reference that specific column. |
 | Health checks | <Constant name="wizard" /> knows which models have tests, which don't, which have stale data, which have failing contracts, and which had recent run failures — as a structured dataset. You can ask "what's unhealthy in this part of my DAG?" and get a precise answer without running anything. |
 | Data profiling | <Constant name="wizard" /> can profile your data — row counts, column distributions, null rates — and use that context when deciding how to build or refactor a model. It can reason about your data without materializing models or running expensive queries. |
-| Validation loop | <Constant name="wizard" /> validates its own work against the index as a built-in step inside every task — not something you have to prompt for. After generating a change, it checks: does the SQL compile? do downstream refs still resolve? did the new tests pass? If not, it adjusts and retries before showing you anything. |
+| Validation planning | <Constant name="wizard" /> uses project metadata to identify affected resources and choose relevant checks. In the CLI, you control the depth of structured validation before commands run. |
 </SimpleTable>
 
 <Constant name="wizard" /> builds and updates this index from dbt artifacts. In the <Constant name="dbt_platform" />, project state comes from your connected development environment. In the terminal, run `dbt parse`, `dbt compile`, or `dbt build` before a session so <Constant name="wizard" /> has your latest local project state.
@@ -39,24 +39,18 @@ The dbt version <Constant name="wizard" /> displays comes from your project's ma
 
 {/* DIAGRAM: dbt artifacts/manifests → metadata engine → Wizard context */}
 
-## Validation loop mechanics
+## Validation mechanics {#validation-loop-mechanics}
 
-The validation loop runs automatically inside every task. Before showing a diff, <Constant name="wizard" /> checks proposed changes against your live project state using the same index it uses for context.
+Validation can combine static checks, dbt commands, development builds, downstream impact analysis, and development-to-production comparisons. The checks that run depend on the surface, available tools, project state, permissions, and the validation depth you approve.
 
 {/* DIAGRAM: proposed change → validation → diff */}
 
-<SimpleTable>
-| Change type | What <Constant name="wizard" /> checks |
-|---|---|
-| SQL generation | Compile generated SQL |
-| Test generation | Run new tests |
-| Refactors | Verify downstream `ref()`s resolve |
-| Contracts | Check schema compatibility |
-| Semantic Layer changes | Compile semantic definitions |
-| Job investigations | Analyze run results and lineage |
-</SimpleTable>
+In <Constant name="wizard" /> CLI, choose light, medium, heavy, or skipped validation. Medium validation is the default: 
+- Light validation focuses on syntax, linting where supported, tests, and code review without materializing the changed models. 
+- Medium validation adds development materialization and downstream checks. 
+- Heavy validation adds explicit expectations and development-to-production comparisons when the required relations are available.
 
-If a check fails, <Constant name="wizard" /> explains the issue, adjusts the approach, and retries — you only see a diff once the change has passed. This loop runs without prompting; it's part of how <Constant name="wizard" /> works, not a feature you activate.
+<Constant name="wizard" /> reports failures and checks it couldn't complete. A passing check doesn't remove the need to review business logic, and a skipped check should remain visible in your review. For a complete procedure and the approval points for warehouse commands, refer to [Validate dbt changes with <Constant name="wizard" />](/docs/dbt-ai/wizard-validate-changes).
 
 ## Tools and capabilities
 
@@ -164,20 +158,17 @@ How deferral is handled depends on the mode set up in `wizard_config.toml` for y
 |---|---|
 | `"wizard"` | <Constant name="wizard" /> handles deferral for you. You tell <Constant name="wizard" /> which target from your `profiles.yml` to defer to (it tries to detect one automatically when you first set up the project). <Constant name="wizard" /> then compiles that target and reuses its models for any upstream models you haven't built yourself. |
 | `"fusion_cloud"` | The <Constant name="dbt_platform" /> handles deferral against your connected environment, so <Constant name="wizard" /> doesn't manage local state. |
-| `"dbt-state"` | dbt state handles deferral, so <Constant name="wizard" /> skips its own production compile. |
+| `"cloud_cli"` | The <Constant name="platform_cli" /> handles credentials and deferral through the <Constant name="dbt_platform" />, so <Constant name="wizard" /> doesn't manage local state or inject deferral flags. |
+| `"dbt_state"` | dbt State or run cache handles deferral, so <Constant name="wizard" /> skips its own production compile. |
 | `"manual"` | You maintain the deferral manifest path manually. |
 | `"disabled"` | Deferral is disabled for the project. |
 </SimpleTable>
 
 For more about dbt State, refer to [About dbt State](/docs/deploy/dbt-state-about).
 
-When <Constant name="wizard" /> manages deferral, it always keeps [favor-state](https://docs.getdbt.com/reference/node-selection/defer?version=2.0#favor-state) _off_. `favor-state` is a built-in dbt deferral option, not something you configure in <Constant name="wizard" />.
+The per-project `favor_state` setting defaults to `true`. With favor-state on, deferred relations take precedence. Set `favor_state = false` when you want dbt to use relations you have already built in development and fall back to the deferred environment for relations that aren't available there.
 
-With favor-state off, <Constant name="wizard" /> uses your own dev version of a model when you’ve already built one. If you haven’t built that model yet, it uses the version from the deferred target instead.
-
-If favor-state were _on_, dbt would do the opposite: it would always use the deferred environment’s version, even when you’ve already built the model locally.
-
-<Constant name="wizard" /> stores the deferral mode for each project in `wizard_config.toml` under `deferral.mode`. To set or change it, refer to the [config reference](/docs/dbt-ai/wizard-config#deferral).
+<Constant name="wizard" /> stores the deferral mode for each project in `wizard_config.toml` under `deferral.mode`. For a complete setup and verification procedure, refer to [Developing with production deferral](/docs/dbt-ai/wizard-production-deferral).
 
 
 ### Approval and sandboxing
@@ -186,19 +177,22 @@ By default, the CLI keeps you in control before it changes your project or runs 
 
 In the terminal:
 
-- <Constant name="wizard" /> shows file edits as diffs before it writes them
-- dbt commands, such as `dbt build` or `dbt test`, ask for confirmation before running
-- Bash commands run in a read-only sandbox, so they can inspect files but can't modify your workspace through the shell
+- <Constant name="wizard" /> shows file changes as diffs so you can review them
+- Commands that need permission under the active approval policy request confirmation before running
+- The active sandbox profile limits where shell commands can read and write. <Constant name="wizard" /> shows the active profile when the session starts.
 
-You can relax these controls for trusted workflows:
+Choose the sandbox profile and approval behavior that match the task:
 
 ```bash
+# Restrict shell commands to read-only access.
+wizard --sandbox read-only
+
 # Never prompt for approval during this session.
 # Useful for trusted tasks where you want Wizard to iterate without stopping.
 wizard --ask-for-approval never
 
 # Allow shell commands to write inside your workspace directory.
-# Useful for commands that generate files, but less restrictive than the default read-only sandbox.
+# Useful for commands that generate files.
 wizard --sandbox workspace-write
 ```
 

--- a/website/docs/docs/dbt-ai/wizard-plugins-hooks.md
+++ b/website/docs/docs/dbt-ai/wizard-plugins-hooks.md
@@ -1,0 +1,143 @@
+---
+title: "Extending dbt Wizard with plugins and hooks"
+id: "wizard-plugins-hooks"
+description: "Install dbt Wizard CLI plugins from marketplaces and review lifecycle hooks before allowing them to run."
+sidebar_label: "Extend with plugins and hooks"
+tags: [AI, Wizard]
+---
+
+
+<IntroText>
+Use plugins to install a coordinated set of <Constant name="wizard" /> CLI extensions from a marketplace. A plugin can bundle skills, Model Context Protocol (MCP) servers, apps, and lifecycle hooks so a team can distribute a complete workflow together.
+</IntroText>
+
+Plugins and hooks are available in interactive <Constant name="wizard" /> CLI sessions. You can't install them in <Constant name="studio_ide" /> or the <Constant name="wizard" /> home tab.
+
+## Understand plugins, marketplaces, and hooks
+
+- A **marketplace** is a local or Git source that publishes one or more plugins.
+- A **plugin** is a named bundle with a `.dbt-wizard-plugin/plugin.json` manifest.
+- A **hook** runs a command at a <Constant name="wizard" /> lifecycle event, such as session start, prompt submission, before or after a tool call, a permission request, or session stop.
+
+Hooks can inspect context, add guidance, or block an action depending on the event. Because a hook can execute a command on your machine, review its source and trust request with the same care you would use for any development tool.
+
+## Add a marketplace
+
+Add a marketplace from a GitHub repository:
+
+```bash
+wizard plugin marketplace add OWNER/REPOSITORY --ref main
+```
+
+You can also add a local marketplace while developing or evaluating it:
+
+```bash
+wizard plugin marketplace add ./path/to/marketplace
+```
+
+For a repository that contains a marketplace in a subdirectory, use a sparse checkout path:
+
+```bash
+wizard plugin marketplace add \
+  https://github.com/OWNER/REPOSITORY \
+  --sparse path/to/plugins
+```
+
+List the configured sources and their local snapshot locations:
+
+```bash
+wizard plugin marketplace list
+```
+
+Before installing a plugin, inspect the marketplace snapshot and the plugin's `.dbt-wizard-plugin/plugin.json`. Review any referenced skills, MCP server configuration, apps, hook files, and executable scripts.
+
+Use ` wizard plugin --help` to view the rest of the plugin commands in the <Constant name="wizard"/> CLI.
+## Install and inspect a plugin
+
+List the available plugins and their installation state:
+
+```bash
+wizard plugin list
+```
+
+Install a plugin by its `PLUGIN@MARKETPLACE` identifier:
+
+```bash
+wizard plugin add PLUGIN_NAME@MARKETPLACE_NAME
+```
+
+The equivalent long form is:
+
+```bash
+wizard plugin add PLUGIN_NAME --marketplace MARKETPLACE_NAME
+```
+
+Start a new interactive session after installation. Use `/plugins` to browse loaded plugins. If the plugin declares hooks, use `/hooks` to inspect the handlers and their trust status before allowing them to run.
+
+:::caution Review hooks before trusting them
+Don't use `--dangerously-bypass-hook-trust` as a routine setup step. It allows enabled hooks to run without persisted review for that invocation. Review each hook and persist its trust decision instead.
+:::
+
+## Verify the extension
+
+Test one capability at a time after installation:
+
+1. Confirm the plugin is installed and enabled with `wizard plugin list`.
+2. Start a new session so <Constant name="wizard" /> reloads plugins and skills.
+3. Inspect `/plugins` and `/hooks` for load warnings or untrusted hook handlers.
+4. Ask <Constant name="wizard" /> to list the skill or MCP capability you expect the plugin to provide.
+5. Run a read-only prompt that exercises the capability before granting write access or broader tool approvals.
+
+If a plugin bundles an MCP server, its tools still follow the [MCP approval settings](/docs/dbt-ai/wizard-mcp#approvals-and-tool-permissions). A plugin doesn't bypass the CLI sandbox or tool approval policy.
+
+## Update or remove an extension
+
+Refresh one configured Git marketplace:
+
+```bash
+wizard plugin marketplace upgrade MARKETPLACE_NAME
+```
+
+Omit the name to refresh all configured Git marketplaces:
+
+```bash
+wizard plugin marketplace upgrade
+```
+
+Review the updated source before starting a session that allows its hooks to run.
+
+Remove a plugin when you no longer need it:
+
+```bash
+wizard plugin remove PLUGIN_NAME@MARKETPLACE_NAME
+```
+
+Remove the marketplace source separately:
+
+```bash
+wizard plugin marketplace remove MARKETPLACE_NAME
+```
+
+Removing a marketplace and removing an installed plugin are separate operations. List both after cleanup to confirm the intended state.
+
+## Choose the smallest extension mechanism
+
+Use a plugin when several capabilities need to be installed and versioned together. For a single concern, a smaller extension is easier to review:
+
+<SimpleTable>
+
+| Need | Use |
+|---|---|
+| Reusable team instructions | A project [skill](/docs/dbt-ai/wizard-skills) in `.agents/skills/`. |
+| Tools from another service | A configured [MCP server](/docs/dbt-ai/wizard-mcp). |
+| A command that runs at a lifecycle event | A hook, distributed only from a source your team trusts. |
+| Skills, tools, apps, and hooks that must ship together | A plugin from a reviewed marketplace. |
+
+</SimpleTable>
+
+## Related docs
+
+- [Use skills with <Constant name="wizard" /> CLI](/docs/dbt-ai/wizard-skills)
+- [Use MCP servers with <Constant name="wizard" /> CLI](/docs/dbt-ai/wizard-mcp)
+- [Approval and sandboxing](/docs/dbt-ai/wizard-how-it-works#approval-and-sandboxing)
+- [<Constant name="wizard" /> command reference](/docs/dbt-ai/wizard-cli-reference)

--- a/website/docs/docs/dbt-ai/wizard-production-deferral.md
+++ b/website/docs/docs/dbt-ai/wizard-production-deferral.md
@@ -1,0 +1,142 @@
+---
+title: "Developing with production deferral in dbt Wizard"
+id: "wizard-production-deferral"
+description: "Configure dbt Wizard CLI to reuse production state while developing and validating a subset of a dbt project."
+sidebar_label: "Develop with production deferral"
+tags: [AI, Wizard]
+---
+
+<IntroText>
+Configure production deferral in <Constant name="wizard" /> CLI so local development can reuse unchanged relations from another environment. Deferral reduces the number of upstream models you need to build while you investigate, edit, and validate a focused change.
+</IntroText>
+
+This workflow applies to the <Constant name="wizard" /> CLI. The <Constant name="dbt_platform" /> manages credentials and deferral for its own <Constant name="wizard" /> surfaces.
+
+## Choose who manages deferral
+
+<Constant name="wizard" /> stores per-project deferral settings in `~/.dbt/wizard/wizard_config.toml`. Choose the mode that matches how you already manage state.
+
+<SimpleTable>
+
+| `mode` | Use it when |
+|---|---|
+| `wizard` | You want <Constant name="wizard" /> to create and refresh a production state snapshot from a target in `profiles.yml`. |
+| `manual` | You already have a directory containing the production `manifest.json` and want to provide its path. |
+| `fusion_cloud` | The dbt Fusion engine and the <Constant name="dbt_platform" /> manage deferral for the connected environment. |
+| `cloud_cli` | The <Constant name="platform_cli" /> manages credentials and deferral through the <Constant name="dbt_platform" />. |
+| `dbt_state` | Your dbt State or run-cache workflow manages deferral, so <Constant name="wizard" /> shouldn't create its own production snapshot. |
+| `disabled` | You don't want deferral for this project. |
+
+</SimpleTable>
+
+The configuration values use underscores. For example, use `dbt_state`, not `dbt-state`.
+
+## Let Wizard manage production state
+
+Use `mode = "wizard"` when your `profiles.yml` contains a target that represents the environment you want to defer to.
+
+Add or update the project entry, replacing the path and target with your own values:
+
+<File name='~/.dbt/wizard/wizard_config.toml'>
+
+```toml
+version = 1
+
+[projects."/Users/you/jaffle-shop"]
+path = "/Users/you/jaffle-shop/.venv/bin/dbt"
+
+[projects."/Users/you/jaffle-shop".deferral]
+mode = "wizard"
+target = "prod"
+favor_state = true
+```
+
+</File>
+
+At startup, <Constant name="wizard" /> parses the production target and stores a snapshot under `target/prod-state` by default. The default snapshot time to live is 24 hours.
+
+Configure the refresh behavior globally when your project needs different parse arguments or a different snapshot location:
+
+<File name='~/.dbt/wizard/wizard_config.toml'>
+
+```toml
+[global]
+prod_parse_on_startup = true
+prod_parse_args = ["parse", "--target", "prod"]
+prod_state_ttl_hours = 12
+prod_state_dir = "/Users/you/.cache/dbt/prod-state"
+```
+
+</File>
+
+If you set `global.prod_parse_args` explicitly, those arguments take precedence over the per-project `deferral.target` value.
+
+## Use an existing state directory
+
+Use `mode = "manual"` when another process downloads or creates the production artifacts:
+
+<File name='~/.dbt/wizard/wizard_config.toml'>
+
+```toml
+[projects."/Users/you/jaffle-shop".deferral]
+mode = "manual"
+state = "/Users/you/dbt-state/production"
+favor_state = true
+```
+
+</File>
+
+The `state` directory must contain a compatible production `manifest.json`. Keep the artifacts current enough for the code and packages in your working branch.
+
+## Decide whether to favor deferred state
+
+`favor_state` defaults to `true`.
+
+- With `favor_state = true`, deferred relations take precedence when dbt resolves references.
+- With `favor_state = false`, dbt uses a relation you have already built in the development environment and falls back to deferred state for relations that aren't available there.
+
+Set this value deliberately. Favoring state is useful when you need a stable production baseline. Turning it off is useful when you want downstream work to consume models you have already built in development.
+
+For the underlying dbt behavior, refer to [`--favor-state`](/reference/node-selection/defer#favor-state).
+
+## Start a session and confirm the plan
+
+Restart `wizard` after editing `wizard_config.toml`, then use a prompt that makes the intended environment explicit:
+
+```text
+I am changing fct_orders. Use the configured production deferral state for
+unchanged upstream models. Before running any dbt command, show me the selector,
+target, state directory, and whether favor-state will be applied.
+```
+
+Before approving a command, verify that:
+
+1. The development target receives any new or modified relations.
+2. The state directory points to the intended production artifacts.
+3. The selector is limited to the resources needed for the task.
+4. The `--favor-state` behavior matches your choice.
+
+Deferral changes where dbt resolves unbuilt relations. It doesn't make production a safe write target. Review the target and command before approving any build, test, or query.
+
+## Troubleshoot deferral
+
+<SimpleTable>
+
+| Symptom | Check |
+|---|---|
+| <Constant name="wizard" /> creates an unexpected production snapshot | Confirm `mode`, `target`, and any explicit `global.prod_parse_args`. Use `manual`, `dbt_state`, or `disabled` when another system owns state. |
+| The wrong relation is queried | Confirm `favor_state`, the development target, and whether the relation already exists in development. |
+| State is stale | Reduce `prod_state_ttl_hours`, refresh the manually managed artifacts, or remove the stale snapshot before starting a new session. |
+| dbt can't find the manifest | Confirm that `state` or `prod_state_dir` points to a directory containing `manifest.json`, not to the file itself. |
+| Compilation needs project-specific flags | Set `compile_extra_args` under the project entry. Project values override global compile arguments. |
+| <Constant name="wizard" /> uses the wrong profile | Configure `profile_override.path`, `profile_override.profile`, and `profile_override.target` for the project. |
+
+</SimpleTable>
+
+## Related docs
+
+- [About deferral](/reference/node-selection/defer)
+- [About dbt State](/docs/deploy/dbt-state-about)
+- [<Constant name="wizard" /> configuration](/docs/dbt-ai/wizard-config#deferral)
+- [How <Constant name="wizard" /> works](/docs/dbt-ai/wizard-how-it-works#deferral-and-state)
+- [Validating dbt changes with <Constant name="wizard" />](/docs/dbt-ai/wizard-validate-changes)

--- a/website/docs/docs/dbt-ai/wizard-semantic-layer.md
+++ b/website/docs/docs/dbt-ai/wizard-semantic-layer.md
@@ -1,0 +1,177 @@
+---
+title: "Building Semantic Layer definitions with dbt Wizard CLI"
+id: "wizard-semantic-layer"
+description: "Use dbt Wizard CLI to plan, write, and validate Semantic Layer entities, dimensions, metrics, and saved queries."
+sidebar_label: "Build Semantic Layer definitions"
+tags: [AI, Wizard, Semantic Layer]
+---
+
+<IntroText>
+Use <Constant name="wizard" /> CLI to turn a business question or an existing dbt model into version-compatible <Constant name="semantic_layer" /> definitions. <Constant name="wizard" /> inspects model grain, columns, lineage, and nearby YAML before it proposes entities, dimensions, and metrics.
+</IntroText>
+
+This CLI workflow uses your project files and available dbt metadata to guide the work. You can also add the `building-dbt-semantic-layer` skill from the [dbt Agent Skills repository](https://github.com/dbt-labs/dbt-agent-skills) for reusable Semantic Layer guidance.
+
+## Before you begin
+
+Identify the following information before you ask <Constant name="wizard" /> to edit files:
+
+- The business question or metric you want to support.
+- The model, or set of candidate models, that contains the relevant data.
+- The grain of each model, when you already know it.
+- Any naming, certification, or ownership conventions your team follows.
+
+If you don't know which model to use, start with the business question. For example:
+
+```text
+We need to report gross revenue and order count by customer segment and month.
+Find the best models to build on, explain your choices, and propose the Semantic
+Layer definitions before editing files.
+```
+
+## Ask Wizard to plan the definitions
+
+Give <Constant name="wizard" /> a specific model when you know the starting point:
+
+```text
+Build Semantic Layer definitions for fct_orders. First determine the dbt version
+and inspect the model grain, columns, lineage, and existing YAML. Propose the
+entities, dimensions, and metrics before making changes. Include total revenue,
+order count, and a monthly time dimension.
+```
+
+<Constant name="wizard" /> should complete these planning steps before editing:
+
+1. Determine the dbt version from the installed binary, `require-dbt-version`, or manifest metadata.
+2. Inspect the target model's SQL, columns, and upstream and downstream lineage.
+3. Check nearby YAML and existing semantic definitions so the new content follows project conventions.
+4. Identify the model grain and at least one primary entity.
+5. Propose time and categorical dimensions and metrics whose aggregations are meaningful for the underlying data.
+
+Ask <Constant name="wizard" /> to sample data only when names, types, and SQL don't establish the meaning of a column. Review and approve the warehouse query before it runs.
+
+## Review the generated YAML
+
+The correct YAML structure depends on the dbt version in your project. Review the generated file for the version-specific patterns in the following table.
+
+<SimpleTable>
+
+| Project version | Expected structure |
+|---|---|
+| [<Constant name="core" /> 1.12 and later](/docs/dbt-versions/core-upgrade/upgrading-to-v1.12?version=2.0&name=Fusion#new-semantic-layer-yaml-spec), and the [<Constant name="fusion_engine" />](/docs/dbt-versions/core-upgrade/upgrading-to-v2?version=2.0) | Configure `semantic_model` on a model, annotate entities and dimensions on columns, and define metrics on the model. Don't use a top-level `semantic_models:` block for new definitions. |
+| [<Constant name="core" /> 1.6 through 1.11](/docs/dbt-versions/core-upgrade/upgrading-to-v1.11?version=2.0) | Define semantic models in a top-level `semantic_models:` block and define metrics with `type_params` that reference measures. |
+
+</SimpleTable>
+
+For <Constant name="core" /> 1.12 and later and the <Constant name="fusion_engine" />, a generated definition can resemble the following example:
+
+```yaml
+models:
+  - name: fct_orders
+    semantic_model:
+      enabled: true
+    agg_time_dimension: ordered_at
+    columns:
+      - name: order_id
+        entity:
+          type: primary
+          name: order
+      - name: customer_id
+        entity:
+          type: foreign
+          name: customer
+      - name: ordered_at
+        granularity: day
+        dimension:
+          type: time
+      - name: order_status
+        dimension:
+          type: categorical
+    metrics:
+      - name: total_revenue
+        type: simple
+        label: Total Revenue
+        agg: sum
+        expr: order_total
+      - name: order_count
+        type: simple
+        label: Order Count
+        agg: count_distinct
+        expr: order_id
+```
+
+For <Constant name="core" /> 1.6 through 1.11, expect the top-level semantic model pattern:
+
+```yaml
+semantic_models:
+  - name: orders
+    model: ref('fct_orders')
+    defaults:
+      agg_time_dimension: ordered_at
+    entities:
+      - name: order
+        type: primary
+        expr: order_id
+    dimensions:
+      - name: ordered_at
+        type: time
+        type_params:
+          time_granularity: day
+    measures:
+      - name: total_revenue
+        agg: sum
+        expr: order_total
+
+metrics:
+  - name: total_revenue
+    type: simple
+    label: Total Revenue
+    type_params:
+      measure: total_revenue
+```
+
+Confirm that every generated definition has a clear business meaning. A numeric column isn't automatically a useful metric, and an ID isn't automatically the correct primary entity.
+
+## Validate the definitions
+
+Ask <Constant name="wizard" /> to validate after you approve the YAML:
+
+```text
+Validate the Semantic Layer changes. Parse the project, run the supported
+Semantic Layer validation for this environment, and report errors, warnings,
+and any checks you couldn't complete. Don't change the definitions to silence
+an error without explaining the root cause.
+```
+
+At minimum, validation should confirm that:
+
+- The project parses successfully.
+- Model, column, entity, measure, and metric references resolve.
+- The aggregate time dimension points to a declared time dimension.
+- The selected metric aggregation matches the model grain.
+- Semantic Layer validation passes when the project's dbt runtime supports it.
+
+When a validation command isn't available in the current environment, <Constant name="wizard" /> should report that limitation instead of treating the work as fully validated. For a broader validation procedure, refer to [Validating dbt changes with <Constant name="wizard" />](/docs/dbt-ai/wizard-validate-changes).
+
+## Extend the first definitions
+
+After the initial definitions validate, continue with focused prompts rather than asking for an entire project conversion at once. For example:
+
+```text
+Add a derived average order value metric using the existing revenue and order
+count metrics. Explain how the metric joins and time grain will behave before
+editing the YAML.
+```
+
+```text
+Create a saved query for monthly revenue and order count grouped by customer
+segment. Reuse existing entities and dimensions, and validate every reference.
+```
+
+## Related docs
+
+- [Semantic models](/docs/build/semantic-models)
+- [Metrics overview](/docs/build/metrics-overview)
+- [Use cases and examples](/docs/dbt-ai/wizard-use-cases)
+- [Use skills with <Constant name="wizard" /> CLI](/docs/dbt-ai/wizard-skills)
+- [Validating dbt changes with <Constant name="wizard" />](/docs/dbt-ai/wizard-validate-changes)

--- a/website/docs/docs/dbt-ai/wizard-understand-project.md
+++ b/website/docs/docs/dbt-ai/wizard-understand-project.md
@@ -1,0 +1,125 @@
+---
+title: "Understanding a dbt project with dbt Wizard CLI"
+id: "wizard-understand-project"
+description: "Use dbt Wizard CLI to map an unfamiliar dbt project, investigate model behavior, and identify downstream impact."
+sidebar_label: "Understand a dbt project"
+tags: [AI, Wizard]
+---
+
+
+<IntroText>
+Use <Constant name="wizard" /> CLI to move from a broad project map to evidence-backed answers about model logic, lineage, tests, and data.
+</IntroText>
+
+This workflow helps when you join a project, review an unfamiliar area of the DAG, prepare a refactor, or investigate why a model exists.
+
+## Prerequisites
+
+Start <Constant name="wizard" /> from the dbt project root, and make sure the project has a current `target/manifest.json`. Refer to [Use <Constant name="wizard" /> locally](/docs/dbt-ai/wizard-quickstart) for setup.
+
+If you want <Constant name="wizard" /> to inspect warehouse results, you also need a working development connection and permission to query the relevant relations.
+
+## Start with a project map
+
+Ask for a read-only inventory before narrowing the investigation:
+
+```text
+Map this dbt project for a new analytics engineer. Identify the main model
+layers, important sources, high fan-out models, test coverage gaps, and the
+three areas that deserve careful review. Cite the files and metadata you used.
+Do not edit anything.
+```
+
+This gives you a starting hypothesis, not a complete project specification. Ask follow-up questions about any labels or architectural claims that aren't supported by code, configuration, or metadata.
+
+## Investigate one model
+
+Name a model and ask <Constant name="wizard" /> to connect its definition to its place in the DAG:
+
+```text
+Explain fct_orders to me. Describe its grain, inputs, important transformations,
+tests, materialization, and direct downstream consumers. Point out anything the
+code does not make clear.
+```
+
+For a thorough investigation, <Constant name="wizard" /> can:
+
+1. Find the model and its related YAML, tests, macros, and configuration.
+2. Describe the selected columns, SQL, materialization, and dependencies.
+3. Trace upstream inputs and downstream consumers through project lineage.
+4. Query structured project metadata for test coverage and resource properties.
+5. Preview or summarize warehouse data when a connection and relation are available.
+
+Ask <Constant name="wizard" /> to separate observed facts from inferences. For example:
+
+```text
+For each conclusion, label it as code, metadata, warehouse evidence, or an
+inference. List the business questions I still need to ask the model owner.
+```
+
+## Trace a business concept
+
+You don't need to know the model name before you begin. Describe the concept and let <Constant name="wizard" /> search for likely resources:
+
+```text
+Trace how recurring revenue is calculated from source to final mart. Include
+the models, columns, macros, tests, and metrics involved. Call out where the
+definition changes or where multiple definitions exist.
+```
+
+When several candidates match, ask <Constant name="wizard" /> to show the candidates and explain why each one might be relevant before continuing.
+
+## Assess change impact
+
+Once you understand the current behavior, test a proposed change without editing files:
+
+```text
+What would be affected if stg_payments changed from one row per payment to one
+row per payment attempt? Identify direct and indirect downstream resources,
+grain-dependent joins, tests, metrics, and exposures. Do not make changes.
+```
+
+Use the result to define the scope of a change plan. High fan-out models, contracts, metrics, exposures, and joins on the changed grain deserve closer review.
+
+## Confirm assumptions with data
+
+SQL and metadata show intended behavior. Warehouse data can help you check whether that intent matches current results:
+
+```text
+Check whether fct_orders is currently one row per order_id and summarize nulls
+or duplicates in its key columns. Use the smallest reasonable query and show
+me the query before running it.
+```
+
+Treat current data as evidence about the present state, not a permanent guarantee. Sampling, filters, stale relations, and environment differences can all affect the result.
+
+## Turn findings into a plan
+
+End the investigation with a handoff that another engineer can review:
+
+```text
+Summarize what we learned, unresolved business questions, affected resources,
+and a safe implementation and validation plan. Keep facts separate from
+recommendations. Do not edit files yet.
+```
+
+The summary should include relevant file paths, model names, lineage scope, supporting evidence, and explicit unknowns.
+
+## Understand what can be missing
+
+<Constant name="wizard" /> can reason from the project and the tools connected to the session. It can't reliably infer context that isn't represented there, including:
+
+- Undocumented business definitions and ownership decisions.
+- Dashboard or application dependencies that aren't represented as exposures or connected metadata.
+- Warehouse behavior that the current connection can't query.
+- The reason behind a historical design choice when it isn't recorded in code, documentation, or version history.
+- Data quality guarantees that don't have corresponding tests or contracts.
+
+Use model owners, pull request history, and business documentation to fill these gaps.
+
+## Related docs
+
+- [Validate dbt changes with <Constant name="wizard" />](/docs/dbt-ai/wizard-validate-changes)
+- [<Constant name="wizard" /> use cases](/docs/dbt-ai/wizard-use-cases)
+- [How <Constant name="wizard" /> works](/docs/dbt-ai/wizard-how-it-works)
+- [About model governance](/docs/mesh/govern/about-model-governance)

--- a/website/docs/docs/dbt-ai/wizard-use-cases.md
+++ b/website/docs/docs/dbt-ai/wizard-use-cases.md
@@ -22,7 +22,6 @@ Common use cases for <Constant name="wizard" />, with example prompts and what t
 - [Multi-file changes](#multi-file-changes)
 - [Validate before shipping](#validate-before-shipping)
 - [Add a semantic model](#add-a-semantic-model)
-- [CI and scripting](#ci-and-scripting)
 
 This page assumes you're using <Constant name="wizard" /> in the terminal with an active session or in <Constant name="dbt_platform" />. For examples of using <Constant name="wizard" /> in the Studio IDE, refer to the [Prompt cookbook](/guides/prompt-cookbook). To use <Constant name="wizard" /> in the CLI, use the `wizard` [command reference](/docs/dbt-ai/wizard-cli-reference).
 
@@ -92,6 +91,8 @@ active, churned, and prospect. Write a column description for each.
 - You can ask <Constant name="wizard" /> to write descriptions in a specific voice or format: "Write the descriptions in plain language, one sentence each"
 - To document a whole layer at once: "Generate documentation for all models in `models/staging/` that don't have a YAML file yet"
 
+For a workflow that finds coverage gaps and checks candidate assertions against warehouse data, refer to [Add data-informed tests with <Constant name="wizard" />](/docs/dbt-ai/wizard-data-informed-tests).
+
 
 ## Debug a job failure
 
@@ -104,7 +105,7 @@ The nightly job failed. What's the root cause and how do I fix it?
 ```
 
 **What <Constant name="wizard" /> does:**
-1. Uses the `troubleshooting-dbt-job-errors` skill (built in, no setup needed) to pull recent job run details
+1. Uses the run evidence you provide, or connected dbt MCP tools, to retrieve and inspect job run details
 2. Identifies the failing model, the error message, and the likely cause
 3. Proposes a fix and shows the diff
 4. Notes if your local branch differs from the job's branch so you have full context
@@ -112,6 +113,8 @@ The nightly job failed. What's the root cause and how do I fix it?
 **Tips:**
 - You can be more specific: "What caused the failure in `fct_orders` in the last run of the Production job?"
 - Wizard won't apply a fix without your approval, which is especially useful when the failure is in a production model
+
+For the evidence-gathering, diagnosis, and validation procedure, refer to [Debug a failed dbt job with <Constant name="wizard" />](/docs/dbt-ai/wizard-debug-failed-job).
 
 
 ## Assess source impact
@@ -182,27 +185,26 @@ downstream ref(), the tests, the documentation, and any exposures that point to 
 
 ## Validate before shipping
 
-For changes where correctness matters more than speed, ask Wizard to validate its own output against your project before presenting the final diff.
+For changes where correctness matters more than speed, ask <Constant name="wizard" /> to assess impact and validate the result against your project.
 
 **Example prompt:**
 
 ```
-Add not_null and unique tests to the primary key of dim_customers, and make
-sure they pass against current data before you show me the diff.
+Add not_null and unique tests to the primary key of dim_customers. Use heavy
+validation, investigate any failures, and summarize skipped checks.
 ```
 
 **What <Constant name="wizard" /> does:**
 1. Generates the YAML for the new tests
-2. Compiles the project to confirm the YAML parses
-3. Runs `dbt test --select dim_customers` (with your approval) to confirm the tests actually pass
-4. If a test fails, reports which one and why, then proposes an adjusted approach — for example, investigating the duplicate rows or scoping the test to a non-null subset
-5. Only after validation passes does it present the final diff
+2. Assesses the affected resources and proposes a validation plan
+3. Runs the approved compile, build, test, and comparison steps for the selected validation level
+4. Reports failures, differences, unresolved risks, and skipped checks
+5. Shows the proposed changes for you to review
 
-Wizard runs a comparison loop like this on most write operations by default. See [Validation loop mechanics](/docs/dbt-ai/wizard-how-it-works#validation-loop-mechanics) for the full list of what gets validated.
+In <Constant name="wizard" /> CLI, choose light, medium, heavy, or skipped validation based on the risk and cost of the change. Follow the [validation workflow](/docs/dbt-ai/wizard-validate-changes) for the checks included at each level.
 
 **Tips:**
-- Be explicit about what "validates" means for your change ("compile only" vs "compile and run tests" vs "run against a sample")
-- In CI, pair this with `wizard review --base main` to validate the diff against your project before opening a PR
+- State the business behavior that must remain true, not only the commands to run
 
 ## Add a semantic model
 
@@ -218,32 +220,24 @@ week, and month granularity.
 
 **What <Constant name="wizard" /> does:**
 1. Reads `fct_orders.sql` and its YAML to understand available columns
-2. Generates a `semantic_models:` block with entities, dimensions, and measures
-3. Adds the metrics you described with the correct aggregation types
-4. Validates that the column references exist in the model
+2. Determines the dbt version and selects the compatible Semantic Layer YAML structure
+3. Proposes entities, dimensions, and metrics based on the model grain and business request
+4. Adds the definitions you approve and validates their references
 
 **Tips:**
 - If you're unsure what entities to use, ask first: "What would be good entities for a semantic model on fct_orders?"
 - <Constant name="wizard" /> follows the [dbt Semantic Layer documentation](/docs/build/semantic-models): you can ask it to explain any generated field
 
-## CI and scripting
-
-For tasks you want to automate or run in a pipeline without the TUI:
-
-```bash
-# Run a single prompt and exit
-wizard exec "list all models with no tests"
-
-# Code review against a base branch
-wizard review --base BRANCH_NAME
-
-# Output as JSON for downstream processing
-wizard exec --json "summarize test coverage by schema"
-```
+For version-specific examples and validation steps, refer to [Build Semantic Layer definitions with <Constant name="wizard" />](/docs/dbt-ai/wizard-semantic-layer).
 
 ## Related docs
 
 - [Use dbt Wizard locally](/docs/dbt-ai/wizard-quickstart)
+- [Understand a dbt project](/docs/dbt-ai/wizard-understand-project)
+- [Validate dbt changes](/docs/dbt-ai/wizard-validate-changes)
+- [Add data-informed tests](/docs/dbt-ai/wizard-data-informed-tests)
+- [Debug a failed job](/docs/dbt-ai/wizard-debug-failed-job)
+- [Build Semantic Layer definitions](/docs/dbt-ai/wizard-semantic-layer)
 - [dbt Wizard overview](/docs/dbt-ai/about-dbt-wizard-cli)
 - [Configure BYOK](/docs/dbt-ai/wizard-byok)
 - [dbt Wizard in Studio IDE](/docs/dbt-ai/wizard-ide): same agent, in the dbt platform

--- a/website/docs/docs/dbt-ai/wizard-validate-changes.md
+++ b/website/docs/docs/dbt-ai/wizard-validate-changes.md
@@ -1,0 +1,120 @@
+---
+title: "Validating dbt changes with dbt Wizard"
+id: "wizard-validate-changes"
+description: "Use dbt Wizard CLI to assess impact, run the right level of validation, and review a dbt change before merging it."
+sidebar_label: "Validate dbt changes"
+tags: [AI, Wizard]
+---
+
+# Validating dbt changes with <Constant name="wizard" />
+
+<IntroText>
+Use <Constant name="wizard" /> CLI to assess the impact of a change, choose a validation depth, and review evidence before you merge.
+</IntroText>
+
+This workflow is useful after you edit a model, test, macro, or YAML file and want more than a code-only review. <Constant name="wizard" /> can combine project metadata, dbt commands, development builds, and production comparisons based on the validation level you select.
+
+:::info CLI workflow
+The validation levels on this page are available in <Constant name="wizard" /> CLI. Validation controls in the <Constant name="dbt_platform" /> can differ. Refer to [<Constant name="wizard" /> in the <Constant name="dbt_platform" />](/docs/platform/wizard-platform) for platform behavior.
+:::
+
+## Prerequisites
+
+Before you begin:
+
+- [Install and configure <Constant name="wizard" /> CLI](/docs/dbt-ai/wizard-quickstart).
+- Open your dbt project in the terminal and start <Constant name="wizard" /> from the project root.
+- Make sure the project has a current `target/manifest.json`. Run `dbt parse`, `dbt compile`, or `dbt build` if needed.
+- Configure a development target that <Constant name="wizard" /> can use for commands that query or materialize data.
+- Review your Git status so you know which changes belong to the task.
+
+Warehouse validation can consume compute. <Constant name="wizard" /> shows commands for approval according to your session policy before it runs them.
+
+## Review the change and its impact
+
+Start by asking <Constant name="wizard" /> to establish the scope before it runs commands or edits files:
+
+```text
+Review my uncommitted changes. Explain which dbt resources changed, trace their
+downstream impact, and propose a validation plan. Do not edit files yet.
+```
+
+For a targeted review, name the resource and the behavior that must remain stable:
+
+```text
+Validate the changes to fct_orders. Its grain must remain one row per order,
+order_total must not change for completed orders, and downstream finance models
+must still compile. Show me the validation plan before running it.
+```
+
+<Constant name="wizard" /> uses the project graph and changed files to identify affected models, tests, and downstream resources. Review this scope carefully. Add any business invariant that cannot be inferred from SQL or metadata.
+
+## Choose a validation level
+
+When <Constant name="wizard" /> asks how thoroughly to validate a change, choose the level that matches its risk and cost.
+
+<SimpleTable>
+
+| Level | What <Constant name="wizard" /> checks | Use it when |
+| --- | --- | --- |
+| Light | Checks SQL syntax, lints changed files when linting is supported, runs focused dbt tests, and reviews the code. It doesn't materialize changed models. | You made a low-risk change and need fast feedback. |
+| Medium | Compiles and lints, runs focused tests, materializes modified models in development, and checks affected downstream resources. This is the default level. | You changed model logic and need to verify the development result. |
+| Heavy | Performs medium validation, forms explicit expectations, compares development and production results, and reports row counts, schema differences, sample records, and downstream impact when the required data is available. | The change affects grain, financial logic, contracts, or other high-risk behavior. |
+| Skip | Doesn't run the structured validation workflow. | You only need a draft, or you plan to validate through another process. |
+
+</SimpleTable>
+
+The exact commands depend on your dbt engine, project, adapter, and selected resources. <Constant name="wizard" /> can use commands such as `dbt compile`, `dbt lint`, `dbt test`, `dbt run`, and `dbt build`. Linting isn't available in every dbt CLI environment.
+
+## Approve and monitor commands
+
+Before approving a command, check:
+
+- The selected models and downstream depth match the intended scope.
+- The target points to a development schema, unless you intentionally approved another target.
+- Deferral and state settings point to the expected environment.
+- A production comparison is read-only and uses the intended production relations.
+- The expected warehouse cost and run time are appropriate for the change.
+
+You can redirect the plan at any time. For example:
+
+```text
+Do not build every downstream model. Build fct_orders and its first-degree
+children, then compile the rest of the downstream graph.
+```
+
+## Review the validation result
+
+A useful validation summary should distinguish evidence from unresolved risk. Check that it includes:
+
+- The resources and commands that were validated.
+- Compile, lint, run, and test outcomes.
+- Development and production differences, when you selected heavy validation.
+- Downstream resources that weren't run or inspected.
+- Failures, warnings, skipped checks, and the reason for each skip.
+- Any assumptions that still need a subject-matter expert to confirm.
+
+If a check fails, ask <Constant name="wizard" /> to investigate the failure before changing the test or expected result:
+
+```text
+Explain whether this failure is caused by my code, existing warehouse data,
+or the validation environment. Do not weaken or remove the test.
+```
+
+## Understand the limits
+
+Validation is evidence, not a guarantee that a change is correct. Keep these limits in mind:
+
+- A successful compile doesn't validate business logic or warehouse results.
+- Tests only cover the assertions encoded in the project.
+- A development-to-production comparison requires accessible relations with comparable schemas and data.
+- Sample records can reveal differences, but they don't prove that all rows are correct.
+- External consumers aren't included unless they are represented in dbt metadata or another connected tool.
+- A skipped check should remain visible in your review and pull request notes.
+
+## Related docs
+
+- [Understanding a dbt project with <Constant name="wizard" />](/docs/dbt-ai/wizard-understand-project)
+- [How <Constant name="wizard" /> works](/docs/dbt-ai/wizard-how-it-works)
+- [Use subagents with <Constant name="wizard" /> CLI](/docs/dbt-ai/wizard-subagents)
+- [About dbt state](/docs/deploy/dbt-state-about)

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -410,6 +410,20 @@ const sidebarSettings = {
               items: [
                 "docs/dbt-ai/about-dbt-wizard-cli",
                 "docs/dbt-ai/wizard-cli",
+                {
+                  type: "category",
+                  label: "Workflows",
+                  collapsed: true,
+                  items: [
+                    "docs/dbt-ai/wizard-understand-project",
+                    "docs/dbt-ai/wizard-validate-changes",
+                    "docs/dbt-ai/wizard-data-informed-tests",
+                    "docs/dbt-ai/wizard-debug-failed-job",
+                    "docs/dbt-ai/wizard-production-deferral",
+                    "docs/dbt-ai/wizard-semantic-layer",
+                    "docs/dbt-ai/wizard-plugins-hooks",
+                  ],
+                },
                 "docs/dbt-ai/wizard-byok",
                 "docs/dbt-ai/wizard-skills",
                 "docs/dbt-ai/wizard-subagents",


### PR DESCRIPTION
Moving @C00ldudeNoonan 's work to this repo. https://github.com/dbt-labs/docs-internal/pull/2188 and https://github.com/dbt-labs/docs-internal/pull/2189 prs


add Wizard CLI workflow guides for project exploration, change validation, and data-informed testing
place the new workflows under the Wizard CLI navigation
align validation documentation with current light, medium, heavy, and skipped behavior
distinguish wizard review evidence from deterministic dbt validation

Combines docs-internal PRs #2188 and #2189.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-wizard-workflow-drafts-public-dbt-labs.vercel.app/docs/dbt-ai/wizard-config
- https://docs-getdbt-com-git-wizard-workflow-drafts-public-dbt-labs.vercel.app/docs/dbt-ai/wizard-data-informed-tests
- https://docs-getdbt-com-git-wizard-workflow-drafts-public-dbt-labs.vercel.app/docs/dbt-ai/wizard-debug-failed-job
- https://docs-getdbt-com-git-wizard-workflow-drafts-public-dbt-labs.vercel.app/docs/dbt-ai/wizard-how-it-works
- https://docs-getdbt-com-git-wizard-workflow-drafts-public-dbt-labs.vercel.app/docs/dbt-ai/wizard-plugins-hooks
- https://docs-getdbt-com-git-wizard-workflow-drafts-public-dbt-labs.vercel.app/docs/dbt-ai/wizard-production-deferral
- https://docs-getdbt-com-git-wizard-workflow-drafts-public-dbt-labs.vercel.app/docs/dbt-ai/wizard-semantic-layer
- https://docs-getdbt-com-git-wizard-workflow-drafts-public-dbt-labs.vercel.app/docs/dbt-ai/wizard-understand-project
- https://docs-getdbt-com-git-wizard-workflow-drafts-public-dbt-labs.vercel.app/docs/dbt-ai/wizard-use-cases
- https://docs-getdbt-com-git-wizard-workflow-drafts-public-dbt-labs.vercel.app/docs/dbt-ai/wizard-validate-changes

<!-- end-vercel-deployment-preview -->