### PR TITLE
Add troubleshooting tip to Single Tenant Entra SSO Setup for Signing Cert Issue

### DIFF
--- a/website/docs/docs/platform/manage-access/set-up-sso-microsoft-entra-id.md
+++ b/website/docs/docs/platform/manage-access/set-up-sso-microsoft-entra-id.md
@@ -234,7 +234,7 @@ Server error! There was a server error. Please try again, or contact support@get
 
 This typically happens when Microsoft Entra ID can't find a SAML signing certificate configured for the application. The underlying error (`AADSTS500031: Cannot find signing certificate configured`) isn't surfaced to the user.
 
-To confirm this is the cause, check your Entra ID **Enterprise Application → Sign-in logs** and filter by "Failure" status. If you see the AADSTS500031 error there, resolve it by going to **Enterprise Application → Single sign-on → SAML Signing Certificate**, and add the missing certificate. If a certificate exists but is corrupted, create a new certificate, set an expiration date, mark it **Active** to override the existing one, and then remove the unused certificate.
+To confirm this is the cause, check your Entra ID **Enterprise Applications → YOUR_APP → Sign-in logs** and filter by **Failure** status. If you see the AADSTS500031 error there, resolve it by going to **Enterprise Applications → YOUR_APP → Single sign-on → SAML Signing Certificate**, and add the missing certificate. If a certificate exists but is corrupted, create a new certificate, set an expiration date, mark it **Active** to override the existing one, and then remove the unused certificate.
 
 </Expandable>
 

--- a/website/docs/docs/platform/manage-access/set-up-sso-microsoft-entra-id.md
+++ b/website/docs/docs/platform/manage-access/set-up-sso-microsoft-entra-id.md
@@ -227,8 +227,7 @@ Ensure that the domain name under which user accounts exist in Azure matches the
 
 <Expandable alt_header="Receiving a 'Server error' message after signing in">
 
-After completing the Entra ID login flow, users are redirected back to the dbt platform login page and see the following message:
-
+After completing the Entra ID login flow, you're redirected back to the <Constant name="dbt_platform" /> login page and see the following message:
 ```
 Server error! There was a server error. Please try again, or contact support@getdbt.com if this persists.
 ```

--- a/website/docs/docs/platform/manage-access/set-up-sso-microsoft-entra-id.md
+++ b/website/docs/docs/platform/manage-access/set-up-sso-microsoft-entra-id.md
@@ -233,9 +233,9 @@ After completing the Entra ID login flow, users are redirected back to the dbt p
 Server error! There was a server error. Please try again, or contact support@getdbt.com if this persists.
 ```
 
-This typically happens when Microsoft Entra ID can't find a SAML signing certificate configured for the application. The underlying error (`AADSTS500031: Cannot find signing certificate configured`) isn't surfaced to the user — it only appears in identity provider logs.
+This typically happens when Microsoft Entra ID can't find a SAML signing certificate configured for the application. The underlying error (`AADSTS500031: Cannot find signing certificate configured`) isn't surfaced to the user.
 
-To resolve this, go to your Entra ID **Enterprise Application → Single sign-on → SAML Signing Certificate**, and add the missing certificate. If a certificate exists but is corrupted, create a new certificate, set an expiration date, mark it **Active** to override the existing one, and then remove the unused certificate.
+To confirm this is the cause, check your Entra ID **Enterprise Application → Sign-in logs** and filter by "Failure" status. If you see the AADSTS500031 error there, resolve it by going to **Enterprise Application → Single sign-on → SAML Signing Certificate**, and add the missing certificate. If a certificate exists but is corrupted, create a new certificate, set an expiration date, mark it **Active** to override the existing one, and then remove the unused certificate.
 
 </Expandable>
 

--- a/website/docs/docs/platform/manage-access/set-up-sso-microsoft-entra-id.md
+++ b/website/docs/docs/platform/manage-access/set-up-sso-microsoft-entra-id.md
@@ -225,6 +225,20 @@ Ensure that the domain name under which user accounts exist in Azure matches the
 
 </Expandable>
 
+<Expandable alt_header="Receiving a 'Server error' message after signing in">
+
+After completing the Entra ID login flow, users are redirected back to the dbt platform login page and see the following message:
+
+```
+Server error! There was a server error. Please try again, or contact support@getdbt.com if this persists.
+```
+
+This typically happens when Microsoft Entra ID can't find a SAML signing certificate configured for the application. The underlying error (`AADSTS500031: Cannot find signing certificate configured`) isn't surfaced to the user — it only appears in identity provider logs.
+
+To resolve this, go to your Entra ID **Enterprise Application → Single sign-on → SAML Signing Certificate**, and add the missing certificate. If a certificate exists but is corrupted, create a new certificate, set an expiration date, mark it **Active** to override the existing one, and then remove the unused certificate.
+
+</Expandable>
+
 For additional troubleshooting &mdash; including "Admin consent required" prompts for new users, "Access Denied" after SAML authentication, and issues with Entity ID or ACS URL changes &mdash; refer to [SSO FAQs and troubleshooting](/docs/platform/manage-access/sso-faq).
 
 ## Learn more by video

--- a/website/docs/docs/platform/manage-access/set-up-sso-microsoft-entra-id.md
+++ b/website/docs/docs/platform/manage-access/set-up-sso-microsoft-entra-id.md
@@ -234,7 +234,11 @@ Server error! There was a server error. Please try again, or contact support@get
 
 This typically happens when Microsoft Entra ID can't find a SAML signing certificate configured for the application. The underlying error (`AADSTS500031: Cannot find signing certificate configured`) isn't surfaced to the user.
 
-To confirm this is the cause, check your Entra ID **Enterprise Applications → YOUR_APP → Sign-in logs** and filter by **Failure** status. If you see the AADSTS500031 error there, resolve it by going to **Enterprise Applications → YOUR_APP → Single sign-on → SAML Signing Certificate**, and add the missing certificate. If a certificate exists but is corrupted, create a new certificate, set an expiration date, mark it **Active** to override the existing one, and then remove the unused certificate.
+To confirm this is the cause:
+1. Check your Entra ID **Enterprise Applications → YOUR_APP → Sign-in logs** 
+2. Filter by **Failure** status. 
+3. If you see the `AADSTS500031` error there, resolve it by going to **Enterprise Applications → YOUR_APP → Single sign-on → SAML Signing Certificate**, and add the missing certificate. 
+4. If a certificate exists but is corrupted, create a new certificate, set an expiration date, mark it **Active** to override the existing one, and then remove the unused certificate.
 
 </Expandable>
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

We internally document a troubleshooting tip that should be public - based on a real customer issue solved this week. When setting up Entra SSO in dbt platform, if customers don't have a signed certificate (or it's corrupted/inactive) users will get a vague server error when returning to the dbt login page to complete the login flow. The helpful logs get swallowed by Auth0 and don't appear in the network tab of the user's browser tools. The relevant error does appear in the Azure sign-in logs, but it would be helpful to point customers on where to find it.

## Checklist
- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/release-notes).).
