### PR TITLE
Fix stale v2 migration links and typos

### DIFF
--- a/website/docs/community/contributing/contributing-coding.md
+++ b/website/docs/community/contributing/contributing-coding.md
@@ -49,7 +49,7 @@ There are three primary ways to contribute to the dbt projects. We’ll use <Con
 #### Get started
 
 - Read the <Constant name="core" /> [contribution guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and the [Contributor Expectations](/community/resources/contributor-expectations).
-- If contributing to `dbt-core`, find an issue labeled “[good first issue](https://github.com/dbt-labs/dbt-fusion/issues?q=is%3Aopen+is%3Aissue+label%3Agood_first_issue)”, or look for similar labels on other repositories. If in doubt, also feel free to ask the maintainers for a good first issue, they’ll be excited to welcome you!
+- If contributing to `dbt-core`, find an issue labeled “[good first issue](https://github.com/dbt-labs/dbt-core/issues?q=is%3Aopen+is%3Aissue+label%3A%22type%3Agood-first-issue%22)”, or look for similar labels on other repositories. If in doubt, also feel free to ask the maintainers for a good first issue, they’ll be excited to welcome you!
 
 #### Need help?
 

--- a/website/docs/community/resources/oss-sa-projects.md
+++ b/website/docs/community/resources/oss-sa-projects.md
@@ -4,7 +4,7 @@ Looking for a good place to get involved contributing code? dbt Labs supports th
 
 ## Rust
 
-- [<Constant name="core_v2" />](https://github.com/dbt-labs/dbt-core) - the next major version of dbt Core, powered by the <Constant name="fusion_engine" /> (previously located at in [`dbt-fusion`](https://github.com/dbt-labs/dbt-fusion))
+- [<Constant name="core_v2" />](https://github.com/dbt-labs/dbt-core) - the next major version of dbt Core, powered by the <Constant name="fusion_engine" /> (previously in [`dbt-fusion`](https://github.com/dbt-labs/dbt-fusion))
 
 ## Python
 
@@ -13,7 +13,7 @@ Looking for a good place to get involved contributing code? dbt Labs supports th
 
 ## dbt
 
-- [dbt Labs' packages](https://hub.getdbt.com/dbt-labs/) - the dbt pacakges created and supported by dbt Labs. Packages are just dbt projects, so if you know the SQL, Jinja, and YAML necessary to work in dbt, you can contribute to packages.
+- [dbt Labs' packages](https://hub.getdbt.com/dbt-labs/) - the dbt packages created and supported by dbt Labs. Packages are just dbt projects, so if you know the SQL, Jinja, and YAML necessary to work in dbt, you can contribute to packages.
 
 ## YAML and JSON Config
 

--- a/website/docs/docs/local/install-dbt-core-2-oss.md
+++ b/website/docs/docs/local/install-dbt-core-2-oss.md
@@ -72,7 +72,7 @@ dbt Core 2.0 is developed in the open. To contribute, refer to the [`dbt-core` r
 
 ## License
 
-dbt Core 2.0 is licensed under Apache 2.0. Refer to the [LICENSE file](https://github.com/dbt-labs/dbt-core/blob/HEAD/License.md) in the repository. Refer to [dbt licensing](/docs/dbt-licensing?version=2.0) for more info.
+dbt Core 2.0 is licensed under Apache 2.0. Refer to the [LICENSE file](https://github.com/dbt-labs/dbt-core/blob/HEAD/LICENSE) in the repository. Refer to [dbt licensing](/docs/dbt-licensing?version=2.0) for more info.
 
 ## Related
 

--- a/website/docs/docs/local/install-dbt.md
+++ b/website/docs/docs/local/install-dbt.md
@@ -266,7 +266,7 @@ If the pre-made images don't fit your use case, use the [`Dockerfile`](https://g
 Install from source to get unreleased code or a specific commit. Clone the repo and install with `pip`:
 
 ```shell
-git clone https://github.com/dbt-labs/dbt-core.git
+git clone -b 1.latest https://github.com/dbt-labs/dbt-core.git
 cd dbt-core
 python -m pip install -r requirements.txt
 ```
@@ -289,7 +289,7 @@ python -m pip install .
 
 For editable mode: `python -m pip install -e .`
 
-For more details, read the [contributing guidelines](https://github.com/dbt-labs/dbt-core/blob/HEAD/CONTRIBUTING.md).
+For more details, read the [contributing guidelines](https://github.com/dbt-labs/dbt-core/blob/1.latest/CONTRIBUTING.md).
 
 </Expandable>
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

Four small post-v2 hygiene fixes on live docs pages. `dbt-core` `main` is now the Rust engine, so a few install and contributing links still pointed at the wrong branch, repo, or filename.

- Pin the v1 “install from source” clone (`lastVersion="1.99"`) to `1.latest`. The default branch has no `requirements.txt`; Docker links on the same page already use `1.latest`. Point the contributing guidelines link at `blob/1.latest/CONTRIBUTING.md`.
- Retarget the dbt-core “good first issue” link from `dbt-fusion` (`good_first_issue`, tracker disabled) to `dbt-core` `type:good-first-issue`.
- Fix the Core 2.0 license link: `License.md` → `LICENSE` (the file on `main`).
- Typos on the OSS/SA projects page: `pacakges` → `packages`; `previously located at in` → `previously in`.

No issue — these are drive-by link/typo fixes.

## How to test

- Confirm [dbt-core `main`](https://github.com/dbt-labs/dbt-core) has `LICENSE` and no `requirements.txt`.
- Confirm [dbt-core `1.latest`](https://github.com/dbt-labs/dbt-core/tree/1.latest) has `requirements.txt` and `CONTRIBUTING.md`.
- Open the new good-first-issue query: https://github.com/dbt-labs/dbt-core/issues?q=is%3Aopen+is%3Aissue+label%3A%22type%3Agood-first-issue%22
- Preview the four pages on the Vercel deployment.

## Checklist

- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [x] Applied the proper versioning rules if the content is for specific dbt version(s): the source-install clone change is confined to the existing `lastVersion="1.99"` block. The other three files are unversioned.
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/release-notes). Not applicable.
