### PR TITLE
Add VS Code/Cursor snippets for availability badge presets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ website/i18n/*
 
 # IDE configs
 .vscode
+!.vscode/docs.code-snippets
 .idea
 
 # Claude Code local worktrees and settings (never commit)

--- a/.vscode/docs.code-snippets
+++ b/.vscode/docs.code-snippets
@@ -1,0 +1,50 @@
+{
+	"docs.md frontmatter": {
+		"isFileTemplate":true, //
+		"prefix": "docs",
+		"body": [
+		  "---",
+		  "title: \"File title\"",
+		  "id: \"$TM_FILENAME\"",
+		  "description: \"Add clear description.\"",
+		  "tags: [\"product tag, if applicable\"]",
+		  "---"
+		],
+		"description": "This autocompletes the frontmatter properties for a new .md file"
+	  },
+	"availability: all_users": {
+		"prefix": "availability-all-users",
+		"body": "availability: all_users",
+		"description": "Applies to every dbt user, regardless of surface. No badge is rendered."
+	},
+	"availability: platform_login": {
+		"prefix": "availability-platform-login",
+		"body": "availability: platform_login",
+		"description": "dbt platform feature available to all signed-in users (free account, no paid plan)."
+	},
+	"availability: local_free": {
+		"prefix": "availability-local-free",
+		"body": "availability: local_free",
+		"description": "Local/CLI tool with no login required."
+	},
+	"availability: local_all": {
+		"prefix": "availability-local-all",
+		"body": "availability: local_all",
+		"description": "Local tool that also works with dbt platform-connected projects, any dbt version."
+	},
+	"availability: everywhere_usage": {
+		"prefix": "availability-everywhere-usage",
+		"body": "availability: everywhere_usage",
+		"description": "Works across every surface, needs a free dbt account, and is billed on usage."
+	},
+	"availability: paid_plan": {
+		"prefix": "availability-paid-plan",
+		"body": [
+			"availability:",
+			"  surface: ${1|platform,local,local_development|}",
+			"  access: paid_plan",
+			"  minPlan: ${2|starter,enterprise,enterprise_plus|}"
+		],
+		"description": "Paid-plan feature. minPlan is a tier and everything above it (\"starter\" = starter and up)."
+	}
+}


### PR DESCRIPTION
## Summary

Adds a shared `.vscode/docs.code-snippets` entry so writers get autocomplete for the `availability` frontmatter field instead of memorizing preset names. Type `availability-` in any `.md`/`.mdx` file (VS Code or Cursor — both read `.vscode/*.code-snippets` the same way) and pick from a dropdown.

Builds on #[link to the availability simplification PR] — this branches off `update/propose-availability-clarity` since that's where the preset system lives. `.vscode` is gitignored repo-wide, so I added a narrow negation rule (`!.vscode/docs.code-snippets`) so just this file is tracked and shared on clone.

## The availability system, for anyone new to it

The `<Availability />` badge renders under a doc's title (e.g. "dbt platform | Free") and answers, at a glance: which dbt version this applies to, where it runs, and what access a reader needs. It's driven entirely by the `availability` field in frontmatter — either a preset name (string) or an explicit object.

### The three fields

**`surface`** — where the feature runs
| Value | Badge label | Meaning |
|---|---|---|
| `local` | Local development | CLI/local tool, no platform involved |
| `local_development` | Local development | Local tool that also works with platform-connected projects |
| `platform` | dbt platform | Runs on the dbt platform |
| *(omitted)* | — | Applies everywhere, no surface badge |

`local` and `local_development` intentionally render the *same* badge text — the CLI-only vs. platform-compatible distinction lives in the tooltip, not the chip.

**`access`** — what a reader needs to use it
| Value | Behavior |
|---|---|
| `free` | Shows a "Free" chip — but only paired with `surface: platform` (elsewhere, free is assumed and shown with no chip) |
| `login_required` | Shows "Login required" — collapsed away on `surface: platform` since you can't use the platform without an account anyway |
| `usage_based` | Shows "Usage-based", plus "Login required" unless surface is platform |
| `paid_plan` | Shows the plan tier(s) — set via `minPlan` (see below) |
| *(omitted)* | No access chip |

**`minPlan`** — only used with `access: paid_plan`. A single tier that expands to itself and everything above it:
```yaml
availability:
  surface: platform
  access: paid_plan
  minPlan: starter   # renders "Starter, Enterprise, Enterprise+"
```
Valid values: `starter`, `enterprise`, `enterprise_plus`. An explicit `plans: [...]` array is still supported as a fallback for the rare feature that doesn't follow the tier ladder (e.g. Starter-only, with no Enterprise equivalent) — but `minPlan` should be the default choice.

**`engine`** — which dbt version line (`v1` or `v2`), independent of the above, renders its own "Available in v1/v2" chip when set.

### The 5 presets

| Preset | Expands to | Use it for |
|---|---|---|
| `all_users` | `access: free` | Applies to everyone, everywhere — no badge renders |
| `platform_login` | `surface: platform, access: login_required` | dbt platform feature, needs a free account, no paid plan |
| `local_free` | `surface: local, access: free` | CLI/local tool, no login needed |
| `local_all` | `surface: local_development` | Local tool that also works with platform-connected projects, any dbt version |
| `everywhere_usage` | `access: usage_based` | Works everywhere, needs an account, billed on usage |

For anything needing `paid_plan`, skip presets and write the object form directly (`surface` + `access: paid_plan` + `minPlan`).

Bare `platform` (not a preset — a surface shorthand) also works: `availability: platform` renders just the "dbt platform" chip with no access info, for features open to all platform users where access doesn't need calling out.

## Test plan
- [ ] Open a `.md` file in VS Code, type `availability-`, confirm all 6 snippet entries show in the dropdown with correct descriptions
- [ ] Confirm same behavior in Cursor
- [ ] Confirm the `paid_plan` snippet's tab-stops correctly cycle through `surface` then `minPlan` choices