### PR TITLE
Document dev, CI, and prod target setup with environment variables

### DIFF
--- a/website/docs/docs/local/dbt-core-environments.md
+++ b/website/docs/docs/local/dbt-core-environments.md
@@ -16,3 +16,69 @@ You can learn more about different ways to run dbt in production in [this articl
 Targets offer the flexibility to decide how to implement your separate environments – whether you want to use separate schemas, databases, or entirely different clusters altogether! We recommend using _different schemas within one database_ to separate your environments. This is the easiest to set up and is the most cost-effective solution in a modern cloud-based data stack.
 
 In practice, this means that most of the details in a target will be consistent across all targets, except for the `schema` and user credentials. If you have multiple dbt users writing code, it often makes sense for _each user_ to have their own _development_ environment. A pattern we've found useful is to set your dev target schema to be `dbt_<username>`. User credentials should also differ across targets so that each dbt user is using their own data warehouse user.
+
+## Configure a target for each environment
+
+Define one target per environment inside the same profile, then pick between them with the `--target` flag. The following profile shares a single connection and varies only the schema, the credentials, and the thread count:
+
+<File name='~/.dbt/profiles.yml'>
+
+```yaml
+jaffle_shop:
+  target: dev  # the target dbt uses when you don't pass --target
+  outputs:
+    dev:
+      type: snowflake
+      account: abc123
+      database: analytics
+      warehouse: transforming
+      schema: "{{ env_var('DBT_DEV_SCHEMA') }}"  # for example, dbt_alice
+      user: "{{ env_var('DBT_USER') }}"
+      password: "{{ env_var('DBT_ENV_SECRET_PASSWORD') }}"
+      threads: 4
+    ci:
+      type: snowflake
+      account: abc123
+      database: analytics
+      warehouse: transforming
+      schema: "{{ env_var('DBT_CI_SCHEMA') }}"  # for example, ci_pr_142
+      user: "{{ env_var('DBT_USER') }}"
+      password: "{{ env_var('DBT_ENV_SECRET_PASSWORD') }}"
+      threads: 8
+    prod:
+      type: snowflake
+      account: abc123
+      database: analytics
+      warehouse: transforming
+      schema: analytics
+      user: "{{ env_var('DBT_USER') }}"
+      password: "{{ env_var('DBT_ENV_SECRET_PASSWORD') }}"
+      threads: 16
+```
+
+</File>
+
+Select a target by name when you run dbt:
+
+```bash
+dbt run                # uses the default target, dev
+dbt build --target ci
+dbt run --target prod
+```
+
+## Set environment variables for each environment
+
+Because the targets differ by only a few values, supply those values with the [`env_var`](/reference/dbt-jinja-functions/env_var) function instead of hardcoding them. One `profiles.yml` file then works for every developer and every deployment.
+
+- **Development** &mdash; Each developer sets `DBT_DEV_SCHEMA` to their own schema, such as `dbt_alice`, so that no two developers build into the same relations.
+- **Continuous integration** &mdash; Set `DBT_CI_SCHEMA` to a value that is unique per run, such as one derived from the pull request number, so that concurrent CI runs don't overwrite each other. Drop the schema when the pull request closes.
+- **Production** &mdash; Store production credentials as secrets in whichever tool runs dbt on a schedule. Prefix any variable holding a credential with `DBT_ENV_SECRET_` so that dbt scrubs the value from logs.
+
+dbt combines your target schema with a model's custom schema when it generates the final schema name, so confirm how your project generates schema names before you rely on this pattern. Refer to [how does dbt generate a model's schema name](/docs/build/custom-schemas#how-does-dbt-generate-a-models-schema-name).
+
+## Related docs
+
+- [Connection profiles](/docs/local/profiles.yml) to learn how dbt resolves `profiles.yml`
+- [Custom schemas](/docs/build/custom-schemas) to learn how dbt builds schema names
+- [About the `env_var` function](/reference/dbt-jinja-functions/env_var) to learn how to reference environment variables
+- [Get started with continuous integration tests](/guides/set-up-ci) to learn how to run dbt against a CI environment


### PR DESCRIPTION
## What are you changing in this pull request and why?

Resolves #3081.

"dbt environments" explains the *concept* — targets separate dev from prod, prefer separate schemas in one database, name your dev schema `dbt_<username>` — but it stops before showing anyone how to actually set that up. The issue asks for concrete guidance on standing up development, CI, and production environments.

This adds two sections to the existing page:

- **Configure a target for each environment** — a complete `~/.dbt/profiles.yml` with `dev`, `ci`, and `prod` targets on one Snowflake account, following the schema-separation recommendation the page already makes, plus the `dbt run` / `dbt build --target ci` / `dbt run --target prod` invocations for each.
- **Set environment variables for each environment** — what supplies each `env_var()` in the three contexts, including using the `DBT_ENV_SECRET_` prefix for credentials so values are scrubbed from logs.

I extended this page rather than adding a new one, so there's no sidebar or `vercel.json` change and no new URL to maintain. Happy to split it out into its own page if you'd rather have a standalone setup guide.

No versioned content, no release note needed.

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
