### PR TITLE
Document dbt-trino Starburst Data Discovery persist_docs sync

### DIFF
--- a/website/docs/docs/local/connect-data-platform/trino-setup.md
+++ b/website/docs/docs/local/connect-data-platform/trino-setup.md
@@ -64,6 +64,11 @@ The following profile fields are optional to set up. They let you configure your
 | `timezone`                    | `Europe/Brussels`                | The time zone for the Trino session (default: client-side local timezone)                                   |
 | `http_headers`                | `X-Trino-Client-Info: dbt-trino` | HTTP Headers to send alongside requests to Trino, specified as a YAML dictionary of (header, value) pairs.  |
 | `http_scheme`                 | `https` or `http`                | The HTTP scheme to use for requests to Trino   (default: `http`, or `https` if `kerberos`, `ldap` or `jwt`) |
+| `starburst_url`               | `https://my-tenant.galaxy.starburst.io` | The base URL of your Starburst Data Discovery REST API. Must use `https`. Setting this opts in to syncing the model and column descriptions written by [`persist_docs`](/reference/resource-configs/trino-configs#persist_docs) to Starburst's Data Discovery catalog. Available in `dbt-trino` v1.10.3 and later. |
+| `starburst_client_id`         | `{{ env_var('DBT_ENV_SECRET_STARBURST_CLIENT_ID') }}` | The client ID used to authenticate with the Starburst Data Discovery API. Required when `starburst_url` is set. Available in `dbt-trino` v1.10.3 and later. |
+| `starburst_secret_key`        | `{{ env_var('DBT_ENV_SECRET_STARBURST_SECRET_KEY') }}` | The secret key used to authenticate with the Starburst Data Discovery API. Required when `starburst_url` is set. To avoid storing this secret in `profiles.yml`, source it from an environment variable. Available in `dbt-trino` v1.10.3 and later. |
+| `starburst_metadata_failure_strategy` | `continue_on_error` (default) or `fail_fast` | The approach for handling errors from the Data Discovery API when syncing `persist_docs` metadata: `continue_on_error` logs a warning and continues, while `fail_fast` aborts the run. Available in `dbt-trino` v1.10.3 and later. |
+| `starburst_max_column_batch_size` | `100` (default)              | The maximum number of column descriptions sent per batch request when syncing `persist_docs` metadata to Data Discovery. Available in `dbt-trino` v1.10.3 and later. |
 
 ## Authentication parameters
 

--- a/website/docs/reference/resource-configs/persist_docs.md
+++ b/website/docs/reference/resource-configs/persist_docs.md
@@ -137,6 +137,7 @@ The `persist_docs` config is supported on the most widely used dbt adapters:
 - BigQuery
 - Databricks 
 - Apache Spark
+- Starburst Galaxy (via `dbt-trino`)
 
 However, some databases limit where and how descriptions can be added to database objects. Those database adapters might not support `persist_docs`, or might offer only partial support.
 
@@ -193,6 +194,13 @@ Some known issues and limitations:
         alter table analytics.<schema>.<modelname> alter
             "ca_net_ht_N" COMMENT $$This should be the description of the column$$;
         ```
+
+</div>
+
+<div warehouse="Starburst Galaxy (via dbt-trino)">
+
+- Requires configuring an [API Auth token](https://docs.starburst.io/starburst-galaxy/developer-tools/api/api-auth-token.html) and setting `starburst_url`, `starburst_client_id`, and `starburst_secret_key` in the [connection profile](/docs/local/connect-data-platform/trino-setup#additional-parameters).
+
 
 </div>
 

--- a/website/docs/reference/resource-configs/persist_docs.md
+++ b/website/docs/reference/resource-configs/persist_docs.md
@@ -197,7 +197,7 @@ Some known issues and limitations:
 
 </div>
 
-<div warehouse="Starburst Galaxy (via dbt-trino)">
+<div warehouse="Starburst Galaxy (dbt-trino)">
 
 - Requires configuring an [API Auth token](https://docs.starburst.io/starburst-galaxy/developer-tools/api/api-auth-token.html) and setting `starburst_url`, `starburst_client_id`, and `starburst_secret_key` in the [connection profile](/docs/local/connect-data-platform/trino-setup#additional-parameters).
 

--- a/website/docs/reference/resource-configs/persist_docs.md
+++ b/website/docs/reference/resource-configs/persist_docs.md
@@ -137,7 +137,7 @@ The `persist_docs` config is supported on the most widely used dbt adapters:
 - BigQuery
 - Databricks 
 - Apache Spark
-- Starburst Galaxy (via `dbt-trino`)
+- Starburst Galaxy (`dbt-trino`)
 
 However, some databases limit where and how descriptions can be added to database objects. Those database adapters might not support `persist_docs`, or might offer only partial support.
 

--- a/website/docs/reference/resource-configs/trino-configs.md
+++ b/website/docs/reference/resource-configs/trino-configs.md
@@ -370,6 +370,20 @@ models:
 ```
 </File>
 
+## persist_docs
+
+_Available in `dbt-trino` v1.10.3 and later_
+
+By default, [`persist_docs`](/reference/resource-configs/persist_docs) writes model and column descriptions to the underlying catalog using `COMMENT ON` SQL statements.
+
+If you set `starburst_url` along with `starburst_client_id` and `starburst_secret_key` in your connection profile, enabling `persist_docs` also syncs the model and column descriptions to Starburst's Data Discovery catalog through its REST API. This is opt-in and additive &mdash; projects that don't set `starburst_url` are unaffected. For details on configuring these profile fields, refer to [Additional parameters](/docs/local/connect-data-platform/trino-setup#additional-parameters) in the Starburst/Trino setup guide.
+
+Column descriptions sync to Data Discovery in batches. The `starburst_max_column_batch_size` parameter controls the batch size with a default of `100`.
+
+The `starburst_metadata_failure_strategy` controls how dbt handles errors from the Data Discovery API:
+- `continue_on_error` (default) &mdash; Logs a warning and continues the run.
+- `fail_fast` &mdash; Aborts the run.
+
 ## Model contracts
 
 The `dbt-trino` adapter supports [model contracts](/docs/mesh/govern/model-contracts). Currently, only [constraints](/reference/resource-properties/constraints) with `type` as `not_null` are supported.


### PR DESCRIPTION
dbt-trino 1.10.3 added optional syncing of persist_docs descriptions to Starburst's Data Discovery catalog.

## What are you changing in this pull request and why?
Adding documentation for the new configuration options for dbt-trino added in [dbt-trino#520](https://github.com/starburstdata/dbt-trino/pull/520)

## Checklist
<!-- Ensure your PR meets the following items. Feel free to add additional checklist items to the list if additional checks need to happen before the PR is merged, such as:
- [ ] Needs technical review
- [ ] Change base branch
- [ ] Merge on xyz date
-->
- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/release-notes).).


