### PR TITLE
Cost Insights - support for adaptive warehouses

### DIFF
--- a/website/docs/docs/dbt-versions/release-notes.md
+++ b/website/docs/docs/dbt-versions/release-notes.md
@@ -20,6 +20,7 @@ For <Constant name="fusion_engine" /> updates, refer to the [dbt-fusion changelo
 
 ## August 2026
 
+- **Enhancement:** [Cost Insights](/docs/explore/cost-insights) now supports cost attribution for [Snowflake Adaptive Warehouses](https://docs.snowflake.com/en/user-guide/warehouses-adaptive). For setup details, refer to [Assign required permissions](/docs/explore/set-up-cost-insights#assign-required-permissions).
 - **New:** The [Model timing tab](/docs/deploy/run-visibility#model-timing-tab) in job run details has been redesigned with a richer, scalable view that includes metric tiles, an execution timeline with grouping and highlight controls, a concurrency-over-time chart, and a searchable resource details table.
 - **New:** <Constant name="semantic_layer" /> development connections to Redshift now support external OAuth using Okta or Microsoft Entra with AWS IAM Identity Center.
 - **Enhancement:** System for Cross-domain Identity Management (SCIM) API errors for seat or licensing failures now include email addresses so you can identify which users are blocking provisioning.

--- a/website/docs/docs/explore/cost-insights.md
+++ b/website/docs/docs/explore/cost-insights.md
@@ -74,16 +74,13 @@ credits_per_query * price_per_credit
 ```
 
 Where:
-- `credits_per_query` - Cloud services, compute, and query acceleration credits attributed to the query. dbt sources this value from `QUERY_ATTRIBUTION_HISTORY`. For more information, see the [Snowflake documentation](https://docs.snowflake.com/en/sql-reference/account-usage/query_attribution_history).      
+- `credits_per_query` - Cloud services, compute, and query acceleration credits attributed to the query. 
+    - For standard and Generation 2 warehouses, dbt sources this value from [`QUERY_ATTRIBUTION_HISTORY`](https://docs.snowflake.com/en/sql-reference/account-usage/query_attribution_history). 
+    - For [Adaptive Warehouses](https://docs.snowflake.com/en/user-guide/warehouses-adaptive), dbt sources this value from [`QUERY_METERING_HISTORY`](https://docs.snowflake.com/en/sql-reference/account-usage/query_metering_history) &mdash; refer to [Configure platform metadata credentials](/docs/explore/set-up-cost-insights#snowflake) for required permissions.
 - `price_per_credit` - Your Snowflake credit price (from Snowflake system tables when available, otherwise from your configured input or the default rate).
 
-:::info Snowflake attribution limitations
-dbt attributes Snowflake costs at the query level using the [`QUERY_ATTRIBUTION_HISTORY`](https://docs.snowflake.com/en/sql-reference/account-usage/query_attribution_history). Because of how Snowflake populates that view, some warehouse spend can't be attributed to a dbt model and won't appear in Cost Insights:
-
-- **Short-running queries**: Snowflake doesn't attribute cost to queries that run in roughly 100 milliseconds or less.
-- **Adaptive Warehouses**: Queries on [Snowflake Adaptive Warehouses](https://docs.snowflake.com/en/user-guide/warehouses-adaptive) are not included in `QUERY_ATTRIBUTION_HISTORY`.
-
-As a result, Cost Insights totals may be _lower_ than the compute spend shown in your Snowflake billing dashboards. For more information, see the [Snowflake documentation](https://docs.snowflake.com/en/sql-reference/account-usage/query_attribution_history#usage-notes).
+:::info Snowflake attribution limitation
+Snowflake doesn't attribute cost to queries that run in roughly 100 milliseconds or less. As a result, Cost Insights totals may be _lower_ than the compute spend shown in your Snowflake billing dashboards. For more information, see the [Snowflake documentation](https://docs.snowflake.com/en/sql-reference/account-usage/query_attribution_history#usage-notes).
 :::
 </Expandable>
 

--- a/website/docs/docs/explore/cost-insights.md
+++ b/website/docs/docs/explore/cost-insights.md
@@ -74,10 +74,10 @@ credits_per_query * price_per_credit
 ```
 
 Where:
-- `credits_per_query` - Cloud services, compute, and query acceleration credits attributed to the query. 
+- `credits_per_query` &mdash; Cloud services, compute, and query acceleration credits attributed to the query. 
     - For standard and Generation 2 warehouses, dbt sources this value from [`QUERY_ATTRIBUTION_HISTORY`](https://docs.snowflake.com/en/sql-reference/account-usage/query_attribution_history). 
     - For [Adaptive Warehouses](https://docs.snowflake.com/en/user-guide/warehouses-adaptive), dbt sources this value from [`QUERY_METERING_HISTORY`](https://docs.snowflake.com/en/sql-reference/account-usage/query_metering_history) &mdash; refer to [Configure platform metadata credentials](/docs/explore/set-up-cost-insights#snowflake) for required permissions.
-- `price_per_credit` - Your Snowflake credit price (from Snowflake system tables when available, otherwise from your configured input or the default rate).
+- `price_per_credit` &mdash; Your Snowflake credit price (from Snowflake system tables when available, otherwise from your configured input or the default rate).
 
 :::info Snowflake attribution limitation
 Snowflake doesn't attribute cost to queries that run in roughly 100 milliseconds or less. As a result, Cost Insights totals may be _lower_ than the compute spend shown in your Snowflake billing dashboards. For more information, see the [Snowflake documentation](https://docs.snowflake.com/en/sql-reference/account-usage/query_attribution_history#usage-notes).

--- a/website/docs/docs/explore/set-up-cost-insights.md
+++ b/website/docs/docs/explore/set-up-cost-insights.md
@@ -72,6 +72,9 @@ For more information on how to assign permissions to users, refer to [About user
             - `ACCOUNT_USAGE.ACCESS_HISTORY`
             - `ACCOUNT_USAGE.WAREHOUSE_METERING_HISTORY`
             - `ORGANIZATION_USAGE.USAGE_IN_CURRENCY_DAILY` (Optional)
+            - `ACCOUNT_USAGE.QUERY_METERING_HISTORY` (Optional; required for [Adaptive Warehouse](https://docs.snowflake.com/en/user-guide/warehouses-adaptive) cost attribution)
+
+                If `QUERY_METERING_HISTORY` access is not granted, Adaptive Warehouse queries appear as $0 in Cost Insights and a warning is shown in the connection test. For more information, refer to the [Snowflake documentation](https://docs.snowflake.com/en/sql-reference/account-usage/query_metering_history).
         </Expandable>
 
         <Expandable alt_header="BigQuery">


### PR DESCRIPTION
## What are you changing in this pull request and why?
Closes https://github.com/dbt-labs/docs-internal/issues/2198

Documents the Snowflake Adaptive Warehouse cost attribution feature from dbt-labs/codex#2957:

- **`cost-insights.md`**: Updated the `credits_per_query` description to explain that Adaptive Warehouse costs are sourced from `QUERY_METERING_HISTORY` (when access is granted) rather than `QUERY_ATTRIBUTION_HISTORY`. Removed Adaptive Warehouses from the attribution limitations callout since they are now supported.
- **`set-up-cost-insights.md`**: Added `ACCOUNT_USAGE.QUERY_METERING_HISTORY` as an optional permission in the Snowflake section, with a note on the fallback behavior when access is not granted.
- **`release-notes.md`**: Added an August 2026 release note.

## Preview links

- [Release notes](https://docs-getdbt-com-git-cost-insights-snowflake-dbt-labs.vercel.app/docs/dbt-versions/release-notes)
- [Cost Insights](https://docs-getdbt-com-git-cost-insights-snowflake-dbt-labs.vercel.app/docs/explore/cost-insights)
- [Set up Cost Insights](https://docs-getdbt-com-git-cost-insights-snowflake-dbt-labs.vercel.app/docs/explore/set-up-cost-insights)

## Checklist
<!-- Ensure your PR meets the following items. Feel free to add additional checklist items to the list if additional checks need to happen before the PR is merged, such as:
- [ ] Needs technical review
- [ ] Change base branch
- [ ] Merge on xyz date
-->
- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/release-notes).).
<!--
PRE-RELEASE VERSION OF dbt (if so, uncomment):
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
<!-- 
ADDING OR REMOVING PAGES (if so, uncomment):
- [ ] Add/remove page in `website/sidebars.js`
- [ ] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages
-->

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-cost-insights-snowflake-dbt-labs.vercel.app/docs/dbt-versions/release-notes
- https://docs-getdbt-com-git-cost-insights-snowflake-dbt-labs.vercel.app/docs/explore/cost-insights
- https://docs-getdbt-com-git-cost-insights-snowflake-dbt-labs.vercel.app/docs/explore/set-up-cost-insights

<!-- end-vercel-deployment-preview -->