### PR TITLE
Add dbt version label to navbar version dropdown

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -703,7 +703,11 @@ html[data-theme="dark"] .version-dropdown__trigger:hover {
 
 .version-dropdown__label {
   font-size: 0.8rem;
-  color: #999;
+  color: #57534e;
+}
+
+html[data-theme="dark"] .version-dropdown__label {
+  color: #ccc;
 }
 
 .version-dropdown__current {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -702,12 +702,13 @@ html[data-theme="dark"] .version-dropdown__trigger:hover {
 }
 
 .version-dropdown__label {
-  font-size: 0.8rem;
+  font-size: 0.85rem;
+  font-weight: 500;
   color: #57534e;
 }
 
 html[data-theme="dark"] .version-dropdown__label {
-  color: #ccc;
+  color: #e0e0e0;
 }
 
 .version-dropdown__current {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -701,6 +701,11 @@ html[data-theme="dark"] .version-dropdown__trigger:hover {
   color: #999;
 }
 
+.version-dropdown__label {
+  font-size: 0.8rem;
+  color: #999;
+}
+
 .version-dropdown__current {
   font-weight: 600;
 }

--- a/website/src/theme/NavbarItem/DropdownNavbarItem.js
+++ b/website/src/theme/NavbarItem/DropdownNavbarItem.js
@@ -257,6 +257,7 @@ function DropdownNavbarItemDesktop({
           className="version-dropdown__trigger"
           aria-haspopup="listbox"
           aria-expanded={showDropdown}
+          aria-label={`dbt version: ${currentLabel}`}
           onClick={() => setShowDropdown((v) => !v)}
         >
           <span className="version-dropdown__branch" aria-hidden="true">
@@ -267,6 +268,7 @@ function DropdownNavbarItemDesktop({
               />
             </svg>
           </span>
+          <span className="version-dropdown__label" aria-hidden="true">dbt version</span>
           <span className="version-dropdown__current">{currentLabel}</span>
           <span className="version-dropdown__caret" aria-hidden="true">▾</span>
         </button>
@@ -417,7 +419,7 @@ function DropdownNavbarItemMobile({
               />
             </svg>
           </span>
-          <span>Version</span>
+          <span>dbt version</span>
         </div>
         <ul className="menu__list">
           {products.map((product) => {


### PR DESCRIPTION
## Summary
- Field feedback (Slack) flagged that the v1/v2 dropdown in the navbar wasn't obviously a version selector to non-developer users.
- Adds a visible "dbt version" label next to the current version in the navbar trigger so the purpose is clear before clicking.
- Updates the mobile menu header text from "Version" to "dbt version" to match.

## Test plan
- [ ] Verify the navbar dropdown reads "dbt version v2" (or v1/1.x) on desktop, doesn't crowd other nav items
- [ ] Verify mobile menu header shows "dbt version"
- [ ] Verify dropdown open/close and version switching still work