### PR TITLE
dbt State trial

### DIFF
--- a/website/docs/docs/deploy/dbt-state-setup.md
+++ b/website/docs/docs/deploy/dbt-state-setup.md
@@ -41,7 +41,7 @@ To enable dbt State:
    Once started, you cannot pause the trial. After 30 days, you must add a credit card or enterprise contract to continue. For information about how the trial period and billing work, refer to [dbt State trial and billing](/docs/deploy/dbt-state-trial).
 
    :::info Extended trial for state-aware orchestration users
-   If you're using state-aware orchestration prior to June 1, 2026, your dbt State trial will be extended until the billing period begins on September 1, 2026. If the extension isn’t applied to your account, contact your account team.
+   If you were using state-aware orchestration prior to June 1, 2026, your dbt State trial will be extended beyond 30 days. If the extension isn’t applied to your account, contact your account team.
    :::
 
 4. Review and agree to the terms of service.

--- a/website/snippets/_core-migration-table.md
+++ b/website/snippets/_core-migration-table.md
@@ -18,7 +18,7 @@ Self-hosting hides its true cost in engineer hours and wasted compute. dbt platf
 :::caution State-aware orchestration is now dbt State
 [dbt State](/docs/deploy/dbt-state-about) works with all engines and environments: <Constant name="core" />, the <Constant name="dbt_platform" />, and <Constant name="fusion_engine" />.
 
-If you're using state-aware orchestration prior to June 1, 2026, you can continue using it. Existing state-aware orchestration customers automatically receive a 90-day trial of dbt State. To get started, refer to [Migrate from state-aware orchestration](/docs/deploy/dbt-state-migration).
+If you were using state-aware orchestration prior to June 1, 2026, you can continue using it. Once you start your free dbt State trial, it will be extended beyond the standard 30-day period. If the extension isn't applied to your account, contact your account team. To get started, refer to [Migrate from state-aware orchestration](/docs/deploy/dbt-state-migration).
 ::: 
 
 The data layer is the AI layer—make sure it's tested, defined, and trusted end to end.

--- a/website/snippets/_dbt-state-trial-how-it-works.md
+++ b/website/snippets/_dbt-state-trial-how-it-works.md
@@ -1,4 +1,4 @@
 - Eligible new organizations receive 30 days of free use with no usage limit. After the free period, a credit card or enterprise contract (for <Constant name="dbt_platform" /> managed plans) is required to continue. For more information, refer to [Continuing after the trial ends](/docs/deploy/dbt-state-trial#continuing-after-the-trial-ends).
 - To start a dbt State trial, you need a dbt account so you can manage dbt State usage, billing, and spend limits from one dashboard. A paid <Constant name="dbt_platform" /> plan is _not_ required to use dbt State locally.
 - Once started, you cannot pause the trial.
-- If you're using state-aware orchestration prior to June 1, 2026, your trial is extended until the billing period begins on September 1, 2026. If the extension isn't applied to your account, contact your account team.
+- If you were using state-aware orchestration prior to June 1, 2026, your dbt State trial will be extended beyond the standard 30-day period. If the extension isn't applied to your account, contact your account team.

--- a/website/snippets/_dbt-state-vs-sao.md
+++ b/website/snippets/_dbt-state-vs-sao.md
@@ -4,6 +4,6 @@ dbt State improves upon state-aware orchestration in a few key ways:
 - **Smarter data freshness tracking** — dbt State tracks data freshness across the <Term id="dag">DAG</Term> and automatically propagates it through models materialized as views. Unlike state-aware orchestration's `build_after` config which compares against the model's last successful execution, dbt State's `lag_tolerance` compares against the freshness of the underlying data.
 - **Advanced change detection** — dbt State can detect and ignore file modifications that don't change actual transformation logic, such as adding a comment or cleaning up whitespace.
 
-If you were using state-aware orchestration prior to June 1, 2026, you can continue using it. Your dbt State trial will be extended until the billing period begins on September 1, 2026. If your trial wasn't extended, contact your account team. For details on billing after the trial ends, refer to [dbt State usage and pricing](/docs/platform/billing#dbt-state-usage). 
+If you were using state-aware orchestration prior to June 1, 2026, you can continue using it. Once you start your free dbt State trial, it will be extended beyond the standard 30-day period. If the extension isn't applied to your account, contact your account team. For details on billing after the trial ends, refer to [dbt State usage and pricing](/docs/platform/billing#dbt-state-usage). 
 
 While dbt State is in preview, there is no required migration timeline &mdash; dbt Labs will communicate a timeline when dbt State reaches general availability.

--- a/website/snippets/_fusion-upgrade-steps.md
+++ b/website/snippets/_fusion-upgrade-steps.md
@@ -15,6 +15,6 @@ Keep in mind the following considerations during the upgrade process:
   :::caution State-aware orchestration is now dbt State
   [dbt State](/docs/deploy/dbt-state-about) works with all engines and environments: <Constant name="core" />, the <Constant name="dbt_platform" />, and <Constant name="fusion_engine" />.
 
-  If you're using state-aware orchestration prior to June 1, 2026, you can continue using it. Existing state-aware orchestration customers automatically receive a 90-day trial of dbt State. To get started, refer to [Migrate from state-aware orchestration](/docs/deploy/dbt-state-migration).
+  If you were using state-aware orchestration prior to June 1, 2026, you can continue using it. Once you start your free dbt State trial, it will be extended beyond the standard 30-day period. If the extension isn't applied to your account, contact your account team. To get started, refer to [Migrate from state-aware orchestration](/docs/deploy/dbt-state-migration).
   :::
 

--- a/website/snippets/_sao-deprecated.md
+++ b/website/snippets/_sao-deprecated.md
@@ -2,5 +2,5 @@
 
 [dbt State](/docs/deploy/dbt-state-about) works with all engines and environments: <Constant name="core" />, <Constant name="dbt_platform" />, and <Constant name="fusion" />
 
-If you're using state-aware orchestration prior to June 1, 2026, you can continue using it. Your dbt State trial will be extended until the billing period begins on September 1, 2026. If your trial wasn't extended, contact your account team. To get started, refer to [Migrate from state-aware orchestration](/docs/deploy/dbt-state-migration).
+If you were using state-aware orchestration prior to June 1, 2026, you can continue using it. Once you start your free dbt State trial, it will be extended beyond the standard 30-day period. If the extension isn't applied to your account, contact your account team. To get started, refer to [Migrate from state-aware orchestration](/docs/deploy/dbt-state-migration).
 :::


### PR DESCRIPTION
## What are you changing in this pull request and why?

**Directly edited:**
- [Set up dbt State](https://docs-getdbt-com-git-dbt-state-trial-dbt-labs.vercel.app/docs/deploy/dbt-state-setup)

**Via `_dbt-state-trial-how-it-works` snippet:**
- [dbt State trial and billing](https://docs-getdbt-com-git-dbt-state-trial-dbt-labs.vercel.app/docs/deploy/dbt-state-trial)
- [dbt State usage and pricing](https://docs-getdbt-com-git-dbt-state-trial-dbt-labs.vercel.app/docs/platform/billing/dbt-state-usage)
- [Billing](https://docs-getdbt-com-git-dbt-state-trial-dbt-labs.vercel.app/docs/platform/billing)

**Via `_dbt-state-vs-sao` snippet:**
- [Migrate from state-aware orchestration](https://docs-getdbt-com-git-dbt-state-trial-dbt-labs.vercel.app/docs/deploy/dbt-state-migration)
- [What happened to state-aware orchestration?](https://docs-getdbt-com-git-dbt-state-trial-dbt-labs.vercel.app/faqs/Runs/what-happened-to-sao)

**Via `_sao-deprecated` snippet:**
- [About state-aware orchestration](https://docs-getdbt-com-git-dbt-state-trial-dbt-labs.vercel.app/docs/deploy/state-aware-about)
- [Set up state-aware orchestration](https://docs-getdbt-com-git-dbt-state-trial-dbt-labs.vercel.app/docs/deploy/state-aware-setup)
- [State-aware orchestration interface](https://docs-getdbt-com-git-dbt-state-trial-dbt-labs.vercel.app/docs/deploy/state-aware-interface)
- [Cost insights](https://docs-getdbt-com-git-dbt-state-trial-dbt-labs.vercel.app/docs/explore/cost-insights)
- [Set up cost insights](https://docs-getdbt-com-git-dbt-state-trial-dbt-labs.vercel.app/docs/explore/set-up-cost-insights)
- [Incremental models](https://docs-getdbt-com-git-dbt-state-trial-dbt-labs.vercel.app/best-practices/materializations/materializations-guide-4-incremental-models)
- [Fusion upgrade guide](https://docs-getdbt-com-git-dbt-state-trial-dbt-labs.vercel.app/guides/fusion-upgrade)
- [Telemetry and observability](https://docs-getdbt-com-git-dbt-state-trial-dbt-labs.vercel.app/reference/telemetry-observability)
- [freshness (resource property)](https://docs-getdbt-com-git-dbt-state-trial-dbt-labs.vercel.app/reference/resource-properties/freshness)
- [freshness (resource config)](https://docs-getdbt-com-git-dbt-state-trial-dbt-labs.vercel.app/reference/resource-configs/freshness)

**Via `_fusion-upgrade-steps` snippet:**
- [Upgrade dbt platform version](https://docs-getdbt-com-git-dbt-state-trial-dbt-labs.vercel.app/docs/dbt-versions/upgrade-dbt-platform-version)
- [Upgrading to v2](https://docs-getdbt-com-git-dbt-state-trial-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/01-upgrading-to-v2)

**Via `_core-migration-table` snippet:**
- [Move from dbt Core to dbt platform: What you need to know](https://docs-getdbt-com-git-dbt-state-trial-dbt-labs.vercel.app/guides/core-migration-2)
- [Move from dbt Core to dbt platform: Get started](https://docs-getdbt-com-git-dbt-state-trial-dbt-labs.vercel.app/guides/core-migration-1)
- [Move from dbt Core to dbt platform: Optimization tips](https://docs-getdbt-com-git-dbt-state-trial-dbt-labs.vercel.app/guides/core-migration-3)

## Checklist
- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/release-notes).).