### PR TITLE
Strip data-md-hide elements from generated Markdown

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -4,6 +4,7 @@ import katex from "rehype-katex";
 import rehypeCodeLanguage from "./plugins/rehypeCodeLanguage.js";
 import rehypeCleanMarkdown from "./plugins/rehypeCleanMarkdown.js";
 import rehypeTabsToHeadings from "./plugins/rehypeTabsToHeadings.js";
+import rehypeMdHide from "./plugins/rehypeMdHide.js";
 import remarkBlogFootnoteLinks from "./plugins/remarkBlogFootnoteLinks.js";
 import remarkConstantsInCode from "./plugins/remarkConstantsInCode.js";
 const { themes } = require('prism-react-renderer')
@@ -395,7 +396,7 @@ var siteSettings = {
           relativePaths: false,
         },
         processing: {
-          beforeDefaultRehypePlugins: [rehypeCodeLanguage, rehypeCleanMarkdown, rehypeTabsToHeadings],
+          beforeDefaultRehypePlugins: [rehypeCodeLanguage, rehypeCleanMarkdown, rehypeTabsToHeadings, rehypeMdHide],
         },
         include: {
           includeBlog: false,

--- a/website/plugins/rehypeMdHide.js
+++ b/website/plugins/rehypeMdHide.js
@@ -1,0 +1,32 @@
+/**
+ * Rehype plugin that drops any element marked with a data-md-hide attribute
+ * (and its whole subtree) from the HTML before it is converted to markdown.
+ *
+ * Runs only inside the @signalwire/docusaurus-plugin-llms-txt conversion
+ * pipeline (beforeDefaultRehypePlugins), so the rendered site is untouched:
+ * the element still appears on the page, it just never reaches the generated
+ * per-page .md / llms-full.txt.
+ *
+ * To keep any component out of the markdown output, add the attribute to its
+ * root element:
+ *
+ *   <div className={styles.feedbackContainer} data-md-hide="true">
+ *
+ * No selector or class matching -- CSS-module class names are hashed per
+ * build, so a stable marker attribute is the reliable contract.
+ */
+import { visit, SKIP } from "unist-util-visit";
+
+export default function rehypeMdHide() {
+  return (tree) => {
+    visit(tree, "element", (node, index, parent) => {
+      const hide = node.properties?.dataMdHide;
+      if (hide === undefined || hide === false || parent === undefined) {
+        return;
+      }
+      parent.children.splice(index, 1);
+      // Re-visit the node now occupying this index.
+      return [SKIP, index];
+    });
+  };
+}

--- a/website/src/components/feedback/index.js
+++ b/website/src/components/feedback/index.js
@@ -101,7 +101,7 @@ export const Feedback = () => {
   };
 
   return (
-    <div className={styles.feedbackContainer}>
+    <div className={styles.feedbackContainer} data-md-hide="true">
       <h2 id="feedback-header" className={styles.feedbackHeader}>Was this page helpful?</h2>
       <form onSubmit={handleFormSubmit} className={styles.feedbackActions}>
         <div className={styles.feedbackButtons}>


### PR DESCRIPTION
## What are you changing in this pull request and why?

Follow-up to #9765, same ideas as the other generated-markdown cleanups.

The idea behind this PR is that we can use it to hide unwanted "widgets" (for lack of a better word - prose(?)) from the UI.

The most obvious one is the `Was this page helpful?` feedback widget, which shows at the bottom of every generated page.

For example, [dbt_project.yml.md](https://docs.getdbt.com/reference/dbt_project.yml.md) ends with:

```markdown
## Was this page helpful?

YesNo
```

Rather than have to do this for every widget, this adds a small, reusable escape hatch: a `data-md-hide` attribute plus a `rehypeMdHide` plugin.

The actual rendered HTML site is untouched -- the element still shows on the page, it just never shows in the `.md`.

The feedback widget is the first consumer - I have followup PRs for removing card icons, guide pills, and so on which use this.

### How

`rehypeMdHide` runs in the llms-txt conversion pipeline (`processing.beforeDefaultRehypePlugins`). 

It reads `node.properties.dataMdHide` and, when set, splices the node out. There's no selector or class matching on purpose, as the CSS-module class names are hashed per build, so a stable marker attribute is the reliable contract.

To keep any component out of the markdown, add the attribute to its root element:

```jsx
<div className={styles.feedbackContainer} data-md-hide="true">
```

Verified with a full local build: the feedback widget no longer appears in any generated `.md`, and `npm run build` passes with full link checking.

(Please deploy this to vercel to test!).

## Checklist

- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content. (Build tooling only, no content changes.)
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content) -- not applicable.
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/release-notes) -- not applicable.
