### PR TITLE
Snowflake+transient

### DIFF
--- a/website/docs/reference/resource-configs/snowflake-configs.md
+++ b/website/docs/reference/resource-configs/snowflake-configs.md
@@ -818,6 +818,12 @@ To append a target name to the schema:
 
 Snowflake supports the creation of [transient tables](https://docs.snowflake.net/manuals/user-guide/tables-temp-transient.html). Snowflake does not preserve a history for these tables, which can result in a measurable reduction of your Snowflake storage costs. Transient tables participate in time travel to a limited degree with a retention period of 1 day by default with no fail-safe period. Weigh these tradeoffs when deciding whether or not to configure your dbt models as `transient`. **By default, all Snowflake tables created by dbt are `transient`.**
 
+:::note `transient` does not apply to seeds
+
+On Snowflake, the `transient` config applies to models, not seeds. If you set `+transient: true` or `+transient: false` on a seed, dbt still creates a _permanent_ table, and `dbt parse` might not warn you. This behavior applies to dbt Core and the dbt Fusion engine. For related discussion, refer to [dbt-snowflake#396](https://github.com/dbt-labs/dbt-snowflake/issues/396).
+
+:::
+
 ### Configuring transient tables in dbt_project.yml
 
 A whole folder (or package) can be configured to be transient (or not) by adding a line to the `dbt_project.yml` file. This config works just like all of the [model configs](/reference/model-configs) defined in `dbt_project.yml`.

--- a/website/docs/reference/resource-configs/snowflake-configs.md
+++ b/website/docs/reference/resource-configs/snowflake-configs.md
@@ -820,7 +820,7 @@ Snowflake supports the creation of [transient tables](https://docs.snowflake.net
 
 :::note `transient` does not apply to seeds
 
-On Snowflake, the `transient` config applies to models, not seeds. If you set `+transient: true` or `+transient: false` on a seed, dbt still creates a _permanent_ table, and `dbt parse` might not warn you. This behavior applies to dbt Core and the dbt Fusion engine. For related discussion, refer to [dbt-snowflake#396](https://github.com/dbt-labs/dbt-snowflake/issues/396).
+On Snowflake, the `transient` config applies to models, not seeds. If you set `+transient: true` or `+transient: false` on a seed, dbt still creates a _permanent_ table, and `dbt parse` might not warn you. This behavior applies to <Constant name="core" /> and the <Constant name="fusion_engine" />. For related discussion, refer to [dbt-snowflake#396](https://github.com/dbt-labs/dbt-snowflake/issues/396).
 
 :::
 

--- a/website/docs/reference/resource-configs/snowflake-configs.md
+++ b/website/docs/reference/resource-configs/snowflake-configs.md
@@ -820,7 +820,7 @@ Snowflake supports the creation of [transient tables](https://docs.snowflake.net
 
 :::note `transient` is a model configuration
 
-On Snowflake, `transient` is a [model configuration](/reference/model-configs). It is also applied when a [snapshot](/docs/build/snapshots) creates its target table for the first time.
+On Snowflake, `transient` is a configuration for [models](/reference/model-configs) and [snapshots](/docs/build/snapshots).
 
 `transient` does not apply to [seeds](/docs/build/seeds). If you set `+transient: true` or `+transient: false` on a seed, dbt still creates a _permanent_ table, and `dbt parse` might not warn you. This behavior applies to <Constant name="core" /> and the <Constant name="fusion_engine" />.
 

--- a/website/docs/reference/resource-configs/snowflake-configs.md
+++ b/website/docs/reference/resource-configs/snowflake-configs.md
@@ -818,9 +818,11 @@ To append a target name to the schema:
 
 Snowflake supports the creation of [transient tables](https://docs.snowflake.net/manuals/user-guide/tables-temp-transient.html). Snowflake does not preserve a history for these tables, which can result in a measurable reduction of your Snowflake storage costs. Transient tables participate in time travel to a limited degree with a retention period of 1 day by default with no fail-safe period. Weigh these tradeoffs when deciding whether or not to configure your dbt models as `transient`. **By default, all Snowflake tables created by dbt are `transient`.**
 
-:::note `transient` does not apply to seeds
+:::note `transient` is a model configuration
 
-On Snowflake, the `transient` config applies to models, not seeds. If you set `+transient: true` or `+transient: false` on a seed, dbt still creates a _permanent_ table, and `dbt parse` might not warn you. This behavior applies to dbt Core and the dbt Fusion engine. For related discussion, refer to [dbt-snowflake#396](https://github.com/dbt-labs/dbt-snowflake/issues/396).
+On Snowflake, `transient` is a [model configuration](/reference/model-configs). It is also applied when a [snapshot](/docs/build/snapshots) creates its target table for the first time.
+
+`transient` does not apply to [seeds](/docs/build/seeds). If you set `+transient: true` or `+transient: false` on a seed, dbt still creates a _permanent_ table, and `dbt parse` might not warn you. This behavior applies to <Constant name="core" /> and the <Constant name="fusion_engine" />.
 
 :::
 

--- a/website/docs/reference/seed-configs.md
+++ b/website/docs/reference/seed-configs.md
@@ -10,6 +10,9 @@ import ConfigGeneral from '/snippets/_config-description-general.md';
 
 
 ## Available configurations
+
+Configure seeds in your `dbt_project.yml` file or in each seed's [YAML properties](/reference/seed-properties). The subsections below list seed-specific configurations, general configurations shared with other resource types, and Snowflake adapter configurations.
+
 ### Seed-specific configurations
 
 <ConfigResource meta={frontMatter.meta} />
@@ -134,6 +137,10 @@ seeds:
 
 </TabItem>
 </Tabs>
+
+### Snowflake configurations
+
+Seeds do not support warehouse-specific Snowflake configs such as `transient`. If you set those configs on a seed, they have no effect on the relation dbt creates in Snowflake. Refer to [Transient tables on Snowflake](/reference/resource-configs/snowflake-configs#transient-tables) in the Snowflake configurations reference.
 
 ## Configuring seeds
 Seeds can only be configured from YAML files, either in `dbt_project.yml` or within an individual seed's YAML properties. It is not possible to configure a seed from within its CSV file.

--- a/website/docs/reference/seed-configs.md
+++ b/website/docs/reference/seed-configs.md
@@ -11,7 +11,7 @@ import ConfigGeneral from '/snippets/_config-description-general.md';
 
 ## Available configurations
 
-Configure seeds in your `dbt_project.yml` file or in each seed's [YAML properties](/reference/seed-properties). The subsections below list seed-specific configurations, general configurations shared with other resource types, and Snowflake adapter configurations.
+Configure seeds in your `dbt_project.yml` file or in each seed's [YAML properties](/reference/seed-properties). The subsections below list seed-specific configurations.
 
 ### Seed-specific configurations
 
@@ -138,16 +138,15 @@ seeds:
 </TabItem>
 </Tabs>
 
-### Snowflake configurations
-
-Seeds do not support warehouse-specific Snowflake configs such as `transient`. If you set those configs on a seed, they have no effect on the relation dbt creates in Snowflake. Refer to [Transient tables on Snowflake](/reference/resource-configs/snowflake-configs#transient-tables) in the Snowflake configurations reference.
-
 ## Configuring seeds
 Seeds can only be configured from YAML files, either in `dbt_project.yml` or within an individual seed's YAML properties. It is not possible to configure a seed from within its CSV file.
 
 Seed configurations, like model configurations, are applied hierarchically — configurations applied to a `marketing` subdirectory will take precedence over configurations applied to the entire `jaffle_shop` project, and configurations defined in a specific seed's properties will override configurations defined in `dbt_project.yml`.
 
 ### Examples
+
+These examples show how to apply the `schema` configuration at different scopes: all seeds, seeds in your project only, or a single seed.
+
 #### Apply the `schema` configuration to all seeds
 To apply a configuration to all seeds, including those in any installed [packages](/docs/build/packages), nest the configuration directly under the `seeds` key:
 


### PR DESCRIPTION
This PR:

- Documents that the Snowflake `transient` config applies to models, not seeds. Seeds remain permanent tables when `+transient` is set, and `dbt parse` may not warn. 
- Closes [JIRA:PRODDOCS-1232](https://dbtlabs.atlassian.net/browse/PRODDOCS-1232) / [Slack](https://dbt-labs.slack.com/archives/C02NCQ9483C/p1785141470777829) 

## Changes
- **`website/docs/reference/resource-configs/snowflake-configs.md`**: Add a note under **Transient tables** explaining that `transient` does not apply to seeds, with link to [dbt-snowflake#396](https://github.com/dbt-labs/dbt-snowflake/issues/396).
- **`website/docs/reference/seed-configs.md`**: Add intro copy under **Available configurations** (out of scope); add **Snowflake configurations** subsection with a cross-link to the Snowflake transient section.


## Checklist
<!-- Ensure your PR meets the following items. Feel free to add additional checklist items to the list if additional checks need to happen before the PR is merged, such as:
- [ ] Needs technical review
- [ ] Change base branch
- [ ] Merge on xyz date
-->
- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/release-notes).).
<!--
PRE-RELEASE VERSION OF dbt (if so, uncomment):
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
<!-- 
ADDING OR REMOVING PAGES (if so, uncomment):
- [ ] Add/remove page in `website/sidebars.js`
- [ ] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages
-->

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/best-practices/how-to-use-wizard/wizard-7-semantic-layer
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/best-practices/materializations/materializations-guide-6-examining-builds
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/about-dbt-lsp
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/build/about-metricflow
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/build/iceberg/about-catalogs
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/build/iceberg/adapters/bigquery-iceberg-support
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/build/iceberg/adapters/databricks-iceberg-support
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/build/iceberg/adapters/duckdb-iceberg-support
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/build/iceberg/adapters/snowflake-iceberg-support
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/build/iceberg/apache-iceberg-support
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/build/iceberg/catalogs-yml
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/build/osi-semantic-models
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/build/ossie-semantic-models
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/build/semantic-models
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/build/view-documentation
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/community-adapters
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/configure-dbt-extension
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/dbt-ai/integrate-mcp-claude
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/dbt-apis/discovery-api
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/dbt-apis/service-tokens
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/dbt-versions/2025-release-notes
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/03-upgrading-to-v1.12
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/04-upgrading-to-v1.11
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/05-upgrading-to-v1.10
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/dbt-versions/dbt-platform-release-notes-gen
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/dbt-versions/fusion-version-compatibility
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/dbt-versions/product-lifecycles
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/dbt-versions/release-notes
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/deploy/ci-jobs
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/deploy/dbt-state-cicd
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/deploy/dbt-state-enable-jobs
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/deploy/dbt-state-setup
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/deploy/deploy-jobs
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/deploy/merge-jobs
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/deploy/run-visibility
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/explore/cost-insights
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/explore/explore-cost-data
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/explore/set-up-cost-insights
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/fusion/about-core
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/fusion/fusion-releases
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/local/about-local
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/local/connect-data-platform/bigquery-setup
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/local/fusion-networking-requirements
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/local/install-dbt-core-2-oss
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/mesh/cross-platform-mesh
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/mesh/iceberg/about-catalogs
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/mesh/iceberg/apache-iceberg-support
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/mesh/iceberg/bigquery-iceberg-support
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/mesh/iceberg/databricks-iceberg-support
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/mesh/iceberg/snowflake-iceberg-support
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/platform-integrations/semantic-layer/power-bi
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/platform/about-platform/access-regions-ip-addresses
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/platform/about-platform/account-url-migration
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/platform/billing/dbt-ai-usage
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/platform/manage-access/connect-apps-oauth
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/platform/manage-access/set-up-sso-microsoft-entra-id
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/platform/secure/private-connectivity/aws/ingress
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/platform/secure/private-connectivity/azure/fabric
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/platform/studio-ide/lint-format
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/docs/platform/wizard-home
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/guides/debug-schema-names
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/reference/artifacts/dbt-artifacts
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/reference/artifacts/sl-manifest
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/reference/commands/login
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/reference/commands/version
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/reference/events-logging
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/reference/global-configs/logs
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/reference/project-configs/osi-paths
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/reference/resource-configs/bigquery-configs
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/reference/resource-configs/databricks-configs
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/reference/resource-configs/snowflake-configs
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/reference/seed-configs
- https://docs-getdbt-com-git-nfiann-transient-dbt-labs.vercel.app/reference/telemetry-observability

<!-- end-vercel-deployment-preview -->