### PR TITLE
Add July 22 ST release notes

### DIFF
--- a/website/docs/docs/dbt-versions/dbt-platform-release-notes-gen.md
+++ b/website/docs/docs/dbt-versions/dbt-platform-release-notes-gen.md
@@ -22,6 +22,74 @@ Release notes are grouped by date for single-tenant environments.
 
 <span><img src="/img/fontawesome/rss.svg" alt="RSS" className="rss-icon" />Subscribe to release note updates via [RSS](/feeds/release-notes-st-rss.xml), [Atom](/feeds/release-notes-st-atom.xml), or [JSON Feed](/feeds/release-notes-st-rss.json).</span>
 
+## July 22, 2026
+
+## New
+
+### dbt AI and agents
+
+- **Unified `get_node_details` MCP tool**: The [dbt MCP server](/docs/dbt-ai/mcp-available-tools#discovery) now uses one `get_node_details` tool for all resource types. The older type-specific tools are deprecated and will be removed in a future release.
+
+### Orchestration and run status
+
+- **Job deactivation reason in banners**: When a job is deactivated, the banner now shows a specific reason — repeated run failures, account inactivity, or a generic fallback — with tailored reactivation instructions for each case.
+
+## Enhancements
+
+### dbt AI and agents
+
+- **Reliability improvements for wizard platform**: The agent now automatically retries transient LLM provider failures — network timeouts, rate limits, and server errors — with exponential backoff, so brief provider blips are less likely to surface as errors during your session.
+
+- **Unlimited client tool loop iterations**: Client tool loops now run until the agent finishes rather than stopping after 50 iterations, eliminating premature termination of long-running agentic workflows.
+
+- **Copy button on code blocks in dbt Wizard**: Code blocks in dbt Wizard responses now include a Copy button on hover, so you can reuse generated SQL or YAML more easily.
+
+- **Clearer error for Bring-Your-Own-Key models that don't support embeddings**: When a Bring-Your-Own-Key (BYOK) OpenAI model is configured with a deployment that does not support embeddings (for example, a `gpt-4o` Azure deployment), the similar models feature now returns an actionable error message prompting you to use a text-embedding model instead of a generic internal error.
+
+### Catalog
+
+- **Directional lineage filtering in `get_lineage`**: The `get_lineage` tool now accepts a `direction` parameter (`upstream`, `downstream`, or `both`) to narrow results to only ancestors or only descendants of a target node, reducing response size for large graphs. The response also now includes a `description` field on each returned node.
+
+- **Metric filtering by metadata in `list_metrics`**: The `list_metrics` tool now accepts a `meta_filter` parameter to restrict results to metrics whose `config.meta` contains specified key-value pairs (for example, `{"agent_accessible": true}`), keeping result sets small enough to preserve description and metadata in the response.
+
+- **Health status filtering for applied models**: The `ModelAppliedFilter` input type now includes a `health` field, letting you filter applied models by health status (`unknown`, `degraded`, `caution`, or `healthy`) directly in the Discovery API.
+
+- **`warn` run status surfaced in model execution info**: The `RunStatus` enum and the `lastRunStatus` field on model execution information now include `warn`, so models whose last run completed with warnings correctly reflect that status.
+
+- **Warn run status available as a filter**: The run status filter panel now includes a **Warn** option alongside **Success**, **Error**, **Skipped**, and **Reused**.
+
+- **Default search environment matches page context**: When searching from within a project environment route (for example, a Staging page), the Catalog search now defaults the environment filter to that environment type rather than always defaulting to Production.
+
+- **Redesigned search result cards**: A redesigned search result card replaces tooltip-based match pills with inline expandable snippets for columns, tags, descriptions, and code matches. Please contact your account manager to enable.
+
+### Insights
+
+- **Snowflake Adaptive warehouse cost support**: Cost Insights can now attribute query costs to models run on Snowflake Adaptive warehouses using the `QUERY_METERING_HISTORY` table. Without access to this table, Adaptive warehouse queries were previously recorded as $0. The connection test now also checks and reports on `QUERY_METERING_HISTORY` access so you can diagnose missing attribution before it affects cost data. Please contact your account manager to enable.
+
+### Studio IDE
+
+- **Fusion Stable is now the default track**: The `latest-fusion` release track is now Fusion Stable across all settings. Existing configurations have been updated automatically. No action is needed.
+
+- **Environments already on Fusion no longer see upgrade checkbox**: On the Enable Fusion Environments page, environments already running Fusion now show a disabled checkbox, preventing unnecessary saves.
+
+- **More specific error messages on failed Fusion environment upgrades**: When saving a Fusion upgrade fails, the platform now displays the top-level user message from the API instead of internal field-level error details.
+
+- **Faster command status updates in Studio IDE**: The command panel now shows live status updates as commands run, so you see progress sooner without waiting for a refresh.
+
+### dbt platform
+
+- **Consumption pool card renamed and repositioned**: The "Committed spend" card is now labeled "Consumption pool" with copy explaining that usage-based features like dbt State draw from it. The card now appears between the current plan metric tiles and the product-specific sections on billing Overview and usage tab pages.
+
+- **dbt State DATT chart shows billable and free usage separately**: The Daily Active Target Tables (DATTs) chart now stacks billable and free series, so trial users whose usage is entirely free see real bars instead of an empty chart.
+
+### Orchestration and run status
+
+-**Reduced out-of-memory rates in Fusion**: Memory-tuning optimizations are now applied automatically to all Fusion runs, reducing out-of-memory kill rates and improving overall uptime.
+
+## Fixes
+
+- **More reliable Claude responses**: Claude-backed agents can return longer answers and handle some previously broken interactions more reliably.
+
 ## July 15, 2026
 
 ## New

--- a/website/docs/docs/dbt-versions/dbt-platform-release-notes-gen.md
+++ b/website/docs/docs/dbt-versions/dbt-platform-release-notes-gen.md
@@ -84,7 +84,7 @@ Release notes are grouped by date for single-tenant environments.
 
 ### Orchestration and run status
 
--**Reduced out-of-memory rates in Fusion**: Memory-tuning optimizations are now applied automatically to all Fusion runs, reducing out-of-memory kill rates and improving overall uptime.
+- **Reduced out-of-memory rates in Fusion**: Memory-tuning optimizations are now applied automatically to all Fusion runs, reducing out-of-memory kill rates and improving overall uptime.
 
 ## Fixes
 


### PR DESCRIPTION
## Summary
- Adds July 22 single-tenant release notes to the public docs site:

- **Unified `get_node_details` MCP tool**
- **Job deactivation reason in banners**
- **Reliability improvements for wizard platform**
- **Unlimited client tool loop iterations**
- **Copy button on code blocks in dbt Wizard**
- **Clearer error for Bring-Your-Own-Key models that don't support embeddings**
- **Directional lineage filtering in `get_lineage`**
- **Metric filtering by metadata in `list_metrics`**
- **Health status filtering for applied models**
- **`warn` run status surfaced in model execution info**
- **Warn run status available as a filter**
- **Default search environment matches page context**
- **Redesigned search result cards**
- **Snowflake Adaptive warehouse cost support**
- **Fusion Stable is now the default track**
- **Environments already on Fusion no longer see upgrade checkbox**
- **More specific error messages on failed Fusion environment upgrades**
- **Faster command status updates in Studio IDE**
- **Consumption pool card renamed and repositioned**
- **dbt State DATT chart shows billable and free usage separately**
- **Reduced out-of-memory rates in Fusion**
- **More reliable Claude responses**

## Test plan
- [ ] Confirm diff only adds the July 22 section above July 15
- [ ] Confirm RSS subscribe line and existing notes are unchanged

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-nfiann-st240726-dbt-labs.vercel.app/docs/dbt-versions/dbt-platform-release-notes-gen

<!-- end-vercel-deployment-preview -->