### PR TITLE
Fix broken tables in generated markdown (Loading table/Search table..)

### DIFF
--- a/website/docs/docs/platform/about-platform/access-regions-ip-addresses.md
+++ b/website/docs/docs/platform/about-platform/access-regions-ip-addresses.md
@@ -21,7 +21,6 @@ Your <Constant name="dbt" /> account will always connect to your data platform o
 
 ## Amazon Web Services (AWS) {#AWS}
 
-<FilterableTable>
 
 | Region | Location | <div style={{width:'110px'}}>Access URL</div> | <div style={{width:'100px'}}>IP addresses</div> | Available plans | <div style={{width:'200px'}}>Status page link</div> |
 |--------|----------|------------|--------------|-------| --------- |
@@ -31,11 +30,9 @@ Your <Constant name="dbt" /> account will always connect to your data platform o
 | Japan | ap-northeast-1 (Tokyo) | <small>ACCOUNT_PREFIX.jp1.dbt.com</small> | 35.76.76.152 <br />  54.238.211.79 <br /> 13.115.236.233 <br /> | All Enterprise plans | [JP Cell 1 AWS](https://status.getdbt.com/jp-cell-1-aws) | 
 | Virtual Private dbt or Single tenant | Customized |  Customized | Ask [Support](/community/resources/getting-help#dbt-cloud-support) for your IPs | All Enterprise plans | Customized |
 
-</FilterableTable>
 
 ## Google Cloud Platform (GCP) {#GCP}
 
-<FilterableTable>
 
 | Region | Location | <div style={{width:'110px'}}>Access URL</div> | <div style={{width:'100px'}}>IP addresses</div> | Available plans | <div style={{width:'200px'}}>Status page link</div> |
 |--------|----------|------------|--------------|-------| --------- |
@@ -44,11 +41,9 @@ Your <Constant name="dbt" /> account will always connect to your data platform o
 | EMEA  | Frankfurt | <small>ACCOUNT_PREFIX.eu4.dbt.com</small> | 34.185.244.128/26 | All Enterprise plans | [EU4 Cell 1 GCP](https://status.getdbt.com/eu-4-cell-1-gcp) |
 | Virtual Private dbt or Single tenant | Customized |  Customized | Ask [Support](/community/resources/getting-help#dbt-cloud-support) for your IPs | All Enterprise plans | Customized |
 
-</FilterableTable>
 
 ## Microsoft Azure {#Azure}
 
-<FilterableTable>
 | Region | Location | <div style={{width:'110px'}}>Access URL</div> | <div style={{width:'100px'}}>IP addresses</div> | Available plans | <div style={{width:'200px'}}>Status page link</div> |
 |--------|----------|------------|--------------|-------| --------- |
 | North America  | East US 2 (Virginia) | <small>ACCOUNT_PREFIX.us2.dbt.com</small> | 20.10.67.192/26 | All Enterprise plans | [US Cell 1 AZURE](https://status.getdbt.com/us-cell-1-azure) |
@@ -56,7 +51,6 @@ Your <Constant name="dbt" /> account will always connect to your data platform o
 | APAC | Australia East | <small>ACCOUNT_PREFIX.au2.dbt.com</small> | 20.11.97.208/28 | All Enterprise plans | [AUS Cell 1 AZURE](https://status.getdbt.com/au-2-cell-1-azure) |
 | Virtual Private dbt or Single tenant | Customized |  Customized | Ask [Support](/community/resources/getting-help#dbt-cloud-support) for your IPs | All Enterprise plans | Customized |
 
-</FilterableTable>
 
 ## Accessing your account
 

--- a/website/snippets/_enterprise-permissions-table.md
+++ b/website/snippets/_enterprise-permissions-table.md
@@ -21,7 +21,6 @@ Key:
 
 #### Account access for account permissions
 
-<FilterableTable>
 
 | Account-level permission | Account Admin | Billing admin | Cost Insights Admin | Cost Insights Viewer | Manage marketplace apps | Notification Manager | Project creator | Security admin | Account Viewer |
 |:-------------------------|:-------------:|:-------------:|:-------------------:|:--------------------:|:-----------------------:|:--------------------:|:---------------:|:--------------:|:------:|
@@ -42,7 +41,6 @@ Key:
 | Public models            | R             | R             | -                   | -                    | -                       | -                    | R               | R              | R      |
 | Service tokens           | W             | -             | -                   | -                    | -                       | -                    | -               | R              | R      |
 | Webhooks                 | W             | -             | -                   | -                    | -                       | -                    | -               | -              | -      |
-</FilterableTable>
 
 <sup>*</sup>Permission sets with write (**W**) access to Account settings can modify account-level settings. The **Notification Manager** permission set has dedicated write access to **Job notifications** (Slack, Microsoft Teams, and email) without requiring full Account settings access.
 
@@ -57,7 +55,6 @@ An admin can grant `user_credential_write` to any group, regardless of which per
 
 #### Project access for account permissions
 
-<FilterableTable>
 | Project-level permission     | Account Admin | Billing admin | Cost Insights Admin | Cost Insights Viewer | Notification Manager | Project creator | Security admin | Account Viewer |
 |:-----------------------------|:-------------:|:-------------:|:-------------------:|:--------------------:|:--------------------:|:---------------:|:--------------:|:------:|
 | Environment credentials      | W             | -             | -                   | -                    | -                    | W               | -              | R      |
@@ -73,7 +70,6 @@ An admin can grant `user_credential_write` to any group, regardless of which per
 | Repositories                 | W             | -             | -                   | -                    | -                    | W               | -              | R      |
 | Runs                         | W             | -             | -                   | -                    | -                    | W               | -              | R      |
 | Semantic Layer config        | W             | -             | -                   | -                    | -                    | W               | -              | R      |
-</FilterableTable>
 
 ### Project permissions
 
@@ -86,7 +82,6 @@ Key:
 
 #### Account access for project permissions
 
-<FilterableTable>
 | Account-level permission | Admin | Analyst | Analyst read | Cost Insights Admin | Cost Insights Viewer | Database admin | Developer | Git Admin | Job admin | Job creator | Job runner | Job viewer | Metadata (Discovery API only) | Semantic Layer | Stakeholder/Read-Only | Team admin |
 |--------------------------|:-----:|:-------:|:------------:|:-------------------:|:--------------------:|:--------------:|:---------:|:---------:|:---------:|:-----------:|:----------:|:----------:|:-----------------------------:|:--------------:|:---------------------:|:----------:|
 | Account settings         |   R   |    -    |      R       |          -          |          -           |       R        |     -     |     R     |     -     |      -      |     -      |     -      |               -               |       -        |           R           |     R      |
@@ -102,13 +97,11 @@ Key:
 | Public models            |   R   |    R    |      R       |          -          |          -           |       R        |     R     |     R     |     R     |      R      |     R      |     R      |               R               |       R        |           R           |     R      |
 | Service tokens           |   -   |    -    |      -       |          -          |          -           |       -        |     -     |     -     |     -     |      -      |     -      |     -      |               -               |       -        |           -           |     -      |
 | Webhooks                 |   W   |    -    |      -       |          -          |          -           |       -        |     W     |     -     |     -     |      -      |     -      |     -      |               -               |       -        |           -           |     -      |
-</FilterableTable>
 
 <sup>*</sup>**Cost Insights Admin** can edit [platform metadata credentials](/docs/explore/set-up-cost-insights#configure-platform-metadata-credentials) and [Cost Insights](/docs/explore/set-up-cost-insights) settings in **Connection settings**, even though **Connections** is read-only (**R**) for this permission set.
 
 #### Project access for project permissions
 
-<FilterableTable>
 |Project-level permission  | Admin | Analyst | Analyst read<sup>***</sup> | Cost Insights Admin | Cost Insights Viewer | Database admin | Developer | Fusion admin | Git Admin | Job admin | Job creator | Job runner  | Job viewer  | Metadata (Discovery API only) | Semantic Layer | Stakeholder/Read-Only | Team admin |
 |--------------------------|:-----:|:-------:|:------------:|:-------------------:|:--------------------:|:--------------:|:---------:|:------------:|:---------:|:---------:|:-----------:|:-----------:|:-----------:|:---------------------------------------:|:--------------:|:-----------:|:----------:|
 | Environment credentials  |   W   |    R    |      R       |         -           |          -           |       W        |     R     |      -       |     R     |     W     |      R      |    -        |      -      |                  -                      |        -       |     R       |     R      |
@@ -126,7 +119,6 @@ Key:
 | Runs                     |   W   |    R<sup>*</sup>   |      R       |         -           |          -           |       R<sup>*</sup>       |     R<sup>*</sup>    |      -       |     R<sup>*</sup>    |     W     |      W      |      W      |      R      |                  -                      |       -        |     R       |     R<sup>*</sup>     |
 | Semantic Layer config    |   W   |    R    |      R       |         -           |          -           |       W        |     R     |      -       |     R     |     R     |      R      |      -      |      -      |                  -                      |        W       |     R       |     R      |
 
-</FilterableTable>
 
 <sup>*</sup>These permissions are `R`ead-only by default, but may be changed to `W`rite with [environment permissions](/docs/platform/manage-access/environment-permissions#environments-and-roles).
 

--- a/website/src/components/filterableTable/index.js
+++ b/website/src/components/filterableTable/index.js
@@ -370,13 +370,21 @@ const FilterableTable = ({ children }) => {
     );
   }
 
+  // Table data is parsed from the DOM after mount, so during SSR (and for
+  // no-JS visitors and the markdown derived from the built HTML) there is no
+  // parsed data yet. Show the source table itself until parsing completes
+  // rather than a "Loading table..." placeholder, so the static HTML always
+  // contains the real rows.
+  const isParsed = headers.length > 0;
+
   return (
     <div className={styles.filterableTableContainer}>
-      {/* Hidden table for data extraction */}
-      <table ref={tableRef} style={{ display: 'none' }}>
+      {/* Source table: visible until parsed, then kept (hidden) for re-parsing */}
+      <table ref={tableRef} style={isParsed ? { display: 'none' } : undefined}>
         {children}
       </table>
 
+      {isParsed && (
       <div className={styles.tableWrapper}>
         {/* Search bar positioned at top right - always visible */}
         <div className={styles.searchBar}>
@@ -571,6 +579,7 @@ const FilterableTable = ({ children }) => {
           </table>
         )}
       </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## What are you changing in this pull request and why?

Follow-up to #9765.

While reading through the generated per-page `.md` I noticed every table is trailed by a stray `Search table...` line and an empty `| Loading table... |` placeholder table -- and on the site itself, anyone browsing without JavaScript sees only that placeholder, never the rows.

### What seems to happen?

`FilterableTable` wraps every markdown table on the site (`src/theme/MDXComponents/index.js` maps `table` to it). It parses its data with `parseTableFromDOM()` inside a `useEffect`, which never runs during SSR. The static HTML therefore contains:

- the real source table, but as `<table style="display: none">` (used only as a parsing source), and
- a visible "Search table..." box plus a `Loading table...` placeholder row.

So a non-JS visitor (or a search-engine crawler that doesn't execute JS) gets the placeholder with the real rows hidden.

The generated `.md` has a different issue: the HTML-to-markdown step ([hast-util-to-mdast 10.1.2](https://github.com/syntax-tree/hast-util-to-mdast/blob/10.1.2/lib/handlers/table.js), via the [@signalwire/docusaurus-plugin-llms-txt 2.0.0-alpha.2](https://www.npmjs.com/package/@signalwire/docusaurus-plugin-llms-txt/v/2.0.0-alpha.2) pipeline) doesn't evaluate inline styles -- its table handler has no `display`/`visibility` checks -- so the hidden table converts fine, and the placeholder comes along right after it.

So for example, https://docs.getdbt.com/docs/dbt-versions.md :

```
### Release channels[​](#release-channels "Direct link to Release channels")

Fusion is distributed through release channels during the preview period:

| Channel  | Description                            | Stability                                                           |
| -------- | -------------------------------------- | ------------------------------------------------------------------- |
| `latest` | The stable, "known good" version       | ✅ Recommended for most users                                       |
| `canary` | The latest officially released version | ⚠️ Most recent stable version but still undergoing thorough testing |
| `dev`    | The latest development build           | ❌ May not have passed all tests                                    |

Search table...

|                  |   |   |   |   |
| ---------------- | - | - | - | - |
| Loading table... |   |   |   |   |
```

And also https://docs.getdbt.com/docs/platform/about-platform/access-regions-ip-addresses.md shows a `|   |` stub under each heading (see second commit).

From my rough/quick search, roughly 330/~1300 pages are affected.

### The fix

Change the loading state.

Until parsing completes, render the source table visibly and don't mount the search/filter UI. Once `useEffect` has parsed the rows, hide the source table and show the interactive one -- exactly what happens today, just with the plain table (rather than a placeholder) as the initial state.

Hydration is safe: the server render and the first client render both produce the plain source table (parsed data is always empty at that point), and the swap to the interactive table happens after mount, as before.

### Also: redundant explicit wrappers (second commit)

Two files wrap tables in an explicit `<FilterableTable>` (`access-regions-ip-addresses.md` and `snippets/_enterprise-permissions-table.md`).

Since every markdown table is auto-wrapped via the MDXComponents mapping, that nests the component inside itself -- the outer instance's hidden source table contains the inner component rather than rows, which is what converts to the stray two-line `|   |` stub visible on the regions page today, and it stacks a second search bar on the rendered page. The second commit drops the explicit wrappers; the tables keep their search/filter UI through the automatic mapping.

### tl;dr

The generated `.md` now shows the clean tables.

No `Search table...` / `Loading table...` artifacts, no stubs -- and no-JS visitors see the real rows.

Users with JS enabled should see no behaviour change, as the table upgrades to searchable/filterable on mount(?).

> Verified with a full local build, but would love to test this on Vercel (that's where PRs are built, right?).

Happy to rework the approach if you'd rather solve it differently -- e.g. parsing the MDX children directly instead of the DOM would allow SSR-rendering the interactive shell too, but that's a much bigger change and this cleans up the output everywhere with a small diff.

#### References (versions in use)

Triple check versions (see package.json), when looking at source code for dependencies.

- [@signalwire/docusaurus-plugin-llms-txt 2.0.0-alpha.2](https://www.npmjs.com/package/@signalwire/docusaurus-plugin-llms-txt/v/2.0.0-alpha.2) (per `website/package.json`; the [repo](https://github.com/signalwire/docusaurus-plugins)'s latest tag is `v1.2.2` and its `main` currently corresponds to `2.0.0-alpha.7`, so source links point at `main` -- the transformation pipeline is unchanged between alpha.2 and alpha.7)
- Conversion pipeline assembly: [plugin-registry.ts](https://github.com/signalwire/docusaurus-plugins/blob/main/packages/docusaurus-plugin-llms-txt/src/transformation/plugins/plugin-registry.ts) (`rehype-parse` -> [rehype-remark 10.0.1](https://github.com/rehypejs/rehype-remark/tree/10.0.1) -> `remark-stringify`)
- [hast-util-to-mdast 10.1.2 table handler](https://github.com/syntax-tree/hast-util-to-mdast/blob/10.1.2/lib/handlers/table.js) -- no style handling anywhere in `lib/` at that tag, which is why the `display: none` table still converts.

## Checklist

- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content. (Component/theme change; the only content edits remove redundant `<FilterableTable>` wrappers, no prose changes.)
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content) -- not applicable, no versioned content touched.
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/release-notes) -- not applicable, no product behaviour change.
