### PR TITLE
docs: put external partition expression on the partition

### DIFF
--- a/website/docs/reference/resource-properties/external.md
+++ b/website/docs/reference/resource-properties/external.md
@@ -20,8 +20,8 @@ sources:
             - name: <column_name>
               data_type: <string>
               description: <string>
-              config:
-                meta: {dictionary} # changed to config in v1.10
+              expression: <string>
+              meta: {dictionary}
             - ...
           <additional_property>: <additional_value>
 ```
@@ -39,3 +39,5 @@ You may wish to define the `external` property in order to:
 - Define metadata that you can later extract from the [manifest](/reference/artifacts/manifest-json)
 
 For an example of how this property can be used to power custom workflows, see the [`dbt-external-tables`](https://github.com/dbt-labs/dbt-external-tables) package.
+
+[`dbt-external-tables`](https://github.com/dbt-labs/dbt-external-tables) (Snowflake) reads a partition `expression` from the partition itself, or from `meta.expression`. It does not read `config.meta.expression`.


### PR DESCRIPTION
## What are you changing in this pull request and why?

Fixes https://github.com/dbt-labs/docs.getdbt.com/issues/9801

The `external` YAML example put `expression` under `partitions.config.meta`. `dbt-external-tables` on Snowflake reads `partition.expression` or `partition.meta.expression` — not `config.meta`.

I used an assistant on the edit.

## Checklist

- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [x] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/release-notes).
