### PR TITLE
Add dbt State webinar page banner (GTM-1034590)

### DIFF
--- a/website/page-banners.yml
+++ b/website/page-banners.yml
@@ -30,3 +30,20 @@
   text: "dbt Wizard: An agent purpose-built for analytics engineering. Join us virtually on July 22nd to see real demos in the CLI and dbt platform!"
   link: "https://www.getdbt.com/resources/webinars/dbt-wizard-an-agent-purpose-built-for-analytics-engineering"
   open_in_new_tab: true
+
+- paths:
+    - /docs/deploy/dbt-state-about
+    - /docs/deploy/dbt-state-setup
+    - /docs/deploy/dbt-state-enable-jobs
+    - /docs/deploy/dbt-state-enable-studio
+    - /docs/deploy/dbt-state-cicd
+    - /docs/deploy/dbt-state-deferral
+    - /docs/deploy/dbt-state-trial
+    - /docs/deploy/dbt-state-examples
+    - /docs/deploy/dbt-state-interface
+    - /docs/deploy/dbt-state-migration
+    - /docs/platform/billing/dbt-state-usage
+    - /reference/resource-configs/dbt-state-configs
+  text: "dbt State: See volatile SQL, Jinja macros, freshness checks, time travel, and more in action. Join our technical deep dive on Sept 1 &amp; 2!"
+  link: "https://www.getdbt.com/resources/webinars/dbt-state-in-practice/?utm_medium=internal&utm_source=docs&utm_campaign=q3-2027_dbt-state-in-practice_aw&utm_content=themed-webinar____&utm_term=all_all__"
+  open_in_new_tab: true

--- a/website/page-banners.yml
+++ b/website/page-banners.yml
@@ -12,26 +12,6 @@
 #   open_in_new_tab (optional): open the link in a new tab.
 
 - paths:
-    - /docs/platform/wizard-overview
-    - /docs/dbt-ai/about-dbt-wizard-cli
-    - /docs/platform/wizard-platform
-    - /docs/dbt-ai/wizard-quickstart
-    - /docs/dbt-ai/wizard-how-it-works
-    - /docs/dbt-ai/about-dbt-ai
-    - /docs/dbt-ai/copilot-overview
-    - /docs/platform/enable-dbt-ai
-    - /guides/prompt-cookbook
-    - /docs/dbt-ai/about-mcp
-    - /docs/dbt-ai/integrate-mcp-claude
-    - /docs/dbt-ai/mcp-troubleshooting
-    - /docs/dbt-ai/wizard-skills
-    - /docs/dbt-ai/wizard-platform-skills
-    - /docs/dbt-ai/wizard-ide
-  text: "dbt Wizard: An agent purpose-built for analytics engineering. Join us virtually on July 22nd to see real demos in the CLI and dbt platform!"
-  link: "https://www.getdbt.com/resources/webinars/dbt-wizard-an-agent-purpose-built-for-analytics-engineering"
-  open_in_new_tab: true
-
-- paths:
     - /docs/deploy/dbt-state-about
     - /docs/deploy/dbt-state-setup
     - /docs/deploy/dbt-state-enable-jobs


### PR DESCRIPTION
## What

Adds a page-specific promo banner for the **dbt State technical deep dive webinar (Sept 1 & 2)** to the dbt State docs pages, per [GTM-1034590](https://fivetran.atlassian.net/browse/GTM-1034590).

The global announcement bar stays on the dbt Summit promo. This banner replaces it only on the 12 dbt State pages the docs team identified.

Banner copy follows the format of the previous page banner:

> dbt State: See volatile SQL, Jinja macros, freshness checks, time travel, and more in action. Join our technical deep dive on Sept 1 & 2!

## Preview links

**Expect the dbt State webinar banner** (not the dbt Summit bar) on all 12:

| Page | Preview |
|---|---|
| About | [dbt-state-about](https://docs-getdbt-com-git-gtm-1034590-dbt-state-banner-dbt-labs.vercel.app/docs/deploy/dbt-state-about) |
| Set up | [dbt-state-setup](https://docs-getdbt-com-git-gtm-1034590-dbt-state-banner-dbt-labs.vercel.app/docs/deploy/dbt-state-setup) |
| Enable in jobs | [dbt-state-enable-jobs](https://docs-getdbt-com-git-gtm-1034590-dbt-state-banner-dbt-labs.vercel.app/docs/deploy/dbt-state-enable-jobs) |
| Enable in Studio | [dbt-state-enable-studio](https://docs-getdbt-com-git-gtm-1034590-dbt-state-banner-dbt-labs.vercel.app/docs/deploy/dbt-state-enable-studio) |
| CI/CD | [dbt-state-cicd](https://docs-getdbt-com-git-gtm-1034590-dbt-state-banner-dbt-labs.vercel.app/docs/deploy/dbt-state-cicd) |
| Deferral | [dbt-state-deferral](https://docs-getdbt-com-git-gtm-1034590-dbt-state-banner-dbt-labs.vercel.app/docs/deploy/dbt-state-deferral) |
| Trial | [dbt-state-trial](https://docs-getdbt-com-git-gtm-1034590-dbt-state-banner-dbt-labs.vercel.app/docs/deploy/dbt-state-trial) |
| Examples | [dbt-state-examples](https://docs-getdbt-com-git-gtm-1034590-dbt-state-banner-dbt-labs.vercel.app/docs/deploy/dbt-state-examples) |
| Interface | [dbt-state-interface](https://docs-getdbt-com-git-gtm-1034590-dbt-state-banner-dbt-labs.vercel.app/docs/deploy/dbt-state-interface) |
| Migration | [dbt-state-migration](https://docs-getdbt-com-git-gtm-1034590-dbt-state-banner-dbt-labs.vercel.app/docs/deploy/dbt-state-migration) |
| Billing usage | [dbt-state-usage](https://docs-getdbt-com-git-gtm-1034590-dbt-state-banner-dbt-labs.vercel.app/docs/platform/billing/dbt-state-usage) |
| Reference configs | [dbt-state-configs](https://docs-getdbt-com-git-gtm-1034590-dbt-state-banner-dbt-labs.vercel.app/reference/resource-configs/dbt-state-configs) |

**Expect the global dbt Summit bar** (control pages — confirms no over-matching, and that the expired Wizard banner removal landed):

* [/docs/introduction](https://docs-getdbt-com-git-gtm-1034590-dbt-state-banner-dbt-labs.vercel.app/docs/introduction) — unrelated page, global bar unchanged
* [/docs/dbt-ai/about-dbt-ai](https://docs-getdbt-com-git-gtm-1034590-dbt-state-banner-dbt-labs.vercel.app/docs/dbt-ai/about-dbt-ai) — former dbt Wizard banner page, now falls back to the global bar

Also worth a click: [dbt-state-usage?version=2](https://docs-getdbt-com-git-gtm-1034590-dbt-state-banner-dbt-labs.vercel.app/docs/platform/billing/dbt-state-usage?version=2) — confirms the version query param doesn't break banner matching.

## Commits

1. **Add dbt State webinar page banner** — one new entry in `website/page-banners.yml`. No component, plugin, or CSS changes.
2. **Remove expired dbt Wizard webinar page banner** — its webinar was July 22nd. Separate commit so it can be dropped or reverted independently. Those 15 dbt Wizard/AI pages now fall back to the global dbt Summit bar.

## Notes

- Banner path matching is exact pathname equality, so the nested pages are enumerated individually rather than matched by prefix.
- Versioning on this site is a client-side query param that never changes the pathname, so the `?version=2` URLs in the ticket need no special handling.
- `&amp;` in `text` (injected via `dangerouslySetInnerHTML`) but a bare `&` in `link` (React escapes `href` attributes) is intentional, not an inconsistency.

## Verification

Checked the server-rendered HTML on the preview deploy above — all 14 pages return 200, and the banner is present in the static markup rather than swapped in client-side:

- **12/12 target pages**: dbt State banner present, dbt Summit bar absent.
- **2/2 control pages**: global dbt Summit bar present, no dbt State banner.
- Zero `[page-banners] No page found for banner path` warnings from the build plugin — every configured path resolves to a real page.
- Webinar link resolves with utm params intact and opens in a new tab.

## Follow-up (not in this PR)

Page banners have no expiry mechanism — no `start_date`/`end_date` in `buildPageBanners`. Entries render until someone deletes them by hand and the site rebuilds, which is how the Wizard banner outlived its webinar by a month. **This banner will need manual removal after Sept 2.** Adding date support to the plugin would prevent the recurrence; worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
