### PR TITLE
Fix <Constant> inside code fences and inline code

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -5,6 +5,7 @@ import rehypeCodeLanguage from "./plugins/rehypeCodeLanguage.js";
 import rehypeCleanMarkdown from "./plugins/rehypeCleanMarkdown.js";
 import rehypeTabsToHeadings from "./plugins/rehypeTabsToHeadings.js";
 import remarkBlogFootnoteLinks from "./plugins/remarkBlogFootnoteLinks.js";
+import remarkConstantsInCode from "./plugins/remarkConstantsInCode.js";
 const { themes } = require('prism-react-renderer')
 
 const { products, versions, versionedPages, versionedCategories } = require("./dbt-versions");
@@ -333,7 +334,7 @@ var siteSettings = {
           path: "docs",
           routeBasePath: "/",
           sidebarPath: require.resolve("./sidebars.js"),
-          remarkPlugins: [math],
+          remarkPlugins: [math, remarkConstantsInCode],
           rehypePlugins: [katex],
 
           editUrl:
@@ -353,7 +354,7 @@ var siteSettings = {
           postsPerPage: 20,
           blogSidebarTitle: "Recent posts",
           blogSidebarCount: 5,
-          remarkPlugins: [math, remarkBlogFootnoteLinks],
+          remarkPlugins: [math, remarkBlogFootnoteLinks, remarkConstantsInCode],
           rehypePlugins: [katex],
           // Un-truncated blog posts will throw an error
           // https://docusaurus.io/blog/releases/3.5#onuntruncatedblogposts

--- a/website/plugins/remarkConstantsInCode.js
+++ b/website/plugins/remarkConstantsInCode.js
@@ -19,8 +19,9 @@
 import { visit } from "unist-util-visit";
 import { CONSTANTS } from "../constants.js";
 
-// Matches <Constant name="x" /> or <Constant name='x'>, self-closing or not.
-const CONSTANT_IN_CODE_RE = /<Constant\s+name\s*=\s*["']([^"']+)["']\s*\/?>/g;
+// Matches <Constant name="x" /> and <Constant name="x"></Constant> (empty paired tag).
+const CONSTANT_IN_CODE_RE =
+  /<Constant\s+name\s*=\s*["']([^"']+)["']\s*(?:\/\s*>|>\s*<\/Constant\s*>)/g;
 
 export default function remarkConstantsInCode() {
   return (tree) => {

--- a/website/plugins/remarkConstantsInCode.js
+++ b/website/plugins/remarkConstantsInCode.js
@@ -1,0 +1,35 @@
+/**
+ * Remark plugin that resolves `<Constant name="..." />` inside code.
+ *
+ * `<Constant>` is a render-time React component wired through the MDX theme
+ * override, so MDX only turns it into the component in JSX positions. Inside
+ * inline code (single backticks) and fenced code blocks the tag is literal
+ * text, so the reader sees the raw `<Constant name="core" />` string instead of
+ * the product name.
+ *
+ * This runs on the mdast before compilation and substitutes the tag with its
+ * value from `constants.js` (the single source of truth) directly in the code
+ * node's text. It works for both inline (`inlineCode`) and fenced (`code`)
+ * nodes, and happens before rehype/Prism highlighting so fenced blocks are
+ * highlighted with the substituted text already in place.
+ *
+ * Unknown names are left untouched (visible literal) rather than blanked, so a
+ * typo is noticeable rather than silently dropped.
+ */
+import { visit } from "unist-util-visit";
+import { CONSTANTS } from "../constants.js";
+
+// Matches <Constant name="x" /> or <Constant name='x'>, self-closing or not.
+const CONSTANT_IN_CODE_RE = /<Constant\s+name\s*=\s*["']([^"']+)["']\s*\/?>/g;
+
+export default function remarkConstantsInCode() {
+  return (tree) => {
+    visit(tree, ["inlineCode", "code"], (node) => {
+      if (!node.value || !node.value.includes("<Constant")) return;
+
+      node.value = node.value.replace(CONSTANT_IN_CODE_RE, (match, name) =>
+        Object.prototype.hasOwnProperty.call(CONSTANTS, name) ? CONSTANTS[name] : match
+      );
+    });
+  };
+}


### PR DESCRIPTION
## What are you changing in this pull request and why?

In the rendered markdown, Constants within markdown blocks don't work, see https://docs.getdbt.com/reference/commands/dbt-environment.md :

~~~
```bash
❯ dbt env show
Local Configuration:
  Active account ID              185854
  Active project ID              271692
  Active host name               cloud.getdbt.com
  dbt_cloud.yml file path        /Users/cesar/.dbt/dbt_cloud.yml
  dbt_project.yml file path      /Users/cesar/git/cloud-cli-test-project/dbt_project.yml
  <Constant name="dbt" /> CLI version          0.35.7
~~~

These files have 'em:

- docs/docs/local/connect-data-platform/watsonx-spark-setup.md:42
- docs/faqs/Troubleshooting/ide-session-unknown-error.md:12
- docs/guides/databricks-workflows.md:86
- docs/guides/zapier-ms-teams.md:100
- docs/guides/zapier-refresh-mode-report.md:102
- docs/guides/zapier-refresh-mode-report.md:63
- docs/guides/zapier-refresh-tableau-workbook.md:108
- docs/guides/zapier-refresh-tableau-workbook.md:115
- docs/guides/zapier-refresh-tableau-workbook.md:70
- docs/guides/zapier-slack.md:232
- docs/guides/zapier-slack.md:89
- docs/reference/commands/dbt-environment.md:41

This fixes that issue, by replacing the Constant value via a remark plugin.

## Checklist
- [ ] Needs technical review
- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.