### PR TITLE
Give each tab panel a labelled heading in generated markdown

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -2,6 +2,7 @@ import path from "path";
 import math from "remark-math";
 import katex from "rehype-katex";
 import rehypeCodeLanguage from "./plugins/rehypeCodeLanguage.js";
+import rehypeTabsToHeadings from "./plugins/rehypeTabsToHeadings.js";
 import remarkBlogFootnoteLinks from "./plugins/remarkBlogFootnoteLinks.js";
 const { themes } = require('prism-react-renderer')
 
@@ -392,7 +393,7 @@ var siteSettings = {
           relativePaths: false,
         },
         processing: {
-          beforeDefaultRehypePlugins: [rehypeCodeLanguage],
+          beforeDefaultRehypePlugins: [rehypeCodeLanguage, rehypeTabsToHeadings],
         },
         include: {
           includeBlog: false,

--- a/website/plugins/rehypeTabsToHeadings.js
+++ b/website/plugins/rehypeTabsToHeadings.js
@@ -1,0 +1,99 @@
+/**
+ * Rehype plugin that restructures Docusaurus tabs for markdown conversion.
+ *
+ * A `<Tabs>` block renders as:
+ *
+ *   <div class="tabs-container">
+ *     <ul role="tablist"><li role="tab">Models</li><li role="tab">Seeds</li>...</ul>
+ *     <div><div role="tabpanel">...</div><div role="tabpanel" hidden>...</div>...</div>
+ *   </div>
+ *
+ * Converted to markdown as-is, the labels become an orphaned bullet list and
+ * every panel's content is concatenated with nothing marking where one tab
+ * ends and the next begins. Replace the tablist with a heading per panel,
+ * carrying that panel's label, so the generated markdown keeps the structure:
+ *
+ *   ### Models
+ *   ...panel content...
+ *   ### Seeds
+ *   ...
+ *
+ * Labels map to panels by order, which is how Docusaurus renders them. Panels
+ * are un-hidden so downstream processing treats them all alike. Nested tabs
+ * inside a panel are handled by the continuing traversal.
+ *
+ * Runs in the @signalwire/docusaurus-plugin-llms-txt conversion pipeline only
+ * (beforeDefaultRehypePlugins); the rendered site is unaffected.
+ */
+import { visit } from "unist-util-visit";
+
+function isElement(node) {
+  return node?.type === "element";
+}
+
+function textOf(node) {
+  if (node.type === "text") {
+    return node.value;
+  }
+  return (node.children || []).map(textOf).join("");
+}
+
+export default function rehypeTabsToHeadings() {
+  return (tree) => {
+    visit(tree, "element", (node) => {
+      const className = node.properties?.className;
+      if (!Array.isArray(className) || !className.includes("tabs-container")) {
+        return;
+      }
+
+      const tablist = node.children?.find(
+        (child) => isElement(child) && child.properties?.role === "tablist"
+      );
+      if (!tablist) {
+        return;
+      }
+
+      const labels = (tablist.children || [])
+        .filter((child) => isElement(child) && child.properties?.role === "tab")
+        .map((child) => textOf(child).trim());
+
+      // Panels sit either directly in the container or one wrapper div down.
+      const panels = [];
+      for (const child of node.children) {
+        if (child === tablist || !isElement(child)) {
+          continue;
+        }
+        if (child.properties?.role === "tabpanel") {
+          panels.push(child);
+          continue;
+        }
+        for (const grandchild of child.children || []) {
+          if (isElement(grandchild) && grandchild.properties?.role === "tabpanel") {
+            panels.push(grandchild);
+          }
+        }
+      }
+      if (panels.length === 0) {
+        return;
+      }
+
+      const rebuilt = [];
+      panels.forEach((panel, index) => {
+        const label = labels[index];
+        if (label) {
+          rebuilt.push({
+            type: "element",
+            tagName: "h3",
+            properties: {},
+            children: [{ type: "text", value: label }],
+          });
+        }
+        if (panel.properties) {
+          delete panel.properties.hidden;
+        }
+        rebuilt.push(panel);
+      });
+      node.children = rebuilt;
+    });
+  };
+}


### PR DESCRIPTION
## What are you changing in this pull request and why?

Follow-up to #9765, follows on from the other generated-markdown cleanups.

Pages using `<Tabs>` lose their structure in the generated per-page `.md`: the tab labels convert to an orphaned bullet list, and then every panel's content is concatenated with nothing marking where one tab ends and the next begins.

A reader can't tell which content belongs to which tab.

FWIW, 186 built pages use tabs.

For example, [alias.md](https://docs.getdbt.com/reference/resource-configs/alias.md) shows:

```markdown
* Models
* Seeds
* Snapshots
* Tests

Specify a custom alias for a model in your project YAML file...
```

(...followed by the Seeds, Snapshots, and Tests panels with no separators at all.)

After:

```markdown
### Models

Specify a custom alias for a model in your project YAML file...

### Seeds

Configure a seed's alias in your project file...
```

### How

Another plugin :-).

The `rehypeTabsToHeadings` plugin in the llms-txt conversion pipeline (`processing.beforeDefaultRehypePlugins`, alongside `rehypeCodeLanguage`). For each `.tabs-container` it drops the `role="tablist"` label list and inserts a heading carrying each label before its matching `role="tabpanel"`.

Labels map to panels by order, which is how Docusaurus renders them; the `hidden` attribute on inactive panels is removed so they all convert alike, and nested tabs inside a panel are handled by the continuing traversal. The plugin only runs during HTML-to-markdown conversion -- the rendered site is untouched.

## One judgement call please

The inserted headings are fixed at `h3`.

Tabs usually sit under an `h2` section so that reads naturally; a page whose tabs sit under a deeper heading would get a slightly off level.

Figuring out the level from the nearest preceding heading is possible if you'd prefer -- it just didn't seem worth the complexity for a first pass.

Verified with a full local build, tabbed pages now carry one labelled heading per panel and the orphaned label lists are gone.

## Checklist

- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content. (Build tooling only, no content changes.)
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content) -- not applicable.
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/release-notes) -- not applicable.
