### PR TITLE
Rename View as Markdown element id for analytics grouping

### DIFF
--- a/website/src/components/copyPage/index.js
+++ b/website/src/components/copyPage/index.js
@@ -66,7 +66,7 @@ function CopyPage({ dropdownRight = false, pageUrl }) {
         </button>
 
         <Link
-          id="view_as_markdown"
+          id="llm_view_as_markdown"
           className={styles.dropdownItem}
           href={markdownUrl}
           target="_blank"


### PR DESCRIPTION
## What changed

Renames the "View as Markdown" dropdown item's element id from `view_as_markdown` to `llm_view_as_markdown`.

## Why

The internal-analytics Snowplow model (`event_web__link_clicks`) derives `element_type` from the first `_`-delimited part of the id. The existing dropdown links use `llm_open_in_chatgpt` / `_claude` / `_perplexity`, so they group under `element_type = 'llm'`.

`view_as_markdown` parsed to `element_type = 'view'`, landing in a separate bucket and excluded from any LLM link picker filtered to `element_type = 'llm'`. The `llm_` prefix makes it group with the other LLM link items automatically — no analytics model change needed.