### PR TITLE
19 August single tenant release notes

### DIFF
--- a/website/docs/docs/dbt-versions/dbt-platform-release-notes-gen.md
+++ b/website/docs/docs/dbt-versions/dbt-platform-release-notes-gen.md
@@ -22,6 +22,18 @@ Release notes are grouped by date for single-tenant environments.
 
 <span><img src="/img/fontawesome/rss.svg" alt="RSS" className="rss-icon" />Subscribe to release note updates via [RSS](/feeds/release-notes-st-rss.xml), [Atom](/feeds/release-notes-st-atom.xml), or [JSON Feed](/feeds/release-notes-st-rss.json).</span>
 
+## August 19, 2026
+
+## Enhancements
+
+### Studio IDE
+
+- **Console tab persists across sessions**: New sessions open on the Wizard tab when available, and the Studio IDE remember your last-used tab for each project so you can pick up where you left off.
+
+### Catalog
+
+- **Exact model relation name in the Discovery API**: A new `relationName` field on the `ModelAppliedStateNode` and `ModelAppliedStateNestedNode` GraphQL types exposes the fully-qualified, adapter-rendered relation name (for example, `"database"."schema"."model_name"`) from the last successful model build.
+
 ## August 12, 2026
 
 ## Enhancements

--- a/website/docs/docs/dbt-versions/dbt-platform-release-notes-gen.md
+++ b/website/docs/docs/dbt-versions/dbt-platform-release-notes-gen.md
@@ -28,7 +28,7 @@ Release notes are grouped by date for single-tenant environments.
 
 ### Studio IDE
 
-- **Console tab persists across sessions**: New sessions open on the Wizard tab when available, and the Studio IDE remember your last-used tab for each project so you can pick up where you left off.
+- **Console tab persists across sessions**: New sessions open on the Wizard tab when available, and the Studio IDE remembers your last-used tab for each project so you can pick up where you left off.
 
 ### Catalog
 


### PR DESCRIPTION
## Summary
- Promotes the 19 August 2026 single-tenant release notes from docs-internal (Studio IDE console tab persistence, Discovery API `relationName`).

**Console tab persists across sessions** 
**Exact model relation name in the Discovery API**

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-nfiann-st190826-dbt-labs.vercel.app/docs/dbt-versions/dbt-platform-release-notes-gen

<!-- end-vercel-deployment-preview -->