### PR TITLE
Clarify install footprint and fix wizard uninstall command

### DIFF
--- a/website/docs/docs/dbt-ai/wizard-cli.md
+++ b/website/docs/docs/dbt-ai/wizard-cli.md
@@ -58,12 +58,12 @@ wizard update
   wizard uninstall
   ```
 
-  - If you'd rather remove things yourself (or don't have `sudo` access), run the same two commands directly:
-  
-  ```shell
-  sudo rm -f /usr/local/bin/wizard   # remove the binary
-  rm -rf ~/.dbt/wizard                # remove config, chat history, logs, and cache
-  ```
+    - If you'd rather remove things yourself (or don't have `sudo` access), run the same two commands directly:
+    
+    ```shell
+    sudo rm -f /usr/local/bin/wizard   # remove the binary
+    rm -rf ~/.dbt/wizard                # remove config, chat history, logs, and cache
+    ```
 
 :::caution
 Removing `~/.dbt/wizard` is irreversible. Your dbt profiles (`~/.dbt/`) and dbt projects aren't part of <Constant name="wizard" /> and won't be touched.

--- a/website/docs/docs/dbt-ai/wizard-cli.md
+++ b/website/docs/docs/dbt-ai/wizard-cli.md
@@ -52,20 +52,30 @@ wizard update
 
 ## Uninstall
 
-1. Run the built-in uninstall command — it removes the binaries (`dbt-wizard`, `wizard`, `dbt-index`, `dbt-wizard-app-server`) and the `~/.dbt/wizard/` config/data directory:
+Run `wizard uninstall` and follow the prompts. <Constant name="wizard" /> checks what's installed on your machine, tells you what it's about to remove, and asks for your approval before touching anything:
 
-  ```shell
-  wizard uninstall
-  ```
+```shell
+wizard uninstall
+```
 
-2. Confirm when prompted, or skip the prompt with `--force`.
-3. You can then confirm that the binary has been completely removed by checking your system path:
+If you'd rather remove things yourself (or don't have `sudo` access), run the same two commands directly:
 
-  ```bash
-  which dbt-wizard
-  ```
+```shell
+sudo rm -f /usr/local/bin/wizard   # remove the binary
+rm -rf ~/.dbt/wizard                # remove config, chat history, logs, and cache
+```
 
-  If no output path is returned, dbt Wizard is successfully uninstalled.
+:::caution
+Removing `~/.dbt/wizard` is irreversible. Your dbt profiles (`~/.dbt/`) and dbt projects aren't part of <Constant name="wizard" /> and won't be touched.
+:::
+
+Confirm the binary is gone by checking your system path:
+
+```bash
+which wizard
+```
+
+If no output path is returned, <Constant name="wizard" /> is successfully uninstalled.
 
 
 ## Telemetry

--- a/website/docs/docs/dbt-ai/wizard-cli.md
+++ b/website/docs/docs/dbt-ai/wizard-cli.md
@@ -65,7 +65,7 @@ wizard update
     rm -rf ~/.dbt/wizard                # remove local config, logs, and cache
     ```
 
-:::caution
+:::info
 Removing `~/.dbt/wizard` deletes your local config, logs, and cache, and can't be undone. Your dbt profiles (`~/.dbt/`) and dbt projects aren't part of <Constant name="wizard" /> and won't be touched.
 :::
 

--- a/website/docs/docs/dbt-ai/wizard-cli.md
+++ b/website/docs/docs/dbt-ai/wizard-cli.md
@@ -66,7 +66,7 @@ wizard update
     ```
 
 :::caution
-Removing `~/.dbt/wizard` deletes your local config, logs, and cache, and can't be undone. Your dbt profiles (`~/.dbt/`) and dbt projects aren't part of <Constant name="wizard" /> and won't be touched. For how conversation history is stored and deleted, refer to [dbt AI FAQs](/docs/dbt-ai/dbt-ai-faqs).
+Removing `~/.dbt/wizard` deletes your local config, logs, and cache, and can't be undone. Your dbt profiles (`~/.dbt/`) and dbt projects aren't part of <Constant name="wizard" /> and won't be touched.
 :::
 
 2. Confirm the binary is gone by checking your system path:

--- a/website/docs/docs/dbt-ai/wizard-cli.md
+++ b/website/docs/docs/dbt-ai/wizard-cli.md
@@ -55,7 +55,7 @@ wizard update
 1. Run the built-in uninstall command — it removes the binaries (`dbt-wizard`, `wizard`, `dbt-index`, `dbt-wizard-app-server`) and the `~/.dbt/wizard/` config/data directory:
 
   ```shell
-  wizard system uninstall
+  wizard uninstall
   ```
 
 2. Confirm when prompted, or skip the prompt with `--force`.

--- a/website/docs/docs/dbt-ai/wizard-cli.md
+++ b/website/docs/docs/dbt-ai/wizard-cli.md
@@ -54,9 +54,9 @@ wizard update
 
 1. Run `wizard uninstall` and follow the prompts. <Constant name="wizard" /> checks what's installed on your machine, tells you what it's about to remove, and asks for your approval before touching anything:
 
-  ```shell
-  wizard uninstall
-  ```
+    ```shell
+    wizard uninstall
+    ```
 
     - If you'd rather remove things yourself (or don't have `sudo` access), run the same two commands directly:
     
@@ -71,9 +71,9 @@ Removing `~/.dbt/wizard` is irreversible. Your dbt profiles (`~/.dbt/`) and dbt 
 
 2. Confirm the binary is gone by checking your system path:
 
-  ```bash
-  which wizard
-  ```
+    ```bash
+    which wizard
+    ```
 
 If no output path is returned, <Constant name="wizard" /> is successfully uninstalled.
 

--- a/website/docs/docs/dbt-ai/wizard-cli.md
+++ b/website/docs/docs/dbt-ai/wizard-cli.md
@@ -52,7 +52,7 @@ wizard update
 
 ## Uninstall
 
-1. Run the built-in uninstall command. It lists every binary, config, and data directory it's about to remove, then asks you to confirm (`Proceed? [y/N]`) before deleting anything:
+1. Run the built-in uninstall command. It lists every binary, config, and data directory it's about to remove, then asks you to confirm (`Proceed? [Y/N]`) before deleting anything:
 
     ```shell
     wizard system uninstall

--- a/website/docs/docs/dbt-ai/wizard-cli.md
+++ b/website/docs/docs/dbt-ai/wizard-cli.md
@@ -52,22 +52,10 @@ wizard update
 
 ## Uninstall
 
-1. Run the built-in uninstall command. It lists everything it's about to remove and asks you to confirm before deleting anything:
+1. Run the built-in uninstall command. It lists every binary, config, and data directory it's about to remove, then asks you to confirm (`Proceed? [y/N]`) before deleting anything:
 
     ```shell
     wizard system uninstall
-    ```
-
-    ```shell
-    This will remove:
-      /usr/local/bin/dbt-wizard
-      /usr/local/bin/wizard
-      /usr/local/bin/dbt-wizard-app-server
-      /usr/local/bin/dbt-index
-      ~/.dbt/wizard (config directory)
-      ~/Library/Application Support/dbt-wizard (data directory, macOS)
-
-    Proceed? [y/N]:
     ```
 
 :::info Uninstalling Wizard

--- a/website/docs/docs/dbt-ai/wizard-cli.md
+++ b/website/docs/docs/dbt-ai/wizard-cli.md
@@ -62,11 +62,11 @@ If you'd rather remove things yourself (or don't have `sudo` access), run the sa
 
 ```shell
 sudo rm -f /usr/local/bin/wizard   # remove the binary
-rm -rf ~/.dbt/wizard                # remove config, chat history, logs, and cache
+rm -rf ~/.dbt/wizard                # remove local config, logs, and cache
 ```
 
 :::caution
-Removing `~/.dbt/wizard` is irreversible. Your dbt profiles (`~/.dbt/`) and dbt projects aren't part of <Constant name="wizard" /> and won't be touched.
+Removing `~/.dbt/wizard` deletes your local config, logs, and cache, and can't be undone. Your dbt profiles (`~/.dbt/`) and dbt projects aren't part of <Constant name="wizard" /> and won't be touched. For how conversation history is stored and deleted, refer to [dbt AI FAQs](/docs/dbt-ai/dbt-ai-faqs).
 :::
 
 Confirm the binary is gone by checking your system path:

--- a/website/docs/docs/dbt-ai/wizard-cli.md
+++ b/website/docs/docs/dbt-ai/wizard-cli.md
@@ -52,21 +52,26 @@ wizard update
 
 ## Uninstall
 
-1. Run `wizard uninstall` and follow the prompts. <Constant name="wizard" /> checks what's installed on your machine, tells you what it's about to remove, and asks for your approval before touching anything:
+1. Run the built-in uninstall command. It lists everything it's about to remove and asks you to confirm before deleting anything:
 
     ```shell
-    wizard uninstall
+    wizard system uninstall
     ```
 
-    - If you'd rather remove things yourself (or don't have `sudo` access), run the same two commands directly:
-
     ```shell
-    sudo rm -f /usr/local/bin/wizard   # remove the binary
-    rm -rf ~/.dbt/wizard                # remove local config, logs, and cache
+    This will remove:
+      /usr/local/bin/dbt-wizard
+      /usr/local/bin/wizard
+      /usr/local/bin/dbt-wizard-app-server
+      /usr/local/bin/dbt-index
+      ~/.dbt/wizard (config directory)
+      ~/Library/Application Support/dbt-wizard (data directory, macOS)
+
+    Proceed? [y/N]:
     ```
 
 :::caution
-Removing `~/.dbt/wizard` deletes your local config, logs, and cache, and can't be undone. Your dbt profiles (`~/.dbt/`) and dbt projects aren't part of <Constant name="wizard" /> and won't be touched. For how conversation history is stored and deleted, refer to [dbt AI FAQs](/docs/dbt-ai/dbt-ai-faqs).
+This can't be undone. Your dbt profiles (`~/.dbt/`) and dbt projects aren't part of <Constant name="wizard" /> and won't be touched. For how conversation history is stored and deleted, refer to [dbt AI FAQs](/docs/dbt-ai/dbt-ai-faqs).
 :::
 
 2. Confirm the binary is gone by checking your system path:

--- a/website/docs/docs/dbt-ai/wizard-cli.md
+++ b/website/docs/docs/dbt-ai/wizard-cli.md
@@ -65,7 +65,7 @@ wizard update
     rm -rf ~/.dbt/wizard                # remove local config, logs, and cache
     ```
 
-:::info
+:::info Uninstalling Wizard
 Removing `~/.dbt/wizard` deletes your local config, logs, and cache, and can't be undone. Your dbt profiles (`~/.dbt/`) and dbt projects aren't part of <Constant name="wizard" /> and won't be touched.
 :::
 

--- a/website/docs/docs/dbt-ai/wizard-cli.md
+++ b/website/docs/docs/dbt-ai/wizard-cli.md
@@ -62,7 +62,7 @@ wizard update
 Removing `~/.dbt/wizard` deletes your local config, logs, and cache, and can't be undone. Your dbt profiles (`~/.dbt/`) and dbt projects aren't part of <Constant name="wizard" /> and won't be touched.
 :::
 
-2. Confirm the binary is gone by checking your system path:
+2. Confirm the binary is deleted by checking your system path:
 
     ```bash
     which wizard

--- a/website/docs/docs/dbt-ai/wizard-cli.md
+++ b/website/docs/docs/dbt-ai/wizard-cli.md
@@ -52,28 +52,28 @@ wizard update
 
 ## Uninstall
 
-Run `wizard uninstall` and follow the prompts. <Constant name="wizard" /> checks what's installed on your machine, tells you what it's about to remove, and asks for your approval before touching anything:
+1. Run `wizard uninstall` and follow the prompts. <Constant name="wizard" /> checks what's installed on your machine, tells you what it's about to remove, and asks for your approval before touching anything:
 
-```shell
-wizard uninstall
-```
+  ```shell
+  wizard uninstall
+  ```
 
-If you'd rather remove things yourself (or don't have `sudo` access), run the same two commands directly:
-
-```shell
-sudo rm -f /usr/local/bin/wizard   # remove the binary
-rm -rf ~/.dbt/wizard                # remove config, chat history, logs, and cache
-```
+  - If you'd rather remove things yourself (or don't have `sudo` access), run the same two commands directly:
+  
+  ```shell
+  sudo rm -f /usr/local/bin/wizard   # remove the binary
+  rm -rf ~/.dbt/wizard                # remove config, chat history, logs, and cache
+  ```
 
 :::caution
 Removing `~/.dbt/wizard` is irreversible. Your dbt profiles (`~/.dbt/`) and dbt projects aren't part of <Constant name="wizard" /> and won't be touched.
 :::
 
-Confirm the binary is gone by checking your system path:
+2. Confirm the binary is gone by checking your system path:
 
-```bash
-which wizard
-```
+  ```bash
+  which wizard
+  ```
 
 If no output path is returned, <Constant name="wizard" /> is successfully uninstalled.
 

--- a/website/docs/docs/local/install-dbt.md
+++ b/website/docs/docs/local/install-dbt.md
@@ -43,6 +43,8 @@ To upgrade later, run `brew upgrade dbt`.
 curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh -s -- --update
 ```
 
+This installs the dbt binary to a local user directory and adds it to your `$PATH`. See [uninstalling a curl install](#frequently-asked-questions) if you ever need to remove it.
+
 Close and reopen your terminal (or run `exec $SHELL`) so the new `$PATH` is recognized. 
 
 To upgrade later, run `dbt system update`.

--- a/website/docs/docs/local/install-dbt.md
+++ b/website/docs/docs/local/install-dbt.md
@@ -43,7 +43,7 @@ To upgrade later, run `brew upgrade dbt`.
 curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh -s -- --update
 ```
 
-This installs the dbt binary to `~/.local/bin/dbt` and adds that directory to your `$PATH`. See [uninstalling a curl install](#frequently-asked-questions) if you ever need to remove it.
+This installs the dbt binary to `~/.local/bin/dbt` and adds that directory to your `$PATH`. See [uninstalling a curl install](#faqs) if you ever need to remove it.
 
 Close and reopen your terminal (or run `exec $SHELL`) so the new `$PATH` is recognized. 
 
@@ -101,7 +101,7 @@ Common issues and resolutions:
 - **Version conflicts:** Check that no other <Constant name="core" /> or <Constant name="platform_cli" /> versions are installed or active on your machine.
 - **Installation permissions:** Make sure your user account can install software locally.
 
-## Frequently asked questions
+## FAQs
 
 - <Expandable alt_header="Can I revert to my previous dbt installation?">
     Yes. To test a new install without affecting your existing workflows, use a separate environment or virtual machine.

--- a/website/docs/docs/local/install-dbt.md
+++ b/website/docs/docs/local/install-dbt.md
@@ -43,7 +43,7 @@ To upgrade later, run `brew upgrade dbt`.
 curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh -s -- --update
 ```
 
-This installs the dbt binary to a local user directory and adds it to your `$PATH`. See [uninstalling a curl install](#frequently-asked-questions) if you ever need to remove it.
+This installs the dbt binary to `~/.local/bin/dbt` and adds that directory to your `$PATH`. See [uninstalling a curl install](#frequently-asked-questions) if you ever need to remove it.
 
 Close and reopen your terminal (or run `exec $SHELL`) so the new `$PATH` is recognized. 
 

--- a/website/snippets/_wizard-cli-install-by-version.md
+++ b/website/snippets/_wizard-cli-install-by-version.md
@@ -9,7 +9,7 @@ Install <Constant name="wizard"/> as `wizard` on your `PATH` using the curl scri
 curl -fsSL https://public.cdn.getdbt.com/dbt-wizard/install/install-wizard.sh | sh
 ```
 
-This installs <Constant name="wizard"/> to `/usr/local/bin/dbt-wizard`, along with its supporting binaries (including `dbt-index`, the [metadata engine](/docs/dbt-ai/wizard-how-it-works#native-metadata-engine) that powers <Constant name="wizard"/>'s project-aware answers). See [Uninstall](/docs/dbt-ai/wizard-cli#uninstall) if you ever need to remove them.
+This installs <Constant name="wizard"/> to `/usr/local/bin/wizard`, along with `dbt-index`, the [metadata engine](/docs/dbt-ai/wizard-how-it-works#native-metadata-engine) that powers <Constant name="wizard"/>'s project-aware answers. See [Uninstall](/docs/dbt-ai/wizard-cli#uninstall) if you ever need to remove them.
 
 </TabItem>
 <TabItem value="windows" label="Windows">

--- a/website/snippets/_wizard-cli-install-by-version.md
+++ b/website/snippets/_wizard-cli-install-by-version.md
@@ -9,7 +9,7 @@ Install <Constant name="wizard"/> as `wizard` on your `PATH` using the curl scri
 curl -fsSL https://public.cdn.getdbt.com/dbt-wizard/install/install-wizard.sh | sh
 ```
 
-This installs <Constant name="wizard"/> to `/usr/local/bin/dbt-wizard`, along with its supporting binaries (including `dbt-index`, the search index <Constant name="wizard"/> uses to answer questions about your project). See [Uninstall](/docs/dbt-ai/wizard-cli#uninstall) if you ever need to remove them.
+This installs <Constant name="wizard"/> to `/usr/local/bin/dbt-wizard`, along with its supporting binaries (including `dbt-index`, which indexes your project's metadata so <Constant name="wizard"/> can answer questions about it). See [Uninstall](/docs/dbt-ai/wizard-cli#uninstall) if you ever need to remove them.
 
 </TabItem>
 <TabItem value="windows" label="Windows">

--- a/website/snippets/_wizard-cli-install-by-version.md
+++ b/website/snippets/_wizard-cli-install-by-version.md
@@ -9,6 +9,8 @@ Install <Constant name="wizard"/> as `wizard` on your `PATH` using the curl scri
 curl -fsSL https://public.cdn.getdbt.com/dbt-wizard/install/install-wizard.sh | sh
 ```
 
+This installs <Constant name="wizard"/> and its supporting binaries to your local `$PATH`. See [Uninstall](/docs/dbt-ai/wizard-cli#uninstall) if you ever need to remove them.
+
 </TabItem>
 <TabItem value="windows" label="Windows">
 

--- a/website/snippets/_wizard-cli-install-by-version.md
+++ b/website/snippets/_wizard-cli-install-by-version.md
@@ -9,7 +9,7 @@ Install <Constant name="wizard"/> as `wizard` on your `PATH` using the curl scri
 curl -fsSL https://public.cdn.getdbt.com/dbt-wizard/install/install-wizard.sh | sh
 ```
 
-This installs <Constant name="wizard"/> to `/usr/local/bin/dbt-wizard`, along with its supporting binaries (including `dbt-index`, which indexes your project's metadata so <Constant name="wizard"/> can answer questions about it). See [Uninstall](/docs/dbt-ai/wizard-cli#uninstall) if you ever need to remove them.
+This installs <Constant name="wizard"/> to `/usr/local/bin/dbt-wizard`, along with its supporting binaries (including `dbt-index`, the [metadata engine](/docs/dbt-ai/wizard-how-it-works#native-metadata-engine) that powers <Constant name="wizard"/>'s project-aware answers). See [Uninstall](/docs/dbt-ai/wizard-cli#uninstall) if you ever need to remove them.
 
 </TabItem>
 <TabItem value="windows" label="Windows">

--- a/website/snippets/_wizard-cli-install-by-version.md
+++ b/website/snippets/_wizard-cli-install-by-version.md
@@ -9,7 +9,7 @@ Install <Constant name="wizard"/> as `wizard` on your `PATH` using the curl scri
 curl -fsSL https://public.cdn.getdbt.com/dbt-wizard/install/install-wizard.sh | sh
 ```
 
-This installs <Constant name="wizard"/> and its supporting binaries to your local `$PATH`. See [Uninstall](/docs/dbt-ai/wizard-cli#uninstall) if you ever need to remove them.
+This installs <Constant name="wizard"/> to `/usr/local/bin/dbt-wizard`, along with its supporting binaries (including `dbt-index`, the search index <Constant name="wizard"/> uses to answer questions about your project). See [Uninstall](/docs/dbt-ai/wizard-cli#uninstall) if you ever need to remove them.
 
 </TabItem>
 <TabItem value="windows" label="Windows">


### PR DESCRIPTION
## What changed
Follow-up to #9646 and #9667.

- Added a one-line note under each curl/PowerShell install command (fusion and wizard) explaining that it installs a binary and updates `$PATH`. This addresses the "it installs binaries and modifies my system without explaining what will happen" concern from #9646 without going into exhaustive per-OS path detail.
- Fixed `wizard-cli.md`: the uninstall command is `wizard uninstall`, not `wizard system uninstall`. This was flagged and confirmed in the Slack follow-up after #9667 merged but never made it into the docs.

Closes https://github.com/dbt-labs/docs.getdbt.com/issues/9789

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-worktree-wizard-uninstall-clarity-dbt-labs.vercel.app/docs/dbt-ai/wizard-cli
- https://docs-getdbt-com-git-worktree-wizard-uninstall-clarity-dbt-labs.vercel.app/docs/local/install-dbt

<!-- end-vercel-deployment-preview -->