### PR TITLE
Document that `--state` resolves relative to the project directory

### DIFF
--- a/website/docs/reference/node-selection/configure-state.md
+++ b/website/docs/reference/node-selection/configure-state.md
@@ -14,6 +14,28 @@ If `--defer-state` is not specified, deferral will use the artifacts supplied by
 
 If both the flag and env var are provided, the flag takes precedence.
 
+#### Path resolution
+
+Relative `--state` and `--defer-state` paths resolve against your project directory, not against the directory you ran dbt from. The project directory is wherever dbt found `dbt_project.yml`, which you can point elsewhere with [`--project-dir`](/reference/dbt_project.yml) or <VersionBlock lastVersion="1.10">`DBT_PROJECT_DIR`</VersionBlock><VersionBlock firstVersion="1.11">`DBT_ENGINE_PROJECT_DIR`</VersionBlock>.
+
+Without `--project-dir`, the two directories are the same and relative and absolute paths both work. With `--project-dir`, they aren't, and only absolute paths work:
+
+```shell
+# Looks for projects/data_warehouse/tmp/state/manifest.json
+dbt ls --project-dir projects/data_warehouse --select "state:modified" --state tmp/state
+
+# Looks for /full/path/to/tmp/state/manifest.json
+dbt ls --project-dir projects/data_warehouse --select "state:modified" --state /full/path/to/tmp/state
+```
+
+When dbt finds no `manifest.json` at the resolved path, it doesn't tell you the file is missing. It reports the selection method failing instead:
+
+```text
+Encountered an error:
+Runtime Error
+  Got a state selector method, but no comparison manifest
+```
+
 #### Notes
 - The `--state` artifacts must be of schema versions that are compatible with the currently running dbt version.
 - These are powerful, complex features. Read about [known caveats and limitations](/reference/node-selection/state-comparison-caveats) to state comparison.

--- a/website/docs/reference/node-selection/defer.md
+++ b/website/docs/reference/node-selection/defer.md
@@ -17,6 +17,8 @@ It is possible to use separate state for `state:modified` and `--defer`, by pass
 
 If `--defer-state` is not specified, deferral will use the manifest supplied to `--state`. In most cases, you will want to use the same state for both; compare logical changes against production, and also "fail over" to the production environment for unbuilt upstream resources.
 
+Relative paths passed to `--state` and `--defer-state` resolve against your project directory rather than the directory you ran dbt from. This matters when you use `--project-dir`. Refer to [path resolution](/reference/node-selection/configure-state#path-resolution) for details.
+
 ### Usage
 
 ```shell


### PR DESCRIPTION
## What are you changing in this pull request and why?

Resolves #8713.

`--state` (and `--defer-state`) resolve relative paths against the **project directory**, not the current working directory. When the two are the same -- the normal case -- nobody notices. When you pass `--project-dir`, they diverge, and a relative `--state` silently points somewhere that doesn't exist.

The failure mode is what makes this worth documenting: dbt doesn't say the manifest is missing. It says the *selector* has no comparison manifest:

```text
Encountered an error:
Runtime Error
  Got a state selector method, but no comparison manifest
```

That message sends you looking at `state:modified`, not at your path.

### Where the behavior comes from

`PreviousState.__init__` in `core/dbt/contracts/state.py` joins the state path onto the project root:

```python
# Note: if state_path is absolute, project_root will be ignored.
manifest_path = self.project_root / self.state_path / "manifest.json"
```

`pathlib` drops the left operand when the right one is absolute, which is exactly why absolute paths work and relative ones don't. `runnable.py` builds both `previous_state` (from `--state`) and `previous_defer_state` (from `--defer-state`) with `project_root=Path(self.config.project_root)`, so the two flags behave identically. The error text is raised in `selector_methods.py`.

## What changed

- **`reference/node-selection/configure-state`** -- new `#### Path resolution` section under the flag/env-var list: how the path resolves, a two-command example contrasting relative and absolute with `--project-dir`, and the error you get when it goes wrong.
- **`reference/node-selection/defer`** -- one sentence next to the `--defer-state` paragraph pointing at that section, since `--defer-state` has the same behavior.

I put the explanation on `configure-state` rather than `state-comparison-caveats` because it's a property of how the flag is read, not a caveat of state comparison -- it bites `--defer-state` users who never touch `state:modified`.

## Checklist

- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [x] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)) -- the `DBT_PROJECT_DIR` / `DBT_ENGINE_PROJECT_DIR` env var name is wrapped in `VersionBlock`s, matching the flag list directly above it on the same page.
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/release-notes). -- not applicable, this documents existing behavior, no version introduces it.
- [ ] Adds or removes pages -- no, both pages already exist, so no `sidebars.js` or `vercel.json` changes.
