### PR TITLE
12 August single tenant release notes

### DIFF
--- a/website/docs/docs/dbt-versions/dbt-platform-release-notes-gen.md
+++ b/website/docs/docs/dbt-versions/dbt-platform-release-notes-gen.md
@@ -22,6 +22,18 @@ Release notes are grouped by date for single-tenant environments.
 
 <span><img src="/img/fontawesome/rss.svg" alt="RSS" className="rss-icon" />Subscribe to release note updates via [RSS](/feeds/release-notes-st-rss.xml), [Atom](/feeds/release-notes-st-atom.xml), or [JSON Feed](/feeds/release-notes-st-rss.json).</span>
 
+## August 12, 2026
+
+## Enhancements
+
+### dbt Copilot and agents
+
+- **Auto-expanding Wizard chat input**: The Wizard chat input grows vertically as you type or paste text, and shrinks back when content is removed.
+
+### APIs, Identity, and Administration
+
+- **Job read access is now included in the `account:read` OAuth scope**: Applications authorized with `account:read` can now read job data without also requesting the `jobs:run` scope.
+
 ## August 5, 2026
 
 ## New

--- a/website/docs/docs/dbt-versions/dbt-platform-release-notes-gen.md
+++ b/website/docs/docs/dbt-versions/dbt-platform-release-notes-gen.md
@@ -26,7 +26,7 @@ Release notes are grouped by date for single-tenant environments.
 
 ## Enhancements
 
-### dbt Copilot and agents
+### dbt AI and agents
 
 - **Auto-expanding Wizard chat input**: The Wizard chat input grows vertically as you type or paste text, and shrinks back when content is removed.
 


### PR DESCRIPTION
## Summary
- Promotes the 12 August 2026 single-tenant release notes from docs-internal (auto-expanding Wizard chat input, `account:read` job read access).

## Test plan
- [ ] Preview the ST release notes page and confirm the August 12 section renders at the top


Made with [Cursor](https://cursor.com)

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-nfiann-st140826-dbt-labs.vercel.app/docs/dbt-versions/dbt-platform-release-notes-gen

<!-- end-vercel-deployment-preview -->