### PR TITLE
Serve Markdown to AI clients via Accept header

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,6 +1,15 @@
 {
   "cleanUrls": true,
   "trailingSlash": false,
+  "rewrites": [
+    {
+      "source": "/:path((?!.*\\.).*)",
+      "has": [
+        { "type": "header", "key": "accept", "value": ".*text/markdown.*" }
+      ],
+      "destination": "/:path.md"
+    }
+  ],
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## What changed

Adds content negotiation to `website/vercel.json`: when a request's `Accept` header prefers Markdown, Vercel serves the page's sibling `.md` file instead of the HTML page. Same URL — the response format just adapts to who's asking.

- Humans (browsers send `Accept: text/html`) get the normal page, untouched.
- AI tools/agents that send `Accept: text/markdown` get the clean `.md` we already generate.
- Rewrite (not redirect), so the URL a user pastes never changes.

The `source` regex matches only extensionless paths, so `.md`, CSS, JS, and image requests are skipped.

## How to test

On the preview deployment:

```bash
# Should return Markdown
curl -H "Accept: text/markdown" <preview-url>/docs/build/cumulative

# Should return HTML (unchanged)
curl <preview-url>/docs/build/cumulative
```

## Open items

- Confirm which AI clients send `text/markdown` vs `text/plain` — the `value` match may need widening.
- Pages without a generated `.md` will 404 for Markdown-preferring clients. Confirm coverage from the llms-txt plugin.
- Follow-up PR: add `<link rel="alternate" type="text/markdown">` to page `<head>` for clients that don't send the header (for example, Codex CLI).