### PR TITLE
Add dbt Core v1.12 Live CTA to dbt Core upgrade guides

### DIFF
--- a/website/blog/ctas.yml
+++ b/website/blog/ctas.yml
@@ -47,3 +47,9 @@
   subheader: Meet us in Las Vegas, September 15–18, to learn from other dbt practitioners, swap ideas, and come together to shape the future of data and AI.
   button_text: Learn more
   url: https://www.getdbt.com/dbt-summit/?utm_medium=internal&utm_source=docs&utm_campaign=q3-2027_dbt-summit-2026_aw&utm_content=dbt-summit____&utm_term=all_all__
+
+- name: dbt_core_v1_12_live
+  header: "dbt Core v1.12 Live"
+  subheader: Release updates, the road to dbt Core v2.0, and Q&A. Join a global-friendly session on August 26 or 27.
+  button_text: Register here
+  url: https://www.getdbt.com/resources/webinars/dbt-core-v1-12-live/?utm_medium=internal&utm_source=www&utm_campaign=q3-2027_dbt-core-v1.12-live_aw&utm_content=themed-webinar____&utm_term=all_all__

--- a/website/blog/ctas.yml
+++ b/website/blog/ctas.yml
@@ -52,4 +52,4 @@
   header: "dbt Core v1.12 Live"
   subheader: Release updates, the road to dbt Core v2.0, and Q&A. Join a global-friendly session on August 26 or 27.
   button_text: Register here
-  url: https://www.getdbt.com/resources/webinars/dbt-core-v1-12-live/?utm_medium=internal&utm_source=www&utm_campaign=q3-2027_dbt-core-v1.12-live_aw&utm_content=themed-webinar____&utm_term=all_all__
+  url: https://www.getdbt.com/resources/webinars/dbt-core-v1-12-live/?utm_medium=internal&utm_source=docs&utm_campaign=q3-2027_dbt-core-v1.12-live_aw&utm_content=themed-webinar____&utm_term=all_all__

--- a/website/docs/docs/dbt-versions/core-upgrade/01-upgrading-to-v2.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/01-upgrading-to-v2.md
@@ -3,6 +3,7 @@ title: "Upgrading to v2"
 id: upgrading-to-v2
 description: New features and changes in v2
 displayed_sidebar: "docs"
+cta: dbt_core_v1_12_live
 availability:
   engine: v2
   access: free

--- a/website/docs/docs/dbt-versions/core-upgrade/03-upgrading-to-v1.12.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/03-upgrading-to-v1.12.md
@@ -3,6 +3,7 @@ title: "Upgrading to v1.12"
 id: upgrading-to-v1.12
 description: New features and changes in dbt Core v1.12
 displayed_sidebar: "docs"
+cta: dbt_core_v1_12_live
 availability:
   engine: v1
   access: free

--- a/website/docs/docs/dbt-versions/core-upgrade/04-upgrading-to-v1.11.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/04-upgrading-to-v1.11.md
@@ -3,6 +3,7 @@ title: "Upgrading to v1.11"
 id: upgrading-to-v1.11
 description: New features and changes in dbt Core v1.11
 displayed_sidebar: "docs"
+cta: dbt_core_v1_12_live
 availability:
   engine: v1
   access: free

--- a/website/docs/docs/dbt-versions/core-upgrade/05-upgrading-to-v1.10.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/05-upgrading-to-v1.10.md
@@ -3,6 +3,7 @@ title: "Upgrading to v1.10"
 id: upgrading-to-v1.10
 description: New features and changes in dbt Core v1.10
 displayed_sidebar: "docs"
+cta: dbt_core_v1_12_live
 availability:
   engine: v1
   access: free

--- a/website/docs/docs/dbt-versions/core-upgrade/06-upgrading-to-v1.9.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/06-upgrading-to-v1.9.md
@@ -3,6 +3,7 @@ title: "Upgrading to v1.9"
 id: upgrading-to-v1.9
 description: New features and changes in dbt Core v1.9
 displayed_sidebar: "docs"
+cta: dbt_core_v1_12_live
 availability:
   engine: v1
   access: free

--- a/website/docs/docs/dbt-versions/core-upgrade/07-upgrading-to-v1.8.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/07-upgrading-to-v1.8.md
@@ -3,6 +3,7 @@ title: "Upgrading to v1.8"
 id: upgrading-to-v1.8
 description: New features and changes in dbt Core v1.8
 displayed_sidebar: "docs"
+cta: dbt_core_v1_12_live
 availability:
   engine: v1
   access: free

--- a/website/docs/docs/dbt-versions/core-upgrade/08-upgrading-to-v1.7.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/08-upgrading-to-v1.7.md
@@ -3,6 +3,7 @@ title: "Upgrading to v1.7"
 id: upgrading-to-v1.7
 description: New features and changes in dbt Core v1.7
 displayed_sidebar: "docs"
+cta: dbt_core_v1_12_live
 availability:
   engine: v1
   access: free


### PR DESCRIPTION
## What are you changing in this pull request and why?

Adds the **dbt Core v1.12 Live** webinar CTA to the dbt Core upgrade guides, per [GTM-1031617](https://fivetran.atlassian.net/browse/GTM-1031617).

Two changes:

1. **`website/blog/ctas.yml`** — new `dbt_core_v1_12_live` entry (header, subheader, button text, and the campaign URL).
2. **Seven upgrade guides** — added `cta: dbt_core_v1_12_live` to the frontmatter of each.

The CTA renders in the right-hand table-of-contents sidebar via the existing `CTA` component (`website/src/components/cta/index.js`), which `DocItem/Layout` passes the frontmatter value into.

### Slugs the CTA appears on

| Slug | Source file |
|---|---|
| `/docs/dbt-versions/core-upgrade/upgrading-to-v2` | `01-upgrading-to-v2.md` |
| `/docs/dbt-versions/core-upgrade/upgrading-to-v1.12` | `03-upgrading-to-v1.12.md` |
| `/docs/dbt-versions/core-upgrade/upgrading-to-v1.11` | `04-upgrading-to-v1.11.md` |
| `/docs/dbt-versions/core-upgrade/upgrading-to-v1.10` | `05-upgrading-to-v1.10.md` |
| `/docs/dbt-versions/core-upgrade/upgrading-to-v1.9` | `06-upgrading-to-v1.9.md` |
| `/docs/dbt-versions/core-upgrade/upgrading-to-v1.8` | `07-upgrading-to-v1.8.md` |
| `/docs/dbt-versions/core-upgrade/upgrading-to-v1.7` | `08-upgrading-to-v1.7.md` |

All source files live in `website/docs/docs/dbt-versions/core-upgrade/`.

### Notes for reviewers

- **This is the first use of `cta:` frontmatter on a docs page.** The mechanism already existed but had only ever been used by the blog (globally, via `blog/metadata.yml`). Rendering was confirmed locally on the v1.12 page.
- **Desktop only.** The CTA renders in the desktop TOC; the mobile `TOCCollapsible` doesn't include it.
- **Requires a TOC.** `DocItem/Layout` gates the sidebar on `canRender = !hidden && toc.length > 0`, so a page with `hide_table_of_contents: true` or no `##` headings can't show the CTA. All seven pages here have headings. This is why `/docs/fusion/about-core` was considered and excluded — it has only an `h1`, so no sidebar renders at all. A page banner (`website/page-banners.yml`) would be the route there if it's wanted later.
- **UTMs use `utm_source=docs`**, confirmed with the data team. The URL originally supplied in the ticket used `utm_source=www`, which would have attributed docs-sourced clicks to the marketing site; corrected in 6a2b7cd. This now matches the other six entries in `ctas.yml`.
- **Timing:** sessions are August 26–27, so this wants to merge well before then.

Not included: the archived upgrade guides under `11-Older versions/` (v1.6 and earlier), and the dbt Core install pages under `docs/docs/local/`. Happy to add either if wanted.

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [x] Applied the proper versioning rules if the content is for specific dbt version(s)
- [ ] The content in this PR requires a dbt release note — not applicable, this is a marketing CTA rather than a product change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-gtm-1031617-core-v112-live-cta-dbt-labs.vercel.app/docs/build/about-metricflow
- https://docs-getdbt-com-git-gtm-1031617-core-v112-live-cta-dbt-labs.vercel.app/docs/build/iceberg/adapters/bigquery-iceberg-support
- https://docs-getdbt-com-git-gtm-1031617-core-v112-live-cta-dbt-labs.vercel.app/docs/build/iceberg/adapters/databricks-iceberg-support
- https://docs-getdbt-com-git-gtm-1031617-core-v112-live-cta-dbt-labs.vercel.app/docs/build/iceberg/adapters/duckdb-iceberg-support
- https://docs-getdbt-com-git-gtm-1031617-core-v112-live-cta-dbt-labs.vercel.app/docs/build/iceberg/adapters/snowflake-iceberg-support
- https://docs-getdbt-com-git-gtm-1031617-core-v112-live-cta-dbt-labs.vercel.app/docs/build/iceberg/catalogs-yml
- https://docs-getdbt-com-git-gtm-1031617-core-v112-live-cta-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/01-upgrading-to-v2
- https://docs-getdbt-com-git-gtm-1031617-core-v112-live-cta-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/03-upgrading-to-v1.12
- https://docs-getdbt-com-git-gtm-1031617-core-v112-live-cta-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/04-upgrading-to-v1.11
- https://docs-getdbt-com-git-gtm-1031617-core-v112-live-cta-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/05-upgrading-to-v1.10
- https://docs-getdbt-com-git-gtm-1031617-core-v112-live-cta-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/06-upgrading-to-v1.9
- https://docs-getdbt-com-git-gtm-1031617-core-v112-live-cta-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/07-upgrading-to-v1.8
- https://docs-getdbt-com-git-gtm-1031617-core-v112-live-cta-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/08-upgrading-to-v1.7
- https://docs-getdbt-com-git-gtm-1031617-core-v112-live-cta-dbt-labs.vercel.app/docs/dbt-versions/dbt-platform-release-notes-gen
- https://docs-getdbt-com-git-gtm-1031617-core-v112-live-cta-dbt-labs.vercel.app/docs/local/install-dbt-core-2-oss
- https://docs-getdbt-com-git-gtm-1031617-core-v112-live-cta-dbt-labs.vercel.app/docs/local/install-dbt
- https://docs-getdbt-com-git-gtm-1031617-core-v112-live-cta-dbt-labs.vercel.app/docs/mesh/cross-platform-mesh
- https://docs-getdbt-com-git-gtm-1031617-core-v112-live-cta-dbt-labs.vercel.app/docs/platform/manage-access/enterprise-permissions
- https://docs-getdbt-com-git-gtm-1031617-core-v112-live-cta-dbt-labs.vercel.app/reference/global-configs/about-global-configs
- https://docs-getdbt-com-git-gtm-1031617-core-v112-live-cta-dbt-labs.vercel.app/reference/telemetry-observability

<!-- end-vercel-deployment-preview -->