### PR TITLE
Add August 2026 compatible track changelog

### DIFF
--- a/website/docs/docs/dbt-versions/compatible-track-changelog.md
+++ b/website/docs/docs/dbt-versions/compatible-track-changelog.md
@@ -13,6 +13,52 @@ Each monthly **Compatible** release includes functionality matching up-to-date o
 
 For more information, see [release tracks](/docs/dbt-versions/dbt-release-tracks).
 
+## August 2026
+
+Release date: August 18, 2026
+
+This compatible release includes functionality from the following versions of dbt Core OSS:
+
+```
+dbt-core==1.12.0
+
+# shared interfaces
+dbt-adapters==1.24.5
+dbt-common==1.38.0
+dbt-extractor==0.6.0
+dbt-semantic-interfaces==0.9.0
+dbt-sl-sdk[sync]==0.13.4
+
+# adapters
+dbt-athena==1.11.0
+dbt-bigquery==1.12.0
+dbt-databricks==1.12.4
+dbt-fabric==1.9.4
+dbt-postgres==1.11.0
+dbt-redshift==1.11.0
+dbt-snowflake==1.12.0
+dbt-spark==1.10.3
+dbt-synapse==1.8.5
+dbt-teradata==1.11.0
+dbt-trino==1.10.3
+```
+
+Changelogs:
+- [dbt-core 1.12.0](https://github.com/dbt-labs/dbt-core/blob/1.12.latest/CHANGELOG.md)
+- [dbt-adapters 1.24.5](https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-adapters/CHANGELOG.md)
+- [dbt-common 1.38.0](https://github.com/dbt-labs/dbt-common/blob/main/CHANGELOG.md)
+- [dbt-athena 1.11.0](https://github.com/dbt-labs/dbt-adapters/blob/stable/dbt-athena/CHANGELOG.md)
+- [dbt-bigquery 1.12.0](https://github.com/dbt-labs/dbt-adapters/blob/stable/dbt-bigquery/CHANGELOG.md)
+- [dbt-databricks 1.12.4](https://github.com/databricks/dbt-databricks/blob/main/CHANGELOG.md)
+- [dbt-fabric 1.9.4](https://github.com/microsoft/dbt-fabric/releases/tag/v1.9.4)
+- [dbt-postgres 1.11.0](https://github.com/dbt-labs/dbt-adapters/blob/stable/dbt-postgres/CHANGELOG.md)
+- [dbt-redshift 1.11.0](https://github.com/dbt-labs/dbt-adapters/blob/stable/dbt-redshift/CHANGELOG.md)
+- [dbt-snowflake 1.12.0](https://github.com/dbt-labs/dbt-adapters/blob/stable/dbt-snowflake/CHANGELOG.md)
+- [dbt-spark 1.10.3](https://github.com/dbt-labs/dbt-adapters/blob/stable/dbt-spark/CHANGELOG.md)
+- [dbt-synapse 1.8.5](https://github.com/microsoft/dbt-synapse/blob/v1.8.latest/CHANGELOG.md)
+- [dbt-teradata 1.11.0](https://github.com/Teradata/dbt-teradata/releases/tag/v1.11.0)
+- [dbt-trino 1.10.3](https://github.com/starburstdata/dbt-trino/blob/master/CHANGELOG.md)
+
 ## July 2026
 
 Release date: July 21, 2026
@@ -707,7 +753,7 @@ Changelogs:
 - [dbt-bigquery 1.9.1](https://github.com/dbt-labs/dbt-bigquery/blob/1.9.latest/CHANGELOG.md#dbt-bigquery-191---january-10-2025)
 - [dbt-databricks 1.9.7](https://github.com/databricks/dbt-databricks/blob/main/CHANGELOG.md#dbt-databricks-197-feb-25-2025)
 - [dbt-fabric 1.9.4](https://github.com/microsoft/dbt-fabric/releases/tag/v1.9.4)
-- [dbt-postgres 1.9.0](https://github.com/dbt-labs/dbt-postgres/blob/main/CHANGELOG.md#dbt-postgres-190---december-09-2024)
+- [dbt-postgres 1.9.0](https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-postgres/CHANGELOG.md#dbt-postgres-190---december-09-2024)
 - [dbt-redshift 1.9.3](https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-redshift/CHANGELOG.md#dbt-redshift-193---april-01-2025)
 - [dbt-snowflake 1.9.2](https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-snowflake/CHANGELOG.md#dbt-snowflake-192---march-07-2025)
 - [dbt-spark 1.9.2](https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-spark/CHANGELOG.md#dbt-spark-192---march-07-2025)
@@ -902,7 +948,7 @@ Changelogs:
 - [dbt-bigquery 1.9.0](https://github.com/dbt-labs/dbt-bigquery/blob/1.9.latest/CHANGELOG.md#dbt-bigquery-190---december-09-2024)
 - [dbt-databricks 1.9.0](https://github.com/databricks/dbt-databricks/blob/main/CHANGELOG.md#dbt-databricks-190-december-9-2024)
 - [dbt-fabric 1.8.8](https://github.com/microsoft/dbt-fabric/blob/v1.8.latest/CHANGELOG.md)
-- [dbt-postgres 1.9.0](https://github.com/dbt-labs/dbt-postgres/blob/main/CHANGELOG.md#dbt-postgres-190---december-09-2024)
+- [dbt-postgres 1.9.0](https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-postgres/CHANGELOG.md#dbt-postgres-190---december-09-2024)
 - [dbt-redshift 1.9.0](https://github.com/dbt-labs/dbt-redshift/blob/1.9.latest/CHANGELOG.md#dbt-redshift-190---december-09-2024)
 - [dbt-snowflake 1.9.0](https://github.com/dbt-labs/dbt-snowflake/blob/1.9.latest/CHANGELOG.md#dbt-snowflake-190---december-09-2024)
 - [dbt-spark 1.9.0](https://github.com/dbt-labs/dbt-spark/blob/1.9.latest/CHANGELOG.md#dbt-spark-190---december-10-2024)

--- a/website/docs/docs/dbt-versions/compatible-track-changelog.md
+++ b/website/docs/docs/dbt-versions/compatible-track-changelog.md
@@ -28,6 +28,7 @@ dbt-common==1.38.0
 dbt-extractor==0.6.0
 dbt-semantic-interfaces==0.9.0
 dbt-sl-sdk[sync]==0.13.4
+dbt-state==2.42.0
 
 # adapters
 dbt-athena==1.11.0
@@ -47,6 +48,7 @@ Changelogs:
 - [dbt-core 1.12.0](https://github.com/dbt-labs/dbt-core/blob/1.12.latest/CHANGELOG.md)
 - [dbt-adapters 1.24.5](https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-adapters/CHANGELOG.md)
 - [dbt-common 1.38.0](https://github.com/dbt-labs/dbt-common/blob/main/CHANGELOG.md)
+- [dbt-state 2.42.0](https://github.com/dbt-labs/dbt-state)
 - [dbt-athena 1.11.0](https://github.com/dbt-labs/dbt-adapters/blob/stable/dbt-athena/CHANGELOG.md)
 - [dbt-bigquery 1.12.0](https://github.com/dbt-labs/dbt-adapters/blob/stable/dbt-bigquery/CHANGELOG.md)
 - [dbt-databricks 1.12.4](https://github.com/databricks/dbt-databricks/blob/main/CHANGELOG.md)


### PR DESCRIPTION
## Summary
Adds the August 2026 entry to the [compatible track changelog](https://docs.getdbt.com/docs/dbt-versions/compatible-track-changelog), covering the dbt-mantle `compatible_track` release that moved tags on 2026-08-13 (dbt-mantle PR [#2097](https://github.com/dbt-labs/dbt-mantle/pull/2097)).

Dependency versions pulled from the [Compatible Track Dependencies and Changelogs](https://github.com/dbt-labs/dbt-mantle/actions/runs/31718721988) workflow run artifact, cross-checked against `dbt-core/__version__.py` at the moved `compatible` tag.

No user-facing "Fixes"/"Features" bullets this cycle — the mantle changelog artifact is unchanged since July 17 (the only PR that landed, #2097, carries a `Skip Changelog` label).

Excluded dbt-labs-internal-only packages (`dbt-state`, `dbt-protos`, `dbtlabs-proto-private`, `dbtlabs-vortex`, `dbt-sl-sdk-internal`, `dbt-core-experimental-parser`) from the dependency list, consistent with every prior monthly entry in this doc.

## Test plan
- [ ] Review from `#ask-product-docs` per the [Mantle Release FAQ](https://app.notion.com/p/dbtlabs/Mantle-Release-FAQ-142bb38ebda780bbbe31fcf79b01fdc9)'s guidance
- [ ] Confirm release date (currently listed as August 18, 2026) matches the actual GA date before merging
- [ ] Best merged once the compatible track is confirmed stable in prod

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-compatible-track-changelog-2026-08-dbt-labs.vercel.app/docs/dbt-versions/compatible-track-changelog

<!-- end-vercel-deployment-preview -->