### PR TITLE
Cost Insights - All/Jobs buttons

### DIFF
--- a/website/docs/docs/dbt-versions/release-notes.md
+++ b/website/docs/docs/dbt-versions/release-notes.md
@@ -57,6 +57,7 @@ To simplify the docs experience, clarify availability, and make it easier to fin
 
 ## June 2026
 
+- **Enhancement**: The [Cost Insights](/docs/explore/cost-insights) table view now includes **All** and **Jobs** buttons to switch between an aggregated cost view and a per-job cost breakdown. Available in the project dashboard and the **Model performance** section in <Constant name="catalog" />. When **Jobs** is selected, the CSV export includes job-level data. For more information, refer to [Explore cost data](/docs/explore/explore-cost-data).
 - **Enhancement:** [<Constant name="wizard" />](/docs/platform/wizard-platform) tool calls for dbt command invocations now stream their output live in chat, in both the <Constant name="studio_ide" /> and [Wizard home](/docs/platform/wizard-home).
 - **Enhancement:** You can now download files from the <Constant name="studio_ide" /> File explorer. Right-click a file and select **Download** to save it to your computer. For more information, refer to the [<Constant name="studio_ide" /> user interface](/docs/platform/studio-ide/ide-user-interface#basic-layout).
 - **Fix:** If you use the Administrator API to manage [SCIM](/docs/platform/manage-access/scim) to sync users from your identity provider, the `/api/v3/accounts/{account_id}/scim/v2/Users` response now returns `value` and `display` on each embedded group reference. `id` and `displayName` are retained so existing integrations keep working — this is a non-breaking change.

--- a/website/docs/docs/explore/cost-insights.md
+++ b/website/docs/docs/explore/cost-insights.md
@@ -25,8 +25,8 @@ With Cost Insights, you can see:
 - **How much your dbt models cost to run**: See the compute cost and times for each model and job in your warehouse's native units.
 - **The cost reductions from using dbt State or state-aware orchestration**: Understand the cost reduction when dbt State or state-aware orchestration reuses unchanged models.
 - **Cost trends over time**: Track your warehouse spend and optimization impact across your dbt projects.
-- **Filter by asset type**: On Cost Insights charts (**Cost**, **Usage**, **Query run time**, **Builds**), use the **Assets** dropdown menu to filter data by **Models**, **Tests**, or **All**. Each tab keeps its own selection.
-- **View costs by job**: In the Cost Insights table view, use the **All** and **Jobs** buttons to switch between an aggregated view and a per-job cost breakdown.
+- **Asset type filtering**: On Cost Insights charts (**Cost**, **Usage**, **Query run time**, **Builds**), use the **Assets** dropdown menu to filter data by **Models**, **Tests**, or **All**. Each tab keeps its own selection.
+- **Per-job cost breakdown**: In the Cost Insights table view, use the **All** and **Jobs** buttons to switch between an aggregated view and a per-job cost breakdown.
 
 The Cost Insights section is available in different <Constant name="dbt_platform" /> areas and lets you view your cost data and the impact of dbt State and state-aware orchestration optimizations across various dimensions:
 

--- a/website/docs/docs/explore/cost-insights.md
+++ b/website/docs/docs/explore/cost-insights.md
@@ -26,6 +26,7 @@ With Cost Insights, you can see:
 - **The cost reductions from using dbt State or state-aware orchestration**: Understand the cost reduction when dbt State or state-aware orchestration reuses unchanged models.
 - **Cost trends over time**: Track your warehouse spend and optimization impact across your dbt projects.
 - **Filter by asset type**: On Cost Insights charts (**Cost**, **Usage**, **Query run time**, **Builds**), use the **Assets** dropdown menu to filter data by **Models**, **Tests**, or **All**. Each tab keeps its own selection.
+- **View costs by job**: In the Cost Insights table view, use the **All** and **Jobs** buttons to switch between an aggregated view and a per-job cost breakdown.
 
 The Cost Insights section is available in different <Constant name="dbt_platform" /> areas and lets you view your cost data and the impact of dbt State and state-aware orchestration optimizations across various dimensions:
 

--- a/website/docs/docs/explore/explore-cost-data.md
+++ b/website/docs/docs/explore/explore-cost-data.md
@@ -79,6 +79,7 @@ The project dashboard includes the following tabs that help you analyze cost and
 
 Access the table view by clicking **Show table**, which provides detailed optimization data such as models reused, usage reduction, and cost reduction.
 
+
 import TableView from '/snippets/_table-view.md';
 
 <TableView />

--- a/website/snippets/_table-view.md
+++ b/website/snippets/_table-view.md
@@ -1,1 +1,5 @@
-When viewing the table, you can export the data as a CSV file using the **Download** button.
+Use the **All** and **Jobs** buttons to switch between views:
+- **All**: Shows aggregated cost data across all jobs in the project.
+- **Jobs**: Shows cost data broken down by individual jobs.
+
+When viewing the table, you can export the data as a CSV file using the **Download** button. When **Jobs** is selected, the CSV export includes job-level data.


### PR DESCRIPTION
## What are you changing in this pull request and why?
Closes https://github.com/dbt-labs/docs-internal/issues/2060

Documents the new **All** and **Jobs** buttons in the Cost Insights table view, which let users switch between an aggregated cost view and a per-job cost breakdown. When **Jobs** is selected, the CSV export includes job-level data. Available in the project dashboard and the **Model performance** section in Catalog.

## Previews

- [Cost Insights](https://docs-getdbt-com-git-cost-insights-job-dbt-labs.vercel.app/docs/explore/cost-insights)
- [Explore cost data](https://docs-getdbt-com-git-cost-insights-job-dbt-labs.vercel.app/docs/explore/explore-cost-data)
- [Release notes](https://docs-getdbt-com-git-cost-insights-job-dbt-labs.vercel.app/docs/dbt-versions/release-notes)

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [x] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/release-notes).).

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-cost-insights-job-dbt-labs.vercel.app/docs/dbt-versions/release-notes
- https://docs-getdbt-com-git-cost-insights-job-dbt-labs.vercel.app/docs/explore/cost-insights
- https://docs-getdbt-com-git-cost-insights-job-dbt-labs.vercel.app/docs/explore/explore-cost-data

<!-- end-vercel-deployment-preview -->