### PR TITLE
Close the unterminated code fence in the alias snapshot example

### DIFF
--- a/website/docs/reference/resource-configs/alias.md
+++ b/website/docs/reference/resource-configs/alias.md
@@ -126,6 +126,8 @@ snapshots:
   - name: your_snapshot_name
     config:
       alias: the_best_snapshot
+```
+
 </File>
 
 In `snapshots/your_snapshot.sql` file:


### PR DESCRIPTION
## What are you changing in this pull request and why?

One-line fix for a garbled example on [reference/resource-configs/alias](https://docs.getdbt.com/reference/resource-configs/alias): the `snapshots/snapshot_name.yml` example opens a ` ```yml ` fence and never closes it.

The still-open fence swallows everything up to the next example's closing fence, so the page currently renders the raw `</File>` tag, the "In `snapshots/your_snapshot.sql` file:" prose, and the literal `<File name='snapshots/your_snapshot.sql'>` tag inside the YAML code block.

<img width="1785" height="1088" alt="image" src="https://github.com/user-attachments/assets/ca7a21a6-97cb-4319-8db5-4218f228c742" />


What readers see today (inside the code block):

```
snapshots:
  - name: your_snapshot_name
    config:
      alias: the_best_snapshot
</File>

In `snapshots/your_snapshot.sql` file:

<File name='snapshots/your_snapshot.sql'>
```

The fix is adding the missing closing ` ``` ` after the YAML example, which restores the two examples to separate, properly rendered `<File>` blocks. I noticed it while checking the generated per-page `.md` (the garbling comes through there too), but the bug is visible on the live page itself.

## Checklist

- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content) -- not applicable, formatting fix only.
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/release-notes) -- not applicable.