### PR TITLE
"Versioning APIs" ~~> "Evolving APIs" in  model-versions.md

### DIFF
--- a/website/docs/docs/mesh/govern/model-versions.md
+++ b/website/docs/docs/mesh/govern/model-versions.md
@@ -13,7 +13,7 @@ import LatestVersionPointerCollision from '/snippets/_latest-version-pointer-col
 
 <VersionsCallout />
 
-Versioning APIs is a hard problem in software engineering. The root of the challenge is that the producers and consumers of an API have competing incentives:
+Evolving APIs is a hard problem in software engineering. The root of the challenge is that the producers and consumers of an API have competing incentives:
 - Producers of an API need the ability to modify its logic and structure. There is a real cost to maintaining legacy endpoints forever, but losing the trust of downstream users is far costlier.
 - Consumers of an API need to trust in its stability: their queries will keep working, and won't break without warning. Although migrating to a newer API version incurs an expense, an unplanned migration is far costlier.
 


### PR DESCRIPTION
The last sentence of the section says that "versioning" is a tool to solve the problem, so it would be better to name the problem itself differently. Hence the suggestion: `Versioning APIs is a hard problem` ~~> `Evolving APIs is a hard problem`.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-vgapeyev-patch-1-dbt-labs.vercel.app/docs/mesh/govern/model-versions

<!-- end-vercel-deployment-preview -->