### PR TITLE
Cross-link OTel logging from Logs and events pages (PRODDOCS-1233)

### DIFF
--- a/website/docs/reference/events-logging.md
+++ b/website/docs/reference/events-logging.md
@@ -30,6 +30,16 @@ As dbt runs, it generates events. The most common way to see those events is as 
 
 ## Structured logging
 
+<VersionBlock firstVersion="2.0">
+
+The <Constant name="fusion_engine" /> emits structured run telemetry using [OpenTelemetry](https://opentelemetry.io/) conventions instead of <Constant name="core" />'s JSON event logs. Use `--log-format otel` or the options in [<Constant name="fusion" /> telemetry and observability](/reference/telemetry-observability) to consume it locally. On the <Constant name="dbt_platform" />, you can [download OTel logs](/docs/deploy/run-visibility#access-logs) from Fusion job runs.
+
+For `--log-format`, `--log-level`, and related CLI configs, refer to [Logs](/reference/global-configs/logs).
+
+</VersionBlock>
+
+<VersionBlock lastVersion="1.99">
+
 _For more details about how the eventing system has been implemented in dbt-core, see the [`events` module README](https://github.com/dbt-labs/dbt-core/blob/HEAD/core/dbt/events/README.md)._
 
 The structure of each event in `dbt-core` is backed by a schema defined using [protocol buffers](https://developers.google.com/protocol-buffers). All schemas are defined in the [`types.proto`](https://github.com/dbt-labs/dbt-core/blob/3bf148c443e6b1da394b62e88a08f1d7f1d8ccaa/core/dbt/events/core_types.proto) file within the `dbt-core` codebase.
@@ -117,7 +127,11 @@ Many events are fired while compiling or running a specific DAG node (model, see
 }
 ```
 
+</VersionBlock>
+
 ## Python interface
+
+<VersionBlock lastVersion="1.99">
 
 Older versions of `dbt-core` made available a full history of events fired during an invocation, in the form of an `EVENT_HISTORY` object.
 
@@ -125,3 +139,5 @@ When [invoking dbt programmatically](programmatic-invocations#registering-callba
 
 
 The Python interface into events is significantly less mature than the structured logging interface. For all standard use cases, we recommend parsing JSON-formatted logs.
+
+</VersionBlock>

--- a/website/docs/reference/global-configs/logs.md
+++ b/website/docs/reference/global-configs/logs.md
@@ -8,7 +8,27 @@ sidebar: "logs"
 
 dbt outputs logs to two different locations: CLI console and the log file.
 
+<VersionBlock lastVersion="1.99">
+
 The `LOG_FORMAT` and `LOG_FORMAT_FILE` configs specify how dbt's logs should be formatted, and they each have the same options: `json`, `text`, and `debug`.
+
+</VersionBlock>
+
+<VersionBlock firstVersion="2.0">
+
+The `LOG_FORMAT` and `LOG_FORMAT_FILE` configs specify how dbt's logs should be formatted, and they each have the same options: `text`, `json`, `default`, and `otel`.
+
+The `otel` format streams [OpenTelemetry](https://opentelemetry.io/)-style structured telemetry to the console. It uses a different schema than <Constant name="core" />'s `json` logs. For JSONL files, Parquet export, OTLP, and how this maps to <Constant name="core" /> structured logging, refer to [<Constant name="fusion" /> telemetry and observability](/reference/telemetry-observability).
+
+<File name='Usage'>
+
+```text
+dbtf build --log-format otel
+```
+
+</File>
+
+</VersionBlock>
 
 <File name='Usage'>
 
@@ -25,6 +45,8 @@ The `text` format is the default for console logs and has plain text messages pr
 23:30:17  Registered adapter: postgres=1.8.0
 ```
 
+<VersionBlock lastVersion="1.99">
+
 The `debug` format is the default for the log file and is the same as the `text` format but with a more detailed timestamp and also includes the [`invocation_id`](/reference/dbt-jinja-functions/invocation_id), [`thread_id`](/reference/dbt-jinja-functions/thread_id), and [log level](/reference/global-configs/logs#log-level) of each message:
 
 ```
@@ -32,6 +54,8 @@ The `debug` format is the default for the log file and is the same as the `text`
 16:12:08.555032 [info ] [MainThread]: Running with dbt=1.8.0
 16:12:08.751069 [info ] [MainThread]: Registered adapter: postgres=1.8.0
 ```
+
+</VersionBlock>
 
 The `json` format outputs fully structured logs in the <Term id="json" /> format:
 
@@ -50,6 +74,8 @@ dbt run --log-format-file json
 
 </File>
 
+<VersionBlock lastVersion="1.99">
+
 :::tip Tip: verbose structured logs
 
 Use `json` formatting value in conjunction with the `DEBUG` config to produce rich log information which can be piped into monitoring tools for analysis:
@@ -61,6 +87,24 @@ dbt run --debug --log-format json
 See [structured logging](/reference/events-logging#structured-logging) for more details.
 
 :::
+
+</VersionBlock>
+
+<VersionBlock firstVersion="2.0">
+
+:::tip Tip: structured observability
+
+Use `--log-format otel` to stream OpenTelemetry-style telemetry to the console, or use `--otel-file-name` and related flags for file and platform integrations. See [<Constant name="fusion" /> telemetry and observability](/reference/telemetry-observability).
+
+For legacy-compatible JSON lines (similar to <Constant name="core" />), use `--log-format json` with the `DEBUG` config:
+
+```text
+dbtf build --debug --log-format json
+```
+
+:::
+
+</VersionBlock>
 
 ### Log Level
 

--- a/website/docs/reference/telemetry-observability.md
+++ b/website/docs/reference/telemetry-observability.md
@@ -11,6 +11,8 @@ import SaoDeprecated from '/snippets/_sao-deprecated.md';
 
 The <Constant name="fusion_engine" /> provides a comprehensive observability system that replaces [<Constant name="core" />'s structured logging](/reference/events-logging#structured-logging). Built on [OpenTelemetry](https://opentelemetry.io/) conventions and backed by a stable protobuf schema, it enables deep integration with orchestrators, observability platforms, and custom tooling.
 
+For shared CLI logging configs such as `--log-format` and `--log-level`, refer to [Logs](/reference/global-configs/logs).
+
 This system is separate from the anonymous usage statistics that dbt sends to dbt Labs. To configure anonymous usage statistics, refer to [Anonymous usage stats](/reference/global-configs/usage-stats).
 
 This uses the same integration that <Constant name="dbt_platform" /> relies on for orchestration and monitoring, providing proven and production-ready features that work at scale.


### PR DESCRIPTION
## Summary
- Add Fusion (2.0+) callouts on [Logs](https://docs.getdbt.com/reference/global-configs/logs) for `--log-format otel` and link to Fusion telemetry.
- Add a Fusion pointer at [structured logging](https://docs.getdbt.com/reference/events-logging#structured-logging); keep Core content in 1.x version blocks.
- Back-link from [Fusion telemetry and observability](https://docs.getdbt.com/reference/telemetry-observability) to Logs.

## Test plan
- [x] Local: `dbtf parse --log-format otel` emits OTel JSON lines
- [x] Platform: Fusion job run → Download OTel log (Parquet)
- [ ] Preview docs site at `?version=2.0` and `?version=1.12` on the three pages

Jira: https://dbtlabs.atlassian.net/browse/PRODDOCS-1233

Made with [Cursor](https://cursor.com)

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-nfiann-opentel-dbt-labs.vercel.app/reference/events-logging
- https://docs-getdbt-com-git-nfiann-opentel-dbt-labs.vercel.app/reference/global-configs/logs
- https://docs-getdbt-com-git-nfiann-opentel-dbt-labs.vercel.app/reference/telemetry-observability

<!-- end-vercel-deployment-preview -->